### PR TITLE
Standardize acceptance test feature files to 2 space indent

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -1,593 +1,594 @@
 @api
 Feature: capabilities
-	Background:
-		Given using OCS API version "1"
-		And as user "%admin%"
 
-	@smokeTest
-	Scenario: Check that the sharing API can be enabled
-		Given parameter "shareapi_enabled" of app "core" has been set to "no"
-		And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be ""
-		When the administrator sets parameter "shareapi_enabled" of app "core" to "yes"
-		Then the capabilities setting of "files_sharing" path "api_enabled" should be "1"
+  Background:
+    Given using OCS API version "1"
+    And as user "%admin%"
 
-	@smokeTest
-	Scenario: Check that the sharing API can be disabled
-		Given parameter "shareapi_enabled" of app "core" has been set to "yes"
-		And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be "1"
-		When the administrator sets parameter "shareapi_enabled" of app "core" to "no"
-		Then the capabilities setting of "files_sharing" path "api_enabled" should be ""
+  @smokeTest
+  Scenario: Check that the sharing API can be enabled
+    Given parameter "shareapi_enabled" of app "core" has been set to "no"
+    And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be ""
+    When the administrator sets parameter "shareapi_enabled" of app "core" to "yes"
+    Then the capabilities setting of "files_sharing" path "api_enabled" should be "1"
 
-	Scenario: Check that group sharing can be enabled
-		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be ""
+  @smokeTest
+  Scenario: Check that the sharing API can be disabled
+    Given parameter "shareapi_enabled" of app "core" has been set to "yes"
+    And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be "1"
+    When the administrator sets parameter "shareapi_enabled" of app "core" to "no"
+    Then the capabilities setting of "files_sharing" path "api_enabled" should be ""
 
-		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes"
-		Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
+  Scenario: Check that group sharing can be enabled
+    Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be ""
 
-	Scenario: Check that group sharing can be disabled
-		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "yes"
-		And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be "1"
-		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
-		Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
+    When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes"
+    Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
 
-	@smokeTest
-	Scenario: getting capabilities with admin user
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Check that group sharing can be disabled
+    Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "yes"
+    And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be "1"
+    When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
+    Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 
-	Scenario: Changing public upload
-		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | EMPTY             |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  @smokeTest
+  Scenario: getting capabilities with admin user
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Disabling share api
-		Given parameter "shareapi_enabled" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element       | value             |
-			| core          | pollinterval          | 60                |
-			| core          | webdav-root           | remote.php/webdav |
-			| files_sharing | api_enabled           | EMPTY             |
-			| files_sharing | can_share             | EMPTY             |
-			| files_sharing | public@@@enabled      | EMPTY             |
-			| files_sharing | public@@@upload       | EMPTY             |
-			| files_sharing | resharing             | EMPTY             |
-			| files_sharing | federation@@@outgoing | 1                 |
-			| files_sharing | federation@@@incoming | 1                 |
-			| files         | bigfilechunking       | 1                 |
-			| files         | undelete              | 1                 |
-			| files         | versioning            | 1                 |
+  Scenario: Changing public upload
+    Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | EMPTY             |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Disabling public links
-		Given parameter "shareapi_allow_links" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | EMPTY             |
-			| files_sharing | public@@@upload                       | EMPTY             |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Disabling share api
+    Given parameter "shareapi_enabled" of app "core" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element       | value             |
+      | core          | pollinterval          | 60                |
+      | core          | webdav-root           | remote.php/webdav |
+      | files_sharing | api_enabled           | EMPTY             |
+      | files_sharing | can_share             | EMPTY             |
+      | files_sharing | public@@@enabled      | EMPTY             |
+      | files_sharing | public@@@upload       | EMPTY             |
+      | files_sharing | resharing             | EMPTY             |
+      | files_sharing | federation@@@outgoing | 1                 |
+      | files_sharing | federation@@@incoming | 1                 |
+      | files         | bigfilechunking       | 1                 |
+      | files         | undelete              | 1                 |
+      | files         | versioning            | 1                 |
 
-	Scenario: Changing resharing
-		Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | EMPTY             |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Disabling public links
+    Given parameter "shareapi_allow_links" of app "core" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | EMPTY             |
+      | files_sharing | public@@@upload                       | EMPTY             |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing federation outgoing
-		Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | EMPTY             |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing resharing
+    Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | EMPTY             |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing federation incoming
-		Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | EMPTY             |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing federation outgoing
+    Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | EMPTY             |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing "password enforced for read-only public link shares"
-		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                                | value             |
-			| core          | pollinterval                                   | 60                |
-			| core          | webdav-root                                    | remote.php/webdav |
-			| files_sharing | api_enabled                                    | 1                 |
-			| files_sharing | can_share                                      | 1                 |
-			| files_sharing | public@@@enabled                               | 1                 |
-			| files_sharing | public@@@upload                                | 1                 |
-			| files_sharing | public@@@send_mail                             | EMPTY             |
-			| files_sharing | public@@@social_share                          | 1                 |
-			| files_sharing | public@@@password@@@enforced_for@@@read_only   | 1                 |
-			| files_sharing | public@@@password@@@enforced_for@@@read_write  | EMPTY             |
-			| files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY             |
-			| files_sharing | resharing                                      | 1                 |
-			| files_sharing | federation@@@outgoing                          | 1                 |
-			| files_sharing | federation@@@incoming                          | 1                 |
-			| files_sharing | group_sharing                                  | 1                 |
-			| files_sharing | share_with_group_members_only                  | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                     | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
-			| files         | bigfilechunking                                | 1                 |
-			| files         | undelete                                       | 1                 |
-			| files         | versioning                                     | 1                 |
+  Scenario: Changing federation incoming
+    Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | EMPTY             |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing "password enforced for read-write public link shares"
-		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                                | value             |
-			| core          | pollinterval                                   | 60                |
-			| core          | webdav-root                                    | remote.php/webdav |
-			| files_sharing | api_enabled                                    | 1                 |
-			| files_sharing | can_share                                      | 1                 |
-			| files_sharing | public@@@enabled                               | 1                 |
-			| files_sharing | public@@@upload                                | 1                 |
-			| files_sharing | public@@@send_mail                             | EMPTY             |
-			| files_sharing | public@@@social_share                          | 1                 |
-			| files_sharing | public@@@password@@@enforced_for@@@read_only   | EMPTY             |
-			| files_sharing | public@@@password@@@enforced_for@@@read_write  | 1                 |
-			| files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY             |
-			| files_sharing | resharing                                      | 1                 |
-			| files_sharing | federation@@@outgoing                          | 1                 |
-			| files_sharing | federation@@@incoming                          | 1                 |
-			| files_sharing | group_sharing                                  | 1                 |
-			| files_sharing | share_with_group_members_only                  | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                     | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
-			| files         | bigfilechunking                                | 1                 |
-			| files         | undelete                                       | 1                 |
-			| files         | versioning                                     | 1                 |
+  Scenario: Changing "password enforced for read-only public link shares"
+    Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                                | value             |
+      | core          | pollinterval                                   | 60                |
+      | core          | webdav-root                                    | remote.php/webdav |
+      | files_sharing | api_enabled                                    | 1                 |
+      | files_sharing | can_share                                      | 1                 |
+      | files_sharing | public@@@enabled                               | 1                 |
+      | files_sharing | public@@@upload                                | 1                 |
+      | files_sharing | public@@@send_mail                             | EMPTY             |
+      | files_sharing | public@@@social_share                          | 1                 |
+      | files_sharing | public@@@password@@@enforced_for@@@read_only   | 1                 |
+      | files_sharing | public@@@password@@@enforced_for@@@read_write  | EMPTY             |
+      | files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY             |
+      | files_sharing | resharing                                      | 1                 |
+      | files_sharing | federation@@@outgoing                          | 1                 |
+      | files_sharing | federation@@@incoming                          | 1                 |
+      | files_sharing | group_sharing                                  | 1                 |
+      | files_sharing | share_with_group_members_only                  | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled                     | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
+      | files         | bigfilechunking                                | 1                 |
+      | files         | undelete                                       | 1                 |
+      | files         | versioning                                     | 1                 |
 
-	Scenario: Changing "password enforced for write-only public link shares"
-		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                                | value             |
-			| core          | pollinterval                                   | 60                |
-			| core          | webdav-root                                    | remote.php/webdav |
-			| files_sharing | api_enabled                                    | 1                 |
-			| files_sharing | can_share                                      | 1                 |
-			| files_sharing | public@@@enabled                               | 1                 |
-			| files_sharing | public@@@upload                                | 1                 |
-			| files_sharing | public@@@send_mail                             | EMPTY             |
-			| files_sharing | public@@@social_share                          | 1                 |
-			| files_sharing | public@@@password@@@enforced_for@@@read_only   | EMPTY             |
-			| files_sharing | public@@@password@@@enforced_for@@@read_write  | EMPTY             |
-			| files_sharing | public@@@password@@@enforced_for@@@upload_only | 1                 |
-			| files_sharing | resharing                                      | 1                 |
-			| files_sharing | federation@@@outgoing                          | 1                 |
-			| files_sharing | federation@@@incoming                          | 1                 |
-			| files_sharing | group_sharing                                  | 1                 |
-			| files_sharing | share_with_group_members_only                  | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                     | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
-			| files         | bigfilechunking                                | 1                 |
-			| files         | undelete                                       | 1                 |
-			| files         | versioning                                     | 1                 |
+  Scenario: Changing "password enforced for read-write public link shares"
+    Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                                | value             |
+      | core          | pollinterval                                   | 60                |
+      | core          | webdav-root                                    | remote.php/webdav |
+      | files_sharing | api_enabled                                    | 1                 |
+      | files_sharing | can_share                                      | 1                 |
+      | files_sharing | public@@@enabled                               | 1                 |
+      | files_sharing | public@@@upload                                | 1                 |
+      | files_sharing | public@@@send_mail                             | EMPTY             |
+      | files_sharing | public@@@social_share                          | 1                 |
+      | files_sharing | public@@@password@@@enforced_for@@@read_only   | EMPTY             |
+      | files_sharing | public@@@password@@@enforced_for@@@read_write  | 1                 |
+      | files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY             |
+      | files_sharing | resharing                                      | 1                 |
+      | files_sharing | federation@@@outgoing                          | 1                 |
+      | files_sharing | federation@@@incoming                          | 1                 |
+      | files_sharing | group_sharing                                  | 1                 |
+      | files_sharing | share_with_group_members_only                  | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled                     | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
+      | files         | bigfilechunking                                | 1                 |
+      | files         | undelete                                       | 1                 |
+      | files         | versioning                                     | 1                 |
 
-	Scenario: Changing public notifications
-		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | 1                 |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing "password enforced for write-only public link shares"
+    Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                                | value             |
+      | core          | pollinterval                                   | 60                |
+      | core          | webdav-root                                    | remote.php/webdav |
+      | files_sharing | api_enabled                                    | 1                 |
+      | files_sharing | can_share                                      | 1                 |
+      | files_sharing | public@@@enabled                               | 1                 |
+      | files_sharing | public@@@upload                                | 1                 |
+      | files_sharing | public@@@send_mail                             | EMPTY             |
+      | files_sharing | public@@@social_share                          | 1                 |
+      | files_sharing | public@@@password@@@enforced_for@@@read_only   | EMPTY             |
+      | files_sharing | public@@@password@@@enforced_for@@@read_write  | EMPTY             |
+      | files_sharing | public@@@password@@@enforced_for@@@upload_only | 1                 |
+      | files_sharing | resharing                                      | 1                 |
+      | files_sharing | federation@@@outgoing                          | 1                 |
+      | files_sharing | federation@@@incoming                          | 1                 |
+      | files_sharing | group_sharing                                  | 1                 |
+      | files_sharing | share_with_group_members_only                  | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled                     | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
+      | files         | bigfilechunking                                | 1                 |
+      | files         | undelete                                       | 1                 |
+      | files         | versioning                                     | 1                 |
 
-	Scenario: Changing public social share
-		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | EMPTY             |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing public notifications
+    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | 1                 |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing expire date
-		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | public@@@expire_date@@@enabled        | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing public social share
+    Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | EMPTY             |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing expire date enforcing
-		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
-		And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | public@@@expire_date@@@enabled        | 1                 |
-			| files_sharing | public@@@expire_date@@@enforced       | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing expire date
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | public@@@expire_date@@@enabled        | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing group sharing allowed
-		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | EMPTY             |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing expire date enforcing
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | public@@@expire_date@@@enabled        | 1                 |
+      | files_sharing | public@@@expire_date@@@enforced       | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing only share with group member
-		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | 1                 |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing group sharing allowed
+    Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | EMPTY             |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing allow share dialog user enumeration
-		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element               | value             |
-			| core          | pollinterval                  | 60                |
-			| core          | webdav-root                   | remote.php/webdav |
-			| files_sharing | api_enabled                   | 1                 |
-			| files_sharing | can_share                     | 1                 |
-			| files_sharing | public@@@enabled              | 1                 |
-			| files_sharing | public@@@upload               | 1                 |
-			| files_sharing | public@@@send_mail            | EMPTY             |
-			| files_sharing | public@@@social_share         | 1                 |
-			| files_sharing | resharing                     | 1                 |
-			| files_sharing | federation@@@outgoing         | 1                 |
-			| files_sharing | federation@@@incoming         | 1                 |
-			| files_sharing | group_sharing                 | 1                 |
-			| files_sharing | share_with_group_members_only | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled    | EMPTY             |
-			| files         | bigfilechunking               | 1                 |
-			| files         | undelete                      | 1                 |
-			| files         | versioning                    | 1                 |
+  Scenario: Changing only share with group member
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | 1                 |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: Changing allow share dialog user enumeration for group members only
-		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | 1                 |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+  Scenario: Changing allow share dialog user enumeration
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element               | value             |
+      | core          | pollinterval                  | 60                |
+      | core          | webdav-root                   | remote.php/webdav |
+      | files_sharing | api_enabled                   | 1                 |
+      | files_sharing | can_share                     | 1                 |
+      | files_sharing | public@@@enabled              | 1                 |
+      | files_sharing | public@@@upload               | 1                 |
+      | files_sharing | public@@@send_mail            | EMPTY             |
+      | files_sharing | public@@@social_share         | 1                 |
+      | files_sharing | resharing                     | 1                 |
+      | files_sharing | federation@@@outgoing         | 1                 |
+      | files_sharing | federation@@@incoming         | 1                 |
+      | files_sharing | group_sharing                 | 1                 |
+      | files_sharing | share_with_group_members_only | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled    | EMPTY             |
+      | files         | bigfilechunking               | 1                 |
+      | files         | undelete                      | 1                 |
+      | files         | versioning                    | 1                 |
 
-	Scenario: Changing exclude groups from sharing
-		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-		And group "grp1" has been created
-		And group "hash#group" has been created
-		And group "group-3" has been created
-		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                           | value             |
-			| core          | pollinterval                              | 60                |
-			| core          | webdav-root                               | remote.php/webdav |
-			| files_sharing | api_enabled                               | 1                 |
-			| files_sharing | can_share                                 | 1                 |
-			| files_sharing | public@@@enabled                          | 1                 |
-			| files_sharing | public@@@upload                           | 1                 |
-			| files_sharing | public@@@send_mail                        | EMPTY             |
-			| files_sharing | public@@@social_share                     | 1                 |
-			| files_sharing | resharing                                 | 1                 |
-			| files_sharing | federation@@@outgoing                     | 1                 |
-			| files_sharing | federation@@@incoming                     | 1                 |
-			| files_sharing | group_sharing                             | 1                 |
-			| files_sharing | share_with_group_members_only             | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
-			| files         | bigfilechunking                           | 1                 |
-			| files         | undelete                                  | 1                 |
-			| files         | versioning                                | 1                 |
+  Scenario: Changing allow share dialog user enumeration for group members only
+    Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | 1                 |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: When in a group that is excluded from sharing, can_share is off
-		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-		And user "user0" has been created
-		And group "grp1" has been created
-		And group "hash#group" has been created
-		And group "group-3" has been created
-		And group "ordinary-group" has been created
-		And user "user0" has been added to group "hash#group"
-		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-		And as user "user0"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                           | value             |
-			| core          | pollinterval                              | 60                |
-			| core          | webdav-root                               | remote.php/webdav |
-			| files_sharing | api_enabled                               | 1                 |
-			| files_sharing | can_share                                 | EMPTY             |
-			| files_sharing | public@@@enabled                          | 1                 |
-			| files_sharing | public@@@upload                           | 1                 |
-			| files_sharing | public@@@send_mail                        | EMPTY             |
-			| files_sharing | public@@@social_share                     | 1                 |
-			| files_sharing | resharing                                 | 1                 |
-			| files_sharing | federation@@@outgoing                     | 1                 |
-			| files_sharing | federation@@@incoming                     | 1                 |
-			| files_sharing | group_sharing                             | 1                 |
-			| files_sharing | share_with_group_members_only             | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
-			| files         | bigfilechunking                           | 1                 |
-			| files         | undelete                                  | 1                 |
-			| files         | versioning                                | 1                 |
+  Scenario: Changing exclude groups from sharing
+    Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And group "grp1" has been created
+    And group "hash#group" has been created
+    And group "group-3" has been created
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: When not in any group that is excluded from sharing, can_share is on
-		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-		And user "user0" has been created
-		And group "grp1" has been created
-		And group "hash#group" has been created
-		And group "group-3" has been created
-		And group "ordinary-group" has been created
-		And user "user0" has been added to group "ordinary-group"
-		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-		And as user "user0"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                           | value             |
-			| core          | pollinterval                              | 60                |
-			| core          | webdav-root                               | remote.php/webdav |
-			| files_sharing | api_enabled                               | 1                 |
-			| files_sharing | can_share                                 | 1                 |
-			| files_sharing | public@@@enabled                          | 1                 |
-			| files_sharing | public@@@upload                           | 1                 |
-			| files_sharing | public@@@send_mail                        | EMPTY             |
-			| files_sharing | public@@@social_share                     | 1                 |
-			| files_sharing | resharing                                 | 1                 |
-			| files_sharing | federation@@@outgoing                     | 1                 |
-			| files_sharing | federation@@@incoming                     | 1                 |
-			| files_sharing | group_sharing                             | 1                 |
-			| files_sharing | share_with_group_members_only             | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
-			| files         | bigfilechunking                           | 1                 |
-			| files         | undelete                                  | 1                 |
-			| files         | versioning                                | 1                 |
+  Scenario: When in a group that is excluded from sharing, can_share is off
+    Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And user "user0" has been created
+    And group "grp1" has been created
+    And group "hash#group" has been created
+    And group "group-3" has been created
+    And group "ordinary-group" has been created
+    And user "user0" has been added to group "hash#group"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+    And as user "user0"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | EMPTY             |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
 
-	Scenario: When in a group that is excluded from sharing and in another group, can_share is off
-		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-		And user "user0" has been created
-		And group "grp1" has been created
-		And group "hash#group" has been created
-		And group "group-3" has been created
-		And group "ordinary-group" has been created
-		And user "user0" has been added to group "hash#group"
-		And user "user0" has been added to group "ordinary-group"
-		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-		And as user "user0"
-		When the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                           | value             |
-			| core          | pollinterval                              | 60                |
-			| core          | webdav-root                               | remote.php/webdav |
-			| files_sharing | api_enabled                               | 1                 |
-			| files_sharing | can_share                                 | EMPTY             |
-			| files_sharing | public@@@enabled                          | 1                 |
-			| files_sharing | public@@@upload                           | 1                 |
-			| files_sharing | public@@@send_mail                        | EMPTY             |
-			| files_sharing | public@@@social_share                     | 1                 |
-			| files_sharing | resharing                                 | 1                 |
-			| files_sharing | federation@@@outgoing                     | 1                 |
-			| files_sharing | federation@@@incoming                     | 1                 |
-			| files_sharing | group_sharing                             | 1                 |
-			| files_sharing | share_with_group_members_only             | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
-			| files         | bigfilechunking                           | 1                 |
-			| files         | undelete                                  | 1                 |
-			| files         | versioning                                | 1                 |
+  Scenario: When not in any group that is excluded from sharing, can_share is on
+    Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And user "user0" has been created
+    And group "grp1" has been created
+    And group "hash#group" has been created
+    And group "group-3" has been created
+    And group "ordinary-group" has been created
+    And user "user0" has been added to group "ordinary-group"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+    And as user "user0"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |
+
+  Scenario: When in a group that is excluded from sharing and in another group, can_share is off
+    Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And user "user0" has been created
+    And group "grp1" has been created
+    And group "hash#group" has been created
+    And group "group-3" has been created
+    And group "ordinary-group" has been created
+    And user "user0" has been added to group "hash#group"
+    And user "user0" has been added to group "ordinary-group"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+    And as user "user0"
+    When the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | EMPTY             |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+      | files         | undelete                              | 1                 |
+      | files         | versioning                            | 1                 |

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -1,205 +1,206 @@
 @api @federation-app-required
 Feature: federated
-	Background:
-		Given using OCS API version "1"
-		And using server "REMOTE"
-		And user "user0" has been created
-		And using server "LOCAL"
-		And user "user1" has been created
-		
-	Scenario: Federate share a file with another server
-		When user "user1" from server "LOCAL" shares "/textfile0.txt" with user "user0" from server "REMOTE" using the sharing API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                     | A_NUMBER       |
-			| item_type              | file           |
-			| item_source            | A_NUMBER       |
-			| share_type             | 6              |
-			| file_source            | A_NUMBER       |
-			| path                   | /textfile0.txt |
-			| permissions            | 19             |
-			| stime                  | A_NUMBER       |
-			| storage                | A_NUMBER       |
-			| mail_send              | 0              |
-			| uid_owner              | user1          |
-			| file_parent            | A_NUMBER       |
-			| displayname_owner      | user1          |
-			| share_with             | user0@REMOTE   |
-			| share_with_displayname | user0@REMOTE   |
 
-	Scenario: Federate share a file with local server
-		When user "user0" from server "REMOTE" shares "/textfile0.txt" with user "user1" from server "LOCAL" using the sharing API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                     | A_NUMBER       |
-			| item_type              | file           |
-			| item_source            | A_NUMBER       |
-			| share_type             | 6              |
-			| file_source            | A_NUMBER       |
-			| path                   | /textfile0.txt |
-			| permissions            | 19             |
-			| stime                  | A_NUMBER       |
-			| storage                | A_NUMBER       |
-			| mail_send              | 0              |
-			| uid_owner              | user0          |
-			| file_parent            | A_NUMBER       |
-			| displayname_owner      | user0          |
-			| share_with             | user1@LOCAL    |
-			| share_with_displayname | user1@LOCAL    |
+  Background:
+    Given using OCS API version "1"
+    And using server "REMOTE"
+    And user "user0" has been created
+    And using server "LOCAL"
+    And user "user1" has been created
 
-	Scenario: Remote sharee can see the pending share
-		Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
-		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id          | A_NUMBER                                   |
-			| remote      | REMOTE                                     |
-			| remote_id   | A_NUMBER                                   |
-			| share_token | A_TOKEN                                    |
-			| name        | /textfile0.txt                             |
-			| owner       | user0                                      |
-			| user        | user1                                      |
-			| mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
-			| accepted    | 0                                          |
+  Scenario: Federate share a file with another server
+    When user "user1" from server "LOCAL" shares "/textfile0.txt" with user "user0" from server "REMOTE" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                     | A_NUMBER       |
+      | item_type              | file           |
+      | item_source            | A_NUMBER       |
+      | share_type             | 6              |
+      | file_source            | A_NUMBER       |
+      | path                   | /textfile0.txt |
+      | permissions            | 19             |
+      | stime                  | A_NUMBER       |
+      | storage                | A_NUMBER       |
+      | mail_send              | 0              |
+      | uid_owner              | user1          |
+      | file_parent            | A_NUMBER       |
+      | displayname_owner      | user1          |
+      | share_with             | user0@REMOTE   |
+      | share_with_displayname | user0@REMOTE   |
 
-	Scenario: accept a pending remote share
-		Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
-		When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  Scenario: Federate share a file with local server
+    When user "user0" from server "REMOTE" shares "/textfile0.txt" with user "user1" from server "LOCAL" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                     | A_NUMBER       |
+      | item_type              | file           |
+      | item_source            | A_NUMBER       |
+      | share_type             | 6              |
+      | file_source            | A_NUMBER       |
+      | path                   | /textfile0.txt |
+      | permissions            | 19             |
+      | stime                  | A_NUMBER       |
+      | storage                | A_NUMBER       |
+      | mail_send              | 0              |
+      | uid_owner              | user0          |
+      | file_parent            | A_NUMBER       |
+      | displayname_owner      | user0          |
+      | share_with             | user1@LOCAL    |
+      | share_with_displayname | user1@LOCAL    |
 
-	Scenario: Reshare a federated shared file
-		Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		And using server "LOCAL"
-		And user "user2" has been created
-		When user "user1" creates a share using the sharing API with settings
-			| path        | /textfile0 (2).txt |
-			| shareType   | 0                  |
-			| shareWith   | user2              |
-			| permissions | 19                 |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                     | A_NUMBER           |
-			| item_type              | file               |
-			| item_source            | A_NUMBER           |
-			| share_type             | 0                  |
-			| file_source            | A_NUMBER           |
-			| path                   | /textfile0 (2).txt |
-			| permissions            | 19                 |
-			| stime                  | A_NUMBER           |
-			| storage                | A_NUMBER           |
-			| mail_send              | 0                  |
-			| uid_owner              | user1              |
-			| file_parent            | A_NUMBER           |
-			| displayname_owner      | user1              |
-			| share_with             | user2              |
-			| share_with_displayname | user2              |
+  Scenario: Remote sharee can see the pending share
+    Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id          | A_NUMBER                                   |
+      | remote      | REMOTE                                     |
+      | remote_id   | A_NUMBER                                   |
+      | share_token | A_TOKEN                                    |
+      | name        | /textfile0.txt                             |
+      | owner       | user0                                      |
+      | user        | user1                                      |
+      | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
+      | accepted    | 0                                          |
 
-	Scenario: Overwrite a federated shared file as recipient - local server shares - remote server receives
-		Given user "user1" from server "LOCAL" has shared "/textfile0.txt" with user "user0" from server "REMOTE"
-		And user "user0" from server "REMOTE" has accepted the last pending share
-		And using server "REMOTE"
-		When user "user0" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
-		And using server "LOCAL"
-		Then the content of file "/textfile0.txt" for user "user1" should be "BLABLABLA" plus end-of-line
+  Scenario: accept a pending remote share
+    Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	Scenario: Overwrite a federated shared file as recipient - remote server shares - local server receives
-		Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
-		And using server "REMOTE"
-		Then the content of file "/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
+  Scenario: Reshare a federated shared file
+    Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    And user "user2" has been created
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /textfile0 (2).txt |
+      | shareType   | 0                  |
+      | shareWith   | user2              |
+      | permissions | 19                 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                     | A_NUMBER           |
+      | item_type              | file               |
+      | item_source            | A_NUMBER           |
+      | share_type             | 0                  |
+      | file_source            | A_NUMBER           |
+      | path                   | /textfile0 (2).txt |
+      | permissions            | 19                 |
+      | stime                  | A_NUMBER           |
+      | storage                | A_NUMBER           |
+      | mail_send              | 0                  |
+      | uid_owner              | user1              |
+      | file_parent            | A_NUMBER           |
+      | displayname_owner      | user1              |
+      | share_with             | user2              |
+      | share_with_displayname | user2              |
 
-	Scenario: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
-		Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
-		And user "user0" from server "REMOTE" has accepted the last pending share
-		And using server "REMOTE"
-		When user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-		And using server "LOCAL"
-		Then the content of file "/PARENT/textfile0.txt" for user "user1" should be "BLABLABLA" plus end-of-line
+  Scenario: Overwrite a federated shared file as recipient - local server shares - remote server receives
+    Given user "user1" from server "LOCAL" has shared "/textfile0.txt" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    When user "user0" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
+    And using server "LOCAL"
+    Then the content of file "/textfile0.txt" for user "user1" should be "BLABLABLA" plus end-of-line
 
-	Scenario: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
-		Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-		And using server "REMOTE"
-		Then the content of file "/PARENT/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
+  Scenario: Overwrite a federated shared file as recipient - remote server shares - local server receives
+    Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    When user "user1" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
+    And using server "REMOTE"
+    Then the content of file "/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
 
-	Scenario: Overwrite a federated shared file as recipient using old chunking
-		Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		When user "user1" uploads the following "3" chunks to "/textfile0 (2).txt" with old chunking and using the WebDAV API
-			| 1 | AAAAA |
-			| 2 | BBBBB |
-			| 3 | CCCCC |
-		Then the content of file "/textfile0 (2).txt" for user "user1" should be "AAAAABBBBBCCCCC"
-		And using server "REMOTE"
-		Then the content of file "/textfile0.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+  Scenario: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    When user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    And using server "LOCAL"
+    Then the content of file "/PARENT/textfile0.txt" for user "user1" should be "BLABLABLA" plus end-of-line
 
-	Scenario: Overwrite a file in a federated shared folder as recipient using old chunking
-		Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		When user "user1" uploads the following "3" chunks to "/PARENT (2)/textfile0.txt" with old chunking and using the WebDAV API
-			| 1 | AAAAA |
-			| 2 | BBBBB |
-			| 3 | CCCCC |
-		Then the content of file "/PARENT (2)/textfile0.txt" for user "user1" should be "AAAAABBBBBCCCCC"
-		And using server "REMOTE"
-		And the content of file "/PARENT/textfile0.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+  Scenario: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
+    Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    And using server "REMOTE"
+    Then the content of file "/PARENT/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
 
-	Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
-		Given using server "LOCAL"
-		And using OCS API version "2"
-		When user "UNAUTHORIZED_USER" sends HTTP method "POST" to OCS API endpoint "/apps/federation/api/v1/request-shared-secret"
-		Then the HTTP status code should be "403"
+  Scenario: Overwrite a federated shared file as recipient using old chunking
+    Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    When user "user1" uploads the following "3" chunks to "/textfile0 (2).txt" with old chunking and using the WebDAV API
+      | 1 | AAAAA |
+      | 2 | BBBBB |
+      | 3 | CCCCC |
+    Then the content of file "/textfile0 (2).txt" for user "user1" should be "AAAAABBBBBCCCCC"
+    And using server "REMOTE"
+    Then the content of file "/textfile0.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
-	Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
-		Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
-		And user "user0" from server "REMOTE" has accepted the last pending share
-		And using server "REMOTE"
-		And user "user0" has stored etag of element "/PARENT (2)"
-		And using server "LOCAL"
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
-		Then using server "REMOTE"
-		And the etag of element "/PARENT (2)" of user "user0" should have changed
+  Scenario: Overwrite a file in a federated shared folder as recipient using old chunking
+    Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    When user "user1" uploads the following "3" chunks to "/PARENT (2)/textfile0.txt" with old chunking and using the WebDAV API
+      | 1 | AAAAA |
+      | 2 | BBBBB |
+      | 3 | CCCCC |
+    Then the content of file "/PARENT (2)/textfile0.txt" for user "user1" should be "AAAAABBBBBCCCCC"
+    And using server "REMOTE"
+    And the content of file "/PARENT/textfile0.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
-	Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
-		Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
-		And user "user1" has stored etag of element "/PARENT"
-		And user "user0" from server "REMOTE" has accepted the last pending share
-		And using server "REMOTE"
-		When user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-		Then using server "LOCAL"
-		And the etag of element "/PARENT" of user "user1" should have changed
+  Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
+    Given using server "LOCAL"
+    And using OCS API version "2"
+    When user "UNAUTHORIZED_USER" sends HTTP method "POST" to OCS API endpoint "/apps/federation/api/v1/request-shared-secret"
+    Then the HTTP status code should be "403"
 
-	Scenario: Upload file to received federated share while quota is set on home storage
-		Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		And using server "LOCAL"
-		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "201"
-		And using server "REMOTE"
-		And as "user0" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
+  Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    And user "user0" has stored etag of element "/PARENT (2)"
+    And using server "LOCAL"
+    When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
+    Then using server "REMOTE"
+    And the etag of element "/PARENT (2)" of user "user0" should have changed
 
-	Scenario: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives
-		Given using server "LOCAL"
-		And the quota of user "user1" has been set to "20 B"
-		And user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
-		And user "user0" from server "REMOTE" has accepted the last pending share
-		And using server "REMOTE"
-		When user "user0" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "507"
+  Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user1" has stored etag of element "/PARENT"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    When user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    Then using server "LOCAL"
+    And the etag of element "/PARENT" of user "user1" should have changed
 
-	Scenario: Upload file to received federated share while quota is set on remote storage - remote server shares - local server receives
-		Given using server "REMOTE"
-		And the quota of user "user0" has been set to "20 B"
-		And user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		And using server "LOCAL"
-		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "507"
+  Scenario: Upload file to received federated share while quota is set on home storage
+    Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "201"
+    And using server "REMOTE"
+    And as "user0" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
+
+  Scenario: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives
+    Given using server "LOCAL"
+    And the quota of user "user1" has been set to "20 B"
+    And user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    When user "user0" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"
+
+  Scenario: Upload file to received federated share while quota is set on remote storage - remote server shares - local server receives
+    Given using server "REMOTE"
+    And the quota of user "user0" has been set to "20 B"
+    And user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"

--- a/tests/acceptance/features/apiMain/auth.feature
+++ b/tests/acceptance/features/apiMain/auth.feature
@@ -1,94 +1,94 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: auth
 
-	Background:
-		Given user "user0" has been created
-		And a new client token for "user0" has been generated
+  Background:
+    Given user "user0" has been created
+    And a new client token for "user0" has been generated
 
 	# FILES APP
-	@smokeTest
-	Scenario: access files app anonymously
-		When a user requests "/index.php/apps/files" with "GET" and no authentication
-		Then the HTTP status code should be "401"
+  @smokeTest
+  Scenario: access files app anonymously
+    When a user requests "/index.php/apps/files" with "GET" and no authentication
+    Then the HTTP status code should be "401"
 
-	@smokeTest
-	Scenario: access files app with basic auth
-		When user "user0" requests "/index.php/apps/files" with "GET" using basic auth
-		Then the HTTP status code should be "200"
+  @smokeTest
+  Scenario: access files app with basic auth
+    When user "user0" requests "/index.php/apps/files" with "GET" using basic auth
+    Then the HTTP status code should be "200"
 
-	@smokeTest
-	Scenario: access files app with basic token auth
-		When user "user0" requests "/index.php/apps/files" with "GET" using basic token auth
-		Then the HTTP status code should be "200"
+  @smokeTest
+  Scenario: access files app with basic token auth
+    When user "user0" requests "/index.php/apps/files" with "GET" using basic token auth
+    Then the HTTP status code should be "200"
 
-	@smokeTest
-	Scenario: access files app with a client token
-		When the user requests "/index.php/apps/files" with "GET" using the generated client token
-		Then the HTTP status code should be "200"
+  @smokeTest
+  Scenario: access files app with a client token
+    When the user requests "/index.php/apps/files" with "GET" using the generated client token
+    Then the HTTP status code should be "200"
 
-	@smokeTest
-	Scenario: access files app with browser session
-		Given a new browser session for "user0" has been started
-		When the user requests "/index.php/apps/files" with "GET" using the browser session
-		Then the HTTP status code should be "200"
+  @smokeTest
+  Scenario: access files app with browser session
+    Given a new browser session for "user0" has been started
+    When the user requests "/index.php/apps/files" with "GET" using the browser session
+    Then the HTTP status code should be "200"
 
-	@smokeTest
-	Scenario: access files app with an app password
-		Given a new browser session for "user0" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/index.php/apps/files" with "GET" using the generated app password
-		Then the HTTP status code should be "200"
+  @smokeTest
+  Scenario: access files app with an app password
+    Given a new browser session for "user0" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/index.php/apps/files" with "GET" using the generated app password
+    Then the HTTP status code should be "200"
 
 	# WebDAV
 
-	Scenario: using WebDAV anonymously
-		When a user requests "/remote.php/webdav" with "PROPFIND" and no authentication
-		Then the HTTP status code should be "401"
+  Scenario: using WebDAV anonymously
+    When a user requests "/remote.php/webdav" with "PROPFIND" and no authentication
+    Then the HTTP status code should be "401"
 
-	Scenario: using WebDAV with basic auth
-		When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic auth
-		Then the HTTP status code should be "207"
+  Scenario: using WebDAV with basic auth
+    When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic auth
+    Then the HTTP status code should be "207"
 
-	Scenario: using WebDAV with token auth
-		When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
-		Then the HTTP status code should be "207"
+  Scenario: using WebDAV with token auth
+    When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
+    Then the HTTP status code should be "207"
 
 	# DAV token auth is not possible yet
 	#Scenario: using WebDAV with a client token
 	#	When requesting "/remote.php/webdav" with "PROPFIND" using a client token
 	#	Then the HTTP status code should be "207"
 
-	Scenario: using WebDAV with browser session
-		Given a new browser session for "user0" has been started
-		When the user requests "/remote.php/webdav" with "PROPFIND" using the browser session
-		Then the HTTP status code should be "207"
+  Scenario: using WebDAV with browser session
+    Given a new browser session for "user0" has been started
+    When the user requests "/remote.php/webdav" with "PROPFIND" using the browser session
+    Then the HTTP status code should be "207"
 
 
 	# OCS
 
-	Scenario: using OCS anonymously
-		When a user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" and no authentication
-		Then the OCS status code should be "997"
+  Scenario: using OCS anonymously
+    When a user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" and no authentication
+    Then the OCS status code should be "997"
 
-	Scenario: using OCS with basic auth
-		When user "user0" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
-		Then the OCS status code should be "100"
+  Scenario: using OCS with basic auth
+    When user "user0" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
+    Then the OCS status code should be "100"
 
-	Scenario: using OCS with token auth
-		When user "user0" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic token auth
-		Then the OCS status code should be "100"
+  Scenario: using OCS with token auth
+    When user "user0" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic token auth
+    Then the OCS status code should be "100"
 
-	Scenario: using OCS with client token
-		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the generated client token
-		Then the OCS status code should be "100"
+  Scenario: using OCS with client token
+    When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the generated client token
+    Then the OCS status code should be "100"
 
-	Scenario: using OCS with browser session
-		Given a new browser session for "user0" has been started
-		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the browser session
-		Then the OCS status code should be "100"
+  Scenario: using OCS with browser session
+    Given a new browser session for "user0" has been started
+    When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the browser session
+    Then the OCS status code should be "100"
 
-	Scenario: using OCS with an app password
-		Given a new browser session for "user0" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the generated app password
-		Then the HTTP status code should be "200"
+  Scenario: using OCS with an app password
+    Given a new browser session for "user0" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the generated app password
+    Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -1,34 +1,34 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: caldav
 
-	Background:
-		Given user "user0" has been created
+  Background:
+    Given user "user0" has been created
 
-	@caldav
-	Scenario: Accessing a not existing calendar of another user
-		When user "%admin%" requests calendar "user0/MyCalendar" using the new WebDAV API
-		Then the CalDAV HTTP status code should be "404"
-		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
-		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
+  @caldav
+  Scenario: Accessing a not existing calendar of another user
+    When user "%admin%" requests calendar "user0/MyCalendar" using the new WebDAV API
+    Then the CalDAV HTTP status code should be "404"
+    And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
+    And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
-	@caldav
-	Scenario: Accessing a not shared calendar of another user
-		Given user "%admin%" has successfully created a calendar named "MyCalendar"
-		When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
-		Then the CalDAV HTTP status code should be "404"
-		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
-		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
+  @caldav
+  Scenario: Accessing a not shared calendar of another user
+    Given user "%admin%" has successfully created a calendar named "MyCalendar"
+    When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
+    Then the CalDAV HTTP status code should be "404"
+    And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
+    And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
-	@caldav
-	Scenario: Accessing a not existing calendar of myself
-		When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
-		Then the CalDAV HTTP status code should be "404"
-		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
-		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
+  @caldav
+  Scenario: Accessing a not existing calendar of myself
+    When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
+    Then the CalDAV HTTP status code should be "404"
+    And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
+    And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
-	@caldav
-	@smokeTest
-	Scenario: Creating a new calendar
-		Given user "user0" has successfully created a calendar named "MyCalendar"
-		When user "user0" requests calendar "user0/MyCalendar" using the new WebDAV API
-		Then the CalDAV HTTP status code should be "200"
+  @caldav
+  @smokeTest
+  Scenario: Creating a new calendar
+    Given user "user0" has successfully created a calendar named "MyCalendar"
+    When user "user0" requests calendar "user0/MyCalendar" using the new WebDAV API
+    Then the CalDAV HTTP status code should be "200"

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -9,9 +9,9 @@ Feature: checksums
     When user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
     Then the webdav response should have a status code "201"
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   @smokeTest
   Scenario Outline: Uploading a file with checksum should return the checksum in the propfind
@@ -20,9 +20,9 @@ Feature: checksums
     When user "user0" requests the checksum of "/myChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   @smokeTest
   Scenario Outline: Uploading a file with checksum should return the checksum in the download header
@@ -31,9 +31,9 @@ Feature: checksums
     When user "user0" downloads the file "/myChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: Moving a file with checksum should return the checksum in the propfind
     Given using <dav_version> DAV path
@@ -42,9 +42,9 @@ Feature: checksums
     And user "user0" requests the checksum of "/myMovedChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario: Downloading a file with checksum should return the checksum in the download header
     Given using old DAV path
@@ -80,9 +80,9 @@ Feature: checksums
     And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
     Then the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: Moving file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
@@ -91,9 +91,9 @@ Feature: checksums
     And user "user0" downloads the file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario: Copying a file with checksum should return the checksum in the propfind using new DAV path
     Given using new DAV path
@@ -154,9 +154,9 @@ Feature: checksums
     And user "user0" should not see the following elements
       | /chksumtst.txt |
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: Upload a file where checksum does match
     Given using <dav_version> DAV path
@@ -164,9 +164,9 @@ Feature: checksums
     When user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: Uploaded file should have the same checksum when downloaded
     Given using <dav_version> DAV path
@@ -176,9 +176,9 @@ Feature: checksums
     Then the following headers should be set
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   @local_storage @skipOnEncryptionType:user-keys @encryption-issue-42
   Scenario Outline: Uploaded file to external storage should have the same checksum when downloaded
@@ -189,9 +189,9 @@ Feature: checksums
     Then the following headers should be set
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+      | dav_version |
+      | old         |
+      | new         |
     
 
   ## Validation Plugin or Old Endpoint Specific
@@ -216,9 +216,9 @@ Feature: checksums
       Cheers.
       """
     Examples:
-      | dav_version   |
-      | old           |
-      | new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: Uploading a file with SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
@@ -232,9 +232,9 @@ Feature: checksums
       Cheers.
       """
     Examples:
-      | dav_version   |
-      | old           |
-      | new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   @skipOnStorage:ceph @files_primary_s3-issue-128
   Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
@@ -244,9 +244,9 @@ Feature: checksums
     Then the webdav checksum should match "SHA1:0c1d334e686d1039c9ead0dbc047f02dbf696be8 MD5:d991cd854c53729d066c6ed5e34bcda3 ADLER32:8685092b"
     And the content of file "/textfile0.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
     Examples:
-      | dav_version   |
-      | old           |
-      | new           |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path

--- a/tests/acceptance/features/apiMain/dav-versions.feature
+++ b/tests/acceptance/features/apiMain/dav-versions.feature
@@ -1,6 +1,7 @@
 @api @files_versions-app-required
 
 Feature: dav-versions
+
   Background:
     Given using OCS API version "2"
     And using new DAV path
@@ -54,141 +55,141 @@ Feature: dav-versions
       | permissions | 8            |
     Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element
 
-	Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
-		Given user "user1" has been created
-		And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
-		And user "user0" has shared file "sharefile.txt" with user "user1"
-		When user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
-		Then the HTTP status code should be "204"
-		And the version folder of file "/sharefile.txt" for user "user0" should contain "1" element
+  Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
+    Given user "user1" has been created
+    And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
+    And user "user0" has shared file "sharefile.txt" with user "user1"
+    When user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
+    Then the HTTP status code should be "204"
+    And the version folder of file "/sharefile.txt" for user "user0" should contain "1" element
 
-	Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
-		Given user "user1" has been created
-		And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
-		And user "user0" has shared file "sharefile.txt" with user "user1"
-		And user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharefile.txt" for user "user0" should be "user0 content"
-		And the content of file "/sharefile.txt" for user "user1" should be "user0 content"
+  Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
+    Given user "user1" has been created
+    And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
+    And user "user0" has shared file "sharefile.txt" with user "user1"
+    And user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
+    When user "user0" restores version index "1" of file "/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharefile.txt" for user "user0" should be "user0 content"
+    And the content of file "/sharefile.txt" for user "user1" should be "user0 content"
 
-	Scenario: sharer can restore a file inside a shared folder modified by sharee
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with user "user1"
-		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
-		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
+  Scenario: sharer can restore a file inside a shared folder modified by sharee
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with user "user1"
+    And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
+    And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
+    When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
-	Scenario: sharee can restore a file inside a shared folder modified by sharee
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with user "user1"
-		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
-		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
-		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
+  Scenario: sharee can restore a file inside a shared folder modified by sharee
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with user "user1"
+    And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
+    And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
+    When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
-	Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with user "user1"
-		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
-		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
+  Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with user "user1"
+    And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
+    And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
+    When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
-	Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with user "user1"
-		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
-		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
-		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
+  Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with user "user1"
+    And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
+    And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
+    When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
-	Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with user "user1"
-		And user "user1" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
-		And user "user1" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
+  Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with user "user1"
+    And user "user1" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
+    And user "user1" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
+    When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
-	Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with user "user1"
-		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
-		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
-		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
+  Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with user "user1"
+    And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
+    And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
+    When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
-	Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with user "user1"
-		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
-		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
-		And user "user1" has created a folder "/received"
-		And user "user1" has moved folder "/sharingfolder" to "/received/sharingfolder"
-		When user "user1" restores version index "1" of file "/received/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
-		And the content of file "/received/sharingfolder/sharefile.txt" for user "user1" should be "old content"
+  Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with user "user1"
+    And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
+    And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
+    And user "user1" has created a folder "/received"
+    And user "user1" has moved folder "/sharingfolder" to "/received/sharingfolder"
+    When user "user1" restores version index "1" of file "/received/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+    And the content of file "/received/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
-	Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
-		Given user "user1" has been created
-		And user "user0" has uploaded file with content "old content" to "/sharefile.txt"
-		And user "user0" has uploaded file with content "new content" to "/sharefile.txt"
-		And user "user0" has shared file "/sharefile.txt" with user "user1"
-		And user "user1" has created a folder "/received"
-		And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
-		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
-		And the content of file "/sharefile.txt" for user "user0" should be "old content"
-		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
+  Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
+    Given user "user1" has been created
+    And user "user0" has uploaded file with content "old content" to "/sharefile.txt"
+    And user "user0" has uploaded file with content "new content" to "/sharefile.txt"
+    And user "user0" has shared file "/sharefile.txt" with user "user1"
+    And user "user1" has created a folder "/received"
+    And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
+    When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/sharefile.txt" for user "user0" should be "old content"
+    And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
 
-	Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
-		Given user "user1" has been created
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
-		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
-		And user "user0" has shared file "/sharingfolder/sharefile.txt" with user "user1"
-		And user "user1" has created a folder "/received"
-		And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
-		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
-		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
+  Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
+    Given user "user1" has been created
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
+    And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
+    And user "user0" has shared file "/sharingfolder/sharefile.txt" with user "user1"
+    And user "user1" has created a folder "/received"
+    And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
+    When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+    And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
 
-	Scenario: sharer can restore a file inside a group shared folder modified by sharee
-		Given user "user1" has been created
-		And user "user2" has been created
-		And group "newgroup" has been created
-		And user "user1" has been added to group "newgroup"
-		And user "user2" has been added to group "newgroup"
-		And user "user0" has created a folder "/sharingfolder"
-		And user "user0" has shared folder "/sharingfolder" with group "newgroup"
-		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
-		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
-		And user "user2" has uploaded file with content "user2 content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "2" of file "/sharingfolder/sharefile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
-		And the content of file "/sharingfolder/sharefile.txt" for user "user2" should be "user0 content"
+  Scenario: sharer can restore a file inside a group shared folder modified by sharee
+    Given user "user1" has been created
+    And user "user2" has been created
+    And group "newgroup" has been created
+    And user "user1" has been added to group "newgroup"
+    And user "user2" has been added to group "newgroup"
+    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has shared folder "/sharingfolder" with group "newgroup"
+    And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
+    And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
+    And user "user2" has uploaded file with content "user2 content" to "/sharingfolder/sharefile.txt"
+    When user "user0" restores version index "2" of file "/sharingfolder/sharefile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
+    And the content of file "/sharingfolder/sharefile.txt" for user "user2" should be "user0 content"

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -1,5 +1,6 @@
 @api @local_storage
 Feature: external-storage
+
   Background:
     Given using OCS API version "1"
     And using old DAV path
@@ -11,7 +12,7 @@ Feature: external-storage
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
     And user "user0" has shared folder "/local_storage/foo" with user "user1"
     When user "user1" creates a public link share using the sharing API with settings
-      | path      | foo |
+      | path | foo |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the share fields of the last share should include

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -1,153 +1,154 @@
 @api
 Feature: quota
-	Background:
-		Given using OCS API version "1"
+
+  Background:
+    Given using OCS API version "1"
 
 	# Owner
 
-	Scenario Outline: Uploading a file as owner having enough quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And the quota of user "user0" has been set to "10 MB"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "201"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Uploading a file as owner having enough quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And the quota of user "user0" has been set to "10 MB"
+    When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "201"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	@smokeTest
-	Scenario Outline: Uploading a file as owner having insufficient quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And the quota of user "user0" has been set to "20 B"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota.txt" should not exist
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  @smokeTest
+  Scenario Outline: Uploading a file as owner having insufficient quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And the quota of user "user0" has been set to "20 B"
+    When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"
+    And as "user0" the file "/testquota.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: Overwriting a file as owner having enough quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And the quota of user "user0" has been set to "10 MB"
-		And user "user0" has uploaded file with content "test" to "/testquota.txt"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be between "201" and "204"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Overwriting a file as owner having enough quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And the quota of user "user0" has been set to "10 MB"
+    And user "user0" has uploaded file with content "test" to "/testquota.txt"
+    When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be between "201" and "204"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: Overwriting a file as owner having insufficient quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And the quota of user "user0" has been set to "20 B"
-		And user "user0" has uploaded file with content "test" to "/testquota.txt"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota.txt" should not exist
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Overwriting a file as owner having insufficient quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And the quota of user "user0" has been set to "20 B"
+    And user "user0" has uploaded file with content "test" to "/testquota.txt"
+    When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"
+    And as "user0" the file "/testquota.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
 	# Received shared folder
 
-	Scenario Outline: Uploading a file in received folder having enough quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And the quota of user "user0" has been set to "20 B"
-		And the quota of user "user1" has been set to "10 MB"
-		And user "user1" has created a folder "/testquota"
-		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "201"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Uploading a file in received folder having enough quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And the quota of user "user0" has been set to "20 B"
+    And the quota of user "user1" has been set to "10 MB"
+    And user "user1" has created a folder "/testquota"
+    And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+    When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "201"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: Uploading a file in received folder having insufficient quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And the quota of user "user0" has been set to "10 MB"
-		And the quota of user "user1" has been set to "20 B"
-		And user "user1" has created a folder "/testquota"
-		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota/testquota.txt" should not exist
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Uploading a file in received folder having insufficient quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And the quota of user "user0" has been set to "10 MB"
+    And the quota of user "user1" has been set to "20 B"
+    And user "user1" has created a folder "/testquota"
+    And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+    When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"
+    And as "user0" the file "/testquota/testquota.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: Overwriting a file in received folder having enough quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And the quota of user "user0" has been set to "20 B"
-		And the quota of user "user1" has been set to "10 MB"
-		And user "user1" has created a folder "/testquota"
-		And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
-		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be between "201" and "204"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Overwriting a file in received folder having enough quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And the quota of user "user0" has been set to "20 B"
+    And the quota of user "user1" has been set to "10 MB"
+    And user "user1" has created a folder "/testquota"
+    And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
+    And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+    When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be between "201" and "204"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: Overwriting a file in received folder having insufficient quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And the quota of user "user0" has been set to "10 MB"
-		And the quota of user "user1" has been set to "20 B"
-		And user "user1" has created a folder "/testquota"
-		And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
-		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota/testquota.txt" should not exist
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Overwriting a file in received folder having insufficient quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And the quota of user "user0" has been set to "10 MB"
+    And the quota of user "user1" has been set to "20 B"
+    And user "user1" has created a folder "/testquota"
+    And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
+    And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+    When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"
+    And as "user0" the file "/testquota/testquota.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
 	# Received shared file
 
-	Scenario Outline: Overwriting a received file having enough quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And the quota of user "user0" has been set to "20 B"
-		And the quota of user "user1" has been set to "10 MB"
-		And user "user1" has uploaded file with content "test" to "/testquota.txt"
-		And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be between "201" and "204"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Overwriting a received file having enough quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And the quota of user "user0" has been set to "20 B"
+    And the quota of user "user1" has been set to "10 MB"
+    And user "user1" has uploaded file with content "test" to "/testquota.txt"
+    And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
+    When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be between "201" and "204"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: Overwriting a received file having insufficient quota
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And the quota of user "user0" has been set to "10 MB"
-		And the quota of user "user1" has been set to "20 B"
-		And user "user1" has moved file "/textfile0.txt" to "/testquota.txt"
-		And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "507"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Overwriting a received file having insufficient quota
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And the quota of user "user0" has been set to "10 MB"
+    And the quota of user "user1" has been set to "20 B"
+    And user "user1" has moved file "/textfile0.txt" to "/testquota.txt"
+    And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
+    When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -2,8 +2,8 @@
 Feature: Status
 
   Scenario: Status.php is correct
-      When the administrator requests status.php
-      Then the status.php response should match with
+    When the administrator requests status.php
+    Then the status.php response should match with
       """
       {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"Community","productname":"ownCloud"}
       """

--- a/tests/acceptance/features/apiMain/tokenAuth.feature
+++ b/tests/acceptance/features/apiMain/tokenAuth.feature
@@ -1,41 +1,41 @@
 @api
 Feature: tokenAuth
 
-	Background:
-		Given using OCS API version "1"
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And token auth has been enforced
+  Background:
+    Given using OCS API version "1"
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And token auth has been enforced
 
-	Scenario: creating a user with basic auth should be blocked when token auth is enforced
-		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
+  Scenario: creating a user with basic auth should be blocked when token auth is enforced
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
 
-	Scenario: moving a file should be blocked when token auth is enforced
-		Given using new DAV path
-		When user "user1" moves file "/textfile0.txt" to "/renamed_textfile0.txt" using the WebDAV API
-		Then the HTTP status code should be "401"
+  Scenario: moving a file should be blocked when token auth is enforced
+    Given using new DAV path
+    When user "user1" moves file "/textfile0.txt" to "/renamed_textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "401"
 
-	@smokeTest
-	Scenario: can access files app with an app password when token auth is enforced
-		Given a new browser session for "user1" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/index.php/apps/files" with "GET" using the generated app password
-		Then the HTTP status code should be "200"
+  @smokeTest
+  Scenario: can access files app with an app password when token auth is enforced
+    Given a new browser session for "user1" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/index.php/apps/files" with "GET" using the generated app password
+    Then the HTTP status code should be "200"
 
-	@smokeTest
-	Scenario: cannot access files app with basic auth when token auth is enforced
-		When user "user1" requests "/index.php/apps/files" with "GET" using basic auth
-		Then the HTTP status code should be "401"
+  @smokeTest
+  Scenario: cannot access files app with basic auth when token auth is enforced
+    When user "user1" requests "/index.php/apps/files" with "GET" using basic auth
+    Then the HTTP status code should be "401"
 
-	Scenario: using WebDAV with basic auth should be blocked when token auth is enforced
-		When user "user1" requests "/remote.php/webdav" with "PROPFIND" using basic auth
-		Then the HTTP status code should be "401"
+  Scenario: using WebDAV with basic auth should be blocked when token auth is enforced
+    When user "user1" requests "/remote.php/webdav" with "PROPFIND" using basic auth
+    Then the HTTP status code should be "401"
 
-	Scenario: using OCS with basic auth should be blocked when token auth is enforced
-		When user "user1" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
+  Scenario: using OCS with basic auth should be blocked when token auth is enforced
+    When user "user1" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -1,301 +1,301 @@
 @api
 Feature: transfer-ownership
 
-	@smokeTest
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of a file
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And the downloaded content when downloading file "/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
+  @smokeTest
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of a file
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And the downloaded content when downloading file "/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of a file after updating the file
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has uploaded file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
-		And user "user0" has uploaded the following "3" chunks to "/PARENT/textfile0.txt" with old chunking
-			| 1 | AA |
-			| 2 | BB |
-			| 3 | CC |
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And the downloaded content when downloading file "/PARENT/textfile0.txt" for user "user1" with range "bytes=0-5" should be "AABBCC"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of a file after updating the file
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
+    And user "user0" has uploaded the following "3" chunks to "/PARENT/textfile0.txt" with old chunking
+      | 1 | AA |
+      | 2 | BB |
+      | 3 | CC |
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And the downloaded content when downloading file "/PARENT/textfile0.txt" for user "user1" with range "bytes=0-5" should be "AABBCC"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of a folder
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of a folder
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of file shares
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
-		And user "user0" has shared file "/somefile.txt" with user "user2" with permissions 19
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of file shares
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+    And user "user0" has shared file "/somefile.txt" with user "user2" with permissions 19
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder shared with third user
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder shared with third user
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared folder "/test" with user "user2" with permissions 31
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder shared with transfer recipient
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 31
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And as "user1" the folder "/test" should not exist
-		And using received transfer folder of "user1" as dav path
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder shared with transfer recipient
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 31
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And as "user1" the folder "/test" should not exist
+    And using received transfer folder of "user1" as dav path
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder doubly shared with third user
-		Given group "group1" has been created
-		And user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-    	And user "user2" has been added to group "group1"
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared folder "/test" with group "group1" with permissions 31
-		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder doubly shared with third user
+    Given group "group1" has been created
+    And user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user2" has been added to group "group1"
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared folder "/test" with group "group1" with permissions 31
+    And user "user0" has shared folder "/test" with user "user2" with permissions 31
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership does not transfer received shares
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user2" has created a folder "/test"
-		And user "user2" has shared folder "/test" with user "user0" with permissions 31
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/test" should not exist
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership does not transfer received shares
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user2" has created a folder "/test"
+    And user "user2" has shared folder "/test" with user "user0" with permissions 31
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And as "user1" the folder "/test" should not exist
 
-	@local_storage @skipOnEncryptionType:user-keys
-	Scenario: transferring ownership does not transfer external storage
-		Given user "user0" has been created
-		And user "user1" has been created
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/local_storage" should not exist
+  @local_storage @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership does not transfer external storage
+    Given user "user0" has been created
+    And user "user1" has been created
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And as "user1" the folder "/local_storage" should not exist
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership does not fail with shared trashed files
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/sub"
-		And user "user0" has created a folder "/sub/test"
-		And user "user0" has shared folder "/sub/test" with user "user2" with permissions 31
-		And user "user0" has deleted folder "/sub"
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership does not fail with shared trashed files
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has created a folder "/sub"
+    And user "user0" has created a folder "/sub/test"
+    And user "user0" has shared folder "/sub/test" with user "user2" with permissions 31
+    And user "user0" has deleted folder "/sub"
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
 
-	Scenario: transferring ownership fails with invalid source user
-		Given user "user0" has been created
-		When the administrator transfers ownership from "invalid_user" to "user0" using the occ command
-		Then the command output should contain the text "Unknown source user"
-		And the command should have failed with exit code 1
+  Scenario: transferring ownership fails with invalid source user
+    Given user "user0" has been created
+    When the administrator transfers ownership from "invalid_user" to "user0" using the occ command
+    Then the command output should contain the text "Unknown source user"
+    And the command should have failed with exit code 1
 
-	Scenario: transferring ownership fails with invalid destination user
-		Given user "user0" has been created
-		When the administrator transfers ownership from "user0" to "invalid_user" using the occ command
-		Then the command output should contain the text "Unknown destination user"
-		And the command should have failed with exit code 1
+  Scenario: transferring ownership fails with invalid destination user
+    Given user "user0" has been created
+    When the administrator transfers ownership from "user0" to "invalid_user" using the occ command
+    Then the command output should contain the text "Unknown destination user"
+    And the command should have failed with exit code 1
 
-	@smokeTest
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of only a single folder containing a file
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
+  @smokeTest
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of only a single folder containing a file
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
-	Scenario: transferring ownership of only a single folder containing an empty folder
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has created a folder "/test/subfolder"
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/test" should exist
-		And as "user1" the folder "/test/subfolder" should exist
+  Scenario: transferring ownership of only a single folder containing an empty folder
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has created a folder "/test/subfolder"
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And as "user1" the folder "/test" should exist
+    And as "user1" the folder "/test/subfolder" should exist
 
-	Scenario: transferring ownership of an account containing only an empty folder
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has deleted everything from folder "/"
-		And user "user0" has created a folder "/test"
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/test" should exist
+  Scenario: transferring ownership of an account containing only an empty folder
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has deleted everything from folder "/"
+    And user "user0" has created a folder "/test"
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And as "user1" the folder "/test" should exist
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of file shares
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared file "/test/somefile.txt" with user "user2" with permissions 19
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of file shares
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared file "/test/somefile.txt" with user "user2" with permissions 19
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder shares which has public link
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		And user "user1" has created a public link share with settings
-			| path      | /test/somefile.txt |
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		And the command should have been successful
-		Then the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder shares which has public link
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared folder "/test" with user "user2" with permissions 31
+    And user "user1" has created a public link share with settings
+      | path | /test/somefile.txt |
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    And the command should have been successful
+    Then the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder shared with third user
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder shared with third user
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared folder "/test" with user "user2" with permissions 31
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder shared with transfer recipient
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 31
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And as "user1" the folder "/test" should not exist
-		And using received transfer folder of "user1" as dav path
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder shared with transfer recipient
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 31
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And as "user1" the folder "/test" should not exist
+    And using received transfer folder of "user1" as dav path
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder doubly shared with third user
-		Given group "group1" has been created
-		And user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user2" has been added to group "group1"
-		And user "user0" has created a folder "/test"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" has shared folder "/test" with group "group1" with permissions 31
-		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder doubly shared with third user
+    Given group "group1" has been created
+    And user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user2" has been added to group "group1"
+    And user "user0" has created a folder "/test"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" has shared folder "/test" with group "group1" with permissions 31
+    And user "user0" has shared folder "/test" with user "user2" with permissions 31
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-	Scenario: transferring ownership does not transfer received shares
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user2" has created a folder "/test"
-		And user "user0" has created a folder "/sub"
-		And user "user2" has shared folder "/test" with user "user0" with permissions 31
-		And user "user0" has moved folder "/test" to "/sub/test"
-		When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/sub/test" should not exist
+  Scenario: transferring ownership does not transfer received shares
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user2" has created a folder "/test"
+    And user "user0" has created a folder "/sub"
+    And user "user2" has shared folder "/test" with user "user0" with permissions 31
+    And user "user0" has moved folder "/test" to "/sub/test"
+    When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And as "user1" the folder "/sub/test" should not exist
 
-	@skipOnEncryptionType:user-keys
-	Scenario: transferring ownership of folder shared with transfer recipient and public link created of received share works
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has created a folder "/test/foo"
-		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" creates a public link share using the sharing API with settings
-			| path      | /test/somefile.txt |
-		And user "user0" has shared file "/test" with user "user1" with permissions 31
-		And user "user1" creates a public link share using the sharing API with settings
-			| path      | /test |
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And as "user0" the folder "/test" should not exist
+  @skipOnEncryptionType:user-keys
+  Scenario: transferring ownership of folder shared with transfer recipient and public link created of received share works
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has created a folder "/test/foo"
+    And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+    And user "user0" creates a public link share using the sharing API with settings
+      | path | /test/somefile.txt |
+    And user "user0" has shared file "/test" with user "user1" with permissions 31
+    And user "user1" creates a public link share using the sharing API with settings
+      | path | /test |
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And as "user0" the folder "/test" should not exist
 
-	@local_storage
-	Scenario: transferring ownership does not transfer external storage
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/sub"
-		When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
-		Then the command should have been successful
-		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/local_storage" should not exist
+  @local_storage
+  Scenario: transferring ownership does not transfer external storage
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/sub"
+    When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
+    Then the command should have been successful
+    And using received transfer folder of "user1" as dav path
+    And as "user1" the folder "/local_storage" should not exist
 
-	Scenario: transferring ownership fails with invalid source user
-		Given user "user0" has been created
-		And user "user0" has created a folder "/sub"
-		When the administrator transfers ownership of path "sub" from "invalid_user" to "user0" using the occ command
-		Then the command output should contain the text "Unknown source user"
-		And the command should have failed with exit code 1
+  Scenario: transferring ownership fails with invalid source user
+    Given user "user0" has been created
+    And user "user0" has created a folder "/sub"
+    When the administrator transfers ownership of path "sub" from "invalid_user" to "user0" using the occ command
+    Then the command output should contain the text "Unknown source user"
+    And the command should have failed with exit code 1
 
-	Scenario: transferring ownership fails with invalid destination user
-		Given user "user0" has been created
-		And user "user0" has created a folder "/sub"
-		When the administrator transfers ownership of path "sub" from "user0" to "invalid_user" using the occ command
-		Then the command output should contain the text "Unknown destination user"
-		And the command should have failed with exit code 1
+  Scenario: transferring ownership fails with invalid destination user
+    Given user "user0" has been created
+    And user "user0" has created a folder "/sub"
+    When the administrator transfers ownership of path "sub" from "user0" to "invalid_user" using the occ command
+    Then the command output should contain the text "Unknown destination user"
+    And the command should have failed with exit code 1
 
-	Scenario: transferring ownership fails with invalid path
-		Given user "user0" has been created
-		And user "user1" has been created
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		Then the command output should contain the text "Unknown path provided"
-		And the command should have failed with exit code 1
+  Scenario: transferring ownership fails with invalid path
+    Given user "user0" has been created
+    And user "user1" has been created
+    When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+    Then the command output should contain the text "Unknown path provided"
+    And the command should have failed with exit code 1
 
-	Scenario: transferring ownership fails with empty files
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has deleted everything from folder "/"
-		When the administrator transfers ownership from "user0" to "user1" using the occ command
-		Then the command output should contain the text "No files/folders to transfer"
-		And the command should have failed with exit code 1
+  Scenario: transferring ownership fails with empty files
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has deleted everything from folder "/"
+    When the administrator transfers ownership from "user0" to "user1" using the occ command
+    Then the command output should contain the text "No files/folders to transfer"
+    And the command should have failed with exit code 1

--- a/tests/acceptance/features/apiMetadataApps/comments.feature
+++ b/tests/acceptance/features/apiMetadataApps/comments.feature
@@ -1,5 +1,6 @@
 @api @TestAlsoOnExternalUserBackend @comments-app-required
 Feature: Comments
+
   Background:
     Given using new DAV path
 
@@ -13,8 +14,8 @@ Feature: Comments
     Examples:
       | comment          |
       | My first comment |
-      | 😀    🤖        |
-      | नेपालि                      |
+      | 😀    🤖         |
+      | नेपालि           |
 
   Scenario: Creating a comment on a shared file belonging to another user
     Given user "user0" has been created
@@ -111,44 +112,44 @@ Feature: Comments
     And the single response should contain a property "{http://owncloud.org/ns}comments-unread" with value "0"
     And the single response should contain a property "{http://owncloud.org/ns}comments-href" with value "a_comment_url"
 
-	Scenario: sharee comments on a group shared file
-		Given user "user0" has been created
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
-		And user "user0" has shared file "/myFileToComment.txt" with group "grp1"
-		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
-		And user "user0" should have the following comments on file "/myFileToComment.txt"
-			| user1 | Comment from sharee |
+  Scenario: sharee comments on a group shared file
+    Given user "user0" has been created
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has shared file "/myFileToComment.txt" with group "grp1"
+    When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "user0" should have the following comments on file "/myFileToComment.txt"
+      | user1 | Comment from sharee |
 
-	Scenario: sharee comments on read-only shared file
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
-		And user "user0" has created a share with settings
-			| path        | /myFileToComment.txt |
-			| shareType   | 0                    |
-			| shareWith   | user1                |
-			| permissions | 1                    |
-		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
-		And user "user0" should have the following comments on file "/myFileToComment.txt"
-			| user1 | Comment from sharee |
+  Scenario: sharee comments on read-only shared file
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has created a share with settings
+      | path        | /myFileToComment.txt |
+      | shareType   | 0                    |
+      | shareWith   | user1                |
+      | permissions | 1                    |
+    When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "user0" should have the following comments on file "/myFileToComment.txt"
+      | user1 | Comment from sharee |
 
-	Scenario: sharee comments on upload-only shared file
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
-		And user "user0" has created a share with settings
-			| path        | /myFileToComment.txt |
-			| shareType   | 0                    |
-			| shareWith   | user1                |
-			| permissions | 4                    |
-		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
-		Then the HTTP status code should be "501"
-		And user "user0" should have 0 comments on file "/myFileToComment.txt"
+  Scenario: sharee comments on upload-only shared file
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has created a share with settings
+      | path        | /myFileToComment.txt |
+      | shareType   | 0                    |
+      | shareWith   | user1                |
+      | permissions | 4                    |
+    When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
+    Then the HTTP status code should be "501"
+    And user "user0" should have 0 comments on file "/myFileToComment.txt"
 
   Scenario: Creating a comment on a folder belonging to myself
     Given user "user0" has been created
@@ -168,87 +169,87 @@ Feature: Comments
       | user1 | A comment from sharee |
       | user0 | A comment from sharer |
 
-	Scenario: Deleting my own comments on a folder belonging to myself
-		Given user "user0" has been created
-		And user "user0" has created a folder "/FOLDER_TO_COMMENT_AND_DELETE"
-		And user "user0" has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT_AND_DELETE"
-		When user "user0" deletes the last created comment using the WebDAV API
-		Then the HTTP status code should be "204"
-		And user "user0" should have 0 comments on folder "/FOLDER_TO_COMMENT_AND_DELETE"
+  Scenario: Deleting my own comments on a folder belonging to myself
+    Given user "user0" has been created
+    And user "user0" has created a folder "/FOLDER_TO_COMMENT_AND_DELETE"
+    And user "user0" has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT_AND_DELETE"
+    When user "user0" deletes the last created comment using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "user0" should have 0 comments on folder "/FOLDER_TO_COMMENT_AND_DELETE"
 
-	Scenario: Deleting a comment on a file belonging to myself having several comments
-		Given user "user0" has been created
-		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
-		And user "user0" has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT"
-		And user "user0" has commented with content "My second comment" on folder "/FOLDER_TO_COMMENT"
-		And user "user0" has commented with content "My third comment" on folder "/FOLDER_TO_COMMENT"
-		And user "user0" has commented with content "My fourth comment" on folder "/FOLDER_TO_COMMENT"
-		When user "user0" deletes the last created comment using the WebDAV API
-		Then the HTTP status code should be "204"
-		And user "user0" should have 3 comments on folder "/FOLDER_TO_COMMENT"
+  Scenario: Deleting a comment on a file belonging to myself having several comments
+    Given user "user0" has been created
+    And user "user0" has created a folder "/FOLDER_TO_COMMENT"
+    And user "user0" has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT"
+    And user "user0" has commented with content "My second comment" on folder "/FOLDER_TO_COMMENT"
+    And user "user0" has commented with content "My third comment" on folder "/FOLDER_TO_COMMENT"
+    And user "user0" has commented with content "My fourth comment" on folder "/FOLDER_TO_COMMENT"
+    When user "user0" deletes the last created comment using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "user0" should have 3 comments on folder "/FOLDER_TO_COMMENT"
 
-	Scenario: Deleting my own comments on a file shared by somebody else
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
-		And user "user0" has shared folder "/FOLDER_TO_COMMENT" with user "user1"
-		And user "user0" has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
-		And user "user1" has commented with content "Sharee comment" on folder "/FOLDER_TO_COMMENT"
-		And user "user1" should have the following comments on folder "/FOLDER_TO_COMMENT"
-			| user0 | Folder owner comment |
-			| user1 | Sharee comment     |
-		When user "user1" deletes the last created comment using the WebDAV API
-		Then the HTTP status code should be "204"
-		And user "user1" should have 1 comments on folder "/FOLDER_TO_COMMENT"
+  Scenario: Deleting my own comments on a file shared by somebody else
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/FOLDER_TO_COMMENT"
+    And user "user0" has shared folder "/FOLDER_TO_COMMENT" with user "user1"
+    And user "user0" has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
+    And user "user1" has commented with content "Sharee comment" on folder "/FOLDER_TO_COMMENT"
+    And user "user1" should have the following comments on folder "/FOLDER_TO_COMMENT"
+      | user0 | Folder owner comment |
+      | user1 | Sharee comment       |
+    When user "user1" deletes the last created comment using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "user1" should have 1 comments on folder "/FOLDER_TO_COMMENT"
 
-	Scenario: Edit my own comments on a folder belonging to myself
-		Given user "user0" has been created
-		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
-		And user "user0" has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
-		When user "user0" edits the last created comment with content "My edited comment" using the WebDAV API
-		Then the HTTP status code should be "207"
-		And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
-			| user0 | My edited comment |
+  Scenario: Edit my own comments on a folder belonging to myself
+    Given user "user0" has been created
+    And user "user0" has created a folder "/FOLDER_TO_COMMENT"
+    And user "user0" has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
+    When user "user0" edits the last created comment with content "My edited comment" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
+      | user0 | My edited comment |
 
-	Scenario: sharee comments on a group shared folder
-		Given user "user0" has been created
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
-		And user "user0" has shared folder "/FOLDER_TO_COMMENT" with group "grp1"
-		When user "user1" comments with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT" using the WebDAV API
-		Then the HTTP status code should be "201"
-		And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
-			| user1 | Comment from sharee |
+  Scenario: sharee comments on a group shared folder
+    Given user "user0" has been created
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a folder "/FOLDER_TO_COMMENT"
+    And user "user0" has shared folder "/FOLDER_TO_COMMENT" with group "grp1"
+    When user "user1" comments with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
+      | user1 | Comment from sharee |
 
-	Scenario: deleting a folder removes existing comments on the folder
-		Given user "user0" has been created
-		And user "user0" has created a folder "/FOLDER_TO_DELETE"
-		When user "user0" comments with content "This should be deleted" on folder "/FOLDER_TO_DELETE" using the WebDAV API
-		Then user "user0" should have 1 comments on folder "/FOLDER_TO_DELETE"
-		When user "user0" deletes folder "/FOLDER_TO_DELETE" using the WebDAV API
-		And user "user0" has created a folder "/FOLDER_TO_DELETE"
-		Then user "user0" should have 0 comments on folder "/FOLDER_TO_DELETE"
+  Scenario: deleting a folder removes existing comments on the folder
+    Given user "user0" has been created
+    And user "user0" has created a folder "/FOLDER_TO_DELETE"
+    When user "user0" comments with content "This should be deleted" on folder "/FOLDER_TO_DELETE" using the WebDAV API
+    Then user "user0" should have 1 comments on folder "/FOLDER_TO_DELETE"
+    When user "user0" deletes folder "/FOLDER_TO_DELETE" using the WebDAV API
+    And user "user0" has created a folder "/FOLDER_TO_DELETE"
+    Then user "user0" should have 0 comments on folder "/FOLDER_TO_DELETE"
 
-	Scenario: deleting a user does not remove the comment
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
-		And user "user0" has shared folder "/FOLDER_TO_COMMENT" with user "user1"
-		And user "user1" has commented with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT"
-		Then user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
-			| user1 | Comment from sharee |
-		And user "user1" has been deleted
-		Then user "user0" should have 1 comments on folder "/FOLDER_TO_COMMENT"
-		And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
-			| deleted_users | Comment from sharee |
+  Scenario: deleting a user does not remove the comment
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/FOLDER_TO_COMMENT"
+    And user "user0" has shared folder "/FOLDER_TO_COMMENT" with user "user1"
+    And user "user1" has commented with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT"
+    Then user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
+      | user1 | Comment from sharee |
+    And user "user1" has been deleted
+    Then user "user0" should have 1 comments on folder "/FOLDER_TO_COMMENT"
+    And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
+      | deleted_users | Comment from sharee |
 
-	Scenario: deleting a content owner deletes the comment
-		Given user "user0" has been created
-		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
-		And user "user0" has commented with content "Comment from owner" on folder "/FOLDER_TO_COMMENT"
-		And user "user0" has been deleted
-		And user "user0" has been created
-		When user "user0" creates a folder "/FOLDER_TO_COMMENT" using the WebDAV API
-		Then user "user0" should have 0 comments on folder "/FOLDER_TO_COMMENT"
+  Scenario: deleting a content owner deletes the comment
+    Given user "user0" has been created
+    And user "user0" has created a folder "/FOLDER_TO_COMMENT"
+    And user "user0" has commented with content "Comment from owner" on folder "/FOLDER_TO_COMMENT"
+    And user "user0" has been deleted
+    And user "user0" has been created
+    When user "user0" creates a folder "/FOLDER_TO_COMMENT" using the WebDAV API
+    Then user "user0" should have 0 comments on folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiMetadataApps/favorites.feature
+++ b/tests/acceptance/features/apiMetadataApps/favorites.feature
@@ -1,174 +1,175 @@
 @api
 Feature: favorite
-    Background:
-        Given using OCS API version "1"
 
-    Scenario Outline: Favorite a folder
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        When user "user0" favorites element "/FOLDER" using the WebDAV API
-        And user "user0" gets the following properties of folder "/FOLDER" using the WebDAV API
-            |{http://owncloud.org/ns}favorite|
-        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Background:
+    Given using OCS API version "1"
 
-    Scenario Outline: Favorite and unfavorite a folder
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        When user "user0" favorites element "/FOLDER" using the WebDAV API
-        And user "user0" unfavorites element "/FOLDER" using the WebDAV API
-        And user "user0" gets the following properties of folder "/FOLDER" using the WebDAV API
-            |{http://owncloud.org/ns}favorite|
-        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Favorite a folder
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    When user "user0" favorites element "/FOLDER" using the WebDAV API
+    And user "user0" gets the following properties of folder "/FOLDER" using the WebDAV API
+      | {http://owncloud.org/ns}favorite |
+    Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-    @smokeTest
-    Scenario Outline: Favorite a file
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        When user "user0" favorites element "/textfile0.txt" using the WebDAV API
-        And user "user0" gets the following properties of file "/textfile0.txt" using the WebDAV API
-            |{http://owncloud.org/ns}favorite|
-        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Favorite and unfavorite a folder
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    When user "user0" favorites element "/FOLDER" using the WebDAV API
+    And user "user0" unfavorites element "/FOLDER" using the WebDAV API
+    And user "user0" gets the following properties of folder "/FOLDER" using the WebDAV API
+      | {http://owncloud.org/ns}favorite |
+    Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-    @smokeTest
-    Scenario Outline: Favorite and unfavorite a file
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        When user "user0" favorites element "/textfile0.txt" using the WebDAV API
-        And user "user0" unfavorites element "/textfile0.txt" using the WebDAV API
-        And user "user0" gets the following properties of file "/textfile0.txt" using the WebDAV API
-            |{http://owncloud.org/ns}favorite|
-        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  @smokeTest
+  Scenario Outline: Favorite a file
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    When user "user0" favorites element "/textfile0.txt" using the WebDAV API
+    And user "user0" gets the following properties of file "/textfile0.txt" using the WebDAV API
+      | {http://owncloud.org/ns}favorite |
+    Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-    @smokeTest
-    Scenario Outline: Get favorited elements of a folder
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        When user "user0" favorites element "/FOLDER" using the WebDAV API
-        And user "user0" favorites element "/textfile0.txt" using the WebDAV API
-        And user "user0" favorites element "/textfile1.txt" using the WebDAV API
-        Then user "user0" in folder "/" should have favorited the following elements
-            | /FOLDER        |
-            | /textfile0.txt |
-            | /textfile1.txt |
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  @smokeTest
+  Scenario Outline: Favorite and unfavorite a file
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    When user "user0" favorites element "/textfile0.txt" using the WebDAV API
+    And user "user0" unfavorites element "/textfile0.txt" using the WebDAV API
+    And user "user0" gets the following properties of file "/textfile0.txt" using the WebDAV API
+      | {http://owncloud.org/ns}favorite |
+    Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-    Scenario Outline: Get favorited elements of a subfolder
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        And user "user0" has created a folder "/subfolder"
-        And user "user0" has moved file "/textfile0.txt" to "/subfolder/textfile0.txt"
-        And user "user0" has moved file "/textfile1.txt" to "/subfolder/textfile1.txt"
-        And user "user0" has moved file "/textfile2.txt" to "/subfolder/textfile2.txt"
-        When user "user0" favorites element "/subfolder/textfile0.txt" using the WebDAV API
-        And user "user0" favorites element "/subfolder/textfile1.txt" using the WebDAV API
-        And user "user0" favorites element "/subfolder/textfile2.txt" using the WebDAV API
-        And user "user0" unfavorites element "/subfolder/textfile1.txt" using the WebDAV API
-        Then user "user0" in folder "/subfolder" should have favorited the following elements
-            | /subfolder/textfile0.txt |
-            | /subfolder/textfile2.txt |
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  @smokeTest
+  Scenario Outline: Get favorited elements of a folder
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    When user "user0" favorites element "/FOLDER" using the WebDAV API
+    And user "user0" favorites element "/textfile0.txt" using the WebDAV API
+    And user "user0" favorites element "/textfile1.txt" using the WebDAV API
+    Then user "user0" in folder "/" should have favorited the following elements
+      | /FOLDER        |
+      | /textfile0.txt |
+      | /textfile1.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-    Scenario Outline: moving a favorite file out of a share keeps favorite state
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        And user "user1" has been created
-        And user "user0" has created a folder "/shared"
-        And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-        And user "user0" has shared folder "/shared" with user "user1"
-        And user "user1" has favorited element "/shared/shared_file.txt"
-        When user "user1" moves file "/shared/shared_file.txt" to "/taken_out.txt" using the WebDAV API
-        Then user "user1" in folder "/" should have favorited the following elements
-            | /taken_out.txt |
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Get favorited elements of a subfolder
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user0" has created a folder "/subfolder"
+    And user "user0" has moved file "/textfile0.txt" to "/subfolder/textfile0.txt"
+    And user "user0" has moved file "/textfile1.txt" to "/subfolder/textfile1.txt"
+    And user "user0" has moved file "/textfile2.txt" to "/subfolder/textfile2.txt"
+    When user "user0" favorites element "/subfolder/textfile0.txt" using the WebDAV API
+    And user "user0" favorites element "/subfolder/textfile1.txt" using the WebDAV API
+    And user "user0" favorites element "/subfolder/textfile2.txt" using the WebDAV API
+    And user "user0" unfavorites element "/subfolder/textfile1.txt" using the WebDAV API
+    Then user "user0" in folder "/subfolder" should have favorited the following elements
+      | /subfolder/textfile0.txt |
+      | /subfolder/textfile2.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-    Scenario Outline: Get favorited elements paginated
-        Given using <dav_version> DAV path
-        And user "user0" has been created
-        And user "user0" has created a folder "/subfolder"
-        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile0.txt"
-        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile1.txt"
-        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile2.txt"
-        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile3.txt"
-        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile4.txt"
-        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile5.txt"
-        When user "user0" favorites element "/subfolder/textfile0.txt" using the WebDAV API
-        And user "user0" favorites element "/subfolder/textfile1.txt" using the WebDAV API
-        And user "user0" favorites element "/subfolder/textfile2.txt" using the WebDAV API
-        And user "user0" favorites element "/subfolder/textfile3.txt" using the WebDAV API
-        And user "user0" favorites element "/subfolder/textfile4.txt" using the WebDAV API
-        And user "user0" favorites element "/subfolder/textfile5.txt" using the WebDAV API
-        Then user "user0" in folder "/subfolder" should have favorited the following elements from offset 3 and limit 2
-            | /subfolder/textfile2.txt |
-            | /subfolder/textfile3.txt |
-        Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: moving a favorite file out of a share keeps favorite state
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has favorited element "/shared/shared_file.txt"
+    When user "user1" moves file "/shared/shared_file.txt" to "/taken_out.txt" using the WebDAV API
+    Then user "user1" in folder "/" should have favorited the following elements
+      | /taken_out.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: sharer file favorite state should not change the favorite state of sharee
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has moved file "/textfile0.txt" to "/favoriteFile.txt"
-		And user "user0" has shared file "/favoriteFile.txt" with user "user1"
-		When user "user0" favorites element "/favoriteFile.txt" using the WebDAV API
-		And user "user1" gets the following properties of file "/favoriteFile.txt" using the WebDAV API
-			|{http://owncloud.org/ns}favorite|
-		Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: Get favorited elements paginated
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user0" has created a folder "/subfolder"
+    And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile0.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile1.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile2.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile3.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile4.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile5.txt"
+    When user "user0" favorites element "/subfolder/textfile0.txt" using the WebDAV API
+    And user "user0" favorites element "/subfolder/textfile1.txt" using the WebDAV API
+    And user "user0" favorites element "/subfolder/textfile2.txt" using the WebDAV API
+    And user "user0" favorites element "/subfolder/textfile3.txt" using the WebDAV API
+    And user "user0" favorites element "/subfolder/textfile4.txt" using the WebDAV API
+    And user "user0" favorites element "/subfolder/textfile5.txt" using the WebDAV API
+    Then user "user0" in folder "/subfolder" should have favorited the following elements from offset 3 and limit 2
+      | /subfolder/textfile2.txt |
+      | /subfolder/textfile3.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: sharee file favorite state should not change the favorite state of sharer
-		Given using <dav_version> DAV path
-		And user "user0" has been created	
-		And user "user1" has been created	
-		And user "user0" has moved file "/textfile0.txt" to "/favoriteFile.txt"	
-		And user "user0" has shared file "/favoriteFile.txt" with user "user1"	
-		When user "user1" favorites element "/favoriteFile.txt" using the WebDAV API
-		And user "user0" gets the following properties of file "/favoriteFile.txt" using the WebDAV API
-			|{http://owncloud.org/ns}favorite|	
-		Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: sharer file favorite state should not change the favorite state of sharee
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has moved file "/textfile0.txt" to "/favoriteFile.txt"
+    And user "user0" has shared file "/favoriteFile.txt" with user "user1"
+    When user "user0" favorites element "/favoriteFile.txt" using the WebDAV API
+    And user "user1" gets the following properties of file "/favoriteFile.txt" using the WebDAV API
+      | {http://owncloud.org/ns}favorite |
+    Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
 
-	Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
-		Given using <dav_version> DAV path
-		And user "user0" has been created
-		When user "user0" favorites element "/PARENT/parent.txt" using the WebDAV API
-		And user "user0" favorites element "/PARENT" using the WebDAV API
-		Then user "user0" in folder "/" should have favorited the following elements
-			| /PARENT            |
-			| /PARENT/parent.txt |
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  Scenario Outline: sharee file favorite state should not change the favorite state of sharer
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has moved file "/textfile0.txt" to "/favoriteFile.txt"
+    And user "user0" has shared file "/favoriteFile.txt" with user "user1"
+    When user "user1" favorites element "/favoriteFile.txt" using the WebDAV API
+    And user "user0" gets the following properties of file "/favoriteFile.txt" using the WebDAV API
+      | {http://owncloud.org/ns}favorite |
+    Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
+    Given using <dav_version> DAV path
+    And user "user0" has been created
+    When user "user0" favorites element "/PARENT/parent.txt" using the WebDAV API
+    And user "user0" favorites element "/PARENT" using the WebDAV API
+    Then user "user0" in folder "/" should have favorited the following elements
+      | /PARENT            |
+      | /PARENT/parent.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiMetadataApps/tags.feature
+++ b/tests/acceptance/features/apiMetadataApps/tags.feature
@@ -7,14 +7,14 @@ Feature: tags
     When user "user0" creates a "normal" tag with name "<tag_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following tags should exist for "%admin%"
-      |<tag_name>|normal|
+      | <tag_name> | normal |
     And the following tags should exist for "user0"
-      |<tag_name>|normal|
+      | <tag_name> | normal |
     Examples:
       | tag_name            |
       | JustARegularTagName |
       | 😀                  |
-             |सिमप्ले                   |
+      | सिमप्ले             |
 
   Scenario: Creating a not user-assignable tag as regular user should fail
     Given user "user0" has been created
@@ -52,7 +52,7 @@ Feature: tags
       | tag_name            |
       | JustARegularTagName |
       | 😀                  |
-             |सिमप्ले                   |
+      | सिमप्ले             |
 
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given user "user0" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -1,94 +1,94 @@
 @api @provisioning_api-app-required
 Feature: add groups
-As an admin
-I want to be able to add groups
-So that I can more easily manage access to resources by groups rather than individual users
+  As an admin
+  I want to be able to add groups
+  So that I can more easily manage access to resources by groups rather than individual users
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario Outline: admin creates a group
-		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should exist
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली                                   | Unicode group name                       |
+  @smokeTest
+  Scenario Outline: admin creates a group
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should exist
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: admin creates a group
-		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should exist
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: admin creates a group
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should exist
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
 	# Note: these groups do get created OK, but the "should exist" step fails
 	# because the API to check their existence does not work.
-	@skip @issue-31015
-	Scenario Outline: admin creates a group with a forward-slash in the group name
-		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should exist
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: admin creates a group with a forward-slash in the group name
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should exist
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
 	# A group name must not end in "/subadmins" because that would create ambiguity
 	# with the endpoint for getting the subadmins of a group
-	@skip @issue-31015
-	Scenario: admin tries to create a group with name ending in "/subadmins"
-		Given group "new-group" has been created
-		When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-		Then the OCS status code should be "101"
-		And the HTTP status code should be "200"
-		And group "priv/subadmins" should not exist
+  @skip @issue-31015
+  Scenario: admin tries to create a group with name ending in "/subadmins"
+    Given group "new-group" has been created
+    When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And group "priv/subadmins" should not exist
 
-	Scenario: admin tries to create a group that already exists
-		Given group "new-group" has been created
-		When the administrator sends a group creation request for group "new-group" using the provisioning API
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
-		And group "new-group" should exist
+  Scenario: admin tries to create a group that already exists
+    Given group "new-group" has been created
+    When the administrator sends a group creation request for group "new-group" using the provisioning API
+    Then the OCS status code should be "102"
+    And the HTTP status code should be "200"
+    And group "new-group" should exist
 
-	Scenario: normal user tries to create a group
-		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-			| groupid   | new-group   |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And group "new-group" should not exist
+  Scenario: normal user tries to create a group
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And group "new-group" should not exist
 
-	Scenario: subadmin tries to create a group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-			| groupid   | another-group   |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And group "another-group" should not exist
+  Scenario: subadmin tries to create a group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
+      | groupid | another-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And group "another-group" should not exist

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -1,120 +1,120 @@
 @api @provisioning_api-app-required
 Feature: add users to group
-As a admin
-I want to be able to add users to a group
-So that I can give a user access to the resources of the group
+  As a admin
+  I want to be able to add users to a group
+  So that I can give a user access to the resources of the group
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario Outline: adding a user to a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली              | Unicode group name                      |
+  @smokeTest
+  Scenario Outline: adding a user to a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: adding a user to a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: adding a user to a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
-	@skip @issue-31015
-	Scenario Outline: adding a user to a group that has a forward-slash in the group name
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: adding a user to a group that has a forward-slash in the group name
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	Scenario: normal user tries to add himself to a group
-		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: normal user tries to add himself to a group
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
 
-	Scenario: admin tries to add user to a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | not-group |
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to add user to a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | not-group |
+    Then the OCS status code should be "102"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: admin tries to add user to a group without sending the group
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid |  |
-		Then the OCS status code should be "101"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to add user to a group without sending the group
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid |  |
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: admin tries to add a user which does not exist to a group
-		Given user "not-user" has been deleted
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "103"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to add a user which does not exist to a group
+    Given user "not-user" has been deleted
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "103"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: a subadmin cannot add users to groups the subadmin is responsible for
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "104"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not belong to group "new-group"
+  Scenario: a subadmin cannot add users to groups the subadmin is responsible for
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "104"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "new-group"
 
-	Scenario: a subadmin cannot add users to groups the subadmin is not responsible for
-		Given user "other-subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And group "other-group" has been created
-		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "104"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not belong to group "new-group"
+  Scenario: a subadmin cannot add users to groups the subadmin is not responsible for
+    Given user "other-subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And group "other-group" has been created
+    And user "other-subadmin" has been made a subadmin of group "other-group"
+    When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "104"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -1,38 +1,38 @@
 @api @provisioning_api-app-required
 Feature: add user
-As an admin
-I want to be able to add users
-So that I can give people controlled individual access to resources on the ownCloud server
+  As an admin
+  I want to be able to add users
+  So that I can give people controlled individual access to resources on the ownCloud server
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin creates a user
-		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should exist
+  @smokeTest
+  Scenario: admin creates a user
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
 
-	Scenario: admin tries to create an existing user
-		Given user "brand-new-user" has been created
-		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to create an existing user
+    Given user "brand-new-user" has been created
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "102"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: admin tries to create an existing disabled user
-		Given user "brand-new-user" has been created
-		And user "brand-new-user" has been disabled
-		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to create an existing disabled user
+    Given user "brand-new-user" has been created
+    And user "brand-new-user" has been disabled
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "102"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: Admin creates a new user and adds him directly to a group
-		Given group "newgroup" has been created
-		When the administrator sends a user creation request for user "newuser" password "%alt1%" group "newgroup" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "newuser" should belong to group "newgroup"
+  Scenario: Admin creates a new user and adds him directly to a group
+    Given group "newgroup" has been created
+    When the administrator sends a user creation request for user "newuser" password "%alt1%" group "newgroup" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "newuser" should belong to group "newgroup"

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -1,67 +1,68 @@
 @api @provisioning_api-app-required
 Feature: access user provisioning API using app password
-As an ownCloud user
-I want to be able to use the provisioning API with an app password
-So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
-	Background:
-		Given using OCS API version "1"
+  As an ownCloud user
+  I want to be able to use the provisioning API with an app password
+  So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
 
-	@smokeTest
-	Scenario: admin deletes the user
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And a new client token for "%admin%" has been generated
-		And a new browser session for "%admin%" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v1.php/cloud/users/brand-new-user" with "DELETE" using the generated app password 
-		Then the HTTP status code should be "200"
-		And user "brand-new-user" should not exist
+  Background:
+    Given using OCS API version "1"
 
-	Scenario: subadmin gets user of his group
-		Given user "brand-new-user" has been created
-		And user "another-new-user" has been created
-		And group "new-group" has been created
-		And user "another-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		And a new client token for "brand-new-user" has been generated
-		And a new browser session for "brand-new-user" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password 
-		Then the users returned by the API should be
-			| another-new-user |
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin deletes the user
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And a new client token for "%admin%" has been generated
+    And a new browser session for "%admin%" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v1.php/cloud/users/brand-new-user" with "DELETE" using the generated app password
+    Then the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
 
-	@smokeTest
-	Scenario: normal user gets his own information using the app password
-		Given user "newuser" has been created
-		And a new client token for "newuser" has been generated
-		Given a new browser session for "newuser" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v1.php/cloud/users/newuser" with "GET" using the generated app password
-		Then the HTTP status code should be "200"
-		And the display name returned by the API should be "newuser"
+  Scenario: subadmin gets user of his group
+    Given user "brand-new-user" has been created
+    And user "another-new-user" has been created
+    And group "new-group" has been created
+    And user "another-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    And a new client token for "brand-new-user" has been generated
+    And a new browser session for "brand-new-user" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password
+    Then the users returned by the API should be
+      | another-new-user |
+    And the HTTP status code should be "200"
 
-	Scenario: subadmin tries to get users of other group
-		Given user "brand-new-user" has been created
-		And user "another-new-user" has been created
-		And group "new-group" has been created
-		And group "another-new-group" has been created
-		And user "another-new-user" has been added to group "another-new-group"
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		And a new client token for "brand-new-user" has been generated
-		And a new browser session for "brand-new-user" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password 
-		Then the users returned by the API should not include "another-new-user"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: normal user gets his own information using the app password
+    Given user "newuser" has been created
+    And a new client token for "newuser" has been generated
+    Given a new browser session for "newuser" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v1.php/cloud/users/newuser" with "GET" using the generated app password
+    Then the HTTP status code should be "200"
+    And the display name returned by the API should be "newuser"
 
-	Scenario: normal user tries to get other user information using the app password
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		And a new client token for "newuser" has been generated
-		Given a new browser session for "newuser" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v1.php/cloud/users/anotheruser" with "GET" using the generated app password
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: subadmin tries to get users of other group
+    Given user "brand-new-user" has been created
+    And user "another-new-user" has been created
+    And group "new-group" has been created
+    And group "another-new-group" has been created
+    And user "another-new-user" has been added to group "another-new-group"
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    And a new client token for "brand-new-user" has been generated
+    And a new browser session for "brand-new-user" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password
+    Then the users returned by the API should not include "another-new-user"
+    And the HTTP status code should be "200"
+
+  Scenario: normal user tries to get other user information using the app password
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    And a new client token for "newuser" has been generated
+    Given a new browser session for "newuser" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v1.php/cloud/users/anotheruser" with "GET" using the generated app password
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -1,49 +1,49 @@
 @api @provisioning_api-app-required
 Feature: create a subadmin
-As an admin
-I want to be able to make a user the subadmin of a group
-So that I can give administrative privilege of a group to a user
+  As an admin
+  I want to be able to make a user the subadmin of a group
+  So that I can give administrative privilege of a group to a user
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin creates a subadmin
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the user "brand-new-user" should be the subadmin of the group "new-group"
+  @smokeTest
+  Scenario: admin creates a subadmin
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the user "brand-new-user" should be the subadmin of the group "new-group"
 
-	Scenario: admin tries to create a subadmin using a user which does not exist
-		Given user "not-user" has been deleted
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "101"
-		And the HTTP status code should be "200"
-		And the user "not-user" should not be the subadmin of the group "new-group"
+  Scenario: admin tries to create a subadmin using a user which does not exist
+    Given user "not-user" has been deleted
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And the user "not-user" should not be the subadmin of the group "new-group"
 
-	Scenario: admin tries to create a subadmin using a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | not-group |
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to create a subadmin using a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | not-group |
+    Then the OCS status code should be "102"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: subadmin of a group tries to make another user subadmin of their group
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "%admin%" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the user "brand-new-user" should not be the subadmin of the group "new-group"
+  Scenario: subadmin of a group tries to make another user subadmin of their group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "%admin%" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the user "brand-new-user" should not be the subadmin of the group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -1,78 +1,78 @@
 @api @provisioning_api-app-required
 Feature: delete groups
-As an admin
-I want to be able to delete groups
-So that I can remove unnecessary groups
+  As an admin
+  I want to be able to delete groups
+  So that I can remove unnecessary groups
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario Outline: admin deletes a group
-		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should not exist
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली              | Unicode group name                      |
+  @smokeTest
+  Scenario Outline: admin deletes a group
+    Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: admin deletes a group
-		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should not exist
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: admin deletes a group
+    Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
-	@skip @issue-31015
-	Scenario Outline: admin deletes a group that has a forward-slash in the group name
-		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should not exist
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: admin deletes a group that has a forward-slash in the group name
+    Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	Scenario: normal user tries to delete the group
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And group "new-group" should exist
+  Scenario: normal user tries to delete the group
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And group "new-group" should exist
 
-	Scenario: subadmin of the group tries to delete the group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And group "new-group" should exist
+  Scenario: subadmin of the group tries to delete the group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And group "new-group" should exist

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -1,36 +1,36 @@
 @api @provisioning_api-app-required
 Feature: delete users
-As an admin
-I want to be able to delete users
-So that I can remove user from ownCloud
+  As an admin
+  I want to be able to delete users
+  So that I can remove user from ownCloud
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: Delete a user
-		Given user "brand-new-user" has been created
-		When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not exist
+  @smokeTest
+  Scenario: Delete a user
+    Given user "brand-new-user" has been created
+    When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
 
-	@smokeTest
-	Scenario: subadmin deletes a user in his group
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not exist
+  @smokeTest
+  Scenario: subadmin deletes a user in his group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
 
-	Scenario: normal user tries to delete a user
-		Given user "user1" has been created
-		And user "user2" has been created
-		When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And user "user2" should exist
+  Scenario: normal user tries to delete a user
+    Given user "user1" has been created
+    And user "user2" has been created
+    When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "user2" should exist

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,34 +1,34 @@
 @api @provisioning_api-app-required @comments-app-required
 Feature: disable an app
-As an admin
-I want to be able to disable an enabled app
-So that I can stop the app features being used
+  As an admin
+  I want to be able to disable an enabled app
+  So that I can stop the app features being used
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: Admin disables an app
-		Given the app "comments" has been enabled
-		When the administrator disables the app "comments"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And app "comments" should be disabled
+  @smokeTest
+  Scenario: Admin disables an app
+    Given the app "comments" has been enabled
+    When the administrator disables the app "comments"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And app "comments" should be disabled
 
-	Scenario: subadmin tries to disable an app
-		Given user "subadmin" has been created
-		And group "newgroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		And the app "comments" has been enabled
-		When user "subadmin" disables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be enabled
+  Scenario: subadmin tries to disable an app
+    Given user "subadmin" has been created
+    And group "newgroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    And the app "comments" has been enabled
+    When user "subadmin" disables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be enabled
 
-	Scenario: normal user tries to disable an app
-		Given user "newuser" has been created
-		And the app "comments" has been enabled
-		When user "newuser" disables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be enabled
+  Scenario: normal user tries to disable an app
+    Given user "newuser" has been created
+    And the app "comments" has been enabled
+    When user "newuser" disables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -1,107 +1,107 @@
 @api @provisioning_api-app-required
 Feature: disable user
-As an admin
-I want to be able to disable a user
-So that I can remove access to files and resources for a user, without actually deleting the files and resources
+  As an admin
+  I want to be able to disable a user
+  So that I can remove access to files and resources for a user, without actually deleting the files and resources
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin disables an user
-		Given user "user1" has been created
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "user1" should be disabled
+  @smokeTest
+  Scenario: admin disables an user
+    Given user "user1" has been created
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "user1" should be disabled
 
-	@smokeTest
-	Scenario: Subadmin should be able to disable an user in their group
-		Given user "subadmin" has been created
-		And user "user1" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "user1" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "user1" should be disabled
+  @smokeTest
+  Scenario: Subadmin should be able to disable an user in their group
+    Given user "subadmin" has been created
+    And user "user1" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "user1" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "user1" should be disabled
 
-	Scenario: Subadmin should not be able to disable an user not in their group
-		Given user "subadmin" has been created
-		And user "user1" has been created
-		And group "new-group" has been created
-		And group "another-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "user1" has been added to group "another-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And user "user1" should be enabled
+  Scenario: Subadmin should not be able to disable an user not in their group
+    Given user "subadmin" has been created
+    And user "user1" has been created
+    And group "new-group" has been created
+    And group "another-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "user1" has been added to group "another-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "user1" should be enabled
 
-	Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-		Given user "another-admin" has been created
-		And user "subadmin" has been created
-		And group "new-group" has been created
-		And user "another-admin" has been added to group "admin"
-		And user "subadmin" has been added to group "new-group"
-		And user "another-admin" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And user "another-admin" should be enabled
+  Scenario: Subadmins should not be able to disable users that have admin permissions in their group
+    Given user "another-admin" has been created
+    And user "subadmin" has been created
+    And group "new-group" has been created
+    And user "another-admin" has been added to group "admin"
+    And user "subadmin" has been added to group "new-group"
+    And user "another-admin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-admin" should be enabled
 
-	Scenario: Admin can disable another admin user
-		Given user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "another-admin" should be disabled
+  Scenario: Admin can disable another admin user
+    Given user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "another-admin" should be disabled
 
-	Scenario: Admin can disable subadmins in the same group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "%admin%" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "subadmin" should be disabled
+  Scenario: Admin can disable subadmins in the same group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "%admin%" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "subadmin" should be disabled
 
-	Scenario: Admin user cannot disable himself
-		Given user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
-		Then the OCS status code should be "101"
-		And the HTTP status code should be "200"
-		And user "another-admin" should be enabled
+  Scenario: Admin user cannot disable himself
+    Given user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And user "another-admin" should be enabled
 
-	Scenario: disable an user with a regular user
-		Given user "user1" has been created
-		And user "user2" has been created
-		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And user "user2" should be enabled
+  Scenario: disable an user with a regular user
+    Given user "user1" has been created
+    And user "user2" has been created
+    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "user2" should be enabled
 
-	Scenario: Subadmin should not be able to disable himself
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
-		Then the OCS status code should be "101"
-		And the HTTP status code should be "200"
-		And user "subadmin" should be enabled
+  Scenario: Subadmin should not be able to disable himself
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And user "subadmin" should be enabled
 
-	@smokeTest
-	Scenario: Making a web request with a disabled user
-		Given user "user0" has been created
-		And user "user0" has been disabled
-		When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
-		Then the HTTP status code should be "403"
+  @smokeTest
+  Scenario: Making a web request with a disabled user
+    Given user "user0" has been created
+    And user "user0" has been disabled
+    When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
+    Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -1,68 +1,68 @@
 @api @provisioning_api-app-required
 Feature: edit users
-As an admin
-I want to be able to edit a user
-So that I can change user information
+  As an admin
+  I want to be able to edit a user
+  So that I can change user information
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: Edit a user
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | quota                    |
-			| value | 12MB                     |
-			| key   | email                    |
-			| value | brand-new-user@gmail.com |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should exist
+  @smokeTest
+  Scenario: Edit a user
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | quota                    |
+      | value | 12MB                     |
+      | key   | email                    |
+      | value | brand-new-user@gmail.com |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
 
-	Scenario: Override existing user email
-		Given user "brand-new-user" has been created
-		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | email                    |
-			| value | brand-new-user@gmail.com |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | email                      |
-			| value | brand-new-user@example.com |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the user attributes returned by the API should include
-			| email | brand-new-user@example.com |
+  Scenario: Override existing user email
+    Given user "brand-new-user" has been created
+    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | email                    |
+      | value | brand-new-user@gmail.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | email                      |
+      | value | brand-new-user@example.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the user attributes returned by the API should include
+      | email | brand-new-user@example.com |
 
-	@smokeTest
-	Scenario: subadmin should be able to edit the user information in his group
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | quota                      |
-			| value | 12MB                       |
-		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | email                      |
-			| value | brand-new-user@example.com |
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the user attributes returned by the API should include
-			| quota definition | 12 MB           |
-			| email | brand-new-user@example.com |
+  @smokeTest
+  Scenario: subadmin should be able to edit the user information in his group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | quota |
+      | value | 12MB  |
+    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | email                      |
+      | value | brand-new-user@example.com |
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the user attributes returned by the API should include
+      | quota definition | 12 MB                      |
+      | email            | brand-new-user@example.com |
 
-	Scenario: normal user should not be able to change their quota
-		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | quota                      |
-			| value | 12MB                       |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the attributes of user "brand-new-user" returned by the API should include
-			| quota definition | default |
+  Scenario: normal user should not be able to change their quota
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | quota |
+      | value | 12MB  |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | quota definition | default |

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,35 +1,35 @@
 @api @provisioning_api-app-required
 Feature: enable an app
-As an admin
-I want to be able to enable a disabled app
-So that I can use the app features again
+  As an admin
+  I want to be able to enable a disabled app
+  So that I can use the app features again
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: Admin enables an app
-		Given the app "comments" has been disabled
-		When the administrator enables the app "comments"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And app "comments" should be enabled
-		And the information for app "comments" should have a valid version
+  @smokeTest
+  Scenario: Admin enables an app
+    Given the app "comments" has been disabled
+    When the administrator enables the app "comments"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And app "comments" should be enabled
+    And the information for app "comments" should have a valid version
 
-	Scenario: subadmin tries to enable an app
-		Given user "subadmin" has been created
-		And group "newgroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		And the app "comments" has been disabled
-		When user "subadmin" enables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be disabled
+  Scenario: subadmin tries to enable an app
+    Given user "subadmin" has been created
+    And group "newgroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    And the app "comments" has been disabled
+    When user "subadmin" enables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be disabled
 
-	Scenario: normal user tries to enable an app
-		Given user "newuser" has been created
-		And the app "comments" has been disabled
-		When user "newuser" enables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be disabled
+  Scenario: normal user tries to enable an app
+    Given user "newuser" has been created
+    And the app "comments" has been disabled
+    When user "newuser" enables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -1,67 +1,67 @@
 @api @provisioning_api-app-required
 Feature: enable user
-As an admin
-I want to be able to enable a user
-So that I can give a user access to their files and resources again if they are now authorized for that
+  As an admin
+  I want to be able to enable a user
+  So that I can give a user access to their files and resources again if they are now authorized for that
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin enables an user
-		Given user "user1" has been created
-		And user "user1" has been disabled
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "user1" should be enabled
+  @smokeTest
+  Scenario: admin enables an user
+    Given user "user1" has been created
+    And user "user1" has been disabled
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "user1" should be enabled
 
-	Scenario: admin enables another admin user
-		Given user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		And user "another-admin" has been disabled
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "another-admin" should be enabled
+  Scenario: admin enables another admin user
+    Given user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    And user "another-admin" has been disabled
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "another-admin" should be enabled
 
-	Scenario: admin enables subadmins in the same group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "%admin%" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "subadmin" should be disabled
+  Scenario: admin enables subadmins in the same group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "%admin%" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "subadmin" should be disabled
 
-	Scenario: admin tries to enable himself
-		And user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		And user "another-admin" has been disabled
-		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
-		Then user "another-admin" should be disabled
+  Scenario: admin tries to enable himself
+    And user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    And user "another-admin" has been disabled
+    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    Then user "another-admin" should be disabled
 
-	Scenario: normal user tries to enable other user
-		Given user "user1" has been created
-		And user "user2" has been created
-		And user "user2" has been disabled
-		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And user "user2" should be disabled
+  Scenario: normal user tries to enable other user
+    Given user "user1" has been created
+    And user "user2" has been created
+    And user "user2" has been disabled
+    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "user2" should be disabled
 
-	Scenario: subadmin tries to enable himself
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" has been disabled
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
-		And user "subadmin" should be disabled
+  Scenario: subadmin tries to enable himself
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been disabled
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
+    And user "subadmin" should be disabled
 
-	Scenario: Making a web request with an enabled user
-		Given user "user0" has been created
-		When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
-		Then the HTTP status code should be "200"
+  Scenario: Making a web request with an enabled user
+    Given user "user0" has been created
+    When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
+    Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -1,19 +1,19 @@
 @api @provisioning_api-app-required
 Feature: get app info
-As an admin
-I want to be able to get app info
-So that I can get the information of a specific application
+  As an admin
+  I want to be able to get app info
+  So that I can get the information of a specific application
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets app info
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the XML "data" "id" value should be "files"
-		And the XML "data" "name" value should be "Files"
-		And the XML "data" "types" "element" value should be "filesystem"
-		And the XML "data" "dependencies" "owncloud" "min-version" attribute value should be a valid version string
-		And the XML "data" "dependencies" "owncloud" "max-version" attribute value should be a valid version string
+  @smokeTest
+  Scenario: admin gets app info
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the XML "data" "id" value should be "files"
+    And the XML "data" "name" value should be "Files"
+    And the XML "data" "types" "element" value should be "filesystem"
+    And the XML "data" "dependencies" "owncloud" "min-version" attribute value should be a valid version string
+    And the XML "data" "dependencies" "owncloud" "max-version" attribute value should be a valid version string

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -1,27 +1,27 @@
 @api @provisioning_api-app-required
 Feature: get apps
-As an admin
-I want to be able to get the list of apps on my ownCloud
-So that I can manage apps
+  As an admin
+  I want to be able to get the list of apps on my ownCloud
+  So that I can manage apps
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets enabled apps
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the apps returned by the API should include
-			| comments             |
-			| dav                  |
-			| federatedfilesharing |
-			| federation           |
-			| files                |
-			| files_sharing        |
-			| files_trashbin       |
-			| files_versions       |
-			| provisioning_api     |
-			| systemtags           |
-			| updatenotification   |
-			| files_external       |
+  @smokeTest
+  Scenario: admin gets enabled apps
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | comments             |
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
+      | files_trashbin       |
+      | files_versions       |
+      | provisioning_api     |
+      | systemtags           |
+      | updatenotification   |
+      | files_external       |

--- a/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
@@ -1,61 +1,61 @@
 @api @provisioning_api-app-required
 Feature: get group
-As an admin
-I want to be able to get group details
-So that I can know which users are in a group
+  As an admin
+  I want to be able to get group details
+  So that I can know which users are in a group
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets users in the group
-		Given user "brand-new-user" has been created
-		And user "123" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "123" has been added to group "new-group"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the users returned by the API should be
-			| brand-new-user |
-			| 123            |
+  @smokeTest
+  Scenario: admin gets users in the group
+    Given user "brand-new-user" has been created
+    And user "123" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "123" has been added to group "new-group"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the users returned by the API should be
+      | brand-new-user |
+      | 123            |
 
-	Scenario: admin tries to get users in the empty group
-		Given group "new-group" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the list of users returned by the API should be empty
+  Scenario: admin tries to get users in the empty group
+    Given group "new-group" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the list of users returned by the API should be empty
 
-	@smokeTest
-	Scenario: subadmin gets users in a group he is responsible for
-		Given user "user1" has been created
-		And user "user2" has been created
-		And user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "user1" has been added to group "new-group"
-		And user "user2" has been added to group "new-group"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the users returned by the API should be
-			| user1 |
-			| user2 |
+  @smokeTest
+  Scenario: subadmin gets users in a group he is responsible for
+    Given user "user1" has been created
+    And user "user2" has been created
+    And user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "user1" has been added to group "new-group"
+    And user "user2" has been added to group "new-group"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the users returned by the API should be
+      | user1 |
+      | user2 |
 
-	Scenario: subadmin tries to get users in a group he is not responsible for
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And group "another-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
+  Scenario: subadmin tries to get users in a group he is not responsible for
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And group "another-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
 
-	Scenario: normal user tries to get users in his group
-		Given user "newuser" has been created
-		And group "new-group" has been created
-		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
+  Scenario: normal user tries to get users in his group
+    Given user "newuser" has been created
+    And group "new-group" has been created
+    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
@@ -1,20 +1,20 @@
 @api @provisioning_api-app-required
 Feature: get groups
-As an admin
-I want to be able to get groups
-So that I can see all the groups in my ownCloud
+  As an admin
+  I want to be able to get groups
+  So that I can see all the groups in my ownCloud
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets all the groups
-		Given group "0" has been created
-		And group "new-group" has been created
-		And group "España" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
-		Then the groups returned by the API should be
-			| España    |
-			| admin     |
-			| new-group |
-			| 0         |
+  @smokeTest
+  Scenario: admin gets all the groups
+    Given group "0" has been created
+    And group "new-group" has been created
+    And group "España" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
+    Then the groups returned by the API should be
+      | España    |
+      | admin     |
+      | new-group |
+      | 0         |

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
@@ -1,27 +1,27 @@
 @api @provisioning_api-app-required
 Feature: get subadmin groups
-As an admin
-I want to be able to get the groups in which the user is subadmin
-So that I can know in which groups the user has administrative rights
+  As an admin
+  I want to be able to get the groups in which the user is subadmin
+  So that I can know in which groups the user has administrative rights
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets subadmin groups of a user
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
-		Then the subadmin groups returned by the API should be
-			| new-group |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin gets subadmin groups of a user
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
+    Then the subadmin groups returned by the API should be
+      | new-group |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	Scenario: admin tries to get subadmin groups of a user which do not exist
-		Given user "not-user" has been deleted
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
-		Then the OCS status code should be "101"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to get subadmin groups of a user which do not exist
+    Given user "not-user" has been deleted
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,48 +1,48 @@
 @api @provisioning_api-app-required
 Feature: get subadmins
-As an admin
-I want to be able to get the list of subadmins of a group
-So that I can manage subadmins of a group
+  As an admin
+  I want to be able to get the list of subadmins of a group
+  So that I can manage subadmins of a group
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets subadmin users of a group
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
-		Then the subadmin users returned by the API should be
-			| brand-new-user |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin gets subadmin users of a group
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    Then the subadmin users returned by the API should be
+      | brand-new-user |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	Scenario: admin tries to get subadmin users of a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
-		Then the OCS status code should be "101"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to get subadmin users of a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: subadmin tries to get other subadmins of the same group
-		Given user "subadmin" has been created
-		And user "newsubadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: subadmin tries to get other subadmins of the same group
+    Given user "subadmin" has been created
+    And user "newsubadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "newsubadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
 
-	Scenario: normal user tries to get the subadmins of the group
-		Given user "newuser" has been created
-		And user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: normal user tries to get the subadmins of the group
+    Given user "newuser" has been created
+    And user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -1,59 +1,60 @@
 @api @provisioning_api-app-required
 Feature: get user
-As an admin 
-I want to be able to get user
-So that I can get information about user
-	Background:
-		Given using OCS API version "1"
+  As an admin
+  I want to be able to get user
+  So that I can get information about user
 
-	@smokeTest
-	Scenario: admin gets existing user
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the display name returned by the API should be "brand-new-user"
+  Background:
+    Given using OCS API version "1"
 
-	Scenario: admin tries to get a not existing user
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
-		Then the OCS status code should be "998"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  @smokeTest
+  Scenario: admin gets existing user
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "brand-new-user"
 
-	@smokeTest
-	Scenario: subadmin gets information of a user in his group
-		Given user "subadmin" has been created
-		And user "newuser" has been created
-		And group "newgroup" has been created
-		And user "newuser" has been added to group "newgroup"
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the display name returned by the API should be "newuser"
+  Scenario: admin tries to get a not existing user
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+    Then the OCS status code should be "998"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	Scenario: subadmin tries to get information of a user not in his group
-		Given user "subadmin" has been created
-		And user "newuser" has been created
-		And group "newgroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @smokeTest
+  Scenario: subadmin gets information of a user in his group
+    Given user "subadmin" has been created
+    And user "newuser" has been created
+    And group "newgroup" has been created
+    And user "newuser" has been added to group "newgroup"
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "newuser"
 
-	Scenario: normal user tries to get information of another user
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: subadmin tries to get information of a user not in his group
+    Given user "subadmin" has been created
+    And user "newuser" has been created
+    And group "newgroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
 
-	@smokeTest
-	Scenario: normal user gets his own information
-		Given user "newuser" has been created
-		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the display name returned by the API should be "newuser"
+  Scenario: normal user tries to get information of another user
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
+
+  @smokeTest
+  Scenario: normal user gets his own information
+    Given user "newuser" has been created
+    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "newuser"

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -1,99 +1,99 @@
 @api @provisioning_api-app-required
 Feature: get user groups
-As an admin
-I want to be able to get groups
-So that I can manage group membership
+  As an admin
+  I want to be able to get groups
+  So that I can manage group membership
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets groups of an user
-		Given user "brand-new-user" has been created
-		And group "unused-group" has been created
-		And group "new-group" has been created
-		And group "0" has been created
-		And group "Admin & Finance (NP)" has been created
-		And group "admin:Pokhara@Nepal" has been created
-		And group "नेपाली" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been added to group "0"
-		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-		And user "brand-new-user" has been added to group "नेपाली"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
-		Then the groups returned by the API should be
-			| new-group            |
-			| 0                    |
-			| Admin & Finance (NP) |
-			| admin:Pokhara@Nepal  |
-			| नेपाली               |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin gets groups of an user
+    Given user "brand-new-user" has been created
+    And group "unused-group" has been created
+    And group "new-group" has been created
+    And group "0" has been created
+    And group "Admin & Finance (NP)" has been created
+    And group "admin:Pokhara@Nepal" has been created
+    And group "नेपाली" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been added to group "0"
+    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+    And user "brand-new-user" has been added to group "नेपाली"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    Then the groups returned by the API should be
+      | new-group            |
+      | 0                    |
+      | Admin & Finance (NP) |
+      | admin:Pokhara@Nepal  |
+      | नेपाली               |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-	@skip @issue-31015
-	Scenario: admin gets groups of an user, including groups containing a slash
-		Given user "brand-new-user" has been created
-		And group "unused-group" has been created
-		And group "new-group" has been created
-		And group "0" has been created
-		And group "Admin & Finance (NP)" has been created
-		And group "admin:Pokhara@Nepal" has been created
-		And group "नेपाली" has been created
-		And group "Mgmt/Sydney" has been created
-		And group "var/../etc" has been created
-		And group "priv/subadmins/1" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been added to group "0"
-		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-		And user "brand-new-user" has been added to group "नेपाली"
-		And user "brand-new-user" has been added to group "Mgmt/Sydney"
-		And user "brand-new-user" has been added to group "var/../etc"
-		And user "brand-new-user" has been added to group "priv/subadmins/1"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
-		Then the groups returned by the API should be
-			| new-group            |
-			| 0                    |
-			| Admin & Finance (NP) |
-			| admin:Pokhara@Nepal  |
-			| नेपाली               |
-			| Mgmt/Sydney          |
-			| var/../etc           |
-			| priv/subadmins/1     |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  @skip @issue-31015
+  Scenario: admin gets groups of an user, including groups containing a slash
+    Given user "brand-new-user" has been created
+    And group "unused-group" has been created
+    And group "new-group" has been created
+    And group "0" has been created
+    And group "Admin & Finance (NP)" has been created
+    And group "admin:Pokhara@Nepal" has been created
+    And group "नेपाली" has been created
+    And group "Mgmt/Sydney" has been created
+    And group "var/../etc" has been created
+    And group "priv/subadmins/1" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been added to group "0"
+    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+    And user "brand-new-user" has been added to group "नेपाली"
+    And user "brand-new-user" has been added to group "Mgmt/Sydney"
+    And user "brand-new-user" has been added to group "var/../etc"
+    And user "brand-new-user" has been added to group "priv/subadmins/1"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    Then the groups returned by the API should be
+      | new-group            |
+      | 0                    |
+      | Admin & Finance (NP) |
+      | admin:Pokhara@Nepal  |
+      | नेपाली               |
+      | Mgmt/Sydney          |
+      | var/../etc           |
+      | priv/subadmins/1     |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	@smokeTest
-	Scenario: subadmin tries to get other groups of the user in his group
-		Given user "newuser" has been created
-		And user "subadmin" has been created
-		And group "newgroup" has been created
-		And group "anothergroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		And user "newuser" has been added to group "newgroup"
-		And user "newuser" has been added to group "anothergroup"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
-		Then the groups returned by the API should include "newgroup"
-		And the groups returned by the API should not include "anothergroup"
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: subadmin tries to get other groups of the user in his group
+    Given user "newuser" has been created
+    And user "subadmin" has been created
+    And group "newgroup" has been created
+    And group "anothergroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    And user "newuser" has been added to group "newgroup"
+    And user "newuser" has been added to group "anothergroup"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    Then the groups returned by the API should include "newgroup"
+    And the groups returned by the API should not include "anothergroup"
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	Scenario: normal user tries to get the groups of another user
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		And group "newgroup" has been created
-		And user "newuser" has been added to group "newgroup"
-		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: normal user tries to get the groups of another user
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    And group "newgroup" has been created
+    And user "newuser" has been added to group "newgroup"
+    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
 
-	Scenario: admin gets groups of an user who is not in any groups
-		Given user "brand-new-user" has been created
-		And group "unused-group" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the list of groups returned by the API should be empty
+  Scenario: admin gets groups of an user who is not in any groups
+    Given user "brand-new-user" has been created
+    And group "unused-group" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the list of groups returned by the API should be empty

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -1,39 +1,39 @@
 @api @provisioning_api-app-required
 Feature: get users
-As an admin
-I want to be able to list the users that exist
-So that I can see who has access to ownCloud
+  As an admin
+  I want to be able to list the users that exist
+  So that I can see who has access to ownCloud
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin gets all users
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the users returned by the API should be
-			| brand-new-user |
-			| admin          |
+  @smokeTest
+  Scenario: admin gets all users
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the users returned by the API should be
+      | brand-new-user |
+      | admin          |
 
-	@smokeTest
-	Scenario: subadmin gets the users in his group
-		Given user "brand-new-user" has been created
-		And user "another-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
-		Then the users returned by the API should be
-			| brand-new-user |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: subadmin gets the users in his group
+    Given user "brand-new-user" has been created
+    And user "another-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    Then the users returned by the API should be
+      | brand-new-user |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	Scenario: normal user tries to get other users
-		Given user "normaluser" has been created
-		And user "newuser" has been created
-		When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
-		And the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: normal user tries to get other users
+    Given user "normaluser" has been created
+    And user "newuser" has been created
+    When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    And the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -1,116 +1,116 @@
 @api @provisioning_api-app-required
 Feature: remove a user from a group
-As an admin
-I want to be able to remove a user from a group
-So that I can manage user access to group resources
+  As an admin
+  I want to be able to remove a user from a group
+  So that I can manage user access to group resources
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario Outline: admin removes a user from a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		And user "brand-new-user" has been added to group "<group_id>"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200" 
-		And user "brand-new-user" should not belong to group "<group_id>"
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली              | Unicode group name                      |
+  @smokeTest
+  Scenario Outline: admin removes a user from a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: admin removes a user from a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		And user "brand-new-user" has been added to group "<group_id>"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200" 
-		And user "brand-new-user" should not belong to group "<group_id>"
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: admin removes a user from a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
-	@skip @issue-31015
-	Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		And user "brand-new-user" has been added to group "<group_id>"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not belong to group "<group_id>"
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	Scenario: admin tries to remove a user from a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | not-group |
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
-		And the API should not return any data
+  Scenario: admin tries to remove a user from a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | not-group |
+    Then the OCS status code should be "102"
+    And the HTTP status code should be "200"
+    And the API should not return any data
 
-	@smokeTest
-	Scenario: a subadmin can remove users from groups the subadmin is responsible for
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not belong to group "new-group"
+  @smokeTest
+  Scenario: a subadmin can remove users from groups the subadmin is responsible for
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "new-group"
 
-	Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
-		Given user "other-subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And group "other-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "104"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should belong to group "new-group"
+  Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
+    Given user "other-subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And group "other-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "other-subadmin" has been made a subadmin of group "other-group"
+    When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "104"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should belong to group "new-group"
 
-	Scenario: normal user tries to remove the user in his group
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		And group "new-group" has been created
-		And user "newuser" has been added to group "new-group"
-		And user "anotheruser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And user "anotheruser" should belong to group "new-group"
+  Scenario: normal user tries to remove the user in his group
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    And group "new-group" has been created
+    And user "newuser" has been added to group "new-group"
+    And user "anotheruser" has been added to group "new-group"
+    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "anotheruser" should belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -1,43 +1,43 @@
 @api @provisioning_api-app-required
 Feature: remove subadmin
-As an admin
-I want to be able to remove subadmin rights to a user from a group
-So that I cam manage administrative access rights for groups
+  As an admin
+  I want to be able to remove subadmin rights to a user from a group
+  So that I cam manage administrative access rights for groups
 
-	Background:
-		Given using OCS API version "1"
+  Background:
+    Given using OCS API version "1"
 
-	@smokeTest
-	Scenario: admin removes subadmin from a group
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the user "brand-new-user" should not be the subadmin of the group "new-group"
+  @smokeTest
+  Scenario: admin removes subadmin from a group
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the user "brand-new-user" should not be the subadmin of the group "new-group"
 
-	Scenario: subadmin tries to remove other subadmin in the group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "newsubadmin" has been created
-		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the user "newsubadmin" should be the subadmin of the group "new-group"
+  Scenario: subadmin tries to remove other subadmin in the group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "newsubadmin" has been created
+    And user "newsubadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the user "newsubadmin" should be the subadmin of the group "new-group"
 
-	Scenario: normal user tries to remove subadmin in the group
-		Given user "subadmin" has been created
-		And user "newuser" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "newuser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the user "subadmin" should be the subadmin of the group "new-group"
+  Scenario: normal user tries to remove subadmin in the group
+    Given user "subadmin" has been created
+    And user "newuser" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "newuser" has been added to group "new-group"
+    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the user "subadmin" should be the subadmin of the group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -1,95 +1,95 @@
 @api @provisioning_api-app-required
 Feature: add groups
-As an admin
-I want to be able to add groups
-So that I can more easily manage access to resources by groups rather than individual users
+  As an admin
+  I want to be able to add groups
+  So that I can more easily manage access to resources by groups rather than individual users
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario Outline: admin creates a group
-		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should exist
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली                                   | Unicode group name                       |
+  @smokeTest
+  Scenario Outline: admin creates a group
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should exist
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: admin creates a group
-		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should exist
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: admin creates a group
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should exist
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
 	# Note: these groups do get created OK, but the "should exist" step fails
 	# because the API to check their existence does not work.
-	@skip @issue-31015
-	Scenario Outline: admin creates a group with a forward-slash in the group name
-		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should exist
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: admin creates a group with a forward-slash in the group name
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should exist
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
 	# A group name must not end in "/subadmins" because that would create ambiguity
 	# with the endpoint for getting the subadmins of a group
-	@skip @issue-31015
-	Scenario: admin tries to create a group with name ending in "/subadmins"
-		Given group "new-group" has been created
-		When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And group "priv/subadmins" should not exist
+  @skip @issue-31015
+  Scenario: admin tries to create a group with name ending in "/subadmins"
+    Given group "new-group" has been created
+    When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And group "priv/subadmins" should not exist
 
-	Scenario: admin tries to create a group that already exists
-		Given group "new-group" has been created
-		When the administrator sends a group creation request for group "new-group" using the provisioning API
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And group "new-group" should exist
+  Scenario: admin tries to create a group that already exists
+    Given group "new-group" has been created
+    When the administrator sends a group creation request for group "new-group" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And group "new-group" should exist
 
-	@skip @issue-31276
-	Scenario: normal user tries to create a group
-		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-			| groupid   | new-group   |
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And group "new-group" should not exist
+  @skip @issue-31276
+  Scenario: normal user tries to create a group
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And group "new-group" should not exist
 
-	Scenario: subadmin tries to create a group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-			| groupid   | another-group   |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And group "another-group" should not exist
+  Scenario: subadmin tries to create a group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
+      | groupid | another-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And group "another-group" should not exist

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -1,121 +1,121 @@
 @api @provisioning_api-app-required
 Feature: add users to group
-As a admin
-I want to be able to add users to a group
-So that I can give a user access to the resources of the group
+  As a admin
+  I want to be able to add users to a group
+  So that I can give a user access to the resources of the group
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario Outline: adding a user to a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली              | Unicode group name                      |
+  @smokeTest
+  Scenario Outline: adding a user to a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: adding a user to a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: adding a user to a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
-	@skip @issue-31015
-	Scenario Outline: adding a user to a group that has a forward-slash in the group name
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: adding a user to a group that has a forward-slash in the group name
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	@skip @issue-31276
-	Scenario: normal user tries to add himself to a group
-		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @skip @issue-31276
+  Scenario: normal user tries to add himself to a group
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data
 
-	Scenario: admin tries to add user to a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | not-group |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to add user to a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | not-group |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
 
-	Scenario: admin tries to add user to a group without sending the group
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid |  |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to add user to a group without sending the group
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid |  |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
 
-	Scenario: admin tries to add a user which does not exist to a group
-		Given user "not-user" has been deleted
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to add a user which does not exist to a group
+    Given user "not-user" has been deleted
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
 
-	Scenario: subadmin adds users to groups the subadmin is responsible for
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "403"
-		And the HTTP status code should be "403"
-		And user "brand-new-user" should not belong to group "new-group"
+  Scenario: subadmin adds users to groups the subadmin is responsible for
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "403"
+    And user "brand-new-user" should not belong to group "new-group"
 
-	Scenario: subadmin tries to add user to groups the subadmin is not responsible for
-		Given user "other-subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And group "other-group" has been created
-		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "403"
-		And the HTTP status code should be "403"
-		And user "brand-new-user" should not belong to group "new-group"
+  Scenario: subadmin tries to add user to groups the subadmin is not responsible for
+    Given user "other-subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And group "other-group" has been created
+    And user "other-subadmin" has been made a subadmin of group "other-group"
+    When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "403"
+    And user "brand-new-user" should not belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -1,38 +1,38 @@
 @api @provisioning_api-app-required
 Feature: add user
-As an admin
-I want to be able to add users
-So that I can give people controlled individual access to resources on the ownCloud server
+  As an admin
+  I want to be able to add users
+  So that I can give people controlled individual access to resources on the ownCloud server
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: Create a user
-		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should exist
+  @smokeTest
+  Scenario: Create a user
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
 
-	Scenario: admin tries to create an existing user
-		Given user "brand-new-user" has been created
-		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to create an existing user
+    Given user "brand-new-user" has been created
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
 
-	Scenario: admin tries to create an existing disabled user
-		Given user "brand-new-user" has been created
-		And user "brand-new-user" has been disabled
-		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to create an existing disabled user
+    Given user "brand-new-user" has been created
+    And user "brand-new-user" has been disabled
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
 
-	Scenario: Admin creates a new user and adds him directly to a group
-		Given group "newgroup" has been created
-		When the administrator sends a user creation request for user "newuser" password "%alt1%" group "newgroup" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "newuser" should belong to group "newgroup"
+  Scenario: Admin creates a new user and adds him directly to a group
+    Given group "newgroup" has been created
+    When the administrator sends a user creation request for user "newuser" password "%alt1%" group "newgroup" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "newuser" should belong to group "newgroup"

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -1,66 +1,67 @@
 @api @provisioning_api-app-required
 Feature: access user provisioning API using app password
-As an ownCloud user
-I want to be able to use the provisioning API with an app password
-So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
-	Background:
-		Given using OCS API version "2"
+  As an ownCloud user
+  I want to be able to use the provisioning API with an app password
+  So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
 
-	@smokeTest
-	Scenario: admin deletes the user
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And a new client token for "%admin%" has been generated
-		And a new browser session for "%admin%" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v2.php/cloud/users/brand-new-user" with "DELETE" using the generated app password 
-		Then the HTTP status code should be "200"
-		And user "brand-new-user" should not exist
+  Background:
+    Given using OCS API version "2"
 
-	Scenario: subadmin gets user of his group
-		Given user "brand-new-user" has been created
-		And user "another-new-user" has been created
-		And group "new-group" has been created
-		And user "another-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		And a new client token for "brand-new-user" has been generated
-		And a new browser session for "brand-new-user" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v2.php/cloud/users" with "GET" using the generated app password 
-		Then the users returned by the API should be
-			| another-new-user |
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin deletes the user
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And a new client token for "%admin%" has been generated
+    And a new browser session for "%admin%" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v2.php/cloud/users/brand-new-user" with "DELETE" using the generated app password
+    Then the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
 
-	@smokeTest
-	Scenario: normal user gets his own information using the app password
-		Given user "newuser" has been created
-		And a new client token for "newuser" has been generated
-		Given a new browser session for "newuser" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v2.php/cloud/users/newuser" with "GET" using the generated app password
-		Then the HTTP status code should be "200"
-		And the display name returned by the API should be "newuser"
+  Scenario: subadmin gets user of his group
+    Given user "brand-new-user" has been created
+    And user "another-new-user" has been created
+    And group "new-group" has been created
+    And user "another-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    And a new client token for "brand-new-user" has been generated
+    And a new browser session for "brand-new-user" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v2.php/cloud/users" with "GET" using the generated app password
+    Then the users returned by the API should be
+      | another-new-user |
+    And the HTTP status code should be "200"
 
-	Scenario: subadmin tries to get users of other group
-		Given user "brand-new-user" has been created
-		And user "another-new-user" has been created
-		And group "new-group" has been created
-		And group "another-new-group" has been created
-		And user "another-new-user" has been added to group "another-new-group"
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		And a new client token for "brand-new-user" has been generated
-		And a new browser session for "brand-new-user" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password 
-		Then the users returned by the API should not include "another-new-user"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: normal user gets his own information using the app password
+    Given user "newuser" has been created
+    And a new client token for "newuser" has been generated
+    Given a new browser session for "newuser" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v2.php/cloud/users/newuser" with "GET" using the generated app password
+    Then the HTTP status code should be "200"
+    And the display name returned by the API should be "newuser"
 
-	Scenario: normal user tries to get other user information using the app password
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		And a new client token for "newuser" has been generated
-		Given a new browser session for "newuser" has been started
-		And the user has generated a new app password named "my-client"
-		When the user requests "/ocs/v2.php/cloud/users/anotheruser" with "GET" using the generated app password
-		Then the HTTP status code should be "401"
-		And the API should not return any data
+  Scenario: subadmin tries to get users of other group
+    Given user "brand-new-user" has been created
+    And user "another-new-user" has been created
+    And group "new-group" has been created
+    And group "another-new-group" has been created
+    And user "another-new-user" has been added to group "another-new-group"
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    And a new client token for "brand-new-user" has been generated
+    And a new browser session for "brand-new-user" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password
+    Then the users returned by the API should not include "another-new-user"
+    And the HTTP status code should be "200"
+
+  Scenario: normal user tries to get other user information using the app password
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    And a new client token for "newuser" has been generated
+    Given a new browser session for "newuser" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests "/ocs/v2.php/cloud/users/anotheruser" with "GET" using the generated app password
+    Then the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -1,50 +1,50 @@
 @api @provisioning_api-app-required
 Feature: create a subadmin
-As an admin
-I want to be able to make a user the subadmin of a group
-So that I can give administrative privilege of a group to a user
+  As an admin
+  I want to be able to make a user the subadmin of a group
+  So that I can give administrative privilege of a group to a user
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin creates a subadmin
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the user "brand-new-user" should be the subadmin of the group "new-group"
+  @smokeTest
+  Scenario: admin creates a subadmin
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the user "brand-new-user" should be the subadmin of the group "new-group"
 
-	Scenario: admin tries to create a subadmin using a user which does not exist
-		Given user "not-user" has been deleted
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the user "not-user" should not be the subadmin of the group "new-group"
+  Scenario: admin tries to create a subadmin using a user which does not exist
+    Given user "not-user" has been deleted
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the user "not-user" should not be the subadmin of the group "new-group"
 
-	Scenario: admin tries to create a subadmin using a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | not-group |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
+  Scenario: admin tries to create a subadmin using a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | not-group |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
 
-	@skip @issue-31276
-	Scenario: subadmin of a group tries to make another user subadmin of their group
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "%admin%" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the user "not-user" should not be the subadmin of the group "new-group"
+  @skip @issue-31276
+  Scenario: subadmin of a group tries to make another user subadmin of their group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "%admin%" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the user "not-user" should not be the subadmin of the group "new-group"
 	

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -1,80 +1,80 @@
 @api @provisioning_api-app-required
 Feature: delete groups
-As an admin
-I want to be able to delete groups
-So that I can remove unnecessary groups
+  As an admin
+  I want to be able to delete groups
+  So that I can remove unnecessary groups
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario Outline: admin deletes a group
-		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should not exist
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली              | Unicode group name                      |
+  @smokeTest
+  Scenario Outline: admin deletes a group
+    Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: admin deletes a group
-		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should not exist
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: admin deletes a group
+    Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
-	@skip @issue-31015
-	Scenario Outline: admin deletes a group that has a forward-slash in the group name
-		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And group "<group_id>" should not exist
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: admin deletes a group that has a forward-slash in the group name
+    Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	@skip @issue-31276
-	Scenario: normal user tries to delete the group
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And group "new-group" should exist
+  @skip @issue-31276
+  Scenario: normal user tries to delete the group
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And group "new-group" should exist
 
-	@skip @issue-31276
-	Scenario: subadmin of the group tries to delete the group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And group "new-group" should exist
+  @skip @issue-31276
+  Scenario: subadmin of the group tries to delete the group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And group "new-group" should exist

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -1,37 +1,37 @@
 @api @provisioning_api-app-required
 Feature: delete users
-As an admin
-I want to be able to delete users
-So that I can remove user from ownCloud
+  As an admin
+  I want to be able to delete users
+  So that I can remove user from ownCloud
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: Delete a user
-		Given user "brand-new-user" has been created
-		When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not exist
+  @smokeTest
+  Scenario: Delete a user
+    Given user "brand-new-user" has been created
+    When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
 
-	@smokeTest
-	Scenario: subadmin deletes a user in his group
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not exist
+  @smokeTest
+  Scenario: subadmin deletes a user in his group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
 
-	@skip @issue-31276
-	Scenario: normal user tries to delete a user
-		Given user "user1" has been created
-		And user "user2" has been created
-		When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And user "user2" should exist
+  @skip @issue-31276
+  Scenario: normal user tries to delete a user
+    Given user "user1" has been created
+    And user "user2" has been created
+    When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "user2" should exist

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,36 +1,36 @@
 @api @provisioning_api-app-required @comments-app-required
 Feature: disable an app
-As an admin
-I want to be able to disable an enabled app
-So that I can stop the app features being used
+  As an admin
+  I want to be able to disable an enabled app
+  So that I can stop the app features being used
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: Admin disables an app
-		Given the app "comments" has been enabled
-		When the administrator disables the app "comments"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And app "comments" should be disabled
+  @smokeTest
+  Scenario: Admin disables an app
+    Given the app "comments" has been enabled
+    When the administrator disables the app "comments"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And app "comments" should be disabled
 
-	@skip @issue-31276
-	Scenario: subadmin tries to disable an app
-		Given user "subadmin" has been created
-		And group "newgroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		And the app "comments" has been enabled
-		When user "subadmin" disables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be enabled
+  @skip @issue-31276
+  Scenario: subadmin tries to disable an app
+    Given user "subadmin" has been created
+    And group "newgroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    And the app "comments" has been enabled
+    When user "subadmin" disables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be enabled
 
-	@skip @issue-31276
-	Scenario: normal user tries to disable an app
-		Given user "newuser" has been created
-		And the app "comments" has been enabled
-		When user "newuser" disables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be enabled
+  @skip @issue-31276
+  Scenario: normal user tries to disable an app
+    Given user "newuser" has been created
+    And the app "comments" has been enabled
+    When user "newuser" disables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -1,110 +1,110 @@
 @api @provisioning_api-app-required
 Feature: disable user
-As an admin
-I want to be able to disable a user
-So that I can remove access to files and resources for a user, without actually deleting the files and resources
+  As an admin
+  I want to be able to disable a user
+  So that I can remove access to files and resources for a user, without actually deleting the files and resources
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin disables an user
-		Given user "user1" has been created
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "user1" should be disabled
+  @smokeTest
+  Scenario: admin disables an user
+    Given user "user1" has been created
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "user1" should be disabled
 
-	@smokeTest
-	Scenario: Subadmin should be able to disable an user in their group
-		Given user "subadmin" has been created
-		And user "user1" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "user1" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "user1" should be disabled
+  @smokeTest
+  Scenario: Subadmin should be able to disable an user in their group
+    Given user "subadmin" has been created
+    And user "user1" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "user1" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "user1" should be disabled
 
-	@skip @issue-31276
-	Scenario: Subadmin should not be able to disable an user not in their group
-		Given user "subadmin" has been created
-		And user "user1" has been created
-		And group "new-group" has been created
-		And group "another-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "user1" has been added to group "another-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And user "user1" should be enabled
+  @skip @issue-31276
+  Scenario: Subadmin should not be able to disable an user not in their group
+    Given user "subadmin" has been created
+    And user "user1" has been created
+    And group "new-group" has been created
+    And group "another-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "user1" has been added to group "another-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "user1" should be enabled
 
-	@skip @issue-31276
-	Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-		Given user "another-admin" has been created
-		And user "subadmin" has been created
-		And group "new-group" has been created
-		And user "another-admin" has been added to group "admin"
-		And user "subadmin" has been added to group "new-group"
-		And user "another-admin" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And user "another-admin" should be enabled
+  @skip @issue-31276
+  Scenario: Subadmins should not be able to disable users that have admin permissions in their group
+    Given user "another-admin" has been created
+    And user "subadmin" has been created
+    And group "new-group" has been created
+    And user "another-admin" has been added to group "admin"
+    And user "subadmin" has been added to group "new-group"
+    And user "another-admin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "another-admin" should be enabled
 
-	Scenario: Admin can disable another admin user
-		Given user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "another-admin" should be disabled
+  Scenario: Admin can disable another admin user
+    Given user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "another-admin" should be disabled
 
-	Scenario: Admin can disable subadmins in the same group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "%admin%" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "subadmin" should be disabled
+  Scenario: Admin can disable subadmins in the same group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "%admin%" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "subadmin" should be disabled
 
-	Scenario: Admin user cannot disable himself
-		Given user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And user "another-admin" should be enabled
+  Scenario: Admin user cannot disable himself
+    Given user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And user "another-admin" should be enabled
 
-	@skip @issue-31276
-	Scenario: disable an user with a regular user
-		Given user "user1" has been created
-		And user "user2" has been created
-		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And user "user2" should be enabled
+  @skip @issue-31276
+  Scenario: disable an user with a regular user
+    Given user "user1" has been created
+    And user "user2" has been created
+    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "user2" should be enabled
 
-	Scenario: Subadmin should not be able to disable himself
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And user "subadmin" should be enabled
+  Scenario: Subadmin should not be able to disable himself
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And user "subadmin" should be enabled
 
-	@smokeTest
-	Scenario: Making a web request with a disabled user
-		Given user "user0" has been created
-		And user "user0" has been disabled
-		When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
-		And the HTTP status code should be "403"
+  @smokeTest
+  Scenario: Making a web request with a disabled user
+    Given user "user0" has been created
+    And user "user0" has been disabled
+    When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
+    And the HTTP status code should be "403"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -1,69 +1,69 @@
 @api @provisioning_api-app-required
 Feature: edit users
-As an admin
-I want to be able to edit a user
-So that I can change user information
+  As an admin
+  I want to be able to edit a user
+  So that I can change user information
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: Edit a user
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | quota                    |
-			| value | 12MB                     |
-			| key   | email                    |
-			| value | brand-new-user@gmail.com |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should exist
+  @smokeTest
+  Scenario: Edit a user
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | quota                    |
+      | value | 12MB                     |
+      | key   | email                    |
+      | value | brand-new-user@gmail.com |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
 
-	Scenario: Override existing user email
-		Given user "brand-new-user" has been created
-		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | email                    |
-			| value | brand-new-user@gmail.com |
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | email                      |
-			| value | brand-new-user@example.com |
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the user attributes returned by the API should include
-			| email | brand-new-user@example.com |
+  Scenario: Override existing user email
+    Given user "brand-new-user" has been created
+    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | email                    |
+      | value | brand-new-user@gmail.com |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | email                      |
+      | value | brand-new-user@example.com |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the user attributes returned by the API should include
+      | email | brand-new-user@example.com |
 
-	@smokeTest
-	Scenario: subadmin should be able to edit the user information in his group
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | quota                      |
-			| value | 12MB                       |
-		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | email                      |
-			| value | brand-new-user@example.com |
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the user attributes returned by the API should include
-			| quota definition | 12 MB           |
-			| email | brand-new-user@example.com |
+  @smokeTest
+  Scenario: subadmin should be able to edit the user information in his group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | quota |
+      | value | 12MB  |
+    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | email                      |
+      | value | brand-new-user@example.com |
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the user attributes returned by the API should include
+      | quota definition | 12 MB                      |
+      | email            | brand-new-user@example.com |
 
-	@skip @issue-31276
-	Scenario: normal user should not be able to change their quota
-		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-			| key   | quota                      |
-			| value | 12MB                       |
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the attributes of user "brand-new-user" returned by the API should include
-			| quota definition | default |
+  @skip @issue-31276
+  Scenario: normal user should not be able to change their quota
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+      | key   | quota |
+      | value | 12MB  |
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | quota definition | default |

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,36 +1,36 @@
 @api @provisioning_api-app-required
 Feature: enable an app
-As an admin
-I want to be able to enable a disabled app
-So that I can use the app features again
+  As an admin
+  I want to be able to enable a disabled app
+  So that I can use the app features again
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: Admin enables an app
-		Given the app "comments" has been disabled
-		When the administrator enables the app "comments"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And app "comments" should be enabled
+  @smokeTest
+  Scenario: Admin enables an app
+    Given the app "comments" has been disabled
+    When the administrator enables the app "comments"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And app "comments" should be enabled
 
-	@skip @issue-31276
-	Scenario: subadmin tries to enable an app
-		Given user "subadmin" has been created
-		And group "newgroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		And the app "comments" has been disabled
-		When user "subadmin" enables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be disabled
+  @skip @issue-31276
+  Scenario: subadmin tries to enable an app
+    Given user "subadmin" has been created
+    And group "newgroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    And the app "comments" has been disabled
+    When user "subadmin" enables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be disabled
 
-	@skip @issue-31276
-	Scenario: normal user tries to enable an app
-		Given user "newuser" has been created
-		And the app "comments" has been disabled
-		When user "newuser" enables the app "comments"
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And app "comments" should be disabled
+  @skip @issue-31276
+  Scenario: normal user tries to enable an app
+    Given user "newuser" has been created
+    And the app "comments" has been disabled
+    When user "newuser" enables the app "comments"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And app "comments" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -1,68 +1,68 @@
 @api @provisioning_api-app-required
 Feature: enable user
-As an admin
-I want to be able to enable a user
-So that I can give a user access to their files and resources again if they are now authorized for that
+  As an admin
+  I want to be able to enable a user
+  So that I can give a user access to their files and resources again if they are now authorized for that
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin enables an user
-		Given user "user1" has been created
-		And user "user1" has been disabled
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "user1" should be enabled
+  @smokeTest
+  Scenario: admin enables an user
+    Given user "user1" has been created
+    And user "user1" has been disabled
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "user1" should be enabled
 
-	Scenario: admin enables another admin user
-		Given user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		And user "another-admin" has been disabled
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "another-admin" should be enabled
+  Scenario: admin enables another admin user
+    Given user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    And user "another-admin" has been disabled
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "another-admin" should be enabled
 
-	Scenario: admin enables subadmins in the same group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "%admin%" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "subadmin" should be disabled
+  Scenario: admin enables subadmins in the same group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "%admin%" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "subadmin" should be disabled
 
-	Scenario: admin tries to enable himself
-		And user "another-admin" has been created
-		And user "another-admin" has been added to group "admin"
-		And user "another-admin" has been disabled
-		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
-		Then user "another-admin" should be disabled
+  Scenario: admin tries to enable himself
+    And user "another-admin" has been created
+    And user "another-admin" has been added to group "admin"
+    And user "another-admin" has been disabled
+    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    Then user "another-admin" should be disabled
 
-	@skip @issue-31276
-	Scenario: normal user tries to enable other user
-		Given user "user1" has been created
-		And user "user2" has been created
-		And user "user2" has been disabled
-		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And user "user2" should be disabled
+  @skip @issue-31276
+  Scenario: normal user tries to enable other user
+    Given user "user1" has been created
+    And user "user2" has been created
+    And user "user2" has been disabled
+    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "user2" should be disabled
 
-	Scenario: subadmin tries to enable himself
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" has been disabled
-		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
-		And user "subadmin" should be disabled
+  Scenario: subadmin tries to enable himself
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been disabled
+    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
+    And user "subadmin" should be disabled
 
-	Scenario: Making a web request with an enabled user
-		Given user "user0" has been created
-		When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
-		Then the HTTP status code should be "200"
+  Scenario: Making a web request with an enabled user
+    Given user "user0" has been created
+    When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
+    Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -1,19 +1,19 @@
 @api @provisioning_api-app-required
 Feature: get app info
-As an admin
-I want to be able to get app info
-So that I can get the information of a specific application
+  As an admin
+  I want to be able to get app info
+  So that I can get the information of a specific application
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets app info
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the XML "data" "id" value should be "files"
-		And the XML "data" "name" value should be "Files"
-		And the XML "data" "types" "element" value should be "filesystem"
-		And the XML "data" "dependencies" "owncloud" "min-version" attribute value should be a valid version string
-		And the XML "data" "dependencies" "owncloud" "max-version" attribute value should be a valid version string
+  @smokeTest
+  Scenario: admin gets app info
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the XML "data" "id" value should be "files"
+    And the XML "data" "name" value should be "Files"
+    And the XML "data" "types" "element" value should be "filesystem"
+    And the XML "data" "dependencies" "owncloud" "min-version" attribute value should be a valid version string
+    And the XML "data" "dependencies" "owncloud" "max-version" attribute value should be a valid version string

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -1,27 +1,27 @@
 @api @provisioning_api-app-required
 Feature: get apps
-As an admin
-I want to be able to get the list of apps on my ownCloud
-So that I can manage apps
+  As an admin
+  I want to be able to get the list of apps on my ownCloud
+  So that I can manage apps
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets enabled apps
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the apps returned by the API should include
-			| comments             |
-			| dav                  |
-			| federatedfilesharing |
-			| federation           |
-			| files                |
-			| files_sharing        |
-			| files_trashbin       |
-			| files_versions       |
-			| provisioning_api     |
-			| systemtags           |
-			| updatenotification   |
-			| files_external       |
+  @smokeTest
+  Scenario: admin gets enabled apps
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | comments             |
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
+      | files_trashbin       |
+      | files_versions       |
+      | provisioning_api     |
+      | systemtags           |
+      | updatenotification   |
+      | files_external       |

--- a/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
@@ -1,63 +1,63 @@
 @api @provisioning_api-app-required
 Feature: get group
-As an admin
-I want to be able to get group details
-So that I can know which users are in a group
+  As an admin
+  I want to be able to get group details
+  So that I can know which users are in a group
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets users in the group
-		Given user "brand-new-user" has been created
-		And user "123" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "123" has been added to group "new-group"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the users returned by the API should be
-			| brand-new-user |
-			| 123            |
+  @smokeTest
+  Scenario: admin gets users in the group
+    Given user "brand-new-user" has been created
+    And user "123" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "123" has been added to group "new-group"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the users returned by the API should be
+      | brand-new-user |
+      | 123            |
 
-	Scenario: admin tries to get users in the empty group
-		Given group "new-group" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the list of users returned by the API should be empty
+  Scenario: admin tries to get users in the empty group
+    Given group "new-group" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the list of users returned by the API should be empty
 
-	@smokeTest
-	Scenario: subadmin gets users in a group he is responsible for
-		Given user "user1" has been created
-		And user "user2" has been created
-		And user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "user1" has been added to group "new-group"
-		And user "user2" has been added to group "new-group"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the users returned by the API should be
-			| user1 |
-			| user2 |
+  @smokeTest
+  Scenario: subadmin gets users in a group he is responsible for
+    Given user "user1" has been created
+    And user "user2" has been created
+    And user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "user1" has been added to group "new-group"
+    And user "user2" has been added to group "new-group"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the users returned by the API should be
+      | user1 |
+      | user2 |
 
-	@skip @issue-31276
-	Scenario: subadmin tries to get users in a group he is not responsible for
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And group "another-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
+  @skip @issue-31276
+  Scenario: subadmin tries to get users in a group he is not responsible for
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And group "another-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
 
-	@skip @issue-31276
-	Scenario: normal user tries to get users in his group
-		Given user "newuser" has been created
-		And group "new-group" has been created
-		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
+  @skip @issue-31276
+  Scenario: normal user tries to get users in his group
+    Given user "newuser" has been created
+    And group "new-group" has been created
+    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
@@ -1,20 +1,20 @@
 @api @provisioning_api-app-required
 Feature: get groups
-As an admin
-I want to be able to get groups
-So that I can see all the groups in my ownCloud
+  As an admin
+  I want to be able to get groups
+  So that I can see all the groups in my ownCloud
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets all the groups
-		Given group "0" has been created
-		And group "new-group" has been created
-		And group "España" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
-		Then the groups returned by the API should be
-			| España    |
-			| admin     |
-			| new-group |
-			| 0         |
+  @smokeTest
+  Scenario: admin gets all the groups
+    Given group "0" has been created
+    And group "new-group" has been created
+    And group "España" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
+    Then the groups returned by the API should be
+      | España    |
+      | admin     |
+      | new-group |
+      | 0         |

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
@@ -1,27 +1,27 @@
 @api @provisioning_api-app-required
 Feature: get subadmin groups
-As an admin
-I want to be able to get the groups in which the user is subadmin
-So that I can know in which groups the user has administrative rights
+  As an admin
+  I want to be able to get the groups in which the user is subadmin
+  So that I can know in which groups the user has administrative rights
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets subadmin groups of a user
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
-		Then the subadmin groups returned by the API should be
-			| new-group |
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin gets subadmin groups of a user
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
+    Then the subadmin groups returned by the API should be
+      | new-group |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
 
-	Scenario: admin tries to get subadmin groups of a user which do not exist
-		Given user "not-user" has been deleted
-		And group "new-group" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to get subadmin groups of a user which do not exist
+    Given user "not-user" has been deleted
+    And group "new-group" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,50 +1,50 @@
 @api @provisioning_api-app-required
 Feature: get subadmins
-As an admin
-I want to be able to get the list of subadmins of a group
-So that I can manage subadmins of a group
+  As an admin
+  I want to be able to get the list of subadmins of a group
+  So that I can manage subadmins of a group
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets subadmin users of a group
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
-		Then the subadmin users returned by the API should be
-			| brand-new-user |
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin gets subadmin users of a group
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    Then the subadmin users returned by the API should be
+      | brand-new-user |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
 
-	Scenario: admin tries to get subadmin users of a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to get subadmin users of a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
 
-	@skip @issue-31276
-	Scenario: subadmin tries to get other subadmins of the same group
-		Given user "subadmin" has been created
-		And user "newsubadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @skip @issue-31276
+  Scenario: subadmin tries to get other subadmins of the same group
+    Given user "subadmin" has been created
+    And user "newsubadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "newsubadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data
 
-	@skip @issue-31276
-	Scenario: normal user tries to get the subadmins of the group
-		Given user "newuser" has been created
-		And user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @skip @issue-31276
+  Scenario: normal user tries to get the subadmins of the group
+    Given user "newuser" has been created
+    And user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -1,61 +1,62 @@
 @api @provisioning_api-app-required
 Feature: get user
-As an admin 
-I want to be able to get user
-So that I can get information about user
-	Background:
-		Given using OCS API version "2"
+  As an admin
+  I want to be able to get user
+  So that I can get information about user
 
-	@smokeTest
-	Scenario: admin gets an existing user
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the display name returned by the API should be "brand-new-user"
+  Background:
+    Given using OCS API version "2"
 
-	Scenario: admin tries to get a not existing user
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "404"
-		And the API should not return any data
+  @smokeTest
+  Scenario: admin gets an existing user
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "brand-new-user"
 
-	@smokeTest
-	Scenario: subadmin gets information of a user in his group
-		Given user "subadmin" has been created
-		And user "newuser" has been created
-		And group "newgroup" has been created
-		And user "newuser" has been added to group "newgroup"
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the display name returned by the API should be "newuser"
+  Scenario: admin tries to get a not existing user
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "404"
+    And the API should not return any data
 
-	@skip @issue-31276
-	Scenario: subadmin tries to get information of a user not in his group
-		Given user "subadmin" has been created
-		And user "newuser" has been created
-		And group "newgroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @smokeTest
+  Scenario: subadmin gets information of a user in his group
+    Given user "subadmin" has been created
+    And user "newuser" has been created
+    And group "newgroup" has been created
+    And user "newuser" has been added to group "newgroup"
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "newuser"
 
-	@skip @issue-31276
-	Scenario: normal user tries to get information of another user
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @skip @issue-31276
+  Scenario: subadmin tries to get information of a user not in his group
+    Given user "subadmin" has been created
+    And user "newuser" has been created
+    And group "newgroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data
 
-	@smokeTest
-	Scenario: normal user gets his own information
-		Given user "newuser" has been created
-		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the display name returned by the API should be "newuser"
+  @skip @issue-31276
+  Scenario: normal user tries to get information of another user
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data
+
+  @smokeTest
+  Scenario: normal user gets his own information
+    Given user "newuser" has been created
+    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "newuser"

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -1,92 +1,92 @@
 @api @provisioning_api-app-required
 Feature: get user groups
-As an admin
-I want to be able to get groups
-So that I can manage group membership
+  As an admin
+  I want to be able to get groups
+  So that I can manage group membership
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets groups of an user
-		Given user "brand-new-user" has been created
-		And group "unused-group" has been created
-		And group "new-group" has been created
-		And group "0" has been created
-		And group "Admin & Finance (NP)" has been created
-		And group "admin:Pokhara@Nepal" has been created
-		And group "नेपाली" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been added to group "0"
-		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-		And user "brand-new-user" has been added to group "नेपाली"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
-		Then the groups returned by the API should be
-			| new-group            |
-			| 0                    |
-			| Admin & Finance (NP) |
-			| admin:Pokhara@Nepal  |
-			| नेपाली               |
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: admin gets groups of an user
+    Given user "brand-new-user" has been created
+    And group "unused-group" has been created
+    And group "new-group" has been created
+    And group "0" has been created
+    And group "Admin & Finance (NP)" has been created
+    And group "admin:Pokhara@Nepal" has been created
+    And group "नेपाली" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been added to group "0"
+    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+    And user "brand-new-user" has been added to group "नेपाली"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    Then the groups returned by the API should be
+      | new-group            |
+      | 0                    |
+      | Admin & Finance (NP) |
+      | admin:Pokhara@Nepal  |
+      | नेपाली               |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
 
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-	@skip @issue-31015
-	Scenario: admin gets groups of an user, including groups containing a slash
-		Given user "brand-new-user" has been created
-		And group "unused-group" has been created
-		And group "new-group" has been created
-		And group "0" has been created
-		And group "Admin & Finance (NP)" has been created
-		And group "admin:Pokhara@Nepal" has been created
-		And group "नेपाली" has been created
-		And group "Mgmt/Sydney" has been created
-		And group "var/../etc" has been created
-		And group "priv/subadmins/1" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been added to group "0"
-		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-		And user "brand-new-user" has been added to group "नेपाली"
-		And user "brand-new-user" has been added to group "Mgmt/Sydney"
-		And user "brand-new-user" has been added to group "var/../etc"
-		And user "brand-new-user" has been added to group "priv/subadmins/1"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
-		Then the groups returned by the API should be
-			| new-group            |
-			| 0                    |
-			| Admin & Finance (NP) |
-			| admin:Pokhara@Nepal  |
-			| नेपाली               |
-			| Mgmt/Sydney          |
-			| var/../etc           |
-			| priv/subadmins/1     |
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
+  @skip @issue-31015
+  Scenario: admin gets groups of an user, including groups containing a slash
+    Given user "brand-new-user" has been created
+    And group "unused-group" has been created
+    And group "new-group" has been created
+    And group "0" has been created
+    And group "Admin & Finance (NP)" has been created
+    And group "admin:Pokhara@Nepal" has been created
+    And group "नेपाली" has been created
+    And group "Mgmt/Sydney" has been created
+    And group "var/../etc" has been created
+    And group "priv/subadmins/1" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been added to group "0"
+    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+    And user "brand-new-user" has been added to group "नेपाली"
+    And user "brand-new-user" has been added to group "Mgmt/Sydney"
+    And user "brand-new-user" has been added to group "var/../etc"
+    And user "brand-new-user" has been added to group "priv/subadmins/1"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    Then the groups returned by the API should be
+      | new-group            |
+      | 0                    |
+      | Admin & Finance (NP) |
+      | admin:Pokhara@Nepal  |
+      | नेपाली               |
+      | Mgmt/Sydney          |
+      | var/../etc           |
+      | priv/subadmins/1     |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
 
-	@smokeTest
-	Scenario: subadmin tries to get other groups of the user in his group
-		Given user "newuser" has been created
-		And user "subadmin" has been created
-		And group "newgroup" has been created
-		And group "anothergroup" has been created
-		And user "subadmin" has been made a subadmin of group "newgroup"
-		And user "newuser" has been added to group "newgroup"
-		And user "newuser" has been added to group "anothergroup"
-		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
-		Then the groups returned by the API should include "newgroup"
-		And the groups returned by the API should not include "anothergroup"
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: subadmin tries to get other groups of the user in his group
+    Given user "newuser" has been created
+    And user "subadmin" has been created
+    And group "newgroup" has been created
+    And group "anothergroup" has been created
+    And user "subadmin" has been made a subadmin of group "newgroup"
+    And user "newuser" has been added to group "newgroup"
+    And user "newuser" has been added to group "anothergroup"
+    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    Then the groups returned by the API should include "newgroup"
+    And the groups returned by the API should not include "anothergroup"
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
 
-	@skip @issue-31276
-	Scenario: normal user tries to get the groups of another user
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		And group "newgroup" has been created
-		And user "newuser" has been added to group "newgroup"
-		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @skip @issue-31276
+  Scenario: normal user tries to get the groups of another user
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    And group "newgroup" has been created
+    And user "newuser" has been added to group "newgroup"
+    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -1,40 +1,40 @@
 @api @provisioning_api-app-required
 Feature: get users
-As an admin
-I want to be able to list the users that exist
-So that I can see who has access to ownCloud
+  As an admin
+  I want to be able to list the users that exist
+  So that I can see who has access to ownCloud
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin gets all users
-		Given user "brand-new-user" has been created
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the users returned by the API should be
-			| brand-new-user |
-			| admin          |
+  @smokeTest
+  Scenario: admin gets all users
+    Given user "brand-new-user" has been created
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the users returned by the API should be
+      | brand-new-user |
+      | admin          |
 
-	@smokeTest
-	Scenario: subadmin gets the users in his group
-		Given user "brand-new-user" has been created
-		And user "another-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
-		Then the users returned by the API should be
-			| brand-new-user |
-		And the OCS status code should be "200"
-		And the HTTP status code should be "200"
+  @smokeTest
+  Scenario: subadmin gets the users in his group
+    Given user "brand-new-user" has been created
+    And user "another-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    Then the users returned by the API should be
+      | brand-new-user |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
 
-	@skip @issue-31276
-	Scenario: normal user tries to get other users
-		Given user "normaluser" has been created
-		And user "newuser" has been created
-		When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
-		And the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the API should not return any data
+  @skip @issue-31276
+  Scenario: normal user tries to get other users
+    Given user "normaluser" has been created
+    And user "newuser" has been created
+    When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -1,117 +1,117 @@
 @api @provisioning_api-app-required
 Feature: remove a user from a group
-As an admin
-I want to be able to remove a user from a group
-So that I can manage user access to group resources
+  As an admin
+  I want to be able to remove a user from a group
+  So that I can manage user access to group resources
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario Outline: admin removes a user from a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		And user "brand-new-user" has been added to group "<group_id>"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200" 
-		And user "brand-new-user" should not belong to group "<group_id>"
-		Examples:
-			| group_id            | comment                                 |
-			| simplegroup         | nothing special here                    |
-			| España              | special European characters             |
-			| नेपाली              | Unicode group name                      |
+  @smokeTest
+  Scenario Outline: admin removes a user from a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    Examples:
+      | group_id    | comment                     |
+      | simplegroup | nothing special here        |
+      | España      | special European characters |
+      | नेपाली      | Unicode group name          |
 
-	Scenario Outline: admin removes a user from a group
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		And user "brand-new-user" has been added to group "<group_id>"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not belong to group "<group_id>"
-		Examples:
-			| group_id            | comment                                 |
-			| new-group           | dash                                    |
-			| the.group           | dot                                     |
-			| left,right          | comma                                   |
-			| 0                   | The "false" group                       |
-			| Finance (NP)        | Space and brackets                      |
-			| Admin&Finance       | Ampersand                               |
-			| admin:Pokhara@Nepal | Colon and @                             |
-			| maintenance#123     | Hash sign                               |
-			| maint+eng           | Plus sign                               |
-			| $x<=>[y*z^2]!       | Maths symbols                           |
-			| Mgmt\Middle         | Backslash                               |
-			| 50%pass             | Percent sign (special escaping happens) |
-			| 50%25=0             | %25 literal looks like an escaped "%"   |
-			| 50%2Eagle           | %2E literal looks like an escaped "."   |
-			| 50%2Fix             | %2F literal looks like an escaped slash |
-			| staff?group         | Question mark                           |
+  Scenario Outline: admin removes a user from a group
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    Examples:
+      | group_id            | comment                                 |
+      | new-group           | dash                                    |
+      | the.group           | dot                                     |
+      | left,right          | comma                                   |
+      | 0                   | The "false" group                       |
+      | Finance (NP)        | Space and brackets                      |
+      | Admin&Finance       | Ampersand                               |
+      | admin:Pokhara@Nepal | Colon and @                             |
+      | maintenance#123     | Hash sign                               |
+      | maint+eng           | Plus sign                               |
+      | $x<=>[y*z^2]!       | Maths symbols                           |
+      | Mgmt\Middle         | Backslash                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | staff?group         | Question mark                           |
 
-	@skip @issue-31015
-	Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-		Given user "brand-new-user" has been created
-		And group "<group_id>" has been created
-		And user "brand-new-user" has been added to group "<group_id>"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | <group_id> |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not belong to group "<group_id>"
-		Examples:
-			| group_id            | comment                                 |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
-			| var/../etc          | using slash-dot-dot                     |
-			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+  @skip @issue-31015
+  Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	Scenario: admin tries to remove a user from a group which does not exist
-		Given user "brand-new-user" has been created
-		And group "not-group" has been deleted
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | not-group |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
-		And the API should not return any data
+  Scenario: admin tries to remove a user from a group which does not exist
+    Given user "brand-new-user" has been created
+    And group "not-group" has been deleted
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | not-group |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
 
-	@smokeTest
-	Scenario: a subadmin can remove users from groups the subadmin is responsible for
-		Given user "subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should not belong to group "new-group"
+  @smokeTest
+  Scenario: a subadmin can remove users from groups the subadmin is responsible for
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "new-group"
 
-	Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
-		Given user "other-subadmin" has been created
-		And user "brand-new-user" has been created
-		And group "new-group" has been created
-		And group "other-group" has been created
-		And user "brand-new-user" has been added to group "new-group"
-		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "403"
-		And the HTTP status code should be "403"
-		And user "brand-new-user" should belong to group "new-group"
+  Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
+    Given user "other-subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And group "other-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "other-subadmin" has been made a subadmin of group "other-group"
+    When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "403"
+    And user "brand-new-user" should belong to group "new-group"
 
-	@skip @issue-31276
-	Scenario: normal user tries to remove the user in his group
-		Given user "newuser" has been created
-		And user "anotheruser" has been created
-		And group "new-group" has been created
-		And user "newuser" has been added to group "new-group"
-		And user "anotheruser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
-			| groupid | new-group |
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And user "anotheruser" should belong to group "new-group"
+  @skip @issue-31276
+  Scenario: normal user tries to remove the user in his group
+    Given user "newuser" has been created
+    And user "anotheruser" has been created
+    And group "new-group" has been created
+    And user "newuser" has been added to group "new-group"
+    And user "anotheruser" has been added to group "new-group"
+    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
+      | groupid | new-group |
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "anotheruser" should belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -1,45 +1,45 @@
 @api @provisioning_api-app-required
 Feature: remove subadmin
-As an admin
-I want to be able to remove subadmin rights to a user from a group
-So that I cam manage administrative access rights for groups
+  As an admin
+  I want to be able to remove subadmin rights to a user from a group
+  So that I cam manage administrative access rights for groups
 
-	Background:
-		Given using OCS API version "2"
+  Background:
+    Given using OCS API version "2"
 
-	@smokeTest
-	Scenario: admin removes subadmin from a group
-		Given user "brand-new-user" has been created
-		And group "new-group" has been created
-		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And the user "brand-new-user" should not be the subadmin of the group "new-group"
+  @smokeTest
+  Scenario: admin removes subadmin from a group
+    Given user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the user "brand-new-user" should not be the subadmin of the group "new-group"
 
-	@skip @issue-31276
-	Scenario: subadmin tries to remove other subadmin in the group
-		Given user "subadmin" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "newsubadmin" has been created
-		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		And the user "newsubadmin" should be the subadmin of the group "new-group"
+  @skip @issue-31276
+  Scenario: subadmin tries to remove other subadmin in the group
+    Given user "subadmin" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "newsubadmin" has been created
+    And user "newsubadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the user "newsubadmin" should be the subadmin of the group "new-group"
 
-	@skip @issue-31276
-	Scenario: normal user tries to remove subadmin in the group
-		Given user "subadmin" has been created
-		And user "newuser" has been created
-		And group "new-group" has been created
-		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "newuser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
-			| groupid | new-group |
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		And the user "subadmin" should be the subadmin of the group "new-group"
+  @skip @issue-31276
+  Scenario: normal user tries to remove subadmin in the group
+    Given user "subadmin" has been created
+    And user "newuser" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    And user "newuser" has been added to group "new-group"
+    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
+      | groupid | new-group |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the user "subadmin" should be the subadmin of the group "new-group"

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -1,375 +1,375 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: accept/decline shares coming from internal users
-	As a user
-	I want to have control of which received shares I accept
-	So that I can keep my file system clean
+  As a user
+  I want to have control of which received shares I accept
+  So that I can keep my file system clean
 
-	Background:
-		Given using OCS API version "1"
-		And using new DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
+  Background:
+    Given using OCS API version "1"
+    And using new DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
 
-	@smokeTest
-	Scenario: share a file & folder with another internal user when auto accept is enabled
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0.txt           |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /PARENT (2)/             |
-			| /textfile0 (2).txt       |
+  @smokeTest
+  Scenario: share a file & folder with another internal user when auto accept is enabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+    And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0.txt           |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path               |
+      | /PARENT (2)/       |
+      | /textfile0 (2).txt |
 
-	Scenario: share a file & folder with internal group when auto accept is enabled
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0.txt           |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /PARENT (2)/             |
-			| /textfile0 (2).txt       |
-		And user "user2" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0.txt           |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user2" that these shares are in the accepted state
-			| path                     |
-			| /PARENT (2)/             |
-			| /textfile0 (2).txt       |
+  Scenario: share a file & folder with internal group when auto accept is enabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0.txt           |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path               |
+      | /PARENT (2)/       |
+      | /textfile0 (2).txt |
+    And user "user2" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0.txt           |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user2" that these shares are in the accepted state
+      | path               |
+      | /PARENT (2)/       |
+      | /textfile0 (2).txt |
 
-	@smokeTest
-	Scenario: decline a share that has been auto-accepted
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the sharing API
-		And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the sharing API
-		Then user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the declined state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
+  @smokeTest
+  Scenario: decline a share that has been auto-accepted
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user0" has shared file "/textfile0.txt" with user "user1"
+    When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the sharing API
+    And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the sharing API
+    Then user "user1" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the declined state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
 
-	Scenario: accept a share that has been declined before
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		And user "user1" has declined the share "/PARENT (2)" offered by user "user0"
-		And user "user1" has declined the share "/textfile0 (2).txt" offered by user "user0"
-		When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
-		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
-		Then user "user1" should see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /PARENT (2)/             |
-			| /textfile0 (2).txt       |
+  Scenario: accept a share that has been declined before
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user0" has shared file "/textfile0.txt" with user "user1"
+    And user "user1" has declined the share "/PARENT (2)" offered by user "user0"
+    And user "user1" has declined the share "/textfile0 (2).txt" offered by user "user0"
+    When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
+    And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
+    Then user "user1" should see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path               |
+      | /PARENT (2)/       |
+      | /textfile0 (2).txt |
 
-	Scenario: unshare a share that has been auto-accepted
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" unshares folder "/PARENT (2)" using the WebDAV API
-		And user "user1" unshares file "/textfile0 (2).txt" using the WebDAV API
-		Then user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the declined state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
+  Scenario: unshare a share that has been auto-accepted
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user0" has shared file "/textfile0.txt" with user "user1"
+    When user "user1" unshares folder "/PARENT (2)" using the WebDAV API
+    And user "user1" unshares file "/textfile0 (2).txt" using the WebDAV API
+    Then user "user1" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the declined state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
 
-	Scenario: unshare a share that was shared with a group and auto-accepted
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has shared folder "/PARENT" with group "grp1"
-		And user "user0" has shared file "/textfile0.txt" with group "grp1"
-		When user "user1" unshares folder "/PARENT (2)" using the WebDAV API
-		And user "user1" unshares file "/textfile0 (2).txt" using the WebDAV API
-		Then user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the declined state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-		But user "user2" should see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user2" that these shares are in the accepted state
-			| path                     |
-			| /PARENT (2)/             |
-			| /textfile0 (2).txt       |
+  Scenario: unshare a share that was shared with a group and auto-accepted
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has shared folder "/PARENT" with group "grp1"
+    And user "user0" has shared file "/textfile0.txt" with group "grp1"
+    When user "user1" unshares folder "/PARENT (2)" using the WebDAV API
+    And user "user1" unshares file "/textfile0 (2).txt" using the WebDAV API
+    Then user "user1" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the declined state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
+    But user "user2" should see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user2" that these shares are in the accepted state
+      | path               |
+      | /PARENT (2)/       |
+      | /textfile0 (2).txt |
 
-	Scenario: rename accepted share, decline it
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		When user "user1" moves folder "/PARENT (2)" to "/PARENT-renamed" using the WebDAV API
-		And user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the sharing API
-		Then user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT-renamed/         |
-		And the sharing API should report to user "user1" that these shares are in the declined state
-			| path                     |
-			| /PARENT/                 |
+  Scenario: rename accepted share, decline it
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    When user "user1" moves folder "/PARENT (2)" to "/PARENT-renamed" using the WebDAV API
+    And user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the sharing API
+    Then user "user1" should not see the following elements
+      | /PARENT%20(2)/   |
+      | /PARENT-renamed/ |
+    And the sharing API should report to user "user1" that these shares are in the declined state
+      | path     |
+      | /PARENT/ |
 
-	Scenario: rename accepted share, decline it then accept again, name stays
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user1" has moved folder "/PARENT (2)" to "/PARENT-renamed"
-		When user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the sharing API
-		And user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
-		Then user "user1" should see the following elements
-			| /PARENT/                 |
-			| /PARENT-renamed/         |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /PARENT-renamed/         |
+  Scenario: rename accepted share, decline it then accept again, name stays
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user1" has moved folder "/PARENT (2)" to "/PARENT-renamed"
+    When user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the sharing API
+    And user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
+    Then user "user1" should see the following elements
+      | /PARENT/         |
+      | /PARENT-renamed/ |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path             |
+      | /PARENT-renamed/ |
 
-	Scenario: move accepted share, decline it, accept again
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved folder "/shared" to "/PARENT/shared"
-		When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
-		And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
-		Then user "user1" should not see the following elements
-			| /shared/                 |
-		But user "user1" should see the following elements
-			| /PARENT/shared/          |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /PARENT/shared/          |
+  Scenario: move accepted share, decline it, accept again
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved folder "/shared" to "/PARENT/shared"
+    When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
+    And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
+    Then user "user1" should not see the following elements
+      | /shared/ |
+    But user "user1" should see the following elements
+      | /PARENT/shared/ |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path            |
+      | /PARENT/shared/ |
 
-	Scenario: move accepted share, decline it, delete parent folder, accept again
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved folder "/shared" to "/PARENT/shared"
-		When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
-		And user "user1" deletes folder "/PARENT" using the WebDAV API
-		And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
-		Then user "user1" should not see the following elements
-			| /PARENT/                 |
-		But user "user1" should see the following elements
-			| /shared/                 |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /shared/                 |
+  Scenario: move accepted share, decline it, delete parent folder, accept again
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved folder "/shared" to "/PARENT/shared"
+    When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
+    And user "user1" deletes folder "/PARENT" using the WebDAV API
+    And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
+    Then user "user1" should not see the following elements
+      | /PARENT/ |
+    But user "user1" should see the following elements
+      | /shared/ |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path     |
+      | /shared/ |
 
-	Scenario: receive two shares with identical names from different users
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has created a folder "/shared/user0"
-		And user "user1" has created a folder "/shared"
-		And user "user1" has created a folder "/shared/user1"
-		When user "user0" shares folder "/shared" with user "user2" using the sharing API
-		And user "user1" shares folder "/shared" with user "user2" using the sharing API
-		Then user "user2" should see the following elements
-			| /shared/user0/           |
-			| /shared%20(2)/user1/     |
-		And the sharing API should report to user "user2" that these shares are in the accepted state
-			| path                     |
-			| /shared/                 |
-			| /shared (2)/             |
+  Scenario: receive two shares with identical names from different users
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has created a folder "/shared/user0"
+    And user "user1" has created a folder "/shared"
+    And user "user1" has created a folder "/shared/user1"
+    When user "user0" shares folder "/shared" with user "user2" using the sharing API
+    And user "user1" shares folder "/shared" with user "user2" using the sharing API
+    Then user "user2" should see the following elements
+      | /shared/user0/       |
+      | /shared%20(2)/user1/ |
+    And the sharing API should report to user "user2" that these shares are in the accepted state
+      | path         |
+      | /shared/     |
+      | /shared (2)/ |
 
-	@smokeTest
-	Scenario: share a file & folder with another internal group when auto accept is disabled
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-		But user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the pending state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-		And user "user2" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-		But user "user2" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user2" that these shares are in the pending state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
+  @smokeTest
+  Scenario: share a file & folder with another internal group when auto accept is disabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/       |
+      | /PARENT/       |
+      | /textfile0.txt |
+    But user "user1" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the pending state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
+    And user "user2" should see the following elements
+      | /FOLDER/       |
+      | /PARENT/       |
+      | /textfile0.txt |
+    But user "user2" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user2" that these shares are in the pending state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
 
-	Scenario: share a file & folder with another internal user when auto accept is disabled
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-		But user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the pending state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
+  Scenario: share a file & folder with another internal user when auto accept is disabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+    And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/       |
+      | /PARENT/       |
+      | /textfile0.txt |
+    But user "user1" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the pending state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
 
-	@smokeTest
-	Scenario: accept a pending share
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
-		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /PARENT (2)/             |
-			| /textfile0 (2).txt       |
+  @smokeTest
+  Scenario: accept a pending share
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user0" has shared file "/textfile0.txt" with user "user1"
+    When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
+    And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /textfile0.txt           |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path               |
+      | /PARENT (2)/       |
+      | /textfile0 (2).txt |
 
-	Scenario: accept an accepted share
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
-		And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
-		Then user "user1" should see the following elements
-			| /shared/    |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path        |
-			| /shared/    |
+  Scenario: accept an accepted share
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
+    And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
+    Then user "user1" should see the following elements
+      | /shared/ |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path     |
+      | /shared/ |
 
-	@smokeTest
-	Scenario: declines a pending share
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" declines the share "/PARENT" offered by user "user0" using the sharing API
-		And user "user1" declines the share "/textfile0.txt" offered by user "user0" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-		But user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the declined state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
+  @smokeTest
+  Scenario: declines a pending share
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user0" has shared file "/textfile0.txt" with user "user1"
+    When user "user1" declines the share "/PARENT" offered by user "user0" using the sharing API
+    And user "user1" declines the share "/textfile0.txt" offered by user "user0" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/       |
+      | /PARENT/       |
+      | /textfile0.txt |
+    But user "user1" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the declined state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
 
-	@smokeTest
-	Scenario: decline an accepted share
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		And user "user1" has accepted the share "/PARENT" offered by user "user0"
-		And user "user1" has accepted the share "/textfile0.txt" offered by user "user0"
-		When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the sharing API
-		And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the sharing API
-		Then user "user1" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the declined state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-			
-	Scenario: deleting shares in pending state
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has shared folder "/PARENT" with user "user1"
-		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user0" deletes folder "/PARENT" using the WebDAV API
-		And user "user0" deletes file "/textfile0.txt" using the WebDAV API
-		Then the sharing API should report that no shares are shared with user "user1"
+  @smokeTest
+  Scenario: decline an accepted share
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user0" has shared file "/textfile0.txt" with user "user1"
+    And user "user1" has accepted the share "/PARENT" offered by user "user0"
+    And user "user1" has accepted the share "/textfile0.txt" offered by user "user0"
+    When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the sharing API
+    And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the sharing API
+    Then user "user1" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the declined state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
 
-	Scenario: only one user in a group accepts a share
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has shared folder "/PARENT" with group "grp1"
-		And user "user0" has shared file "/textfile0.txt" with group "grp1"
-		When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
-		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
-		Then user "user2" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user2" that these shares are in the pending state
-			| path                     |
-			| /PARENT/                 |
-			| /textfile0.txt           |
-		But user "user1" should see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /textfile0%20(2).txt     |
-		And the sharing API should report to user "user1" that these shares are in the accepted state
-			| path                     |
-			| /PARENT (2)/             |
-			| /textfile0 (2).txt       |
+  Scenario: deleting shares in pending state
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    And user "user0" has shared file "/textfile0.txt" with user "user1"
+    When user "user0" deletes folder "/PARENT" using the WebDAV API
+    And user "user0" deletes file "/textfile0.txt" using the WebDAV API
+    Then the sharing API should report that no shares are shared with user "user1"
 
-	Scenario: receive two shares with identical names from different users, accept one by one
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has created a folder "/shared/user0"
-		And user "user1" has created a folder "/shared"
-		And user "user1" has created a folder "/shared/user1"
-		And user "user0" has shared folder "/shared" with user "user2"
-		And user "user1" has shared folder "/shared" with user "user2"
-		When user "user2" accepts the share "/shared" offered by user "user1" using the sharing API
-		And user "user2" accepts the share "/shared" offered by user "user0" using the sharing API
-		Then user "user2" should see the following elements
-			| /shared/user1/           |
-			| /shared%20(2)/user0/     |
-		And the sharing API should report to user "user2" that these shares are in the accepted state
-			| path                     |
-			| /shared/                 |
-			| /shared (2)/             |
+  Scenario: only one user in a group accepts a share
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has shared folder "/PARENT" with group "grp1"
+    And user "user0" has shared file "/textfile0.txt" with group "grp1"
+    When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
+    And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
+    Then user "user2" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user2" that these shares are in the pending state
+      | path           |
+      | /PARENT/       |
+      | /textfile0.txt |
+    But user "user1" should see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /textfile0%20(2).txt     |
+    And the sharing API should report to user "user1" that these shares are in the accepted state
+      | path               |
+      | /PARENT (2)/       |
+      | /textfile0 (2).txt |
 
-	Scenario: share with a group that you are part of yourself
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		Then the sharing API should report to user "user1" that these shares are in the pending state
-			| path                     |
-			| /PARENT/                 |
-		And the sharing API should report that no shares are shared with user "user0"
+  Scenario: receive two shares with identical names from different users, accept one by one
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has created a folder "/shared/user0"
+    And user "user1" has created a folder "/shared"
+    And user "user1" has created a folder "/shared/user1"
+    And user "user0" has shared folder "/shared" with user "user2"
+    And user "user1" has shared folder "/shared" with user "user2"
+    When user "user2" accepts the share "/shared" offered by user "user1" using the sharing API
+    And user "user2" accepts the share "/shared" offered by user "user0" using the sharing API
+    Then user "user2" should see the following elements
+      | /shared/user1/       |
+      | /shared%20(2)/user0/ |
+    And the sharing API should report to user "user2" that these shares are in the accepted state
+      | path         |
+      | /shared/     |
+      | /shared (2)/ |
+
+  Scenario: share with a group that you are part of yourself
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    Then the sharing API should report to user "user1" that these shares are in the pending state
+      | path     |
+      | /PARENT/ |
+    And the sharing API should report that no shares are shared with user "user0"

--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -1,386 +1,387 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using old DAV path
-		And user "user0" has been created
 
-	@smokeTest
-	@skipOnEncryptionType:user-keys @issue-32322
-	Scenario Outline: Creating a new share with user
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| share_with             | user1              |
-			| file_target            | /welcome.txt       |
-			| path                   | /welcome.txt       |
-			| permissions            | 19                 |
-			| uid_owner              | user0              |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Background:
+    Given using old DAV path
+    And user "user0" has been created
 
-	Scenario Outline: Creating a share with a group
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path      | welcome.txt |
-			| shareWith | grp1        |
-			| shareType | 1           |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| share_with             | grp1         |
-			| file_target            | /welcome.txt |
-			| path                   | /welcome.txt |
-			| permissions            | 19           |
-			| uid_owner              | user0        |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  @skipOnEncryptionType:user-keys @issue-32322
+  Scenario Outline: Creating a new share with user
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | share_with  | user1        |
+      | file_target | /welcome.txt |
+      | path        | /welcome.txt |
+      | permissions | 19           |
+      | uid_owner   | user0        |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new share with user who already received a share through their group
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has shared file "welcome.txt" with group "grp1"
-		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path      | welcome.txt |
-			| shareWith | user1       |
-			| shareType | 0           |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| share_with             | user1              |
-			| file_target            | /welcome.txt       |
-			| path                   | /welcome.txt       |
-			| permissions            | 19                 |
-			| uid_owner              | user0              |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a share with a group
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path      | welcome.txt |
+      | shareWith | grp1        |
+      | shareType | 1           |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | share_with  | grp1         |
+      | file_target | /welcome.txt |
+      | path        | /welcome.txt |
+      | permissions | 19           |
+      | uid_owner   | user0        |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new public link share of a file
-		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path      | welcome.txt |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last public shared file should be able to be downloaded without a password
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new share with user who already received a share through their group
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "welcome.txt" with group "grp1"
+    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path      | welcome.txt |
+      | shareWith | user1       |
+      | shareType | 0           |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | share_with  | user1        |
+      | file_target | /welcome.txt |
+      | path        | /welcome.txt |
+      | permissions | 19           |
+      | uid_owner   | user0        |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: Creating a new public link share of a file with password
-		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path      | welcome.txt |
-			| password  | %public%    |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last public shared file should be able to be downloaded with password "%public%"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new public link share of a file
+    Given using OCS API version "<ocs_api_version>"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path | welcome.txt |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last public shared file should be able to be downloaded without a password
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
-		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path        | welcome.txt |
-			| permissions | 31          |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| file_target            | /welcome.txt       |
-			| path                   | /welcome.txt       |
-			| item_type              | file               |
-			| share_type             | 3                  |
-			| permissions            | 1                  |
-			| uid_owner              | user0              |
-		And the last public shared file should be able to be downloaded without a password
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario Outline: Creating a new public link share of a file with password
+    Given using OCS API version "<ocs_api_version>"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path     | welcome.txt |
+      | password | %public%    |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last public shared file should be able to be downloaded with password "%public%"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new public link share of a folder
-		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path      | PARENT   |
-			| password  | %public% |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Then the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
+    Given using OCS API version "<ocs_api_version>"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | welcome.txt |
+      | permissions | 31          |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | file_target | /welcome.txt |
+      | path        | /welcome.txt |
+      | item_type   | file         |
+      | share_type  | 3            |
+      | permissions | 1            |
+      | uid_owner   | user0        |
+    And the last public shared file should be able to be downloaded without a password
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new share with a disabled user
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user0" has been disabled
-		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path      | welcome.txt |
-			| shareWith | user1       |
-			| shareType | 0           |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "401"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |997            |
+  Scenario Outline: Creating a new public link share of a folder
+    Given using OCS API version "<ocs_api_version>"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path     | PARENT   |
+      | password | %public% |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Then the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@skip @issue-32068
-	Scenario: Creating a new share with a disabled user
-		Given using OCS API version "2"
-		And user "user1" has been created
-		And user "user0" has been disabled
-		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path      | welcome.txt |
-			| shareWith | user1       |
-			| shareType | 0           |
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
+  Scenario Outline: Creating a new share with a disabled user
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user0" has been disabled
+    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path      | welcome.txt |
+      | shareWith | user1       |
+      | shareType | 0           |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "401"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 997             |
 
-	Scenario Outline: Creating a link share with no specified permissions defaults to read permissions
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path      | /afolder |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id          | A_NUMBER |
-			| share_type  | 3        |
-			| permissions | 1        |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @skip @issue-32068
+  Scenario: Creating a new share with a disabled user
+    Given using OCS API version "2"
+    And user "user1" has been created
+    And user "user0" has been disabled
+    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path      | welcome.txt |
+      | shareWith | user1       |
+      | shareType | 0           |
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
 
-	Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
-		Given using OCS API version "<ocs_api_version>"
-		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path      | /afolder |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id          | A_NUMBER |
-			| share_type  | 3        |
-			| permissions | 1        |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a link share with no specified permissions defaults to read permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created a folder "/afolder"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path | /afolder |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id          | A_NUMBER |
+      | share_type  | 3        |
+      | permissions | 1        |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a link share with edit permissions keeps it
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path        | /afolder |
-			| permissions | 15       |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id          | A_NUMBER |
-			| share_type  | 3        |
-			| permissions | 15       |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And user "user0" has created a folder "/afolder"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path | /afolder |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id          | A_NUMBER |
+      | share_type  | 3        |
+      | permissions | 1        |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Share of folder and sub-folder to same user - core#20645
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And group "grp4" has been created
-		And user "user1" has been added to group "grp4"
-		When user "user0" shares file "/PARENT" with user "user1" using the sharing API
-		And user "user0" shares file "/PARENT/CHILD" with group "grp4" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT/parent.txt       |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-			| /CHILD/                  |
-			| /CHILD/child.txt         |
-		And the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a link share with edit permissions keeps it
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created a folder "/afolder"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | /afolder |
+      | permissions | 15       |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id          | A_NUMBER |
+      | share_type  | 3        |
+      | permissions | 15       |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: Share of folder to a group
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user2" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And user "user0" shares file "/PARENT" with group "grp1" using the sharing API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT/parent.txt       |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-		And the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And user "user2" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT/parent.txt       |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-		And the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Share of folder and sub-folder to same user - core#20645
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And group "grp4" has been created
+    And user "user1" has been added to group "grp4"
+    When user "user0" shares file "/PARENT" with user "user1" using the sharing API
+    And user "user0" shares file "/PARENT/CHILD" with group "grp4" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /PARENT/parent.txt       |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+      | /CHILD/                  |
+      | /CHILD/child.txt         |
+    And the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Do not allow public sharing of the root
-		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path      | / |
-		Then the OCS status code should be "<ocs_status_code>"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |403            |
-			|2              |403            |
+  @smokeTest
+  Scenario Outline: Share of folder to a group
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user2" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user0" shares file "/PARENT" with group "grp1" using the sharing API
+    Then user "user1" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /PARENT/parent.txt       |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+    And the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /PARENT/parent.txt       |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+    And the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario: Only allow 1 link share per file/folder
-		Given using OCS API version "1"
-		And as user "user0"
-		And the user has created a public link share with settings
-			| path      | welcome.txt |
-		And the last share id has been remembered
-		When the user creates a public link share using the sharing API with settings
-			| path      | welcome.txt |
-		Then the share ids should match
+  Scenario Outline: Do not allow public sharing of the root
+    Given using OCS API version "<ocs_api_version>"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path | / |
+    Then the OCS status code should be "<ocs_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 403             |
+      | 2               | 403             |
 
-	@smokeTest
-	Scenario: unique target names for incoming shares
-		Given using OCS API version "1"
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/foo"
-		And user "user1" has created a folder "/foo"
-		When user "user0" shares file "/foo" with user "user2" using the sharing API
-		And user "user1" shares file "/foo" with user "user2" using the sharing API
-		Then user "user2" should see the following elements
-			| /foo/       |
-			| /foo%20(2)/ |
+  Scenario: Only allow 1 link share per file/folder
+    Given using OCS API version "1"
+    And as user "user0"
+    And the user has created a public link share with settings
+      | path | welcome.txt |
+    And the last share id has been remembered
+    When the user creates a public link share using the sharing API with settings
+      | path | welcome.txt |
+    Then the share ids should match
 
-	Scenario Outline: sharing again an own file while belonging to a group
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user1" has shared file "welcome.txt" with group "grp1"
-		And user "user1" has deleted the last share
-		When user "user1" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path      | welcome.txt |
-			| shareWith | grp1        |
-			| shareType | 1           |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario: unique target names for incoming shares
+    Given using OCS API version "1"
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has created a folder "/foo"
+    And user "user1" has created a folder "/foo"
+    When user "user0" shares file "/foo" with user "user2" using the sharing API
+    And user "user1" shares file "/foo" with user "user2" using the sharing API
+    Then user "user2" should see the following elements
+      | /foo/       |
+      | /foo%20(2)/ |
 
-	Scenario Outline: sharing subfolder when parent already shared
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has created a folder "/test/sub"
-		And user "user0" has shared file "/test" with group "grp1"
-		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path      | /test/sub |
-			| shareWith | user1     |
-			| shareType | 0         |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And as "user1" the folder "/sub" should exist
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: sharing again an own file while belonging to a group
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user1" has shared file "welcome.txt" with group "grp1"
+    And user "user1" has deleted the last share
+    When user "user1" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path      | welcome.txt |
+      | shareWith | grp1        |
+      | shareType | 1           |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: sharing subfolder when parent already shared with group of sharer
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user0" has been added to group "grp1"
-		And user "user0" has created a folder "/test"
-		And user "user0" has created a folder "/test/sub"
-		And user "user0" has shared file "/test" with group "grp1"
-		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path      | /test/sub |
-			| shareWith | user1     |
-			| shareType | 0         |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And as "user1" the folder "/sub" should exist
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: sharing subfolder when parent already shared
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has created a folder "/test/sub"
+    And user "user0" has shared file "/test" with group "grp1"
+    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path      | /test/sub |
+      | shareWith | user1     |
+      | shareType | 0         |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user1" the folder "/sub" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: sharing subfolder of already shared folder, GET result is correct
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user3" has been created
-		And user "user4" has been created
-		And user "user0" has created a folder "/folder1"
-		And user "user0" has shared file "/folder1" with user "user1"
-		And user "user0" has shared file "/folder1" with user "user2"
-		And user "user0" has created a folder "/folder1/folder2"
-		And user "user0" has shared file "/folder1/folder2" with user "user3"
-		And user "user0" has shared file "/folder1/folder2" with user "user4"
-		And as user "user0"
-		When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the response should contain 4 entries
-		And file "/folder1" should be included as path in the response
-		And file "/folder1/folder2" should be included as path in the response
-		And the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
-		And the response should contain 2 entries
-		And file "/folder1" should not be included as path in the response
-		And file "/folder1/folder2" should be included as path in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: sharing subfolder when parent already shared with group of sharer
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user0" has been added to group "grp1"
+    And user "user0" has created a folder "/test"
+    And user "user0" has created a folder "/test/sub"
+    And user "user0" has shared file "/test" with group "grp1"
+    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path      | /test/sub |
+      | shareWith | user1     |
+      | shareType | 0         |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user1" the folder "/sub" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Cannot create share with zero permissions
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path        | welcome.txt |
-			| shareWith   | user1       |
-			| shareType   | 0           |
-			| permissions | 0           |
-		Then the OCS status code should be "<ocs_status_code>"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |400            |
-			|2              |400            |
+  Scenario Outline: sharing subfolder of already shared folder, GET result is correct
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user3" has been created
+    And user "user4" has been created
+    And user "user0" has created a folder "/folder1"
+    And user "user0" has shared file "/folder1" with user "user1"
+    And user "user0" has shared file "/folder1" with user "user2"
+    And user "user0" has created a folder "/folder1/folder2"
+    And user "user0" has shared file "/folder1/folder2" with user "user3"
+    And user "user0" has shared file "/folder1/folder2" with user "user4"
+    And as user "user0"
+    When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the response should contain 4 entries
+    And file "/folder1" should be included as path in the response
+    And file "/folder1/folder2" should be included as path in the response
+    And the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
+    And the response should contain 2 entries
+    And file "/folder1" should not be included as path in the response
+    And file "/folder1/folder2" should be included as path in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Cannot create share with zero permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path        | welcome.txt |
+      | shareWith   | user1       |
+      | shareType   | 0           |
+      | permissions | 0           |
+    Then the OCS status code should be "<ocs_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 400             |
+      | 2               | 400             |

--- a/tests/acceptance/features/apiShareManagement/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagement/deleteShare.feature
@@ -1,162 +1,163 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
 
-	Scenario Outline: Delete all group shares
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has shared file "textfile0.txt" with group "grp1"
-		And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
-		When user "user0" deletes the last share using the sharing API
-		And user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last share_id should not be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Background:
+    Given using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
 
-	@smokeTest
-	Scenario Outline: delete a share
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "user0" deletes the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last share_id should not be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Delete all group shares
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
+    When user "user0" deletes the last share using the sharing API
+    And user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario: orphaned shares
-		Given using OCS API version "1"
-		And a new browser session for "user0" has been started
-		And user "user0" has created a folder "/common"
-		And user "user0" has created a folder "/common/sub"
-		And user "user0" has shared folder "/common/sub" with user "user1"
-		When user "user0" deletes folder "/common" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And as "user1" the folder "/sub" should not exist
+  @smokeTest
+  Scenario Outline: delete a share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    When user "user0" deletes the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: sharing subfolder of already shared folder, GET result is correct
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user3" has been created
-		And user "user4" has been created
-		And user "user0" has created a folder "/folder1"
-		And user "user0" has shared file "/folder1" with user "user1"
-		And user "user0" has shared file "/folder1" with user "user2"
-		And user "user0" has created a folder "/folder1/folder2"
-		And user "user0" has shared file "/folder1/folder2" with user "user3"
-		And user "user0" has shared file "/folder1/folder2" with user "user4"
-		And as user "user0"
-		When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the response should contain 4 entries
-		And file "/folder1" should be included as path in the response
-		And file "/folder1/folder2" should be included as path in the response
-		When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the response should contain 2 entries
-		And file "/folder1" should not be included as path in the response
-		And file "/folder1/folder2" should be included as path in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario: orphaned shares
+    Given using OCS API version "1"
+    And a new browser session for "user0" has been started
+    And user "user0" has created a folder "/common"
+    And user "user0" has created a folder "/common/sub"
+    And user "user0" has shared folder "/common/sub" with user "user1"
+    When user "user0" deletes folder "/common" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "user1" the folder "/sub" should not exist
 
-	@smokeTest @files_trashbin-app-required
-	Scenario: deleting a file out of a share as recipient creates a backup for the owner
-		Given using OCS API version "1"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And as "user1" the file "/shared/shared_file.txt" should not exist
-		And as "user0" the file "/shared/shared_file.txt" should not exist
-		And as "user0" the file "/shared_file.txt" should exist in trash
-		And as "user1" the file "/shared_file.txt" should exist in trash
+  Scenario Outline: sharing subfolder of already shared folder, GET result is correct
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user3" has been created
+    And user "user4" has been created
+    And user "user0" has created a folder "/folder1"
+    And user "user0" has shared file "/folder1" with user "user1"
+    And user "user0" has shared file "/folder1" with user "user2"
+    And user "user0" has created a folder "/folder1/folder2"
+    And user "user0" has shared file "/folder1/folder2" with user "user3"
+    And user "user0" has shared file "/folder1/folder2" with user "user4"
+    And as user "user0"
+    When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the response should contain 4 entries
+    And file "/folder1" should be included as path in the response
+    And file "/folder1/folder2" should be included as path in the response
+    When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the response should contain 2 entries
+    And file "/folder1" should not be included as path in the response
+    And file "/folder1/folder2" should be included as path in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@files_trashbin-app-required
-	Scenario: deleting a folder out of a share as recipient creates a backup for the owner
-		Given using OCS API version "1"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has created a folder "/shared/sub"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" deletes folder "/shared/sub" using the WebDAV API
-		Then the HTTP status code should be "204"
-		And as "user1" the folder "/shared/sub" should not exist
-		And as "user0" the folder "/shared/sub" should not exist
-		And as "user0" the folder "/sub" should exist in trash
-		And as "user0" the file "/sub/shared_file.txt" should exist in trash
-		And as "user1" the folder "/sub" should exist in trash
-		And as "user1" the file "/sub/shared_file.txt" should exist in trash
+  @smokeTest @files_trashbin-app-required
+  Scenario: deleting a file out of a share as recipient creates a backup for the owner
+    Given using OCS API version "1"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "user1" the file "/shared/shared_file.txt" should not exist
+    And as "user0" the file "/shared/shared_file.txt" should not exist
+    And as "user0" the file "/shared_file.txt" should exist in trash
+    And as "user1" the file "/shared_file.txt" should exist in trash
 
-	@smokeTest
-	Scenario Outline: unshare from self
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user2" has been created
-		And user "user2" has been added to group "grp1"
-		And user "user1" has been added to group "grp1"
-		And user "user2" has shared file "/PARENT/parent.txt" with group "grp1"
-		And user "user2" has stored etag of element "/PARENT"
-		And user "user1" has stored etag of element "/"
-		When user "user1" deletes the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the etag of element "/" of user "user1" should have changed
-		And the etag of element "/PARENT" of user "user2" should not have changed
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @files_trashbin-app-required
+  Scenario: deleting a folder out of a share as recipient creates a backup for the owner
+    Given using OCS API version "1"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has created a folder "/shared/sub"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user1" deletes folder "/shared/sub" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "user1" the folder "/shared/sub" should not exist
+    And as "user0" the folder "/shared/sub" should not exist
+    And as "user0" the folder "/sub" should exist in trash
+    And as "user0" the file "/sub/shared_file.txt" should exist in trash
+    And as "user1" the folder "/sub" should exist in trash
+    And as "user1" the file "/sub/shared_file.txt" should exist in trash
 
-	Scenario: sharee of a read-only share folder tries to delete the shared folder
-		Given using OCS API version "1"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path        | shared |
-			| shareWith   | user1  |
-			| shareType   | 0      |
-			| permissions | 1      |
-		When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
-		Then the HTTP status code should be "403"
-		And as "user1" the file "/shared/shared_file.txt" should exist
+  @smokeTest
+  Scenario Outline: unshare from self
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user2" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    And user "user2" has shared file "/PARENT/parent.txt" with group "grp1"
+    And user "user2" has stored etag of element "/PARENT"
+    And user "user1" has stored etag of element "/"
+    When user "user1" deletes the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the etag of element "/" of user "user1" should have changed
+    And the etag of element "/PARENT" of user "user2" should not have changed
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
-		Given using OCS API version "1"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path        | shared |
-			| shareWith   | user1  |
-			| shareType   | 0      |
-			| permissions | 4      |
-		When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
-		Then the HTTP status code should be "403"
-		And as "user0" the file "/shared/shared_file.txt" should exist
+  Scenario: sharee of a read-only share folder tries to delete the shared folder
+    Given using OCS API version "1"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path        | shared |
+      | shareWith   | user1  |
+      | shareType   | 0      |
+      | permissions | 1      |
+    When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user1" the file "/shared/shared_file.txt" should exist
 
-	Scenario: sharee of a upload-only share folder tries to delete his file in the folder
-		Given using OCS API version "1"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path        | shared |
-			| shareWith   | user1  |
-			| shareType   | 0      |
-			| permissions | 4      |
-		When user "user1" uploads file "data/textfile.txt" to "shared/textfile.txt" using the WebDAV API
-		And user "user1" deletes file "/shared/textfile.txt" using the WebDAV API
-		Then the HTTP status code should be "403"
-		And as "user0" the file "/shared/textfile.txt" should exist
+  Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
+    Given using OCS API version "1"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path        | shared |
+      | shareWith   | user1  |
+      | shareType   | 0      |
+      | permissions | 4      |
+    When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" the file "/shared/shared_file.txt" should exist
+
+  Scenario: sharee of a upload-only share folder tries to delete his file in the folder
+    Given using OCS API version "1"
+    And user "user0" has created a folder "/shared"
+    And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
+      | path        | shared |
+      | shareWith   | user1  |
+      | shareType   | 0      |
+      | permissions | 4      |
+    When user "user1" uploads file "data/textfile.txt" to "shared/textfile.txt" using the WebDAV API
+    And user "user1" deletes file "/shared/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" the file "/shared/textfile.txt" should exist

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -1,156 +1,156 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-As an admin
-I want to be able to disable sharing functionality 
-So that ownCloud users cannot share file or folder
+  As an admin
+  I want to be able to disable sharing functionality
+  So that ownCloud users cannot share file or folder
 
-	Background:
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
+  Background:
+    Given using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
 
-	@smokeTest
-	Scenario Outline: user tries to share a file with another user when the sharing api has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with user "user1" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  @smokeTest
+  Scenario Outline: user tries to share a file with another user when the sharing api has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    When parameter "shareapi_enabled" of app "core" has been set to "no"
+    Then user "user0" should not be able to share file "welcome.txt" with user "user1" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: user tries to share a folder with another user when the sharing api has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share folder "/FOLDER" with user "user1" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: user tries to share a folder with another user when the sharing api has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    When parameter "shareapi_enabled" of app "core" has been set to "no"
+    Then user "user0" should not be able to share folder "/FOLDER" with user "user1" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: user tries to share a file with group when the sharing api has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: user tries to share a file with group when the sharing api has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When parameter "shareapi_enabled" of app "core" has been set to "no"
+    Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: user tries to share a folder with group when the sharing api has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share folder "/FOLDER" with group "grp1" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: user tries to share a folder with group when the sharing api has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When parameter "shareapi_enabled" of app "core" has been set to "no"
+    Then user "user0" should not be able to share folder "/FOLDER" with group "grp1" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: user tries to create public link share of a file when the sharing api has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to create a public link share of file "welcome.txt" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: user tries to create public link share of a file when the sharing api has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    When parameter "shareapi_enabled" of app "core" has been set to "no"
+    Then user "user0" should not be able to create a public link share of file "welcome.txt" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	@smokeTest
-	Scenario Outline: user tries to create public link share of a folder when the sharing api has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to create a public link share of folder "/FOLDER" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  @smokeTest
+  Scenario Outline: user tries to create public link share of a folder when the sharing api has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    When parameter "shareapi_enabled" of app "core" has been set to "no"
+    Then user "user0" should not be able to create a public link share of folder "/FOLDER" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	@smokeTest
-	Scenario Outline: user tries to share a file with user who is not in his group when sharing outside the group has been restricted
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user1" should not be able to share file "welcome.txt" with user "user0" using the sharing API
-		And the OCS status code should be "403"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |403             |
+  @smokeTest
+  Scenario Outline: user tries to share a file with user who is not in his group when sharing outside the group has been restricted
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    Then user "user1" should not be able to share file "welcome.txt" with user "user0" using the sharing API
+    And the OCS status code should be "403"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 403              |
 
-	Scenario Outline: user shares a file with user who is in his group when sharing outside the group has been restricted
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user2" has been created
-		And user "user2" has been added to group "grp1"
-		And user "user1" has been added to group "grp1"
-		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user2" should be able to share file "welcome.txt" with user "user1" using the sharing API
-		And the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: user shares a file with user who is in his group when sharing outside the group has been restricted
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user2" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    Then user "user2" should be able to share file "welcome.txt" with user "user1" using the sharing API
+    And the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: user shares a file with the group he is not member of when sharing outside the group has been restricted
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp2" has been created
-		And group "grp1" has been created
-		And user "user3" has been created
-		And user "user3" has been added to group "grp2"
-		And user "user1" has been added to group "grp1"
-		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user3" should be able to share file "welcome.txt" with group "grp1" using the sharing API
-		And the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: user shares a file with the group he is not member of when sharing outside the group has been restricted
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp2" has been created
+    And group "grp1" has been created
+    And user "user3" has been created
+    And user "user3" has been added to group "grp2"
+    And user "user1" has been added to group "grp1"
+    When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    Then user "user3" should be able to share file "welcome.txt" with group "grp1" using the sharing API
+    And the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: user who is not a member of a group tries to share a file in the group when group sharing has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  @smokeTest
+  Scenario Outline: user who is not a member of a group tries to share a file in the group when group sharing has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: user who is a member of a group tries to share a file in the group when group sharing has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user2" has been created
-		And user "user2" has been added to group "grp1"
-		And user "user1" has been added to group "grp1"
-		When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		Then user "user2" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
-		And the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: user who is a member of a group tries to share a file in the group when group sharing has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user2" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    Then user "user2" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
+    And the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -1,108 +1,109 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
 
-	@smokeTest
-	Scenario: Merging shares for recipient when shared from outside with group and member
-		Given user "user0" has created a folder "/merge-test-outside"
-		When user "user0" shares folder "/merge-test-outside" with group "grp1" using the sharing API
-		And user "user0" shares folder "/merge-test-outside" with user "user1" using the sharing API
-		Then as "user1" the folder "/merge-test-outside" should exist
-		And as "user1" the folder "/merge-test-outside (2)" should not exist
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
 
-	Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
-		Given user "user0" has created a folder "/merge-test-outside-perms"
-		When user "user0" shares folder "/merge-test-outside-perms" with group "grp1" with permissions 1 using the sharing API
-		And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the sharing API
-		And user "user1" gets the following properties of folder "/merge-test-outside-perms" using the WebDAV API
-			|{http://owncloud.org/ns}permissions|
-		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-perms (2)" should not exist
+  @smokeTest
+  Scenario: Merging shares for recipient when shared from outside with group and member
+    Given user "user0" has created a folder "/merge-test-outside"
+    When user "user0" shares folder "/merge-test-outside" with group "grp1" using the sharing API
+    And user "user0" shares folder "/merge-test-outside" with user "user1" using the sharing API
+    Then as "user1" the folder "/merge-test-outside" should exist
+    And as "user1" the folder "/merge-test-outside (2)" should not exist
 
-	Scenario: Merging shares for recipient when shared from outside with two groups
-		Given group "grp4" has been created
-		And user "user1" has been added to group "grp4"
-		And user "user0" has created a folder "/merge-test-outside-twogroups"
-		When user "user0" shares folder "/merge-test-outside-twogroups" with group "grp1" using the sharing API
-		And user "user0" shares folder "/merge-test-outside-twogroups" with group "grp4" using the sharing API
-		Then as "user1" the folder "/merge-test-outside-twogroups" should exist
-		And as "user1" the folder "/merge-test-outside-twogroups (2)" should not exist
+  Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
+    Given user "user0" has created a folder "/merge-test-outside-perms"
+    When user "user0" shares folder "/merge-test-outside-perms" with group "grp1" with permissions 1 using the sharing API
+    And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the sharing API
+    And user "user1" gets the following properties of folder "/merge-test-outside-perms" using the WebDAV API
+      | {http://owncloud.org/ns}permissions |
+    Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" the folder "/merge-test-outside-perms (2)" should not exist
 
-	Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
-		Given group "grp4" has been created
-		And user "user1" has been added to group "grp4"
-		And user "user0" has created a folder "/merge-test-outside-twogroups-perms"
-		When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions 1 using the sharing API
-		And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp4" with permissions 31 using the sharing API
-		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-perms" using the WebDAV API
-			|{http://owncloud.org/ns}permissions|
-		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" should not exist
+  Scenario: Merging shares for recipient when shared from outside with two groups
+    Given group "grp4" has been created
+    And user "user1" has been added to group "grp4"
+    And user "user0" has created a folder "/merge-test-outside-twogroups"
+    When user "user0" shares folder "/merge-test-outside-twogroups" with group "grp1" using the sharing API
+    And user "user0" shares folder "/merge-test-outside-twogroups" with group "grp4" using the sharing API
+    Then as "user1" the folder "/merge-test-outside-twogroups" should exist
+    And as "user1" the folder "/merge-test-outside-twogroups (2)" should not exist
 
-	Scenario: Merging shares for recipient when shared from outside with two groups and member
-		Given group "grp4" has been created
-		And user "user1" has been added to group "grp4"
-		And user "user0" has created a folder "/merge-test-outside-twogroups-member-perms"
-		When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions 1 using the sharing API
-		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp4" with permissions 31 using the sharing API
-		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the sharing API
-		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-member-perms" using the WebDAV API
-			|{http://owncloud.org/ns}permissions|
-		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
+  Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
+    Given group "grp4" has been created
+    And user "user1" has been added to group "grp4"
+    And user "user0" has created a folder "/merge-test-outside-twogroups-perms"
+    When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions 1 using the sharing API
+    And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp4" with permissions 31 using the sharing API
+    And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-perms" using the WebDAV API
+      | {http://owncloud.org/ns}permissions |
+    Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" should not exist
 
-	Scenario: Merging shares for recipient when shared from inside with group
-		Given user "user1" has created a folder "/merge-test-inside-group"
-		When user "user1" shares folder "/merge-test-inside-group" with group "grp1" using the sharing API
-		Then as "user1" the folder "/merge-test-inside-group" should exist
-		And as "user1" the folder "/merge-test-inside-group (2)" should not exist
+  Scenario: Merging shares for recipient when shared from outside with two groups and member
+    Given group "grp4" has been created
+    And user "user1" has been added to group "grp4"
+    And user "user0" has created a folder "/merge-test-outside-twogroups-member-perms"
+    When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions 1 using the sharing API
+    And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp4" with permissions 31 using the sharing API
+    And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the sharing API
+    And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-member-perms" using the WebDAV API
+      | {http://owncloud.org/ns}permissions |
+    Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
 
-	Scenario: Merging shares for recipient when shared from inside with two groups
-		Given group "grp4" has been created
-		And user "user1" has been added to group "grp4"
-		And user "user1" has created a folder "/merge-test-inside-twogroups"
-		When user "user1" shares folder "/merge-test-inside-twogroups" with group "grp1" using the sharing API
-		And user "user1" shares folder "/merge-test-inside-twogroups" with group "grp4" using the sharing API
-		Then as "user1" the folder "/merge-test-inside-twogroups" should exist
-		And as "user1" the folder "/merge-test-inside-twogroups (2)" should not exist
-		And as "user1" the folder "/merge-test-inside-twogroups (3)" should not exist
+  Scenario: Merging shares for recipient when shared from inside with group
+    Given user "user1" has created a folder "/merge-test-inside-group"
+    When user "user1" shares folder "/merge-test-inside-group" with group "grp1" using the sharing API
+    Then as "user1" the folder "/merge-test-inside-group" should exist
+    And as "user1" the folder "/merge-test-inside-group (2)" should not exist
 
-	Scenario: Merging shares for recipient when shared from inside with group with less permissions
-		Given group "grp4" has been created
-		And user "user1" has been added to group "grp4"
-		And user "user1" has created a folder "/merge-test-inside-twogroups-perms"
-		When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API
-		And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp4" using the sharing API
-		And user "user1" gets the following properties of folder "/merge-test-inside-twogroups-perms" using the WebDAV API
-			|{http://owncloud.org/ns}permissions|
-		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
-		And as "user1" the folder "/merge-test-inside-twogroups-perms (2)" should not exist
-		And as "user1" the folder "/merge-test-inside-twogroups-perms (3)" should not exist
+  Scenario: Merging shares for recipient when shared from inside with two groups
+    Given group "grp4" has been created
+    And user "user1" has been added to group "grp4"
+    And user "user1" has created a folder "/merge-test-inside-twogroups"
+    When user "user1" shares folder "/merge-test-inside-twogroups" with group "grp1" using the sharing API
+    And user "user1" shares folder "/merge-test-inside-twogroups" with group "grp4" using the sharing API
+    Then as "user1" the folder "/merge-test-inside-twogroups" should exist
+    And as "user1" the folder "/merge-test-inside-twogroups (2)" should not exist
+    And as "user1" the folder "/merge-test-inside-twogroups (3)" should not exist
 
-	@skip @issue-29016 @skipOnLDAP
-	Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
-		Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
-		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
-		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
-		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
-		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
-			|{http://owncloud.org/ns}permissions|
-		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
+  Scenario: Merging shares for recipient when shared from inside with group with less permissions
+    Given group "grp4" has been created
+    And user "user1" has been added to group "grp4"
+    And user "user1" has created a folder "/merge-test-inside-twogroups-perms"
+    When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API
+    And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp4" using the sharing API
+    And user "user1" gets the following properties of folder "/merge-test-inside-twogroups-perms" using the WebDAV API
+      | {http://owncloud.org/ns}permissions |
+    Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
+    And as "user1" the folder "/merge-test-inside-twogroups-perms (2)" should not exist
+    And as "user1" the folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
-	@skipOnLDAP @user_ldap-issue-274
-	Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
-		Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
-		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
-		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
-		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
-		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
-			|{http://owncloud.org/ns}permissions|
-		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
+  @skip @issue-29016 @skipOnLDAP
+  Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
+    Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+    When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
+    And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
+    And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
+    And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
+      | {http://owncloud.org/ns}permissions |
+    Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
+
+  @skipOnLDAP @user_ldap-issue-274
+  Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
+    Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+    When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
+    And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
+    And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
+    And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
+      | {http://owncloud.org/ns}permissions |
+    Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -1,39 +1,40 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
 
-	Scenario: Keep usergroup shares (#22143)
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And user "user0" has created a folder "/TMP"
-		When user "user0" shares folder "TMP" with group "grp1" using the sharing API
-		And user "user1" creates a folder "/myFOLDER" using the WebDAV API
-		And user "user1" moves folder "/TMP" to "/myFOLDER/myTMP" using the WebDAV API
-		And the administrator deletes user "user2" using the provisioning API
-		Then user "user1" should see the following elements
-			| /myFOLDER/myTMP/ |
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
+    And user "user2" has been created
 
-	Scenario: keep user shared file name same after one of recipient has renamed the file
-		Given user "user0" has uploaded file with content "foo" to "/sharefile.txt"
-		And user "user0" has shared file "/sharefile.txt" with user "user1"
-		And user "user0" has shared file "/sharefile.txt" with user "user2"
-		When user "user2" moves file "/sharefile.txt" to "/renamedsharefile.txt" using the WebDAV API
-		Then as "user2" the file "/renamedsharefile.txt" should exist
-		And as "user0" the file "/sharefile.txt" should exist
-		And as "user1" the file "/sharefile.txt" should exist
+  Scenario: Keep usergroup shares (#22143)
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created a folder "/TMP"
+    When user "user0" shares folder "TMP" with group "grp1" using the sharing API
+    And user "user1" creates a folder "/myFOLDER" using the WebDAV API
+    And user "user1" moves folder "/TMP" to "/myFOLDER/myTMP" using the WebDAV API
+    And the administrator deletes user "user2" using the provisioning API
+    Then user "user1" should see the following elements
+      | /myFOLDER/myTMP/ |
 
-	Scenario: keep user shared file directory same in respect to respective user if one of the recipient has moved the file
-		Given user "user0" has uploaded file with content "foo" to "/sharefile.txt"
-		And user "user0" has shared file "/sharefile.txt" with user "user1"
-		And user "user0" has shared file "/sharefile.txt" with user "user2"
-		And user "user2" has created a folder "newfolder"
-		When user "user2" moves file "/sharefile.txt" to "/newfolder/sharefile.txt" using the WebDAV API
-		Then as "user2" the file "/newfolder/sharefile.txt" should exist
-		And as "user0" the file "/sharefile.txt" should exist
-		And as "user1" the file "/sharefile.txt" should exist
+  Scenario: keep user shared file name same after one of recipient has renamed the file
+    Given user "user0" has uploaded file with content "foo" to "/sharefile.txt"
+    And user "user0" has shared file "/sharefile.txt" with user "user1"
+    And user "user0" has shared file "/sharefile.txt" with user "user2"
+    When user "user2" moves file "/sharefile.txt" to "/renamedsharefile.txt" using the WebDAV API
+    Then as "user2" the file "/renamedsharefile.txt" should exist
+    And as "user0" the file "/sharefile.txt" should exist
+    And as "user1" the file "/sharefile.txt" should exist
+
+  Scenario: keep user shared file directory same in respect to respective user if one of the recipient has moved the file
+    Given user "user0" has uploaded file with content "foo" to "/sharefile.txt"
+    And user "user0" has shared file "/sharefile.txt" with user "user1"
+    And user "user0" has shared file "/sharefile.txt" with user "user2"
+    And user "user2" has created a folder "newfolder"
+    When user "user2" moves file "/sharefile.txt" to "/newfolder/sharefile.txt" using the WebDAV API
+    Then as "user2" the file "/newfolder/sharefile.txt" should exist
+    And as "user0" the file "/sharefile.txt" should exist
+    And as "user1" the file "/sharefile.txt" should exist

--- a/tests/acceptance/features/apiShareManagement/multilinksharing.feature
+++ b/tests/acceptance/features/apiShareManagement/multilinksharing.feature
@@ -1,197 +1,197 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: multilinksharing
 
-	Background:
-		Given using old DAV path
-		And user "user0" has been created
-		And as user "user0"
+  Background:
+    Given using old DAV path
+    And user "user0" has been created
+    And as user "user0"
 
-	@smokeTest
-	Scenario Outline: Creating three public shares of a folder
-		Given using OCS API version "<ocs_api_version>"
-		And the user has created a public link share with settings
-			| path         | FOLDER      |
-			| password     | %public%    |
-			| expireDate   | +3 days     |
-			| publicUpload | true        |
-			| permissions  | 15          |
-			| name         | sharedlink1 |
-		And the user has created a public link share with settings
-			| path         | FOLDER      |
-			| password     | %public%    |
-			| expireDate   | +3 days     |
-			| publicUpload | true        |
-			| permissions  | 15          |
-			| name         | sharedlink2 |
-		And the user has created a public link share with settings
-			| path         | FOLDER      |
-			| password     | %public%    |
-			| expireDate   | +3 days     |
-			| publicUpload | true        |
-			| permissions  | 15          |
-			| name         | sharedlink3 |
-		When the user updates the last share using the sharing API with
-			| permissions | 1 |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And as user "user0" the public shares of folder "/FOLDER" should be
-			| /FOLDER | 15 | sharedlink2 |
-			| /FOLDER | 15 | sharedlink1 |
-			| /FOLDER | 1  | sharedlink3 |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario Outline: Creating three public shares of a folder
+    Given using OCS API version "<ocs_api_version>"
+    And the user has created a public link share with settings
+      | path         | FOLDER      |
+      | password     | %public%    |
+      | expireDate   | +3 days     |
+      | publicUpload | true        |
+      | permissions  | 15          |
+      | name         | sharedlink1 |
+    And the user has created a public link share with settings
+      | path         | FOLDER      |
+      | password     | %public%    |
+      | expireDate   | +3 days     |
+      | publicUpload | true        |
+      | permissions  | 15          |
+      | name         | sharedlink2 |
+    And the user has created a public link share with settings
+      | path         | FOLDER      |
+      | password     | %public%    |
+      | expireDate   | +3 days     |
+      | publicUpload | true        |
+      | permissions  | 15          |
+      | name         | sharedlink3 |
+    When the user updates the last share using the sharing API with
+      | permissions | 1 |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as user "user0" the public shares of folder "/FOLDER" should be
+      | /FOLDER | 15 | sharedlink2 |
+      | /FOLDER | 15 | sharedlink1 |
+      | /FOLDER | 1  | sharedlink3 |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating three public shares of a file
-		Given using OCS API version "<ocs_api_version>"
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink1   |
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink2   |
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink3   |
-		When the user updates the last share using the sharing API with
-			| permissions | 1 |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And as user "user0" the public shares of file "/textfile0.txt" should be
-			| /textfile0.txt | 1 | sharedlink2 |
-			| /textfile0.txt | 1 | sharedlink1 |
-			| /textfile0.txt | 1 | sharedlink3 |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating three public shares of a file
+    Given using OCS API version "<ocs_api_version>"
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink1   |
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink2   |
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink3   |
+    When the user updates the last share using the sharing API with
+      | permissions | 1 |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as user "user0" the public shares of file "/textfile0.txt" should be
+      | /textfile0.txt | 1 | sharedlink2 |
+      | /textfile0.txt | 1 | sharedlink1 |
+      | /textfile0.txt | 1 | sharedlink3 |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Check that updating password doesn't remove name of links
-		Given using OCS API version "<ocs_api_version>"
-		And the user has created a public link share with settings
-			| path         | FOLDER      |
-			| password     | %public%    |
-			| expireDate   | +3 days     |
-			| publicUpload | true        |
-			| permissions  | 15          |
-			| name         | sharedlink1 |
-		And the user has created a public link share with settings
-			| path         | FOLDER      |
-			| password     | %public%    |
-			| expireDate   | +3 days     |
-			| publicUpload | true        |
-			| permissions  | 15          |
-			| name         | sharedlink2 |
-		When the user updates the last share using the sharing API with
-			| password | newpassword |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And as user "user0" the public shares of folder "/FOLDER" should be
-			| /FOLDER | 15 | sharedlink2 |
-			| /FOLDER | 15 | sharedlink1 |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Check that updating password doesn't remove name of links
+    Given using OCS API version "<ocs_api_version>"
+    And the user has created a public link share with settings
+      | path         | FOLDER      |
+      | password     | %public%    |
+      | expireDate   | +3 days     |
+      | publicUpload | true        |
+      | permissions  | 15          |
+      | name         | sharedlink1 |
+    And the user has created a public link share with settings
+      | path         | FOLDER      |
+      | password     | %public%    |
+      | expireDate   | +3 days     |
+      | publicUpload | true        |
+      | permissions  | 15          |
+      | name         | sharedlink2 |
+    When the user updates the last share using the sharing API with
+      | password | newpassword |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as user "user0" the public shares of folder "/FOLDER" should be
+      | /FOLDER | 15 | sharedlink2 |
+      | /FOLDER | 15 | sharedlink1 |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario: Deleting a file deletes also its public links
-		Given using OCS API version "1"
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink1   |
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink2   |
-		And user "user0" has deleted file "/textfile0.txt"
-		And the HTTP status code should be "204"
-		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
-		And as user "user0" the public shares of file "/textfile0.txt" should be
-			| | | |
+  Scenario: Deleting a file deletes also its public links
+    Given using OCS API version "1"
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink1   |
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink2   |
+    And user "user0" has deleted file "/textfile0.txt"
+    And the HTTP status code should be "204"
+    When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as user "user0" the public shares of file "/textfile0.txt" should be
+      |  |  |  |
 
-	Scenario Outline: Deleting one public link share of a file doesn't affect the rest
-		Given using OCS API version "<ocs_api_version>"
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink1   |
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink2   |
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink3   |
-		When user "user0" deletes public link share named "sharedlink2" in file "/textfile0.txt" using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And as user "user0" the public shares of file "/textfile0.txt" should be
-			| /textfile0.txt | 1 | sharedlink1 |
-			| /textfile0.txt | 1 | sharedlink3 |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Deleting one public link share of a file doesn't affect the rest
+    Given using OCS API version "<ocs_api_version>"
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink1   |
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink2   |
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink3   |
+    When user "user0" deletes public link share named "sharedlink2" in file "/textfile0.txt" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as user "user0" the public shares of file "/textfile0.txt" should be
+      | /textfile0.txt | 1 | sharedlink1 |
+      | /textfile0.txt | 1 | sharedlink3 |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario: Overwriting a file doesn't remove its public shares
-		Given using OCS API version "1"
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink1   |
-		And the user has created a public link share with settings
-			| path        | textfile0.txt |
-			| password    | %public%      |
-			| expireDate  | +3 days       |
-			| permissions | 1             |
-			| name        | sharedlink2   |
-		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the WebDAV API
-		Then as user "user0" the public shares of file "/textfile0.txt" should be
-			| /textfile0.txt | 1 | sharedlink1 |
-			| /textfile0.txt | 1 | sharedlink2 |
+  Scenario: Overwriting a file doesn't remove its public shares
+    Given using OCS API version "1"
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink1   |
+    And the user has created a public link share with settings
+      | path        | textfile0.txt |
+      | password    | %public%      |
+      | expireDate  | +3 days       |
+      | permissions | 1             |
+      | name        | sharedlink2   |
+    When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the WebDAV API
+    Then as user "user0" the public shares of file "/textfile0.txt" should be
+      | /textfile0.txt | 1 | sharedlink1 |
+      | /textfile0.txt | 1 | sharedlink2 |
 
-	Scenario: Renaming a folder doesn't remove its public shares
-		Given using OCS API version "1"
-		And the user has created a public link share with settings
-			| path         | FOLDER      |
-			| password     | %public%    |
-			| expireDate   | +3 days     |
-			| publicUpload | true        |
-			| permissions  | 15          |
-			| name         | sharedlink1 |
-		And the user has created a public link share with settings
-			| path         | FOLDER      |
-			| password     | %public%    |
-			| expireDate   | +3 days     |
-			| publicUpload | true        |
-			| permissions  | 15          |
-			| name         | sharedlink2 |
-		When user "user0" moves folder "/FOLDER" to "/FOLDER_RENAMED" using the WebDAV API
-		Then as user "user0" the public shares of file "/FOLDER_RENAMED" should be
-			| /FOLDER_RENAMED | 15 | sharedlink1 |
-			| /FOLDER_RENAMED | 15 | sharedlink2 |
+  Scenario: Renaming a folder doesn't remove its public shares
+    Given using OCS API version "1"
+    And the user has created a public link share with settings
+      | path         | FOLDER      |
+      | password     | %public%    |
+      | expireDate   | +3 days     |
+      | publicUpload | true        |
+      | permissions  | 15          |
+      | name         | sharedlink1 |
+    And the user has created a public link share with settings
+      | path         | FOLDER      |
+      | password     | %public%    |
+      | expireDate   | +3 days     |
+      | publicUpload | true        |
+      | permissions  | 15          |
+      | name         | sharedlink2 |
+    When user "user0" moves folder "/FOLDER" to "/FOLDER_RENAMED" using the WebDAV API
+    Then as user "user0" the public shares of file "/FOLDER_RENAMED" should be
+      | /FOLDER_RENAMED | 15 | sharedlink1 |
+      | /FOLDER_RENAMED | 15 | sharedlink2 |

--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -1,131 +1,132 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
 
-	Scenario Outline: User is not allowed to reshare file
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user0" has created a share with settings
-			| path        | /textfile0.txt |
-			| shareType   | 0              |
-			| shareWith   | user1          |
-			| permissions | 8              |
-		When user "user1" creates a share using the sharing API with settings
-			| path        | /textfile0 (2).txt |
-			| shareType   | 0                  |
-			| shareWith   | user2              |
-			| permissions | 31                 |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Background:
+    Given using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
 
-	Scenario Outline: User is not allowed to reshare file with more permissions
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user0" has created a share with settings
-			| path        | /textfile0.txt |
-			| shareType   | 0              |
-			| shareWith   | user1          |
-			| permissions | 16             |
-		When user "user1" creates a share using the sharing API with settings
-			| path        | /textfile0 (2).txt |
-			| shareType   | 0                  |
-			| shareWith   | user2              |
-			| permissions | 31                 |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: User is not allowed to reshare file
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user0" has created a share with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user1          |
+      | permissions | 8              |
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /textfile0 (2).txt |
+      | shareType   | 0                  |
+      | shareWith   | user2              |
+      | permissions | 31                 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: Do not allow reshare to exceed permissions
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user0" has created a folder "/TMP"
-		And user "user0" has created a share with settings
-			| path        | /TMP  |
-			| shareType   | 0     |
-			| shareWith   | user1 |
-			| permissions | 21    |
-		And as user "user1"
-		And the user has created a share with settings
-			| path        | /TMP  |
-			| shareType   | 0     |
-			| shareWith   | user2 |
-			| permissions | 21    |
-		When the user updates the last share using the sharing API with
-			| permissions | 31 |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: User is not allowed to reshare file with more permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user0" has created a share with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user1          |
+      | permissions | 16             |
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /textfile0 (2).txt |
+      | shareType   | 0                  |
+      | shareWith   | user2              |
+      | permissions | 31                 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario: Reshared files can be still accessed if a user in the middle removes it.
-		Given user "user2" has been created
-		And user "user3" has been created
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		And user "user1" has moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
-		And user "user1" has shared file "textfile0_shared.txt" with user "user2"
-		And user "user2" has shared file "textfile0_shared.txt" with user "user3"
-		When user "user1" deletes file "/textfile0_shared.txt" using the WebDAV API
-		And user "user3" downloads file "/textfile0_shared.txt" with range "bytes=1-7" using the WebDAV API
-		Then the downloaded content should be "wnCloud"
+  Scenario Outline: Do not allow reshare to exceed permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user0" has created a folder "/TMP"
+    And user "user0" has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user1 |
+      | permissions | 21    |
+    And as user "user1"
+    And the user has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user2 |
+      | permissions | 21    |
+    When the user updates the last share using the sharing API with
+      | permissions | 31 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: resharing using a public link with read only permissions is not allowed
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has created a folder "/test"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 1
-		When user "user1" creates a public link share using the sharing API with settings
-			| path         | /test |
-			| publicUpload | false |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario: Reshared files can be still accessed if a user in the middle removes it.
+    Given user "user2" has been created
+    And user "user3" has been created
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And user "user1" has moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
+    And user "user1" has shared file "textfile0_shared.txt" with user "user2"
+    And user "user2" has shared file "textfile0_shared.txt" with user "user3"
+    When user "user1" deletes file "/textfile0_shared.txt" using the WebDAV API
+    And user "user3" downloads file "/textfile0_shared.txt" with range "bytes=1-7" using the WebDAV API
+    Then the downloaded content should be "wnCloud"
 
-	Scenario Outline: resharing using a public link with read and write permissions only is not allowed
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has created a folder "/test"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 15
-		When user "user1" creates a public link share using the sharing API with settings
-			| path         | /test |
-			| publicUpload | false |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: resharing using a public link with read only permissions is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created a folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 1
+    When user "user1" creates a public link share using the sharing API with settings
+      | path         | /test |
+      | publicUpload | false |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user0" has created a share with settings
-			| path        | /textfile0.txt |
-			| shareType   | 0              |
-			| shareWith   | user1          |
-			| permissions | 31             |
-		And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-		When user "user1" creates a share using the sharing API with settings
-			| path        | /textfile0 (2).txt |
-			| shareType   | 0                  |
-			| shareWith   | user2              |
-			| permissions | 31                 |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		And as "user2" the file "/textfile0 (2).txt" should not exist
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: resharing using a public link with read and write permissions only is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created a folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 15
+    When user "user1" creates a public link share using the sharing API with settings
+      | path         | /test |
+      | publicUpload | false |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user0" has created a share with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user1          |
+      | permissions | 31             |
+    And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /textfile0 (2).txt |
+      | shareType   | 0                  |
+      | shareWith   | user2              |
+      | permissions | 31                 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user2" the file "/textfile0 (2).txt" should not exist
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -1,401 +1,402 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And these users have been created: 
-			|username|displayname|
-			|user0   |User Zero  |
 
-	@smokeTest
-	Scenario Outline: Allow modification of reshare
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/TMP"
-		And user "user0" has shared file "TMP" with user "user1"
-		And user "user1" has shared file "TMP" with user "user2"
-		When user "user1" updates the last share using the sharing API with
-			| permissions | 1 |
-		Then the OCS status code should be "<ocs_status_code>"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And these users have been created:
+      | username | displayname |
+      | user0    | User Zero   |
 
-	Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
-		Given using OCS API version "<ocs_api_version>"
-		And as user "user0"
-		When the user creates a public link share using the sharing API with settings
-			| path      | FOLDER |
-		And the user updates the last share using the sharing API with
-			| expireDate | +3 days |
-		And the user gets the info of the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                | A_NUMBER             |
-			| item_type         | folder               |
-			| item_source       | A_NUMBER             |
-			| share_type        | 3                    |
-			| file_source       | A_NUMBER             |
-			| file_target       | /FOLDER              |
-			| permissions       | 1                    |
-			| stime             | A_NUMBER             |
-			| expiration        | +3 days              |
-			| token             | A_TOKEN              |
-			| storage           | A_NUMBER             |
-			| mail_send         | 0                    |
-			| uid_owner         | user0                |
-			| file_parent       | A_NUMBER             |
-			| displayname_owner | User Zero            |
-			| url               | AN_URL               |
-			| mimetype          | httpd/unix-directory |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario Outline: Allow modification of reshare
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user2" has been created
+    And user "user0" has created a folder "/TMP"
+    And user "user0" has shared file "TMP" with user "user1"
+    And user "user1" has shared file "TMP" with user "user2"
+    When user "user1" updates the last share using the sharing API with
+      | permissions | 1 |
+    Then the OCS status code should be "<ocs_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new public link share with password and adding an expiration date
-		Given using OCS API version "<ocs_api_version>"
-		And as user "user0"
-		When the user creates a public link share using the sharing API with settings
-			| path      | welcome.txt |
-			| password  | %public%    |
-		And the user updates the last share using the sharing API with
-			| expireDate | +3 days |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last public shared file should be able to be downloaded with password "%public%"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
+    Given using OCS API version "<ocs_api_version>"
+    And as user "user0"
+    When the user creates a public link share using the sharing API with settings
+      | path | FOLDER |
+    And the user updates the last share using the sharing API with
+      | expireDate | +3 days |
+    And the user gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 3                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /FOLDER              |
+      | permissions       | 1                    |
+      | stime             | A_NUMBER             |
+      | expiration        | +3 days              |
+      | token             | A_TOKEN              |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user0                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User Zero            |
+      | url               | AN_URL               |
+      | mimetype          | httpd/unix-directory |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
-		Given using OCS API version "<ocs_api_version>"
-		And as user "user0"
-		When the user creates a public link share using the sharing API with settings
-			| path      | FOLDER |
-		And the user updates the last share using the sharing API with
-			| expireDate | +3 days |
-		And the user gets the info of the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                | A_NUMBER             |
-			| item_type         | folder               |
-			| item_source       | A_NUMBER             |
-			| share_type        | 3                    |
-			| file_source       | A_NUMBER             |
-			| file_target       | /FOLDER              |
-			| permissions       | 1                    |
-			| stime             | A_NUMBER             |
-			| expiration        | +3 days              |
-			| token             | A_TOKEN              |
-			| storage           | A_NUMBER             |
-			| mail_send         | 0                    |
-			| uid_owner         | user0                |
-			| file_parent       | A_NUMBER             |
-			| displayname_owner | User Zero            |
-			| url               | AN_URL               |
-			| mimetype          | httpd/unix-directory |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new public link share with password and adding an expiration date
+    Given using OCS API version "<ocs_api_version>"
+    And as user "user0"
+    When the user creates a public link share using the sharing API with settings
+      | path     | welcome.txt |
+      | password | %public%    |
+    And the user updates the last share using the sharing API with
+      | expireDate | +3 days |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last public shared file should be able to be downloaded with password "%public%"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new public link share, updating its password and getting its info
-		Given using OCS API version "<ocs_api_version>"
-		And as user "user0"
-		When the user creates a public link share using the sharing API with settings
-			| path      | FOLDER |
-		And the user updates the last share using the sharing API with
-			| password | %public% |
-		And the user gets the info of the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                | A_NUMBER             |
-			| item_type         | folder               |
-			| item_source       | A_NUMBER             |
-			| share_type        | 3                    |
-			| file_source       | A_NUMBER             |
-			| file_target       | /FOLDER              |
-			| permissions       | 1                    |
-			| stime             | A_NUMBER             |
-			| token             | A_TOKEN              |
-			| storage           | A_NUMBER             |
-			| mail_send         | 0                    |
-			| uid_owner         | user0                |
-			| file_parent       | A_NUMBER             |
-			| displayname_owner | User Zero            |
-			| url               | AN_URL               |
-			| mimetype          | httpd/unix-directory |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
+    Given using OCS API version "<ocs_api_version>"
+    And as user "user0"
+    When the user creates a public link share using the sharing API with settings
+      | path | FOLDER |
+    And the user updates the last share using the sharing API with
+      | expireDate | +3 days |
+    And the user gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 3                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /FOLDER              |
+      | permissions       | 1                    |
+      | stime             | A_NUMBER             |
+      | expiration        | +3 days              |
+      | token             | A_TOKEN              |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user0                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User Zero            |
+      | url               | AN_URL               |
+      | mimetype          | httpd/unix-directory |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new public link share, updating its permissions and getting its info
-		Given using OCS API version "<ocs_api_version>"
-		And as user "user0"
-		When the user creates a public link share using the sharing API with settings
-			| path      | FOLDER |
-		And the user updates the last share using the sharing API with
-			| permissions | 7 |
-		And the user gets the info of the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                | A_NUMBER             |
-			| item_type         | folder               |
-			| item_source       | A_NUMBER             |
-			| share_type        | 3                    |
-			| file_source       | A_NUMBER             |
-			| file_target       | /FOLDER              |
-			| permissions       | 15                   |
-			| stime             | A_NUMBER             |
-			| token             | A_TOKEN              |
-			| storage           | A_NUMBER             |
-			| mail_send         | 0                    |
-			| uid_owner         | user0                |
-			| file_parent       | A_NUMBER             |
-			| displayname_owner | User Zero            |
-			| url               | AN_URL               |
-			| mimetype          | httpd/unix-directory |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new public link share, updating its password and getting its info
+    Given using OCS API version "<ocs_api_version>"
+    And as user "user0"
+    When the user creates a public link share using the sharing API with settings
+      | path | FOLDER |
+    And the user updates the last share using the sharing API with
+      | password | %public% |
+    And the user gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 3                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /FOLDER              |
+      | permissions       | 1                    |
+      | stime             | A_NUMBER             |
+      | token             | A_TOKEN              |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user0                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User Zero            |
+      | url               | AN_URL               |
+      | mimetype          | httpd/unix-directory |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Creating a new public link share, updating publicUpload option and getting its info
-		Given using OCS API version "<ocs_api_version>"
-		And as user "user0"
-		When the user creates a public link share using the sharing API with settings
-			| path      | FOLDER |
-		And the user updates the last share using the sharing API with
-			| publicUpload | true |
-		And the user gets the info of the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                | A_NUMBER             |
-			| item_type         | folder               |
-			| item_source       | A_NUMBER             |
-			| share_type        | 3                    |
-			| file_source       | A_NUMBER             |
-			| file_target       | /FOLDER              |
-			| permissions       | 15                   |
-			| stime             | A_NUMBER             |
-			| token             | A_TOKEN              |
-			| storage           | A_NUMBER             |
-			| mail_send         | 0                    |
-			| uid_owner         | user0                |
-			| file_parent       | A_NUMBER             |
-			| displayname_owner | User Zero            |
-			| url               | AN_URL               |
-			| mimetype          | httpd/unix-directory |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new public link share, updating its permissions and getting its info
+    Given using OCS API version "<ocs_api_version>"
+    And as user "user0"
+    When the user creates a public link share using the sharing API with settings
+      | path | FOLDER |
+    And the user updates the last share using the sharing API with
+      | permissions | 7 |
+    And the user gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 3                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /FOLDER              |
+      | permissions       | 15                   |
+      | stime             | A_NUMBER             |
+      | token             | A_TOKEN              |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user0                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User Zero            |
+      | url               | AN_URL               |
+      | mimetype          | httpd/unix-directory |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: keep group permissions in sync
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has shared file "textfile0.txt" with group "grp1"
-		And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
-		And as user "user0"
-		When the user updates the last share using the sharing API with
-			| permissions | 1 |
-		And the user gets the info of the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                | A_NUMBER       |
-			| item_type         | file           |
-			| item_source       | A_NUMBER       |
-			| share_type        | 1              |
-			| file_source       | A_NUMBER       |
-			| file_target       | /textfile0.txt |
-			| permissions       | 1              |
-			| stime             | A_NUMBER       |
-			| storage           | A_NUMBER       |
-			| mail_send         | 0              |
-			| uid_owner         | user0          |
-			| file_parent       | A_NUMBER       |
-			| displayname_owner | User Zero      |
-			| mimetype          | text/plain     |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Creating a new public link share, updating publicUpload option and getting its info
+    Given using OCS API version "<ocs_api_version>"
+    And as user "user0"
+    When the user creates a public link share using the sharing API with settings
+      | path | FOLDER |
+    And the user updates the last share using the sharing API with
+      | publicUpload | true |
+    And the user gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 3                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /FOLDER              |
+      | permissions       | 15                   |
+      | stime             | A_NUMBER             |
+      | token             | A_TOKEN              |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user0                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User Zero            |
+      | url               | AN_URL               |
+      | mimetype          | httpd/unix-directory |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 17
-		And as user "user1"
-		And the user has created a public link share with settings
-			| path         | /test |
-			| publicUpload | false |
-		When the user updates the last share using the sharing API with
-			| publicUpload | true |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: keep group permissions in sync
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
+    And as user "user0"
+    When the user updates the last share using the sharing API with
+      | permissions | 1 |
+    And the user gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                | A_NUMBER       |
+      | item_type         | file           |
+      | item_source       | A_NUMBER       |
+      | share_type        | 1              |
+      | file_source       | A_NUMBER       |
+      | file_target       | /textfile0.txt |
+      | permissions       | 1              |
+      | stime             | A_NUMBER       |
+      | storage           | A_NUMBER       |
+      | mail_send         | 0              |
+      | uid_owner         | user0          |
+      | file_parent       | A_NUMBER       |
+      | displayname_owner | User Zero      |
+      | mimetype          | text/plain     |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Cannot set permissions to zero
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created 
-		And user "user0" has shared folder "/FOLDER" with group "grp1"
-		When user "user0" updates the last share using the sharing API with
-			| permissions | 0 |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |400             |
+  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 17
+    And as user "user1"
+    And the user has created a public link share with settings
+      | path         | /test |
+      | publicUpload | false |
+    When the user updates the last share using the sharing API with
+      | publicUpload | true |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario: Share ownership change after moving a shared file outside of an outer share
-		Given these users have been created: 
-			|username|displayname|
-			|user1   |User One   |
-			|user2   |User Two   |
-		And user "user0" has created a folder "/folder1"
-		And user "user0" has created a folder "/folder1/folder2"
-		And user "user1" has created a folder "/moved-out"
-		And user "user0" has shared folder "/folder1" with user "user1" with permissions 31
-		And user "user1" has shared folder "/folder1/folder2" with user "user2" with permissions 31
-		When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the WebDAV API
-		And user "user1" gets the info of the last share using the sharing API
-		Then the share fields of the last share should include
-			| id                | A_NUMBER             |
-			| item_type         | folder               |
-			| item_source       | A_NUMBER             |
-			| share_type        | 0                    |
-			| file_source       | A_NUMBER             |
-			| file_target       | /folder2             |
-			| permissions       | 31                   |
-			| stime             | A_NUMBER             |
-			| storage           | A_NUMBER             |
-			| mail_send         | 0                    |
-			| uid_owner         | user1                |
-			| file_parent       | A_NUMBER             |
-			| displayname_owner | User One             |
-			| mimetype          | httpd/unix-directory |
-		And as "user0" the folder "/folder1/folder2" should not exist
-		And as "user2" the folder "/folder2" should exist
+  Scenario Outline: Cannot set permissions to zero
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user0" has shared folder "/FOLDER" with group "grp1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | 0 |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 400              |
 
-	Scenario: Share ownership change after moving a shared file to another share
-		Given these users have been created: 
-			|username|displayname|
-			|user1   |User One   |
-			|user2   |User Two   |
-		And user "user0" has created a folder "/user0-folder"
-		And user "user0" has created a folder "/user0-folder/folder2"
-		And user "user2" has created a folder "/user2-folder"
-		And user "user0" has shared folder "/user0-folder" with user "user1" with permissions 31
-		And user "user2" has shared folder "/user2-folder" with user "user1" with permissions 31
-		When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the WebDAV API
-		And user "user1" gets the info of the last share using the sharing API
-		Then the share fields of the last share should include
-			| id                | A_NUMBER             |
-			| item_type         | folder               |
-			| item_source       | A_NUMBER             |
-			| share_type        | 0                    |
-			| file_source       | A_NUMBER             |
-			| file_target       | /user2-folder        |
-			| permissions       | 31                   |
-			| stime             | A_NUMBER             |
-			| storage           | A_NUMBER             |
-			| mail_send         | 0                    |
-			| uid_owner         | user2                |
-			| file_parent       | A_NUMBER             |
-			| displayname_owner | User Two             |
-			| mimetype          | httpd/unix-directory |
-		And as "user0" the folder "/user0-folder/folder2" should not exist
-		And as "user2" the folder "/user2-folder/folder2" should exist
+  Scenario: Share ownership change after moving a shared file outside of an outer share
+    Given these users have been created:
+      | username | displayname |
+      | user1    | User One    |
+      | user2    | User Two    |
+    And user "user0" has created a folder "/folder1"
+    And user "user0" has created a folder "/folder1/folder2"
+    And user "user1" has created a folder "/moved-out"
+    And user "user0" has shared folder "/folder1" with user "user1" with permissions 31
+    And user "user1" has shared folder "/folder1/folder2" with user "user2" with permissions 31
+    When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the WebDAV API
+    And user "user1" gets the info of the last share using the sharing API
+    Then the share fields of the last share should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 0                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /folder2             |
+      | permissions       | 31                   |
+      | stime             | A_NUMBER             |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user1                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User One             |
+      | mimetype          | httpd/unix-directory |
+    And as "user0" the folder "/folder1/folder2" should not exist
+    And as "user2" the folder "/folder2" should exist
 
-	Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 31
-		And as user "user1"
-		And the user has created a public link share with settings
-			| path         | /test |
-			| publicUpload | false |
-		When the user updates the last share using the sharing API with
-			| publicUpload | true |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario: Share ownership change after moving a shared file to another share
+    Given these users have been created:
+      | username | displayname |
+      | user1    | User One    |
+      | user2    | User Two    |
+    And user "user0" has created a folder "/user0-folder"
+    And user "user0" has created a folder "/user0-folder/folder2"
+    And user "user2" has created a folder "/user2-folder"
+    And user "user0" has shared folder "/user0-folder" with user "user1" with permissions 31
+    And user "user2" has shared folder "/user2-folder" with user "user1" with permissions 31
+    When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the WebDAV API
+    And user "user1" gets the info of the last share using the sharing API
+    Then the share fields of the last share should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 0                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /user2-folder        |
+      | permissions       | 31                   |
+      | stime             | A_NUMBER             |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user2                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User Two             |
+      | mimetype          | httpd/unix-directory |
+    And as "user0" the folder "/user0-folder/folder2" should not exist
+    And as "user2" the folder "/user2-folder/folder2" should exist
 
-	Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 17
-		And as user "user1"
-		And the user has created a public link share with settings
-			| path        | /test |
-			| permissions | 1     |
-		When the user updates the last share using the sharing API with
-			| permissions | 15 |
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 31
+    And as user "user1"
+    And the user has created a public link share with settings
+      | path         | /test |
+      | publicUpload | false |
+    When the user updates the last share using the sharing API with
+      | publicUpload | true |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" has shared folder "/test" with user "user1" with permissions 31
-		And as user "user1"
-		And the user has created a public link share with settings
-			| path        | /test |
-			| permissions | 1     |
-		When the user updates the last share using the sharing API with
-			| permissions | 15 |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 17
+    And as user "user1"
+    And the user has created a public link share with settings
+      | path        | /test |
+      | permissions | 1     |
+    When the user updates the last share using the sharing API with
+      | permissions | 15 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: Increasing permissions is allowed for owner
-		Given using OCS API version "<ocs_api_version>"
-		And user "user1" has been created
-		And user "user2" has been created
-		And group "grp1" has been created
-		And user "user2" has been added to group "grp1"
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been made a subadmin of group "grp1"
-		And as user "user2"
-		And the user has shared folder "/FOLDER" with group "grp1"
-		And the user has updated the last share with
-			| permissions | 1 |
-		When the user updates the last share using the sharing API with
-			| permissions | 31 |
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user0" has created a folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 31
+    And as user "user1"
+    And the user has created a public link share with settings
+      | path        | /test |
+      | permissions | 1     |
+    When the user updates the last share using the sharing API with
+      | permissions | 15 |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Increasing permissions is allowed for owner
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created
+    And user "user2" has been created
+    And group "grp1" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been made a subadmin of group "grp1"
+    And as user "user2"
+    And the user has shared folder "/FOLDER" with group "grp1"
+    And the user has updated the last share with
+      | permissions | 1 |
+    When the user updates the last share using the sharing API with
+      | permissions | 31 |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -1,62 +1,63 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
 
-	@smokeTest
-	Scenario Outline: Sharee can see the share
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last share_id should be included in the response
-		Examples:
-		|ocs_api_version|ocs_status_code|
-		|1              |100            |
-		|2              |200            |
+  Background:
+    Given using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
 
-	@smokeTest
-	Scenario Outline: Sharee can see the filtered share
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		And user "user0" has shared file "textfile1.txt" with user "user1"
-		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last share_id should be included in the response
-		Examples:
-		|ocs_api_version|ocs_status_code|
-		|1              |100            |
-		|2              |200            |
+  @smokeTest
+  Scenario Outline: Sharee can see the share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: Sharee can't see the share that is filtered out
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		And user "user0" has shared file "textfile1.txt" with user "user1"
-		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last share_id should not be included in the response
-		Examples:
-		|ocs_api_version|ocs_status_code|
-		|1              |100            |
-		|2              |200            |
+  @smokeTest
+  Scenario Outline: Sharee can see the filtered share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And user "user0" has shared file "textfile1.txt" with user "user1"
+    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: Sharee can see the group share
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has shared file "textfile0.txt" with group "grp1"
-		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last share_id should be included in the response
-		Examples:
-		|ocs_api_version|ocs_status_code|
-		|1              |100            |
-		|2              |200            |
+  @smokeTest
+  Scenario Outline: Sharee can't see the share that is filtered out
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And user "user0" has shared file "textfile1.txt" with user "user1"
+    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @smokeTest
+  Scenario Outline: Sharee can see the group share
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -1,39 +1,40 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
 
-	@smokeTest
-	Scenario: moving a file into a share as recipient
-		Given user "user0" has created a folder "/shared"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the WebDAV API
-		Then as "user1" the file "/shared/shared_file.txt" should exist
-		And as "user0" the file "/shared/shared_file.txt" should exist
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
 
-	@smokeTest @files_trashbin-app-required
-	Scenario: moving a file out of a share as recipient creates a backup for the owner
-		Given user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared file "/shared" with user "user1"
-		And user "user1" has moved folder "/shared" to "/shared_renamed"
-		When user "user1" moves file "/shared_renamed/shared_file.txt" to "/taken_out.txt" using the WebDAV API
-		Then as "user1" the file "/taken_out.txt" should exist
-		And as "user0" the file "/shared/shared_file.txt" should not exist
-		And as "user0" the file "/shared_file.txt" should exist in trash
+  @smokeTest
+  Scenario: moving a file into a share as recipient
+    Given user "user0" has created a folder "/shared"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the WebDAV API
+    Then as "user1" the file "/shared/shared_file.txt" should exist
+    And as "user0" the file "/shared/shared_file.txt" should exist
 
-	@files_trashbin-app-required
-	Scenario: moving a folder out of a share as recipient creates a backup for the owner
-		Given user "user0" has created a folder "/shared"
-		And user "user0" has created a folder "/shared/sub"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
-		And user "user0" has shared file "/shared" with user "user1"
-		And user "user1" has moved folder "/shared" to "/shared_renamed"
-		When user "user1" moves folder "/shared_renamed/sub" to "/taken_out" using the WebDAV API
-		Then as "user1" the file "/taken_out" should exist
-		And as "user0" the folder "/shared/sub" should not exist
-		And as "user0" the folder "/sub" should exist in trash
-		And as "user0" the file "/sub/shared_file.txt" should exist in trash
+  @smokeTest @files_trashbin-app-required
+  Scenario: moving a file out of a share as recipient creates a backup for the owner
+    Given user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared file "/shared" with user "user1"
+    And user "user1" has moved folder "/shared" to "/shared_renamed"
+    When user "user1" moves file "/shared_renamed/shared_file.txt" to "/taken_out.txt" using the WebDAV API
+    Then as "user1" the file "/taken_out.txt" should exist
+    And as "user0" the file "/shared/shared_file.txt" should not exist
+    And as "user0" the file "/shared_file.txt" should exist in trash
+
+  @files_trashbin-app-required
+  Scenario: moving a folder out of a share as recipient creates a backup for the owner
+    Given user "user0" has created a folder "/shared"
+    And user "user0" has created a folder "/shared/sub"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And user "user0" has shared file "/shared" with user "user1"
+    And user "user1" has moved folder "/shared" to "/shared_renamed"
+    When user "user1" moves folder "/shared_renamed/sub" to "/taken_out" using the WebDAV API
+    Then as "user1" the file "/taken_out" should exist
+    And as "user0" the folder "/shared/sub" should not exist
+    And as "user0" the folder "/sub" should exist in trash
+    And as "user0" the file "/sub/shared_file.txt" should exist in trash

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -1,112 +1,113 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And user "user0" has been created
 
-	@smokeTest
-	Scenario: Downloading from upload-only share is forbidden
-		Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
-		When user "user0" creates a public link share using the sharing API with settings
-			| path        | FOLDER |
-			| permissions | 4      |
-		Then the public shared file "test.txt" should not be able to be downloaded
-		And the HTTP status code should be "404"
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And user "user0" has been created
 
-	Scenario: Share a file by multiple channels and download from sub-folder and direct file share
-		Given user "user1" has been created
-		And user "user2" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And user "user0" has created a folder "/common"
-		And user "user0" has created a folder "/common/sub"
-		And user "user0" has shared folder "common" with group "grp1"
-		And user "user1" has shared file "textfile0.txt" with user "user2"
-		And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"
-		And user "user1" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
-		When user "user2" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
-		And user "user2" downloads file "/common/sub/textfile0.txt" with range "bytes=0-8" using the WebDAV API
-		Then the downloaded content should be "BLABLABLA"
-		And the downloaded content when downloading file "/textfile0 (2).txt" for user "user2" with range "bytes=0-8" should be "BLABLABLA"
-		And user "user2" should see the following elements
-			| /common/sub/textfile0.txt |
-			| /textfile0%20(2).txt      |
+  @smokeTest
+  Scenario: Downloading from upload-only share is forbidden
+    Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | FOLDER |
+      | permissions | 4      |
+    Then the public shared file "test.txt" should not be able to be downloaded
+    And the HTTP status code should be "404"
 
-	@smokeTest
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with default permissions
-		Given user "user1" has been created
-		When user "user0" creates a share using the sharing API with settings
-			| path      | PARENT     |
-			| shareType | 0          |
-			| shareWith | user1      |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+  Scenario: Share a file by multiple channels and download from sub-folder and direct file share
+    Given user "user1" has been created
+    And user "user2" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created a folder "/common"
+    And user "user0" has created a folder "/common/sub"
+    And user "user0" has shared folder "common" with group "grp1"
+    And user "user1" has shared file "textfile0.txt" with user "user2"
+    And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"
+    And user "user1" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
+    When user "user2" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
+    And user "user2" downloads file "/common/sub/textfile0.txt" with range "bytes=0-8" using the WebDAV API
+    Then the downloaded content should be "BLABLABLA"
+    And the downloaded content when downloading file "/textfile0 (2).txt" for user "user2" with range "bytes=0-8" should be "BLABLABLA"
+    And user "user2" should see the following elements
+      | /common/sub/textfile0.txt |
+      | /textfile0%20(2).txt      |
 
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		When user "user0" has shared folder "PARENT" with group "grp1"
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+  @smokeTest
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with default permissions
+    Given user "user1" has been created
+    When user "user0" creates a share using the sharing API with settings
+      | path      | PARENT |
+      | shareType | 0      |
+      | shareWith | user1  |
+    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
-	@smokeTest
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
-		When user "user0" creates a public link share using the sharing API with settings
-			| path         | PARENT   |
-			| password     | %public% |
-		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When user "user0" has shared folder "PARENT" with group "grp1"
+    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission 
-		Given user "user1" has been created
-		When user "user0" creates a share using the sharing API with settings
-			| path        | PARENT |
-			| shareType   | 0      |
-			| shareWith   | user1  |
-			| permissions | 15     |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+  @smokeTest
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
+    When user "user0" creates a public link share using the sharing API with settings
+      | path     | PARENT   |
+      | password | %public% |
+    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission 
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		When user "user0" creates a share using the sharing API with settings
-			| path        | PARENT      |
-			| shareType   | 1           |
-			| shareWith   | grp1        |
-			| permissions | 15          |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission
+    Given user "user1" has been created
+    When user "user0" creates a share using the sharing API with settings
+      | path        | PARENT |
+      | shareType   | 0      |
+      | shareWith   | user1  |
+      | permissions | 15     |
+    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission 
-		When user "user0" creates a public link share using the sharing API with settings
-			| path         | PARENT   |
-			| password     | %public% |
-			| permissions  | 15       |
-		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When user "user0" creates a share using the sharing API with settings
+      | path        | PARENT |
+      | shareType   | 1      |
+      | shareWith   | grp1   |
+      | permissions | 15     |
+    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission 
-		Given user "user1" has been created
-		When user "user0" creates a share using the sharing API with settings
-			| path        | PARENT |
-			| shareType   | 0      |
-			| shareWith   | user1  |
-			| permissions | 1      |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | PARENT   |
+      | password    | %public% |
+      | permissions | 15       |
+    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission 
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		When user "user0" creates a share using the sharing API with settings
-			| path        | PARENT      |
-			| shareType   | 1           |
-			| shareWith   | grp1        |
-			| permissions | 1           |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission
+    Given user "user1" has been created
+    When user "user0" creates a share using the sharing API with settings
+      | path        | PARENT |
+      | shareType   | 0      |
+      | shareWith   | user1  |
+      | permissions | 1      |
+    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
-	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission 
-		When user "user0" creates a public link share using the sharing API with settings
-			| path         | PARENT   |
-			| password     | %public% |
-			| permissions  | 1        |
-		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When user "user0" creates a share using the sharing API with settings
+      | path        | PARENT |
+      | shareType   | 1      |
+      | shareWith   | grp1   |
+      | permissions | 1      |
+    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+
+  Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | PARENT   |
+      | password    | %public% |
+      | permissions | 1        |
+    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -1,191 +1,192 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
 
-	@smokeTest
-	Scenario: Correct webdav share-permissions for owned file
-		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		When user "user0" gets the following properties of file "/tmp.txt" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And user "user0" has been created
+    And user "user1" has been created
 
-	Scenario: Correct webdav share-permissions for received file with edit and reshare permissions
-		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		And user "user0" has shared file "/tmp.txt" with user "user1"
-		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+  @smokeTest
+  Scenario: Correct webdav share-permissions for owned file
+    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+    When user "user0" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
-	Scenario: Correct webdav share-permissions for received group shared file with edit and reshare permissions
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		And user "user0" has created a share with settings
-			| path        | /tmp.txt   |
-			| shareType   | 1          |
-			| permissions | 19         |
-			| shareWith   | grp1       |
-		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+  Scenario: Correct webdav share-permissions for received file with edit and reshare permissions
+    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+    And user "user0" has shared file "/tmp.txt" with user "user1"
+    When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
-	Scenario: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
-		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		And user "user0" has shared file "tmp.txt" with user "user1"
-		When user "user0" updates the last share using the sharing API with
-			| permissions | 3 |
-		And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
+  Scenario: Correct webdav share-permissions for received group shared file with edit and reshare permissions
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has uploaded file with content "foo" to "/tmp.txt"
+    And user "user0" has created a share with settings
+      | path        | /tmp.txt |
+      | shareType   | 1        |
+      | permissions | 19       |
+      | shareWith   | grp1     |
+    When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
-	Scenario: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		And user "user0" has created a share with settings
-			| path        | /tmp.txt   |
-			| shareType   | 1          |
-			| permissions | 3          |
-			| shareWith   | grp1       |
-		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
+  Scenario: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
+    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+    And user "user0" has shared file "tmp.txt" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | 3 |
+    And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
 
-	Scenario: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
-		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		And user "user0" has shared file "tmp.txt" with user "user1"
-		When user "user0" updates the last share using the sharing API with
-			| permissions | 17 |
-		And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
+  Scenario: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has uploaded file with content "foo" to "/tmp.txt"
+    And user "user0" has created a share with settings
+      | path        | /tmp.txt |
+      | shareType   | 1        |
+      | permissions | 3        |
+      | shareWith   | grp1     |
+    When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
 
-	Scenario: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		And user "user0" has created a share with settings
-			| path        | /tmp.txt   |
-			| shareType   | 1          |
-			| permissions | 17         |
-			| shareWith   | grp1       |
-		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
+  Scenario: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
+    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+    And user "user0" has shared file "tmp.txt" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | 17 |
+    And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
 
-	Scenario: Correct webdav share-permissions for owned folder
-		Given user "user0" has created a folder "/tmp"
-		When user "user0" gets the following properties of folder "/" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+  Scenario: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has uploaded file with content "foo" to "/tmp.txt"
+    And user "user0" has created a share with settings
+      | path        | /tmp.txt |
+      | shareType   | 1        |
+      | permissions | 17       |
+      | shareWith   | grp1     |
+    When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
 
-	Scenario: Correct webdav share-permissions for received folder with all permissions
-		Given user "user0" has created a folder "/tmp"
-		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+  Scenario: Correct webdav share-permissions for owned folder
+    Given user "user0" has created a folder "/tmp"
+    When user "user0" gets the following properties of folder "/" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
-	Scenario: Correct webdav share-permissions for received group shared folder with all permissions
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a folder "/tmp"
-		And user "user0" has created a share with settings
-			| path        | tmp        |
-			| shareType   | 1          |
-			| shareWith   | grp1       |
-		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+  Scenario: Correct webdav share-permissions for received folder with all permissions
+    Given user "user0" has created a folder "/tmp"
+    And user "user0" has shared file "/tmp" with user "user1"
+    When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
-	Scenario: Correct webdav share-permissions for received folder with all permissions but edit
-		Given user "user0" has created a folder "/tmp"
-		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the sharing API with
-			| permissions | 29 |
-		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
+  Scenario: Correct webdav share-permissions for received group shared folder with all permissions
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a folder "/tmp"
+    And user "user0" has created a share with settings
+      | path      | tmp  |
+      | shareType | 1    |
+      | shareWith | grp1 |
+    When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
-	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but edit
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a folder "/tmp"
-		And user "user0" has created a share with settings
-			| path        | tmp        |
-			| shareType   | 1          |
-			| shareWith   | grp1       |
-			| permissions | 29         |
-		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
+  Scenario: Correct webdav share-permissions for received folder with all permissions but edit
+    Given user "user0" has created a folder "/tmp"
+    And user "user0" has shared file "/tmp" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | 29 |
+    And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
 
-	Scenario: Correct webdav share-permissions for received folder with all permissions but create
-		Given user "user0" has created a folder "/tmp"
-		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the sharing API with
-			| permissions | 27 |
-		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
+  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but edit
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a folder "/tmp"
+    And user "user0" has created a share with settings
+      | path        | tmp  |
+      | shareType   | 1    |
+      | shareWith   | grp1 |
+      | permissions | 29   |
+    When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
 
-	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but create
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a folder "/tmp"
-		And user "user0" has created a share with settings
-			| path        | tmp        |
-			| shareType   | 1          |
-			| shareWith   | grp1       |
-			| permissions | 27         |
-		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
+  Scenario: Correct webdav share-permissions for received folder with all permissions but create
+    Given user "user0" has created a folder "/tmp"
+    And user "user0" has shared file "/tmp" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | 27 |
+    And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
 
-	Scenario: Correct webdav share-permissions for received folder with all permissions but delete
-		Given user "user0" has created a folder "/tmp"
-		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the sharing API with
-			| permissions | 23 |
-		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
+  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but create
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a folder "/tmp"
+    And user "user0" has created a share with settings
+      | path        | tmp  |
+      | shareType   | 1    |
+      | shareWith   | grp1 |
+      | permissions | 27   |
+    When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
 
-	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but delete
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a folder "/tmp"
-		And user "user0" has created a share with settings
-			| path        | tmp        |
-			| shareType   | 1          |
-			| shareWith   | grp1       |
-			| permissions | 23         |
-		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
+  Scenario: Correct webdav share-permissions for received folder with all permissions but delete
+    Given user "user0" has created a folder "/tmp"
+    And user "user0" has shared file "/tmp" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | 23 |
+    And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
 
-	Scenario: Correct webdav share-permissions for received folder with all permissions but share
-		Given user "user0" has created a folder "/tmp"
-		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the sharing API with
-			| permissions | 15 |
-		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but delete
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a folder "/tmp"
+    And user "user0" has created a share with settings
+      | path        | tmp  |
+      | shareType   | 1    |
+      | shareWith   | grp1 |
+      | permissions | 23   |
+    When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
 
-	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but share
-		Given group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a folder "/tmp"
-		And user "user0" has created a share with settings
-			| path        | tmp        |
-			| shareType   | 1          |
-			| shareWith   | grp1       |
-			| permissions | 15         |
-		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-			|{http://open-collaboration-services.org/ns}share-permissions |
-		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+  Scenario: Correct webdav share-permissions for received folder with all permissions but share
+    Given user "user0" has created a folder "/tmp"
+    And user "user0" has shared file "/tmp" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | 15 |
+    And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+
+  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but share
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a folder "/tmp"
+    And user "user0" has created a share with settings
+      | path        | tmp  |
+      | shareType   | 1    |
+      | shareWith   | grp1 |
+      | permissions | 15   |
+    When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | {http://open-collaboration-services.org/ns}share-permissions |
+    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -1,167 +1,168 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using old DAV path
-		And these users have been created:
-			|username|displayname|
-			|user0   |User Zero  |
-			|user1   |User One   |
 
-	@smokeTest
-	Scenario Outline: getting all shares of a user using that user
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
-		And user "user0" has shared file "file_to_share.txt" with user "user1"
-		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And file "file_to_share.txt" should be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Background:
+    Given using old DAV path
+    And these users have been created:
+      | username | displayname |
+      | user0    | User Zero   |
+      | user1    | User One    |
 
-	Scenario Outline: getting all shares of a user using another user
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And file "textfile0.txt" should not be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario Outline: getting all shares of a user using that user
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
+    And user "user0" has shared file "file_to_share.txt" with user "user1"
+    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And file "file_to_share.txt" should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: getting all shares of a file
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user3" has been created
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		And user "user0" has shared file "textfile0.txt" with user "user2"
-		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=textfile0.txt"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And user "user1" should be included in the response
-		And user "user2" should be included in the response
-		And user "user3" should not be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  Scenario Outline: getting all shares of a user using another user
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And file "textfile0.txt" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: getting all shares of a file with reshares
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user3" has been created
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		And user "user1" has shared file "textfile0 (2).txt" with user "user2"
-		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And user "user1" should be included in the response
-		And user "user2" should be included in the response
-		And user "user3" should not be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario Outline: getting all shares of a file
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user3" has been created
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And user "user0" has shared file "textfile0.txt" with user "user2"
+    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=textfile0.txt"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user1" should be included in the response
+    And user "user2" should be included in the response
+    And user "user3" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
-		Given using OCS API version "<ocs_api_version>"
-		And group "grp1" has been created
-		And user "user2" has been created
-		And user "user2" has been added to group "grp1"
-		And user "user2" has created a folder "/shared"
-		And user "user2" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user2" has shared folder "/shared" with user "user1"
-		And user "user1" has shared folder "/shared" with group "grp1"
-		When user "user2" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the last share_id should not be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario Outline: getting all shares of a file with reshares
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user3" has been created
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And user "user1" has shared file "textfile0 (2).txt" with user "user2"
+    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user1" should be included in the response
+    And user "user2" should be included in the response
+    And user "user3" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@smokeTest
-	Scenario Outline: getting share info of a share
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
-		And user "user0" has shared file "file_to_share.txt" with user "user1"
-		When user "user0" gets the info of the last share using the sharing API
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And the share fields of the last share should include
-			| id                     | A_NUMBER           |
-			| item_type              | file               |
-			| item_source            | A_NUMBER           |
-			| share_type             | 0                  |
-			| share_with             | user1              |
-			| file_source            | A_NUMBER           |
-			| file_target            | /file_to_share.txt |
-			| path                   | /file_to_share.txt |
-			| permissions            | 19                 |
-			| stime                  | A_NUMBER           |
-			| storage                | A_NUMBER           |
-			| mail_send              | 0                  |
-			| uid_owner              | user0              |
-			| file_parent            | A_NUMBER           |
-			| share_with_displayname | User One           |
-			| displayname_owner      | User Zero          |
-			| mimetype               | text/plain         |
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @smokeTest
+  Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And user "user2" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user2" has created a folder "/shared"
+    And user "user2" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user2" has shared folder "/shared" with user "user1"
+    And user "user1" has shared folder "/shared" with group "grp1"
+    When user "user2" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	Scenario Outline: Get a share with a user that didn't receive the share
-		Given using OCS API version "<ocs_api_version>"
-		And user "user2" has been created
-		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "user2" gets the info of the last share using the sharing API
-		Then the OCS status code should be "404"
-		And the HTTP status code should be "<http_status_code>"
-		Examples:
-			|ocs_api_version|http_status_code|
-			|1              |200             |
-			|2              |404             |
+  @smokeTest
+  Scenario Outline: getting share info of a share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
+    And user "user0" has shared file "file_to_share.txt" with user "user1"
+    When user "user0" gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id                     | A_NUMBER           |
+      | item_type              | file               |
+      | item_source            | A_NUMBER           |
+      | share_type             | 0                  |
+      | share_with             | user1              |
+      | file_source            | A_NUMBER           |
+      | file_target            | /file_to_share.txt |
+      | path                   | /file_to_share.txt |
+      | permissions            | 19                 |
+      | stime                  | A_NUMBER           |
+      | storage                | A_NUMBER           |
+      | mail_send              | 0                  |
+      | uid_owner              | user0              |
+      | file_parent            | A_NUMBER           |
+      | share_with_displayname | User One           |
+      | displayname_owner      | User Zero          |
+      | mimetype               | text/plain         |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-	@skipOnLDAP
-	Scenario: Share of folder to a group, remove user from that group
-		Given using OCS API version "1"
-		And user "user2" has been created
-		And group "group0" has been created
-		And user "user1" has been added to group "group0"
-		And user "user2" has been added to group "group0"
-		And user "user0" shares file "/PARENT" with group "group0" using the sharing API
-		And the administrator removes user "user2" from group "group0" using the provisioning API
-		Then user "user1" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT/parent.txt       |
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
-		And user "user2" should see the following elements
-			| /FOLDER/                 |
-			| /PARENT/                 |
-			| /PARENT/parent.txt       |
-		But user "user2" should not see the following elements
-			| /PARENT%20(2)/           |
-			| /PARENT%20(2)/parent.txt |
+  Scenario Outline: Get a share with a user that didn't receive the share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    When user "user2" gets the info of the last share using the sharing API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
-	Scenario Outline: getting all the shares inside the folder
-		Given using OCS API version "<ocs_api_version>"
-		And user "user0" has shared file "PARENT/parent.txt" with user "user1"
-		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=PARENT&subfiles=true"
-		Then the OCS status code should be "<ocs_status_code>"
-		And the HTTP status code should be "200"
-		And file "parent.txt" should be included in the response
-		Examples:
-			|ocs_api_version|ocs_status_code|
-			|1              |100            |
-			|2              |200            |
+  @skipOnLDAP
+  Scenario: Share of folder to a group, remove user from that group
+    Given using OCS API version "1"
+    And user "user2" has been created
+    And group "group0" has been created
+    And user "user1" has been added to group "group0"
+    And user "user2" has been added to group "group0"
+    And user "user0" shares file "/PARENT" with group "group0" using the sharing API
+    And the administrator removes user "user2" from group "group0" using the provisioning API
+    Then user "user1" should see the following elements
+      | /FOLDER/                 |
+      | /PARENT/                 |
+      | /PARENT/parent.txt       |
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+    And user "user2" should see the following elements
+      | /FOLDER/           |
+      | /PARENT/           |
+      | /PARENT/parent.txt |
+    But user "user2" should not see the following elements
+      | /PARENT%20(2)/           |
+      | /PARENT%20(2)/parent.txt |
+
+  Scenario Outline: getting all the shares inside the folder
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared file "PARENT/parent.txt" with user "user1"
+    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=PARENT&subfiles=true"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And file "parent.txt" should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -1,234 +1,235 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharing
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And user "user0" has been created
 
-	@smokeTest
-	Scenario: Uploading same file to a public upload-only share multiple times
-		Given as user "user0"
-		And the user has created a public link share with settings
-			| path        | FOLDER |
-			| permissions | 4      |
-		When the public uploads file "test.txt" with content "test" using the old WebDAV API
-		And the public uploads file "test.txt" with content "test2" with autorename mode using the old WebDAV API
-		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
-		And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And user "user0" has been created
 
-	Scenario: Uploading file to a public upload-only share that was deleted does not work
-		Given user "user0" has created a public link share with settings
-			| path        | FOLDER |
-			| permissions | 4      |
-		When user "user0" deletes file "/FOLDER" using the WebDAV API
-		Then publicly uploading a file should not work
-		And the HTTP status code should be "404"
+  @smokeTest
+  Scenario: Uploading same file to a public upload-only share multiple times
+    Given as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER |
+      | permissions | 4      |
+    When the public uploads file "test.txt" with content "test" using the old WebDAV API
+    And the public uploads file "test.txt" with content "test2" with autorename mode using the old WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+    And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
-	Scenario: Uploading file to a public read-only share folder does not work
-		When user "user0" creates a public link share using the sharing API with settings
-			| path        | FOLDER |
-			| permissions | 1      |
-		Then publicly uploading a file should not work
-		And the HTTP status code should be "403"
+  Scenario: Uploading file to a public upload-only share that was deleted does not work
+    Given user "user0" has created a public link share with settings
+      | path        | FOLDER |
+      | permissions | 4      |
+    When user "user0" deletes file "/FOLDER" using the WebDAV API
+    Then publicly uploading a file should not work
+    And the HTTP status code should be "404"
 
-	Scenario: Uploading file to a user read-only share folder does not work
-		Given user "user1" has been created
-		And user "user0" has created a share with settings
-			| path        | FOLDER |
-			| shareType   | 0      |
-			| permissions | 1      |
-			| shareWith   | user1  |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
-		Then the HTTP status code should be "403"
+  Scenario: Uploading file to a public read-only share folder does not work
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | FOLDER |
+      | permissions | 1      |
+    Then publicly uploading a file should not work
+    And the HTTP status code should be "403"
 
-	Scenario: Uploading file to a group read-only share folder does not work
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a share with settings
-			| path        | FOLDER     |
-			| shareType   | 1          |
-			| permissions | 1          |
-			| shareWith   | grp1       |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
-		Then the HTTP status code should be "403"
+  Scenario: Uploading file to a user read-only share folder does not work
+    Given user "user1" has been created
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 0      |
+      | permissions | 1      |
+      | shareWith   | user1  |
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
 
-	Scenario: Uploading to a public upload-only share
-		Given as user "user0"
-		And the user has created a public link share with settings
-			| path        | FOLDER |
-			| permissions | 4      |
-		When the public uploads file "test.txt" with content "test" using the old WebDAV API
-		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+  Scenario: Uploading file to a group read-only share folder does not work
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 1      |
+      | permissions | 1      |
+      | shareWith   | grp1   |
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
 
-	Scenario: Uploading to a public upload-only share with password
-		Given as user "user0"
-		And the user has created a public link share with settings
-			| path        | FOLDER   |
-			| password    | %public% |
-			| permissions | 4        |
-		When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
-		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+  Scenario: Uploading to a public upload-only share
+    Given as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER |
+      | permissions | 4      |
+    When the public uploads file "test.txt" with content "test" using the old WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
-	Scenario: Uploading file to a user upload-only share folder works
-		Given user "user1" has been created
-		And user "user0" has created a share with settings
-			| path        | FOLDER |
-			| shareType   | 0      |
-			| permissions | 4      |
-			| shareWith   | user1  |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
+  Scenario: Uploading to a public upload-only share with password
+    Given as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER   |
+      | password    | %public% |
+      | permissions | 4        |
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
-	Scenario: Uploading file to a group upload-only share folder works
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a share with settings
-			| path        | FOLDER     |
-			| shareType   | 1          |
-			| permissions | 4          |
-			| shareWith   | grp1       |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
+  Scenario: Uploading file to a user upload-only share folder works
+    Given user "user1" has been created
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 0      |
+      | permissions | 4      |
+      | shareWith   | user1  |
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
 
-	Scenario: Uploading to a public read/write share with password
-		Given as user "user0"
-		And the user has created a public link share with settings
-			| path        | FOLDER   |
-			| password    | %public% |
-			| permissions | 15       |
-		When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
-		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+  Scenario: Uploading file to a group upload-only share folder works
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 1      |
+      | permissions | 4      |
+      | shareWith   | grp1   |
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
 
-	@smokeTest
-	Scenario: Uploading file to a user read/write share folder works
-		Given user "user1" has been created
-		And user "user0" has created a share with settings
-			| path        | FOLDER |
-			| shareType   | 0      |
-			| permissions | 15     |
-			| shareWith   | user1  |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
+  Scenario: Uploading to a public read/write share with password
+    Given as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER   |
+      | password    | %public% |
+      | permissions | 15       |
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
-	Scenario: Uploading file to a group read/write share folder works
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a share with settings
-			| path        | FOLDER     |
-			| shareType   | 1          |
-			| permissions | 15         |
-			| shareWith   | grp1       |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
-		Then the HTTP status code should be "201"
+  @smokeTest
+  Scenario: Uploading file to a user read/write share folder works
+    Given user "user1" has been created
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 0      |
+      | permissions | 15     |
+      | shareWith   | user1  |
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
 
-	@smokeTest
-	Scenario: Check quota of owners parent directory of a shared file
-		Given user "user1" has been created
-		And the quota of user "user1" has been set to "0"
-		And user "user0" has moved file "/welcome.txt" to "/myfile.txt"
-		And user "user0" has shared file "myfile.txt" with user "user1"
-		When user "user1" uploads file "data/textfile.txt" to "/myfile.txt" using the WebDAV API
-		Then the HTTP status code should be "204"
+  Scenario: Uploading file to a group read/write share folder works
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 1      |
+      | permissions | 15     |
+      | shareWith   | grp1   |
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
 
-	@smokeTest
-	Scenario: Uploading to a public read/write share with password
-		Given as user "user0"
-		And the user has created a public link share with settings
-			| path        | FOLDER   |
-			| password    | %public% |
-			| permissions | 15       |
-		When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
-		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+  @smokeTest
+  Scenario: Check quota of owners parent directory of a shared file
+    Given user "user1" has been created
+    And the quota of user "user1" has been set to "0"
+    And user "user0" has moved file "/welcome.txt" to "/myfile.txt"
+    And user "user0" has shared file "myfile.txt" with user "user1"
+    When user "user1" uploads file "data/textfile.txt" to "/myfile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
 
-	Scenario: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
-		Given user "user1" has been created
-		And user "user0" has created a share with settings
-			| path        | FOLDER     |
-			| shareType   | 0          |
-			| permissions | 15         |
-			| shareWith   | user1      |
-		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
-		Then the HTTP status code should be "507"
+  @smokeTest
+  Scenario: Uploading to a public read/write share with password
+    Given as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER   |
+      | password    | %public% |
+      | permissions | 15       |
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
-	Scenario: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a share with settings
-			| path        | FOLDER       |
-			| shareType   | 1            |
-			| permissions | 15           |
-			| shareWith   | grp1         |
-		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
-		Then the HTTP status code should be "507"
+  Scenario: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
+    Given user "user1" has been created
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 0      |
+      | permissions | 15     |
+      | shareWith   | user1  |
+    And the quota of user "user0" has been set to "0"
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    Then the HTTP status code should be "507"
 
-	Scenario: Uploading file to a public shared folder with read/write permission when the sharer has unsufficient quota does not work
-		When user "user0" creates a public link share using the sharing API with settings
-			| path        | FOLDER |
-			| permissions | 15     |
-		When the quota of user "user0" has been set to "0"
-		Then publicly uploading a file should not work
-		And the HTTP status code should be "507"
+  Scenario: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 1      |
+      | permissions | 15     |
+      | shareWith   | grp1   |
+    And the quota of user "user0" has been set to "0"
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    Then the HTTP status code should be "507"
 
-	Scenario: Uploading to a user shared folder with upload-only permission when the sharer has unsufficient quota does not work
-		Given user "user1" has been created
-		And user "user0" has created a share with settings
-			| path        | FOLDER     |
-			| shareType   | 0          |
-			| permissions | 4          |
-			| shareWith   | user1      |
-		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
-		Then the HTTP status code should be "507"
+  Scenario: Uploading file to a public shared folder with read/write permission when the sharer has unsufficient quota does not work
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | FOLDER |
+      | permissions | 15     |
+    When the quota of user "user0" has been set to "0"
+    Then publicly uploading a file should not work
+    And the HTTP status code should be "507"
 
-	Scenario: Uploading to a group shared folder with upload-only permission when the sharer has unsufficient quota does not work
-		Given user "user1" has been created
-		And group "grp1" has been created
-		And user "user1" has been added to group "grp1"
-		And user "user0" has created a share with settings
-			| path        | FOLDER      |
-			| shareType   | 1           |
-			| permissions | 4           |
-			| shareWith   | grp1        |
-		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
-		Then the HTTP status code should be "507"
+  Scenario: Uploading to a user shared folder with upload-only permission when the sharer has unsufficient quota does not work
+    Given user "user1" has been created
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 0      |
+      | permissions | 4      |
+      | shareWith   | user1  |
+    And the quota of user "user0" has been set to "0"
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    Then the HTTP status code should be "507"
 
-	Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has unsufficient quota does not work
-		When user "user0" creates a public link share using the sharing API with settings
-			| path        | FOLDER |
-			| permissions | 4      |
-		When the quota of user "user0" has been set to "0"
-		Then publicly uploading a file should not work
-		And the HTTP status code should be "507"
+  Scenario: Uploading to a group shared folder with upload-only permission when the sharer has unsufficient quota does not work
+    Given user "user1" has been created
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has created a share with settings
+      | path        | FOLDER |
+      | shareType   | 1      |
+      | permissions | 4      |
+      | shareWith   | grp1   |
+    And the quota of user "user0" has been set to "0"
+    When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    Then the HTTP status code should be "507"
 
-	Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
-		Given user "user0" has created a public link share with settings
-			| path        | FOLDER |
-			| permissions | 4      |
-		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
-		Then publicly uploading a file should not work
-		And the HTTP status code should be "403"
+  Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has unsufficient quota does not work
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | FOLDER |
+      | permissions | 4      |
+    When the quota of user "user0" has been set to "0"
+    Then publicly uploading a file should not work
+    And the HTTP status code should be "507"
 
-	Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
-		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		And user "user0" has created a public link share with settings
-			| path        | FOLDER |
-			| permissions | 31     |
-		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
-		Then publicly uploading a file should not work
-		And the HTTP status code should be "403"
+  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
+    Given user "user0" has created a public link share with settings
+      | path        | FOLDER |
+      | permissions | 4      |
+    When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
+    Then publicly uploading a file should not work
+    And the HTTP status code should be "403"
 
-	Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
-		Given user "user0" has created a public link share with settings
-			| path        | FOLDER |
-			| permissions | 4      |
-		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
-		When the public uploads file "test.txt" with content "test" using the old WebDAV API
-		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
+    Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And user "user0" has created a public link share with settings
+      | path        | FOLDER |
+      | permissions | 31     |
+    When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
+    Then publicly uploading a file should not work
+    And the HTTP status code should be "403"
+
+  Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
+    Given user "user0" has created a public link share with settings
+      | path        | FOLDER |
+      | permissions | 4      |
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
+    When the public uploads file "test.txt" with content "test" using the old WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -1,361 +1,362 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharees
-	Background:
-		Given using OCS API version "1"
-		And these users have been created: 
-			|username|displayname|
-			|user1   |User One   |
-			|sharee1 |Sharee One |
-		And group "ShareeGroup" has been created
-		And group "ShareeGroup2" has been created
-		And user "user1" has been added to group "ShareeGroup2"
 
-	@smokeTest
-	Scenario: Search without exact match
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be
-			| ShareeGroup  | 1 | ShareeGroup  |
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Background:
+    Given using OCS API version "1"
+    And these users have been created:
+      | username | displayname |
+      | user1    | User One    |
+      | sharee1  | Sharee One  |
+    And group "ShareeGroup" has been created
+    And group "ShareeGroup2" has been created
+    And user "user1" has been added to group "ShareeGroup2"
 
-	Scenario: Search without exact match not-exact casing
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | sHaRee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be
-			| ShareeGroup  | 1 | ShareeGroup  |
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  @smokeTest
+  Scenario: Search without exact match
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup  | 1 | ShareeGroup  |
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search only with group members - denied
-		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be
-			| ShareeGroup  | 1 | ShareeGroup  |
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search without exact match not-exact casing
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sHaRee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup  | 1 | ShareeGroup  |
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	@skipOnLDAP
-	Scenario: Search only with group members - allowed
-		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		And user "Sharee1" has been added to group "ShareeGroup2"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be
-			| ShareeGroup  | 1 | ShareeGroup  |
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search only with group members - denied
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup  | 1 | ShareeGroup  |
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search only with group members - no group as non-member
-		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "Sharee1" gets the sharees using the sharing API with parameters
-			| search   | sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  @skipOnLDAP
+  Scenario: Search only with group members - allowed
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    And user "Sharee1" has been added to group "ShareeGroup2"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup  | 1 | ShareeGroup  |
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search only with membership groups - denied
-		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "Sharee1" gets the sharees using the sharing API with parameters
-			| search   | ShareeGroup |
-			| itemType | file        |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search only with group members - no group as non-member
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "Sharee1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search only with membership groups - denied but users match
-		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "Sharee1" gets the sharees using the sharing API with parameters
-			| search   | sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search only with membership groups - denied
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "Sharee1" gets the sharees using the sharing API with parameters
+      | search   | ShareeGroup |
+      | itemType | file        |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search only with membership groups - allowed
-		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | ShareeGroup |
-			| itemType | file        |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search only with membership groups - denied but users match
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "Sharee1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search only with membership groups - allowed including users
-		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | Sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search only with membership groups - allowed
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | ShareeGroup |
+      | itemType | file        |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search without exact match no iteration allowed
-		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | Sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search only with membership groups - allowed including users
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | Sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search with exact match no iteration allowed
-		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | Sharee1 |
-			| itemType | file    |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search without exact match no iteration allowed
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | Sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search with exact match group no iteration allowed
-		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | ShareeGroup |
-			| itemType | file        |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be
-			| ShareeGroup | 1 | ShareeGroup |
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search with exact match no iteration allowed
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | Sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search with exact match
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | Sharee1 |
-			| itemType | file    |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search with exact match group no iteration allowed
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | ShareeGroup |
+      | itemType | file        |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be
+      | ShareeGroup | 1 | ShareeGroup |
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search with exact match not-exact casing
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | sharee1 |
-			| itemType | file    |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search with exact match
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | Sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search with exact match not-exact casing group
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | shareegroup2 |
-			| itemType | file         |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search with exact match not-exact casing
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Search with "self"
-		When user "Sharee1" gets the sharees using the sharing API with parameters
-			| search   | Sharee1 |
-			| itemType | file    |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Search with exact match not-exact casing group
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | shareegroup2 |
+      | itemType | file         |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Remote sharee for files
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | test@localhost |
-			| itemType | file           |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be
-			| test@localhost | 6 | test@localhost |
-		And the "remotes" sharees returned should be empty
+  Scenario: Search with "self"
+    When user "Sharee1" gets the sharees using the sharing API with parameters
+      | search   | Sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Remote sharee for calendars not allowed
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | test@localhost |
-			| itemType | calendar       |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Remote sharee for files
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | test@localhost |
+      | itemType | file           |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be
+      | test@localhost | 6 | test@localhost |
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Group sharees not returned when group sharing is disabled
-		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | sharee |
-			| itemType | file   |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Remote sharee for calendars not allowed
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | test@localhost |
+      | itemType | calendar       |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	@skipOnLDAP
-	Scenario: Enumerate only group members - only show partial results from member groups
-		Given user "Another" has been created
-		And user "Another" has been added to group "ShareeGroup2"
-		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | anot  |
-			| itemType | file |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be
-			| Another | 0 | Another |
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Group sharees not returned when group sharing is disabled
+    Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Enumerate only group members - accept exact match from non-member groups
-		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | Sharee1 |
-			| itemType | file    |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be
-			| Sharee One | 0 | sharee1 |
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  @skipOnLDAP
+  Scenario: Enumerate only group members - only show partial results from member groups
+    Given user "Another" has been created
+    And user "Another" has been added to group "ShareeGroup2"
+    And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | anot |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Another | 0 | Another |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	Scenario: Enumerate only group members - only show partial results from member groups
-		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | ShareeG |
-			| itemType | file    |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be empty
-		And the "groups" sharees returned should be
-			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Enumerate only group members - accept exact match from non-member groups
+    Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | Sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
-	@skipOnLDAP
-	Scenario: Enumerate only group members - only accept exact group match from non-memberships
-		Given group "ShareeGroupNonMember" has been created
-		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "user1" gets the sharees using the sharing API with parameters
-			| search   | ShareeGroupNonMember |
-			| itemType | file                 |
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And the "exact users" sharees returned should be empty
-		And the "users" sharees returned should be empty
-		And the "exact groups" sharees returned should be
-			| ShareeGroupNonMember | 1 | ShareeGroupNonMember |
-		And the "groups" sharees returned should be empty
-		And the "exact remotes" sharees returned should be empty
-		And the "remotes" sharees returned should be empty
+  Scenario: Enumerate only group members - only show partial results from member groups
+    Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | ShareeG |
+      | itemType | file    |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+
+  @skipOnLDAP
+  Scenario: Enumerate only group members - only accept exact group match from non-memberships
+    Given group "ShareeGroupNonMember" has been created
+    And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | ShareeGroupNonMember |
+      | itemType | file                 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be
+      | ShareeGroupNonMember | 1 | ShareeGroupNonMember |
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty

--- a/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
+++ b/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
@@ -1,11 +1,12 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: sharees_provisioningapiv2
+
   Background:
     Given using OCS API version "2"
-    And these users have been created: 
-      |username|displayname|
-      |user1   |User One   |
-      |sharee1 |Sharee One |
+    And these users have been created:
+      | username | displayname |
+      | user1    | User One    |
+      | sharee1  | Sharee One  |
     And group "ShareeGroup" has been created
     And group "ShareeGroup2" has been created
     And user "user1" has been added to group "ShareeGroup2"

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -1,146 +1,146 @@
 @api @app-required @notifications-app-required @TestAlsoOnExternalUserBackend
 Feature: Display notifications when receiving a share
-	As a user
-	I want to see notifications about shares that have been offered to me
-	So that I can easily decide what I want to do with new received shares
+  As a user
+  I want to see notifications about shares that have been offered to me
+  So that I can easily decide what I want to do with new received shares
 
-	Background:
-		Given the app "notifications" has been enabled
-		And using OCS API version "1"
-		And using new DAV path
-		And these users have been created: 
-			|username|displayname|
-			|user0   |User Zero  |
-			|user1   |User One   |
-			|user2   |User Two   |
-		And these groups have been created:
-			|groupname|
-			|grp1     |
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
+  Background:
+    Given the app "notifications" has been enabled
+    And using OCS API version "1"
+    And using new DAV path
+    And these users have been created:
+      | username | displayname |
+      | user0    | User Zero   |
+      | user1    | User One    |
+      | user2    | User Two    |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
 
-	@smokeTest
-	Scenario: share to user sends notification
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
-		Then user "user1" should have 2 notifications
-		And the last notification of user "user1" should match these regular expressions
-			| app         | /^files_sharing$/                            |
-			| subject     | /^"User Zero" shared "PARENT" with you$/     |
-			| message     | /^"User Zero" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
-			| object_type | /^local_share$/                              |
+  @smokeTest
+  Scenario: share to user sends notification
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+    And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
+    Then user "user1" should have 2 notifications
+    And the last notification of user "user1" should match these regular expressions
+      | app         | /^files_sharing$/                            |
+      | subject     | /^"User Zero" shared "PARENT" with you$/     |
+      | message     | /^"User Zero" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+      | object_type | /^local_share$/                              |
 
-	Scenario: share to group sends notification to every member
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
-		Then user "user1" should have 2 notifications
-		And the last notification of user "user1" should match these regular expressions
-			| app         | /^files_sharing$/                            |
-			| subject     | /^"User Zero" shared "PARENT" with you$/     |
-			| message     | /^"User Zero" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
-			| object_type | /^local_share$/                              |
-		And user "user2" should have 2 notifications
-		And the last notification of user "user2" should match these regular expressions
-			| app         | /^files_sharing$/                            |
-			| subject     | /^"User Zero" shared "PARENT" with you$/     |
-			| message     | /^"User Zero" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
-			| object_type | /^local_share$/                              |
+  Scenario: share to group sends notification to every member
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
+    Then user "user1" should have 2 notifications
+    And the last notification of user "user1" should match these regular expressions
+      | app         | /^files_sharing$/                            |
+      | subject     | /^"User Zero" shared "PARENT" with you$/     |
+      | message     | /^"User Zero" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+      | object_type | /^local_share$/                              |
+    And user "user2" should have 2 notifications
+    And the last notification of user "user2" should match these regular expressions
+      | app         | /^files_sharing$/                            |
+      | subject     | /^"User Zero" shared "PARENT" with you$/     |
+      | message     | /^"User Zero" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+      | object_type | /^local_share$/                              |
 
 	# This scenario documents behavior discussed in core issue 31870
 	# An old share keeps its old auto-accept behavior, even after auto-accept has been disabled.
-	@skipOnLDAP
-	Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
-		Given user "user0" has shared folder "/PARENT" with group "grp1"
-		When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
-		And the administrator creates the user "user3" using the provisioning API
-		And the administrator adds user "user3" to group "grp1" using the provisioning API
-		Then user "user1" should have 0 notifications
-		And user "user2" should have 0 notifications
-		And user "user3" should have 0 notifications
+  @skipOnLDAP
+  Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
+    Given user "user0" has shared folder "/PARENT" with group "grp1"
+    When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
+    And the administrator creates the user "user3" using the provisioning API
+    And the administrator adds user "user3" to group "grp1" using the provisioning API
+    Then user "user1" should have 0 notifications
+    And user "user2" should have 0 notifications
+    And user "user3" should have 0 notifications
 
 	# This scenario documents behavior discussed in core issue 31870
 	# As users are added to an existing group, they are not sent notifications about group shares.
-	@skipOnLDAP
-	Scenario: share to group sends notifications to existing members, but not to new members, for a share created after auto-accept is disabled
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		And the administrator creates the user "user3" using the provisioning API
-		And the administrator adds user "user3" to group "grp1" using the provisioning API
-		Then user "user1" should have 1 notification
-		And the last notification of user "user1" should match these regular expressions
-			| app         | /^files_sharing$/                       |
-			| subject     | /^"User Zero" shared "PARENT" with you$/ |
-			| message     | /^"User Zero" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
-			| object_type | /^local_share$/                         |
-		And user "user2" should have 1 notification
-		And the last notification of user "user2" should match these regular expressions
-			| app         | /^files_sharing$/                       |
-			| subject     | /^"User Zero" shared "PARENT" with you$/ |
-			| message     | /^"User Zero" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
-			| object_type | /^local_share$/                         |
-		And user "user3" should have 0 notifications
+  @skipOnLDAP
+  Scenario: share to group sends notifications to existing members, but not to new members, for a share created after auto-accept is disabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator creates the user "user3" using the provisioning API
+    And the administrator adds user "user3" to group "grp1" using the provisioning API
+    Then user "user1" should have 1 notification
+    And the last notification of user "user1" should match these regular expressions
+      | app         | /^files_sharing$/                            |
+      | subject     | /^"User Zero" shared "PARENT" with you$/     |
+      | message     | /^"User Zero" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+      | object_type | /^local_share$/                              |
+    And user "user2" should have 1 notification
+    And the last notification of user "user2" should match these regular expressions
+      | app         | /^files_sharing$/                            |
+      | subject     | /^"User Zero" shared "PARENT" with you$/     |
+      | message     | /^"User Zero" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+      | object_type | /^local_share$/                              |
+    And user "user3" should have 0 notifications
 
 	# This scenario documents behavior discussed in core issue 31870
 	# Similar to the previous scenario, a new user added to the group does not get a notification,
 	# even though the group, when originally created, had notifications on.
-	@skipOnLDAP
-	Scenario: share to group sends notifications to existing members, but not to new members, for an old share created before auto-accept is enabled
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		And user "user0" has shared folder "/PARENT" with group "grp1"
-		When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "yes"
-		And the administrator creates the user "user3" using the provisioning API
-		And the administrator adds user "user3" to group "grp1" using the provisioning API
-		Then user "user1" should have 1 notification
-		And the last notification of user "user1" should match these regular expressions
-			| app         | /^files_sharing$/                       |
-			| subject     | /^"User Zero" shared "PARENT" with you$/ |
-			| message     | /^"User Zero" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
-			| object_type | /^local_share$/                         |
-		And user "user2" should have 1 notification
-		And the last notification of user "user2" should match these regular expressions
-			| app         | /^files_sharing$/                       |
-			| subject     | /^"User Zero" shared "PARENT" with you$/ |
-			| message     | /^"User Zero" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
-			| object_type | /^local_share$/                         |
-		And user "user3" should have 0 notifications
+  @skipOnLDAP
+  Scenario: share to group sends notifications to existing members, but not to new members, for an old share created before auto-accept is enabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user0" has shared folder "/PARENT" with group "grp1"
+    When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "yes"
+    And the administrator creates the user "user3" using the provisioning API
+    And the administrator adds user "user3" to group "grp1" using the provisioning API
+    Then user "user1" should have 1 notification
+    And the last notification of user "user1" should match these regular expressions
+      | app         | /^files_sharing$/                            |
+      | subject     | /^"User Zero" shared "PARENT" with you$/     |
+      | message     | /^"User Zero" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+      | object_type | /^local_share$/                              |
+    And user "user2" should have 1 notification
+    And the last notification of user "user2" should match these regular expressions
+      | app         | /^files_sharing$/                            |
+      | subject     | /^"User Zero" shared "PARENT" with you$/     |
+      | message     | /^"User Zero" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+      | object_type | /^local_share$/                              |
+    And user "user3" should have 0 notifications
 
-	@skipOnLDAP
-	Scenario: share to group does not send notifications to existing and new members for a share created after auto-accept is enabled
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		And the administrator creates the user "user3" using the provisioning API
-		And the administrator adds user "user3" to group "grp1" using the provisioning API
-		Then user "user1" should have 0 notifications
-		And user "user2" should have 0 notifications
-		And user "user3" should have 0 notifications
+  @skipOnLDAP
+  Scenario: share to group does not send notifications to existing and new members for a share created after auto-accept is enabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator creates the user "user3" using the provisioning API
+    And the administrator adds user "user3" to group "grp1" using the provisioning API
+    Then user "user1" should have 0 notifications
+    And user "user2" should have 0 notifications
+    And user "user3" should have 0 notifications
 
-	Scenario: when auto-accepting is enabled no notifications are sent
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
-		Then user "user1" should have 0 notifications
+  Scenario: when auto-accepting is enabled no notifications are sent
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+    And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
+    Then user "user1" should have 0 notifications
 
-	@skipOnLDAP
-	Scenario: discard notification if target user is not member of the group anymore
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		And the administrator removes user "user1" from group "grp1" using the provisioning API
-		Then user "user1" should have 0 notifications
-		Then user "user2" should have 1 notification
+  @skipOnLDAP
+  Scenario: discard notification if target user is not member of the group anymore
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator removes user "user1" from group "grp1" using the provisioning API
+    Then user "user1" should have 0 notifications
+    Then user "user2" should have 1 notification
 
-	@skipOnLDAP
-	Scenario: discard notification if group is deleted
-		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-		And the administrator deletes group "grp1" using the provisioning API
-		Then user "user1" should have 0 notifications
-		Then user "user2" should have 0 notifications
+  @skipOnLDAP
+  Scenario: discard notification if group is deleted
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator deletes group "grp1" using the provisioning API
+    Then user "user1" should have 0 notifications
+    Then user "user2" should have 0 notifications

--- a/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
@@ -1,214 +1,215 @@
 @api @TestAlsoOnExternalUserBackend @files_trashbin-app-required
 Feature: trashbin-new-endpoint
-	Background:
-		Given using OCS API version "1"
-		And using new DAV path
-		And as user "%admin%"
 
-	@smokeTest
-	Scenario: deleting a file moves it to trashbin
-		Given user "user0" has been created
-		When user "user0" deletes file "/textfile0.txt" using the WebDAV API
-		Then as "user0" the file "/textfile0.txt" should exist in trash
-		But as "user0" the file "/textfile0.txt" should not exist
+  Background:
+    Given using OCS API version "1"
+    And using new DAV path
+    And as user "%admin%"
 
-	Scenario: deleting a folder moves it to trashbin
-		Given user "user0" has been created
-		And user "user0" has created a folder "/tmp"
-		When user "user0" deletes folder "/tmp" using the WebDAV API
-		Then as "user0" the folder "/tmp" should exist in trash
+  @smokeTest
+  Scenario: deleting a file moves it to trashbin
+    Given user "user0" has been created
+    When user "user0" deletes file "/textfile0.txt" using the WebDAV API
+    Then as "user0" the file "/textfile0.txt" should exist in trash
+    But as "user0" the file "/textfile0.txt" should not exist
 
-	Scenario: deleting a file in a folder moves it to the trashbin root
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
-		And as "user0" the file "/new-file.txt" should exist in trash
-		But as "user0" the file "/new-folder/new-file.txt" should not exist
+  Scenario: deleting a folder moves it to trashbin
+    Given user "user0" has been created
+    And user "user0" has created a folder "/tmp"
+    When user "user0" deletes folder "/tmp" using the WebDAV API
+    Then as "user0" the folder "/tmp" should exist in trash
 
-	Scenario: deleting a file in a shared folder moves it to the trashbin root
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
-		Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
-		And as "user0" the file "/shared_file.txt" should exist in trash
-		But as "user0" the file "/shared/shared_file.txt" should not exist
+  Scenario: deleting a file in a folder moves it to the trashbin root
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
+    And as "user0" the file "/new-file.txt" should exist in trash
+    But as "user0" the file "/new-folder/new-file.txt" should not exist
 
-	Scenario: deleting a shared folder moves it to trashbin
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes folder "/shared" using the WebDAV API
-		Then as "user0" the folder with original path "/shared" should exist in trash
+  Scenario: deleting a file in a shared folder moves it to the trashbin root
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
+    And as "user0" the file "/shared_file.txt" should exist in trash
+    But as "user0" the file "/shared/shared_file.txt" should not exist
 
-	Scenario: deleting a received folder doesn't move it to trashbin
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved folder "/shared" to "/renamed_shared"
-		When user "user1" deletes folder "/renamed_shared" using the WebDAV API
-		Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
+  Scenario: deleting a shared folder moves it to trashbin
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user0" deletes folder "/shared" using the WebDAV API
+    Then as "user0" the folder with original path "/shared" should exist in trash
 
-	Scenario: deleting a file in a received folder moves it to trashbin
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved file "/shared" to "/renamed_shared"
-		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
+  Scenario: deleting a received folder doesn't move it to trashbin
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved folder "/shared" to "/renamed_shared"
+    When user "user1" deletes folder "/renamed_shared" using the WebDAV API
+    Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
 
-	Scenario: deleting a file in a received folder when restored it comes back to the original path
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved file "/shared" to "/renamed_shared"
-		And user "user1" has deleted file "/renamed_shared/shared_file.txt"
-		And user "user1" has logged in to a web-style session
-		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
-		And user "user1" should see the following elements
-			| /renamed_shared/                |
-			| /renamed_shared/shared_file.txt |
+  Scenario: deleting a file in a received folder moves it to trashbin
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved file "/shared" to "/renamed_shared"
+    When user "user1" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
+    Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
 
-	@smokeTest
-	Scenario: Trashbin can be emptied
-		Given user "user0" has been created
-		And a new browser session for "user0" has been started
-		And user "user0" has deleted file "/textfile0.txt"
-		And user "user0" has deleted file "/textfile1.txt"
-		And as "user0" the file "/textfile0.txt" should exist in trash
-		And as "user0" the file "/textfile1.txt" should exist in trash
-		When user "user0" empties the trashbin using the trashbin API
-		Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
-		And as "user0" the file with original path "/textfile1.txt" should not exist in trash
+  Scenario: deleting a file in a received folder when restored it comes back to the original path
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved file "/shared" to "/renamed_shared"
+    And user "user1" has deleted file "/renamed_shared/shared_file.txt"
+    And user "user1" has logged in to a web-style session
+    When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
+    Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
+    And user "user1" should see the following elements
+      | /renamed_shared/                |
+      | /renamed_shared/shared_file.txt |
 
-	@smokeTest
-	Scenario: A deleted file can be restored
-		Given user "user0" has been created
-		And user "user0" has deleted file "/textfile0.txt"
-		And as "user0" the file "/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
-		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
-		And user "user0" should see the following elements
-			| /FOLDER/           |
-			| /PARENT/           |
-			| /PARENT/parent.txt |
-			| /textfile0.txt     |
-			| /textfile1.txt     |
-			| /textfile2.txt     |
-			| /textfile3.txt     |
-			| /textfile4.txt     |
+  @smokeTest
+  Scenario: Trashbin can be emptied
+    Given user "user0" has been created
+    And a new browser session for "user0" has been started
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    And as "user0" the file "/textfile0.txt" should exist in trash
+    And as "user0" the file "/textfile1.txt" should exist in trash
+    When user "user0" empties the trashbin using the trashbin API
+    Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should not exist in trash
 
-	Scenario: A file deleted from a folder can be restored to the original folder
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-folder/new-file.txt" should exist
+  @smokeTest
+  Scenario: A deleted file can be restored
+    Given user "user0" has been created
+    And user "user0" has deleted file "/textfile0.txt"
+    And as "user0" the file "/textfile0.txt" should exist in trash
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
+    Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
+    And user "user0" should see the following elements
+      | /FOLDER/           |
+      | /PARENT/           |
+      | /PARENT/parent.txt |
+      | /textfile0.txt     |
+      | /textfile1.txt     |
+      | /textfile2.txt     |
+      | /textfile3.txt     |
+      | /textfile4.txt     |
 
-	Scenario: A file deleted from a folder is restored to root if the original folder does not exist
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-file.txt" should exist
+  Scenario: A file deleted from a folder can be restored to the original folder
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and restored
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the folder with original path "/new-folder" using the trashbin API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-folder/new-file.txt" should exist
+  Scenario: A file deleted from a folder is restored to root if the original folder does not exist
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has deleted folder "/new-folder"
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-file.txt" should exist
 
-	Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session
-		When user "user0" creates a folder "/new-folder" using the WebDAV API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-folder/new-file.txt" should exist
+  Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and restored
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has deleted folder "/new-folder"
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the folder with original path "/new-folder" using the trashbin API
+    And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	@skip @issue-23151
-	Scenario: trashbin can store two files with the same name but different origins when the files are deleted close together in time
-		Given user "user0" has been created
-		And user "user0" has created a folder "/folderA"
-		And user "user0" has created a folder "/folderB"
-		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
-		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
-		And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
-		And user "user0" deletes file "/textfile0.txt" using the WebDAV API
-		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+  Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has deleted folder "/new-folder"
+    And user "user0" has logged in to a web-style session
+    When user "user0" creates a folder "/new-folder" using the WebDAV API
+    And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	Scenario: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
-		Given user "user0" has been created
-		And user "user0" has created a folder "/folderA"
-		And user "user0" has created a folder "/folderB"
-		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
-		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
-		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the WebDAV API
-		And user "user0" waits and deletes file "/textfile0.txt" using the WebDAV API
-		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+  @skip @issue-23151
+  Scenario: trashbin can store two files with the same name but different origins when the files are deleted close together in time
+    Given user "user0" has been created
+    And user "user0" has created a folder "/folderA"
+    And user "user0" has created a folder "/folderB"
+    And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+    When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
+    And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
+    And user "user0" deletes file "/textfile0.txt" using the WebDAV API
+    Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
 
-	@local_storage
-	@skipOnEncryptionType:user-keys @encryption-issue-42
-	@skip_on_objectstore
-	Scenario: Deleting a folder in external storage moves it to the trashbin
-		Given the administrator has invoked occ command "files:scan --all"
-		And user "user0" has been created
-		And user "user0" has created a folder "/local_storage/tmp"
-		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
-		Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
+  Scenario: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
+    Given user "user0" has been created
+    And user "user0" has created a folder "/folderA"
+    And user "user0" has created a folder "/folderB"
+    And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+    When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
+    And user "user0" waits and deletes file "/folderB/textfile0.txt" using the WebDAV API
+    And user "user0" waits and deletes file "/textfile0.txt" using the WebDAV API
+    Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
 
-	@local_storage
-	@skipOnEncryptionType:user-keys @encryption-issue-42
-	@skip_on_objectstore
-	Scenario: Deleting a file in external storage moves it to the trashbin and can be restored
-		Given the administrator has invoked occ command "files:scan --all"
-		And user "user0" has been created
-		And user "user0" has created a folder "/local_storage/tmp"
-		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
-		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
-		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
-		And user "user0" should see the following elements
-			| /local_storage/                  |
-			| /local_storage/tmp/              |
-			| /local_storage/tmp/textfile0.txt |
+  @local_storage
+  @skipOnEncryptionType:user-keys @encryption-issue-42
+  @skip_on_objectstore
+  Scenario: Deleting a folder in external storage moves it to the trashbin
+    Given the administrator has invoked occ command "files:scan --all"
+    And user "user0" has been created
+    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+    When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
+    Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
+
+  @local_storage
+  @skipOnEncryptionType:user-keys @encryption-issue-42
+  @skip_on_objectstore
+  Scenario: Deleting a file in external storage moves it to the trashbin and can be restored
+    Given the administrator has invoked occ command "files:scan --all"
+    And user "user0" has been created
+    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+    And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
+    Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    And user "user0" should see the following elements
+      | /local_storage/                  |
+      | /local_storage/tmp/              |
+      | /local_storage/tmp/textfile0.txt |

--- a/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
@@ -1,230 +1,231 @@
 @api @TestAlsoOnExternalUserBackend @files_trashbin-app-required
 Feature: trashbin-new-endpoint
-	Background:
-		Given using OCS API version "1"
-		And using old DAV path
-		And as user "%admin%"
 
-	@smokeTest
-	Scenario: deleting a file moves it to trashbin
-		Given user "user0" has been created
-		When user "user0" deletes file "/textfile0.txt" using the WebDAV API
-		Then as "user0" the file "/textfile0.txt" should exist in trash
-		But as "user0" the file "/textfile0.txt" should not exist
+  Background:
+    Given using OCS API version "1"
+    And using old DAV path
+    And as user "%admin%"
 
-	Scenario: deleting a folder moves it to trashbin
-		Given user "user0" has been created
-		And user "user0" has created a folder "/tmp"
-		When user "user0" deletes folder "/tmp" using the WebDAV API
-		Then as "user0" the folder "/tmp" should exist in trash
+  @smokeTest
+  Scenario: deleting a file moves it to trashbin
+    Given user "user0" has been created
+    When user "user0" deletes file "/textfile0.txt" using the WebDAV API
+    Then as "user0" the file "/textfile0.txt" should exist in trash
+    But as "user0" the file "/textfile0.txt" should not exist
 
-	Scenario: deleting a file in a folder moves it to the trashbin root
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
-		And as "user0" the file "/new-file.txt" should exist in trash
-		But as "user0" the file "/new-folder/new-file.txt" should not exist
+  Scenario: deleting a folder moves it to trashbin
+    Given user "user0" has been created
+    And user "user0" has created a folder "/tmp"
+    When user "user0" deletes folder "/tmp" using the WebDAV API
+    Then as "user0" the folder "/tmp" should exist in trash
 
-	Scenario: deleting a file in a shared folder moves it to the trashbin root
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
-		Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
-		And as "user0" the file "/shared_file.txt" should exist in trash
-		But as "user0" the file "/shared/shared_file.txt" should not exist
+  Scenario: deleting a file in a folder moves it to the trashbin root
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
+    And as "user0" the file "/new-file.txt" should exist in trash
+    But as "user0" the file "/new-folder/new-file.txt" should not exist
 
-	Scenario: deleting a shared folder moves it to trashbin
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes folder "/shared" using the WebDAV API
-		Then as "user0" the folder with original path "/shared" should exist in trash
+  Scenario: deleting a file in a shared folder moves it to the trashbin root
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
+    And as "user0" the file "/shared_file.txt" should exist in trash
+    But as "user0" the file "/shared/shared_file.txt" should not exist
 
-	Scenario: deleting a received folder doesn't move it to trashbin
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved folder "/shared" to "/renamed_shared"
-		When user "user1" deletes folder "/renamed_shared" using the WebDAV API
-		Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
+  Scenario: deleting a shared folder moves it to trashbin
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    When user "user0" deletes folder "/shared" using the WebDAV API
+    Then as "user0" the folder with original path "/shared" should exist in trash
 
-	Scenario: deleting a file in a received folder moves it to trashbin
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved file "/shared" to "/renamed_shared"
-		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
+  Scenario: deleting a received folder doesn't move it to trashbin
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved folder "/shared" to "/renamed_shared"
+    When user "user1" deletes folder "/renamed_shared" using the WebDAV API
+    Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
 
-	Scenario: deleting a file in a received folder when restored it comes back to the original path
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has moved file "/shared" to "/renamed_shared"
-		And user "user1" has deleted file "/renamed_shared/shared_file.txt"
-		And user "user1" has logged in to a web-style session
-		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
-		And user "user1" should see the following elements
-			| /renamed_shared/                |
-			| /renamed_shared/shared_file.txt |
+  Scenario: deleting a file in a received folder moves it to trashbin
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved file "/shared" to "/renamed_shared"
+    When user "user1" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
+    Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
 
-	@smokeTest
-	Scenario: Trashbin can be emptied
-		Given user "user0" has been created
-		And a new browser session for "user0" has been started
-		And user "user0" has deleted file "/textfile0.txt"
-		And user "user0" has deleted file "/textfile1.txt"
-		And as "user0" the file "/textfile0.txt" should exist in trash
-		And as "user0" the file "/textfile1.txt" should exist in trash
-		When user "user0" empties the trashbin using the trashbin API
-		Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
-		And as "user0" the file with original path "/textfile1.txt" should not exist in trash
+  Scenario: deleting a file in a received folder when restored it comes back to the original path
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/shared"
+    And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "user0" has shared folder "/shared" with user "user1"
+    And user "user1" has moved file "/shared" to "/renamed_shared"
+    And user "user1" has deleted file "/renamed_shared/shared_file.txt"
+    And user "user1" has logged in to a web-style session
+    When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
+    Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
+    And user "user1" should see the following elements
+      | /renamed_shared/                |
+      | /renamed_shared/shared_file.txt |
 
-	@smokeTest
-	Scenario: A deleted file can be restored
-		Given user "user0" has been created
-		And user "user0" has deleted file "/textfile0.txt"
-		And as "user0" the file "/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
-		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
-		And user "user0" should see the following elements
-			| /FOLDER/           |
-			| /PARENT/           |
-			| /PARENT/parent.txt |
-			| /textfile0.txt     |
-			| /textfile1.txt     |
-			| /textfile2.txt     |
-			| /textfile3.txt     |
-			| /textfile4.txt     |
+  @smokeTest
+  Scenario: Trashbin can be emptied
+    Given user "user0" has been created
+    And a new browser session for "user0" has been started
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    And as "user0" the file "/textfile0.txt" should exist in trash
+    And as "user0" the file "/textfile1.txt" should exist in trash
+    When user "user0" empties the trashbin using the trashbin API
+    Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should not exist in trash
 
-	Scenario: A file deleted from a folder can be restored to the original folder
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-folder/new-file.txt" should exist
+  @smokeTest
+  Scenario: A deleted file can be restored
+    Given user "user0" has been created
+    And user "user0" has deleted file "/textfile0.txt"
+    And as "user0" the file "/textfile0.txt" should exist in trash
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
+    Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
+    And user "user0" should see the following elements
+      | /FOLDER/           |
+      | /PARENT/           |
+      | /PARENT/parent.txt |
+      | /textfile0.txt     |
+      | /textfile1.txt     |
+      | /textfile2.txt     |
+      | /textfile3.txt     |
+      | /textfile4.txt     |
 
-	Scenario: A file deleted from a folder is restored to root if the original folder does not exist
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-file.txt" should exist
+  Scenario: A file deleted from a folder can be restored to the original folder
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and restored
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the folder with original path "/new-folder" using the trashbin API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-folder/new-file.txt" should exist
+  Scenario: A file deleted from a folder is restored to root if the original folder does not exist
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has deleted folder "/new-folder"
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-file.txt" should exist
 
-	Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
-		Given user "user0" has been created
-		And user "user0" has created a folder "/new-folder"
-		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session
-		When user "user0" creates a folder "/new-folder" using the WebDAV API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-		And as "user0" the file "/new-folder/new-file.txt" should exist
+  Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and restored
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has deleted folder "/new-folder"
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the folder with original path "/new-folder" using the trashbin API
+    And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	@skip @issue-23151
-	Scenario: trashbin can store two files with the same name but different origins when the files are deleted close together in time
-		Given user "user0" has been created
-		And user "user0" has created a folder "/folderA"
-		And user "user0" has created a folder "/folderB"
-		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
-		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
-		And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
-		And user "user0" deletes file "/textfile0.txt" using the WebDAV API
-		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+  Scenario: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
+    Given user "user0" has been created
+    And user "user0" has created a folder "/new-folder"
+    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "user0" has deleted file "/new-folder/new-file.txt"
+    And user "user0" has deleted folder "/new-folder"
+    And user "user0" has logged in to a web-style session
+    When user "user0" creates a folder "/new-folder" using the WebDAV API
+    And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	Scenario: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
-		Given user "user0" has been created
-		And user "user0" has created a folder "/folderA"
-		And user "user0" has created a folder "/folderB"
-		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
-		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
-		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the WebDAV API
-		And user "user0" waits and deletes file "/textfile0.txt" using the WebDAV API
-		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
-		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+  @skip @issue-23151
+  Scenario: trashbin can store two files with the same name but different origins when the files are deleted close together in time
+    Given user "user0" has been created
+    And user "user0" has created a folder "/folderA"
+    And user "user0" has created a folder "/folderB"
+    And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+    When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
+    And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
+    And user "user0" deletes file "/textfile0.txt" using the WebDAV API
+    Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
 
-	@local_storage
-	@skipOnEncryptionType:user-keys @encryption-issue-42
-	@skip_on_objectstore
-	Scenario: Deleting a folder into external storage moves it to the trashbin
-		Given the administrator has invoked occ command "files:scan --all"
-		And user "user0" has been created
-		And user "user0" has created a folder "/local_storage/tmp"
-		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
-		Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
+  Scenario: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
+    Given user "user0" has been created
+    And user "user0" has created a folder "/folderA"
+    And user "user0" has created a folder "/folderB"
+    And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+    When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
+    And user "user0" waits and deletes file "/folderB/textfile0.txt" using the WebDAV API
+    And user "user0" waits and deletes file "/textfile0.txt" using the WebDAV API
+    Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
 
-	@local_storage
-	@skipOnEncryptionType:user-keys @encryption-issue-42
-	@skip_on_objectstore
-	Scenario: Deleting a file into external storage moves it to the trashbin and can be restored
-		Given the administrator has invoked occ command "files:scan --all"
-		And user "user0" has been created
-		And user "user0" has created a folder "/local_storage/tmp"
-		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
-		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
-		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
-		And user "user0" should see the following elements
-			| /local_storage/                  |
-			| /local_storage/tmp/              |
-			| /local_storage/tmp/textfile0.txt |
+  @local_storage
+  @skipOnEncryptionType:user-keys @encryption-issue-42
+  @skip_on_objectstore
+  Scenario: Deleting a folder into external storage moves it to the trashbin
+    Given the administrator has invoked occ command "files:scan --all"
+    And user "user0" has been created
+    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+    When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
+    Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
 
-	@local_storage
-	@skipOnEncryptionType:user-keys @encryption-issue-42
-	@skip_on_objectstore
-	Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
-		Given the administrator has invoked occ command "files:scan --all"
-		And user "user0" has been created
-		And user "user0" has created a folder "/local_storage/tmp"
-		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
-		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session
-		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
-		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
-		And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
+  @local_storage
+  @skipOnEncryptionType:user-keys @encryption-issue-42
+  @skip_on_objectstore
+  Scenario: Deleting a file into external storage moves it to the trashbin and can be restored
+    Given the administrator has invoked occ command "files:scan --all"
+    And user "user0" has been created
+    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+    And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
+    Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    And user "user0" should see the following elements
+      | /local_storage/                  |
+      | /local_storage/tmp/              |
+      | /local_storage/tmp/textfile0.txt |
+
+  @local_storage
+  @skipOnEncryptionType:user-keys @encryption-issue-42
+  @skip_on_objectstore
+  Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
+    Given the administrator has invoked occ command "files:scan --all"
+    And user "user0" has been created
+    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+    And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
+    And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+    And user "user0" has logged in to a web-style session
+    When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
+    Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -30,7 +30,7 @@ Feature: download file
   Scenario Outline: download a public shared file with range
     Given using <dav_version> DAV path
     When user "user0" creates a public link share using the sharing API with settings
-      | path      | welcome.txt |
+      | path | welcome.txt |
     And the public downloads the last public shared file with range "bytes=51-77" using the old WebDAV API
     Then the downloaded content should be "example file for developers"
     Examples:
@@ -41,7 +41,7 @@ Feature: download file
   Scenario Outline: download a public shared file inside a folder with range
     Given using <dav_version> DAV path
     When user "user0" creates a public link share using the sharing API with settings
-      | path      | PARENT |
+      | path | PARENT |
     And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the old WebDAV API
     Then the downloaded content should be "wnCloud"
     Examples:

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -78,7 +78,7 @@ Feature: Search
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVW\|RMDNVW)$                                                                                 |
       | {DAV:}getlastmodified                      | ^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$ |
-      | {DAV:}getetag                              | ^\"[a-f0-9]{1,32}\"$                                                                                |
+      | {DAV:}getetag                              | ^\"[a-f0-9]{1,32}\"$                                                                              |
       | {DAV:}getcontenttype                       | text\/plain                                                                                       |
       | {http://owncloud.org/ns}size               | 15                                                                                                |
       | {http://owncloud.org/ns}owner-id           | user0                                                                                             |

--- a/tests/acceptance/features/apiWebdavOperations/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFile.feature
@@ -27,13 +27,13 @@ Feature: upload file
     When user "user0" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
     Then the content of file "<file_name>" for user "user0" should be "uploaded content"
     Examples:
-      | dav_version | file_name         |
-      | old         | /C++ file.cpp     |
-      | old         | /file #2.txt      |
-      | old         | /file ?2.txt      |
-      | new         | /C++ file.cpp     |
-      | new         | /file #2.txt      |
-      | new         | /file ?2.txt      |
+      | dav_version | file_name     |
+      | old         | /C++ file.cpp |
+      | old         | /file #2.txt  |
+      | old         | /file ?2.txt  |
+      | new         | /C++ file.cpp |
+      | new         | /file #2.txt  |
+      | new         | /file ?2.txt  |
 
   Scenario Outline: upload a file into a folder and check download content
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -29,13 +29,13 @@ Feature: get file properties
     When user "user0" gets the properties of file "<file_name>" using the WebDAV API
     Then the properties response should contain an etag
     Examples:
-      | dav_version | file_name         |
-      | old         | /C++ file.cpp     |
-      | old         | /file #2.txt      |
-      | old         | /file ?2.txt      |
-      | new         | /C++ file.cpp     |
-      | new         | /file #2.txt      |
-      | new         | /file ?2.txt      |
+      | dav_version | file_name     |
+      | old         | /C++ file.cpp |
+      | old         | /file #2.txt  |
+      | old         | /file ?2.txt  |
+      | new         | /C++ file.cpp |
+      | new         | /file #2.txt  |
+      | new         | /file ?2.txt  |
 
   Scenario Outline: Do a PROPFIND of various folder/file names
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -1,21 +1,21 @@
 @webUI @comments-app-required
 Feature: admin apps settings
-	As an admin
-	I want to be able to manage apps settings on the ownCloud server
-	So that I can enable or disable apps on the ownCloud server
+  As an admin
+  I want to be able to manage apps settings on the ownCloud server
+  So that I can enable or disable apps on the ownCloud server
 
-	Background:
-		Given the administrator has browsed to the admin apps settings page
+  Background:
+    Given the administrator has browsed to the admin apps settings page
 
-	@smokeTest
-	Scenario: admin disables an app
-		Given the app "comments" has been enabled
-		When the administrator disables the app "comments" using the webUI
-		Then app "comments" should be disabled
+  @smokeTest
+  Scenario: admin disables an app
+    Given the app "comments" has been enabled
+    When the administrator disables the app "comments" using the webUI
+    Then app "comments" should be disabled
 
-	@smokeTest
-	Scenario: admin enables an app
-		Given the app "comments" has been disabled
-		And the administrator has browsed to the disabled apps page
-		When the administrator enables the app "comments" using the webUI
-		Then app "comments" should be enabled
+  @smokeTest
+  Scenario: admin enables an app
+    Given the app "comments" has been disabled
+    And the administrator has browsed to the disabled apps page
+    When the administrator enables the app "comments" using the webUI
+    Then app "comments" should be enabled

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -1,194 +1,194 @@
 @webUI
 Feature: admin sharing settings
-	As an admin
-	I want to be able to manage sharing settings on the ownCloud server
-	So that I can enable, disable, allow or restrict different sharing behaviour
+  As an admin
+  I want to be able to manage sharing settings on the ownCloud server
+  So that I can enable, disable, allow or restrict different sharing behaviour
 
-	@smokeTest
-	Scenario: disable share API
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator disables the share API using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value |
-			| files_sharing | api_enabled     | EMPTY |
+  @smokeTest
+  Scenario: disable share API
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator disables the share API using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | api_enabled     | EMPTY |
 
-	Scenario: disable public sharing
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator disables share via link using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element  | value |
-			| files_sharing | public@@@enabled | EMPTY |
+  Scenario: disable public sharing
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator disables share via link using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element  | value |
+      | files_sharing | public@@@enabled | EMPTY |
 
-	Scenario: disable public upload
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator disables public uploads using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value |
-			| files_sharing | public@@@upload | EMPTY |
+  Scenario: disable public upload
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator disables public uploads using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | public@@@upload | EMPTY |
 
-	Scenario: enable mail notification on public link share
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator enables mail notification on public link share using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element    | value |
-			| files_sharing | public@@@send_mail | 1     |
+  Scenario: enable mail notification on public link share
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables mail notification on public link share using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element    | value |
+      | files_sharing | public@@@send_mail | 1     |
 
-	Scenario: disable social media share on public link share
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator disables social media share on public link share using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element       | value |
-			| files_sharing | public@@@social_share | EMPTY |
+  Scenario: disable social media share on public link share
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator disables social media share on public link share using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element       | value |
+      | files_sharing | public@@@social_share | EMPTY |
 
-	Scenario: enable enforce password protection for read-only links
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator enables enforce password protection for read-only links using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                              | value |
-			| files_sharing | public@@@password@@@enforced_for@@@read_only | 1     |
+  Scenario: enable enforce password protection for read-only links
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables enforce password protection for read-only links using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                              | value |
+      | files_sharing | public@@@password@@@enforced_for@@@read_only | 1     |
 
-	Scenario: enable enforce password protection for read and write links
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator enables enforce password protection for read and write links using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                               | value |
-			| files_sharing | public@@@password@@@enforced_for@@@read_write | 1     |
+  Scenario: enable enforce password protection for read and write links
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables enforce password protection for read and write links using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                               | value |
+      | files_sharing | public@@@password@@@enforced_for@@@read_write | 1     |
 
-	Scenario: enable enforce password protection for upload-only links
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator enables enforce password protection for upload only links using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                                | value |
-			| files_sharing | public@@@password@@@enforced_for@@@upload_only | 1     |
+  Scenario: enable enforce password protection for upload-only links
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables enforce password protection for upload only links using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                                | value |
+      | files_sharing | public@@@password@@@enforced_for@@@upload_only | 1     |
 
-	Scenario: disable resharing
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator disables resharing using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value     |
-			| files_sharing | resharing       | EMPTY     |
+  Scenario: disable resharing
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator disables resharing using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | resharing       | EMPTY |
 
-	Scenario: disable sharing with groups
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator disables sharing with groups using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value     |
-			| files_sharing | group_sharing   | EMPTY     |
+  Scenario: disable sharing with groups
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator disables sharing with groups using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | group_sharing   | EMPTY |
 
-	Scenario: enable restrict users to only share with users in their groups
-		Given the administrator has browsed to the admin sharing settings page
-		When the administrator enables restrict users to only share with their group members using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element               | value |
-			| files_sharing | share_with_group_members_only | 1     |
+  Scenario: enable restrict users to only share with users in their groups
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables restrict users to only share with their group members using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element               | value |
+      | files_sharing | share_with_group_members_only | 1     |
 
-	@smokeTest
-	Scenario: enable share API
-		Given parameter "shareapi_enabled" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator enables the share API using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value |
-			| files_sharing | api_enabled     | 1     |
+  @smokeTest
+  Scenario: enable share API
+    Given parameter "shareapi_enabled" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables the share API using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | api_enabled     | 1     |
 
-	Scenario: enable public sharing
-		Given parameter "shareapi_allow_links" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator enables share via link using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element  | value |
-			| files_sharing | public@@@enabled | 1     |
+  Scenario: enable public sharing
+    Given parameter "shareapi_allow_links" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables share via link using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element  | value |
+      | files_sharing | public@@@enabled | 1     |
 
-	Scenario: enable public upload
-		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator enables public uploads using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value |
-			| files_sharing | public@@@upload | 1     |
+  Scenario: enable public upload
+    Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables public uploads using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | public@@@upload | 1     |
 
-	Scenario: disable mail notification on public link share
-		Given parameter "shareapi_allow_public_send_mail" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator disables mail notification on public link share using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element    | value |
-			| files_sharing | public@@@send_mail | EMPTY |
+  Scenario: disable mail notification on public link share
+    Given parameter "shareapi_allow_public_send_mail" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables mail notification on public link share using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element    | value |
+      | files_sharing | public@@@send_mail | EMPTY |
 
-	Scenario: enable social media share on public link share
-		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator enables social media share on public link share using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element       | value |
-			| files_sharing | public@@@social_share | 1     |
+  Scenario: enable social media share on public link share
+    Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables social media share on public link share using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element       | value |
+      | files_sharing | public@@@social_share | 1     |
 
-	Scenario: disable enforce password protection for read-only links
-		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator disables enforce password protection for read-only links using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                              | value |
-			| files_sharing | public@@@password@@@enforced_for@@@read_only | EMPTY |
+  Scenario: disable enforce password protection for read-only links
+    Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables enforce password protection for read-only links using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                              | value |
+      | files_sharing | public@@@password@@@enforced_for@@@read_only | EMPTY |
 
-	Scenario: disable enforce password protection for read and write links
-		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator disables enforce password protection for read and write links using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                               | value |
-			| files_sharing | public@@@password@@@enforced_for@@@read_write | EMPTY |
+  Scenario: disable enforce password protection for read and write links
+    Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables enforce password protection for read and write links using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                               | value |
+      | files_sharing | public@@@password@@@enforced_for@@@read_write | EMPTY |
 
-	Scenario: disable enforce password protection for upload-only links
-		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator disables enforce password protection for upload only links using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element                                | value |
-			| files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY |
+  Scenario: disable enforce password protection for upload-only links
+    Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables enforce password protection for upload only links using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                                | value |
+      | files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY |
 
-	Scenario: enable resharing
-		Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator enables resharing using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value |
-			| files_sharing | resharing       | 1     |
+  Scenario: enable resharing
+    Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables resharing using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | resharing       | 1     |
 
-	Scenario: enable sharing with groups
-		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator enables sharing with groups using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element | value |
-			| files_sharing | group_sharing   | 1     |
+  Scenario: enable sharing with groups
+    Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables sharing with groups using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element | value |
+      | files_sharing | group_sharing   | 1     |
 
-	Scenario: disable restrict users to only share with users in their groups
-		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		And the administrator has browsed to the admin sharing settings page
-		When the administrator disables restrict users to only share with their group members using the webUI
-		And the user retrieves the capabilities using the capabilities API
-		Then the capabilities should contain
-			| capability    | path_to_element               | value |
-			| files_sharing | share_with_group_members_only | EMPTY |
+  Scenario: disable restrict users to only share with users in their groups
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables restrict users to only share with their group members using the webUI
+    And the user retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element               | value |
+      | files_sharing | share_with_group_members_only | EMPTY |

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -1,46 +1,46 @@
 @webUI @insulated @disablePreviews
 Feature: Mark file as favorite
 
-As a user
-I would like to mark any file/folder as favorite
-So that I can find my favorite file/folder easily
+  As a user
+  I would like to mark any file/folder as favorite
+  So that I can find my favorite file/folder easily
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@smokeTest
-	Scenario: mark a file as favorite and list it in favorites page
-		When the user marks the file "data.zip" as favorite using the webUI
-		Then the file "data.zip" should be marked as favorite on the webUI
-		When the user reloads the current page of the webUI
-		Then the file "data.zip" should be marked as favorite on the webUI
-		And the file "data.zip" should be listed in the favorites page on the webUI
-		And the file "lorem.txt" should not be listed in the favorites page on the webUI
+  @smokeTest
+  Scenario: mark a file as favorite and list it in favorites page
+    When the user marks the file "data.zip" as favorite using the webUI
+    Then the file "data.zip" should be marked as favorite on the webUI
+    When the user reloads the current page of the webUI
+    Then the file "data.zip" should be marked as favorite on the webUI
+    And the file "data.zip" should be listed in the favorites page on the webUI
+    And the file "lorem.txt" should not be listed in the favorites page on the webUI
 
-	Scenario: mark a folder as favorite and list it in favorites page
-		When the user marks the folder "simple-folder" as favorite using the webUI
-		Then the folder "simple-folder" should be marked as favorite on the webUI
-		When the user reloads the current page of the webUI
-		Then the folder "simple-folder" should be marked as favorite on the webUI
-		And the folder "simple-folder" should be listed in the favorites page on the webUI
-		And the folder "simple-empty-folder" should not be listed in the favorites page on the webUI
+  Scenario: mark a folder as favorite and list it in favorites page
+    When the user marks the folder "simple-folder" as favorite using the webUI
+    Then the folder "simple-folder" should be marked as favorite on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder "simple-folder" should be marked as favorite on the webUI
+    And the folder "simple-folder" should be listed in the favorites page on the webUI
+    And the folder "simple-empty-folder" should not be listed in the favorites page on the webUI
 
-	Scenario: mark files with same name and different path as favorites and list them in favourites page
-		When the user marks the file "lorem.txt" as favorite using the webUI
-		And the user marks the folder "simple-empty-folder" as favorite using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		And the user marks the file "lorem.txt" as favorite using the webUI
-		And the user marks the folder "simple-empty-folder" as favorite using the webUI
-		And the user browses to the files page
-		And the user opens the folder "strängé नेपाली folder" using the webUI
-		And the user marks the file "lorem.txt" as favorite using the webUI
-		Then the file "lorem.txt" with the path "/" should be listed in the favorites page on the webUI
-		And the file "lorem.txt" with the path "/simple-folder" should be listed in the favorites page on the webUI
-		And the folder "simple-empty-folder" with the path "/" should be listed in the favorites page on the webUI
-		And the file "simple-empty-folder" with the path "/simple-folder" should be listed in the favorites page on the webUI
-		And the file "lorem.txt" with the path "/strängé नेपाली folder" should be listed in the favorites page on the webUI
+  Scenario: mark files with same name and different path as favorites and list them in favourites page
+    When the user marks the file "lorem.txt" as favorite using the webUI
+    And the user marks the folder "simple-empty-folder" as favorite using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    And the user marks the file "lorem.txt" as favorite using the webUI
+    And the user marks the folder "simple-empty-folder" as favorite using the webUI
+    And the user browses to the files page
+    And the user opens the folder "strängé नेपाली folder" using the webUI
+    And the user marks the file "lorem.txt" as favorite using the webUI
+    Then the file "lorem.txt" with the path "/" should be listed in the favorites page on the webUI
+    And the file "lorem.txt" with the path "/simple-folder" should be listed in the favorites page on the webUI
+    And the folder "simple-empty-folder" with the path "/" should be listed in the favorites page on the webUI
+    And the file "simple-empty-folder" with the path "/simple-folder" should be listed in the favorites page on the webUI
+    And the file "lorem.txt" with the path "/strängé नेपाली folder" should be listed in the favorites page on the webUI

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -1,48 +1,48 @@
 @webUI @insulated @disablePreviews
 Feature: Unmark file/folder as favorite
 
-As a user
-I would like to unmark any file/folder
-So that I can remove my favorite file/folder from favorite page
+  As a user
+  I would like to unmark any file/folder
+  So that I can remove my favorite file/folder from favorite page
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@smokeTest
-	Scenario: unmark a file as favorite from files page 
-		Given the user has marked the file "data.zip" as favorite using the webUI
-		When the user unmarks the favorited file "data.zip" using the webUI
-		Then the file "data.zip" should not be marked as favorite on the webUI
-		When the user browses to the favorites page
-		Then the file "data.zip" should not be listed in the favorites page on the webUI
+  @smokeTest
+  Scenario: unmark a file as favorite from files page
+    Given the user has marked the file "data.zip" as favorite using the webUI
+    When the user unmarks the favorited file "data.zip" using the webUI
+    Then the file "data.zip" should not be marked as favorite on the webUI
+    When the user browses to the favorites page
+    Then the file "data.zip" should not be listed in the favorites page on the webUI
 
-	Scenario: unmark a folder as favorite from files page 
-		Given the user has marked the folder "simple-folder" as favorite using the webUI
-		When the user unmarks the favorited folder "simple-folder" using the webUI
-		Then the folder "simple-folder" should not be marked as favorite on the webUI
-		When the user browses to the favorites page
-		Then the folder "simple-folder" should not be listed in the favorites page on the webUI
+  Scenario: unmark a folder as favorite from files page
+    Given the user has marked the folder "simple-folder" as favorite using the webUI
+    When the user unmarks the favorited folder "simple-folder" using the webUI
+    Then the folder "simple-folder" should not be marked as favorite on the webUI
+    When the user browses to the favorites page
+    Then the folder "simple-folder" should not be listed in the favorites page on the webUI
 
-	@smokeTest
-	Scenario: unmark a file as favorite from favorite page 
-		Given the user has marked the file "data.zip" as favorite using the webUI
-		And the user has browsed to the favorites page
-		When the user unmarks the favorited file "data.zip" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "data.zip" should not be listed in the favorites page on the webUI
-		When the user browses to the files page
-		Then the file "data.zip" should not be marked as favorite on the webUI
+  @smokeTest
+  Scenario: unmark a file as favorite from favorite page
+    Given the user has marked the file "data.zip" as favorite using the webUI
+    And the user has browsed to the favorites page
+    When the user unmarks the favorited file "data.zip" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "data.zip" should not be listed in the favorites page on the webUI
+    When the user browses to the files page
+    Then the file "data.zip" should not be marked as favorite on the webUI
 
-	Scenario: unmark a folder as favorite from files page 
-		Given the user has marked the folder "simple-folder" as favorite using the webUI
-		And the user has browsed to the favorites page
-		When the user unmarks the favorited folder "simple-folder" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "simple-folder" should not be listed in the favorites page on the webUI
-		When the user browses to the files page
-		Then the folder "simple-folder" should not be marked as favorite on the webUI
+  Scenario: unmark a folder as favorite from files page
+    Given the user has marked the folder "simple-folder" as favorite using the webUI
+    And the user has browsed to the favorites page
+    When the user unmarks the favorited folder "simple-folder" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "simple-folder" should not be listed in the favorites page on the webUI
+    When the user browses to the files page
+    Then the folder "simple-folder" should not be marked as favorite on the webUI

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -1,41 +1,41 @@
 @webUI @insulated @enablePreviews
 Feature: browse directly to details tab
-As a user
-I want to be able to browse directly to display the details about a file
-So that I can see the details immediately without needing to click in the UI
+  As a user
+  I want to be able to browse directly to display the details about a file
+  So that I can see the details immediately without needing to click in the UI
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
-	@smokeTest
-	Scenario Outline: Browse directly to the sharing details of a file
-		When the user browses directly to display the "sharing" details of file "lorem.txt" in folder "<folder>"
-		Then the thumbnail should be visible in the details panel
-		And the "sharing" details panel should be visible
-		And the share-with field should be visible in the details panel
-		Examples:
-			| folder        |
-			| /             |
-			| simple-folder |
+  @smokeTest
+  Scenario Outline: Browse directly to the sharing details of a file
+    When the user browses directly to display the "sharing" details of file "lorem.txt" in folder "<folder>"
+    Then the thumbnail should be visible in the details panel
+    And the "sharing" details panel should be visible
+    And the share-with field should be visible in the details panel
+    Examples:
+      | folder        |
+      | /             |
+      | simple-folder |
 
-	Scenario Outline: Browse directly to the comments details of a file
-		When the user browses directly to display the "comments" details of file "lorem.txt" in folder "<folder>"
-		Then the thumbnail should be visible in the details panel
-		And the "comments" details panel should be visible
-		Examples:
-			| folder        |
-			| /             |
-			| simple-folder |
+  Scenario Outline: Browse directly to the comments details of a file
+    When the user browses directly to display the "comments" details of file "lorem.txt" in folder "<folder>"
+    Then the thumbnail should be visible in the details panel
+    And the "comments" details panel should be visible
+    Examples:
+      | folder        |
+      | /             |
+      | simple-folder |
 
-	Scenario Outline: Browse directly to the versions details of a file
-		When the user browses directly to display the "versions" details of file "lorem.txt" in folder "<folder>"
-		Then the thumbnail should be visible in the details panel
-		And the "versions" details panel should be visible
-		Examples:
-			| folder        |
-			| /             |
-			| simple-folder |
+  Scenario Outline: Browse directly to the versions details of a file
+    When the user browses directly to display the "versions" details of file "lorem.txt" in folder "<folder>"
+    Then the thumbnail should be visible in the details panel
+    And the "versions" details panel should be visible
+    Examples:
+      | folder        |
+      | /             |
+      | simple-folder |

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -1,28 +1,28 @@
 @webUI @insulated @disablePreviews
 Feature: create folders
-As a user
-I want to create folders
-So that I can organise my data structure
+  As a user
+  I want to create folders
+  So that I can organise my data structure
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@smokeTest
-	Scenario: Create a folder inside another folder
-		When the user creates a folder with the name "top-folder" using the webUI
-		And the user opens the folder "top-folder" using the webUI
-		Then there should be no files/folders listed on the webUI
-		When the user creates a folder with the name "sub-folder" using the webUI
-		Then the folder "sub-folder" should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the folder "sub-folder" should be listed on the webUI
+  @smokeTest
+  Scenario: Create a folder inside another folder
+    When the user creates a folder with the name "top-folder" using the webUI
+    And the user opens the folder "top-folder" using the webUI
+    Then there should be no files/folders listed on the webUI
+    When the user creates a folder with the name "sub-folder" using the webUI
+    Then the folder "sub-folder" should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder "sub-folder" should be listed on the webUI
 
-	Scenario: Create a folder with existing name
-		When the user creates a folder with the invalid name "simple-folder" using the webUI
-		Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed on the webUI
+  Scenario: Create a folder with existing name
+    When the user creates a folder with the invalid name "simple-folder" using the webUI
+    Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed on the webUI
 	

--- a/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
@@ -1,55 +1,55 @@
 @webUI @insulated @disablePreviews
 Feature: create folder
-As a user
-I want to create folders
-So that I can organise my data structure
+  As a user
+  I want to create folders
+  So that I can organise my data structure
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
-	Scenario Outline: Create a folder using special characters
-		When the user creates a folder with the name <folder_name> using the webUI
-		Then the folder <folder_name> should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the folder <folder_name> should be listed on the webUI
-		Examples:
-		|folder_name    |
-		|'सिमप्ले फोल्देर $%#?&@'|
-		|'"somequotes1"'|
-		|"'somequotes2'"|
-		|"^#29][29@({"|
-		|"+-{$(882)"|
-		
-	Scenario Outline: Create a sub-folder inside a folder with problematic name
+  Scenario Outline: Create a folder using special characters
+    When the user creates a folder with the name <folder_name> using the webUI
+    Then the folder <folder_name> should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder <folder_name> should be listed on the webUI
+    Examples:
+      | folder_name              |
+      | 'सिमप्ले फोल्देर $%#?&@' |
+      | '"somequotes1"'          |
+      | "'somequotes2'"          |
+      | "^#29][29@({"            |
+      | "+-{$(882)"              |
+
+  Scenario Outline: Create a sub-folder inside a folder with problematic name
 	# First try and create a folder with problematic name
 	# Then try and create a sub-folder inside the folder with problematic name
-		When the user creates a folder with the name <folder> using the webUI
-		And the user opens the folder <folder> using the webUI
-		Then there should be no files/folders listed on the webUI
-		When the user creates a folder with the name "sub-folder" using the webUI
-		Then the folder "sub-folder" should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the folder "sub-folder" should be listed on the webUI
-		Examples:
-		|folder|
-		|"?&%0"|
-		|"^#2929@"|
+    When the user creates a folder with the name <folder> using the webUI
+    And the user opens the folder <folder> using the webUI
+    Then there should be no files/folders listed on the webUI
+    When the user creates a folder with the name "sub-folder" using the webUI
+    Then the folder "sub-folder" should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder "sub-folder" should be listed on the webUI
+    Examples:
+      | folder    |
+      | "?&%0"    |
+      | "^#2929@" |
 
-	@smokeTest
-	Scenario Outline: Create a sub-folder inside an existing folder with problematic name
+  @smokeTest
+  Scenario Outline: Create a sub-folder inside an existing folder with problematic name
 	# Use an existing folder with problematic name to create a sub-folder
 	# Uses the folder created by skeleton
-		When the user opens the folder <folder> using the webUI
-		And the user creates a folder with the name "sub-folder" using the webUI
-		Then the folder "sub-folder" should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the folder "sub-folder" should be listed on the webUI
-		Examples:
-		|folder|
-		|"0"|
-		|"'single'quotes"|
-		|"strängé नेपाली folder"|
+    When the user opens the folder <folder> using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the folder "sub-folder" should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder "sub-folder" should be listed on the webUI
+    Examples:
+      | folder                  |
+      | "0"                     |
+      | "'single'quotes"        |
+      | "strängé नेपाली folder" |

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -1,97 +1,97 @@
 @webUI @insulated @disablePreviews
 Feature: deleting files and folders
-As a user
-I want to delete files and folders
-So that I can keep my filing system clean and tidy
+  As a user
+  I want to delete files and folders
+  So that I can keep my filing system clean and tidy
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@smokeTest
-	Scenario: Delete files & folders one by one and check its existence after page reload
-		When the user deletes the following elements using the webUI
-		| name                                |
-		| simple-folder                       |
-		| lorem.txt                           |
-		| strängé नेपाली folder                  |
-		| strängé filename (duplicate #2 &).txt |
-		Then the deleted elements should not be listed on the webUI
-		And the deleted elements should not be listed on the webUI after a page reload
+  @smokeTest
+  Scenario: Delete files & folders one by one and check its existence after page reload
+    When the user deletes the following elements using the webUI
+      | name                                  |
+      | simple-folder                         |
+      | lorem.txt                             |
+      | strängé नेपाली folder                 |
+      | strängé filename (duplicate #2 &).txt |
+    Then the deleted elements should not be listed on the webUI
+    And the deleted elements should not be listed on the webUI after a page reload
 
-	Scenario: Delete a file with problematic characters
-		When the user renames the following file using the webUI
-			| from-name-parts | to-name-parts   |
-			| lorem.txt       | 'single'        |
-			|                 | "double" quotes |
-			|                 | question?       |
-			|                 | &and#hash       |
-		And the user reloads the current page of the webUI
-		Then the following file should be listed on the webUI
-			| name-parts      |
-			| 'single'        |
-			| "double" quotes |
-			| question?       |
-			| &and#hash       |
-		And the user deletes the following file using the webUI
-			| name-parts      |
-			| 'single'        |
-			| "double" quotes |
-			| question?       |
-			| &and#hash       |
-		Then the following file should not be listed on the webUI
-			| name-parts      |
-			| 'single'        |
-			| "double" quotes |
-			| question?       |
-			| &and#hash       |
-		When the user reloads the current page of the webUI
-		Then the following file should not be listed on the webUI
-			| name-parts      |
-			| 'single'        |
-			| "double" quotes |
-			| question?       |
-			| &and#hash       |
+  Scenario: Delete a file with problematic characters
+    When the user renames the following file using the webUI
+      | from-name-parts | to-name-parts   |
+      | lorem.txt       | 'single'        |
+      |                 | "double" quotes |
+      |                 | question?       |
+      |                 | &and#hash       |
+    And the user reloads the current page of the webUI
+    Then the following file should be listed on the webUI
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+    And the user deletes the following file using the webUI
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+    Then the following file should not be listed on the webUI
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+    When the user reloads the current page of the webUI
+    Then the following file should not be listed on the webUI
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
 
-	@smokeTest
-	Scenario: Delete multiple files at once
-		When the user batch deletes these files using the webUI
-		| name          |
-		| data.zip      |
-		| lorem.txt     |
-		| simple-folder |
-		Then the deleted elements should not be listed on the webUI
-		And the deleted elements should not be listed on the webUI after a page reload
+  @smokeTest
+  Scenario: Delete multiple files at once
+    When the user batch deletes these files using the webUI
+      | name          |
+      | data.zip      |
+      | lorem.txt     |
+      | simple-folder |
+    Then the deleted elements should not be listed on the webUI
+    And the deleted elements should not be listed on the webUI after a page reload
 
-	Scenario: Delete all files at once
-		When the user marks all files for batch action using the webUI
-		And the user batch deletes the marked files using the webUI
-		Then the folder should be empty on the webUI
-		And the folder should be empty on the webUI after a page reload
+  Scenario: Delete all files at once
+    When the user marks all files for batch action using the webUI
+    And the user batch deletes the marked files using the webUI
+    Then the folder should be empty on the webUI
+    And the folder should be empty on the webUI after a page reload
 
-	Scenario: Delete all except for a few files at once
-		When the user marks all files for batch action using the webUI
-		And the user unmarks these files for batch action using the webUI
-			| name          |
-			| lorem.txt     |
-			| simple-folder |
-		And the user batch deletes the marked files using the webUI
-		Then the folder "simple-folder" should be listed on the webUI
-		And the file "lorem.txt" should be listed on the webUI
+  Scenario: Delete all except for a few files at once
+    When the user marks all files for batch action using the webUI
+    And the user unmarks these files for batch action using the webUI
+      | name          |
+      | lorem.txt     |
+      | simple-folder |
+    And the user batch deletes the marked files using the webUI
+    Then the folder "simple-folder" should be listed on the webUI
+    And the file "lorem.txt" should be listed on the webUI
 		# Check just an example of a file that should not exist any more
-		But the file "data.zip" should not be listed on the webUI
+    But the file "data.zip" should not be listed on the webUI
 
-	Scenario: Delete an empty folder
-		When the user creates a folder with the name "my-empty-folder" using the webUI
-		And the user creates a folder with the name "my-other-empty-folder" using the webUI
-		And the user deletes the folder "my-empty-folder" using the webUI
-		Then the folder "my-other-empty-folder" should be listed on the webUI
-		But the folder "my-empty-folder" should not be listed on the webUI
+  Scenario: Delete an empty folder
+    When the user creates a folder with the name "my-empty-folder" using the webUI
+    And the user creates a folder with the name "my-other-empty-folder" using the webUI
+    And the user deletes the folder "my-empty-folder" using the webUI
+    Then the folder "my-other-empty-folder" should be listed on the webUI
+    But the folder "my-empty-folder" should not be listed on the webUI
 
-	Scenario: Delete the last file in a folder
-		When the user deletes the file "zzzz-must-be-last-file-in-folder.txt" using the webUI
-		Then the file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
+  Scenario: Delete the last file in a folder
+    When the user deletes the file "zzzz-must-be-last-file-in-folder.txt" using the webUI
+    Then the file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -1,21 +1,21 @@
 @webUI @insulated @disablePreviews
 Feature: Hide file/folders
 
-As a user
-I would like to display hidden files/folders
-So that I can choose to see the files that I want.
+  As a user
+  I would like to display hidden files/folders
+  So that I can choose to see the files that I want.
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@smokeTest
-	Scenario: create a hidden folder
-		When the user creates a folder with the name ".xyz" using the webUI
-		Then the folder ".xyz" should not be listed on the webUI
-		When the user enables the setting to view hidden folders on the webUI
-		Then the folder ".xyz" should be listed on the webUI
+  @smokeTest
+  Scenario: create a hidden folder
+    When the user creates a folder with the name ".xyz" using the webUI
+    Then the folder ".xyz" should not be listed on the webUI
+    When the user enables the setting to view hidden folders on the webUI
+    Then the folder ".xyz" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -1,18 +1,18 @@
 @webUI @insulated @disablePreviews
 Feature: scroll menu of actions that can be done on a file into view
-As a user
-I want to see the whole menu of actions that can be done on a file
-So that I can manage and work with my files
+  As a user
+  I want to see the whole menu of actions that can be done on a file
+  So that I can manage and work with my files
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@skipOnINTERNETEXPLORER
-	Scenario: scroll the file actions menu into view
-		When the user creates so many files/folders that they do not fit in one browser page
-		Then the files action menu should be completely visible after opening it using the webUI
+  @skipOnINTERNETEXPLORER
+  Scenario: scroll the file actions menu into view
+    When the user creates so many files/folders that they do not fit in one browser page
+    Then the files action menu should be completely visible after opening it using the webUI

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -1,9 +1,9 @@
 @webUI @insulated @disablePreviews
 Feature: Search
 
-As a user
-I would like to be able to search for files
-So that I can find needed files quickly
+  As a user
+  I would like to be able to search for files
+  So that I can find needed files quickly
 
   Background:
     Given these users have been created:

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -1,44 +1,44 @@
 @webUI @insulated @disablePreviews
 Feature: login users
-	As a user
-	I want to be able to log into my account
-	So that I have access to my files
+  As a user
+  I want to be able to log into my account
+  So that I have access to my files
 
-	As an admin
-	I want only authorised users to log in
-	So that unauthorised access is impossible
+  As an admin
+  I want only authorised users to log in
+  So that unauthorised access is impossible
 
-	@TestAlsoOnExternalUserBackend
-	Scenario: simple user login
-		Given these users have been created but not initialized:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		When the user logs in with username "user1" and password "%regular%" using the webUI
-		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+  @TestAlsoOnExternalUserBackend
+  Scenario: simple user login
+    Given these users have been created but not initialized:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    When the user logs in with username "user1" and password "%regular%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
-	@smokeTest
-	Scenario: admin login
-		Given the user has browsed to the login page
-		When the user logs in with username "%admin%" and password "%admin%" using the webUI
-		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+  @smokeTest
+  Scenario: admin login
+    Given the user has browsed to the login page
+    When the user logs in with username "%admin%" and password "%admin%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
-	@smokeTest
-	Scenario: admin login with invalid password
-		Given the user has browsed to the login page
-		When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
-		Then the user should be redirected to a webUI page with the title "ownCloud"
+  @smokeTest
+  Scenario: admin login with invalid password
+    Given the user has browsed to the login page
+    When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
+    Then the user should be redirected to a webUI page with the title "ownCloud"
 
-	Scenario: access the personal general settings page when not logged in
-		When the user attempts to browse to the personal general settings page
-		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
-		Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
+  Scenario: access the personal general settings page when not logged in
+    When the user attempts to browse to the personal general settings page
+    Then the user should be redirected to a webUI page with the title "ownCloud"
+    When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
+    Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
 
-	Scenario: access the personal general settings page when not logged in using incorrect then correct password
-		When the user attempts to browse to the personal general settings page
-		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
-		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
-		Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
+  Scenario: access the personal general settings page when not logged in using incorrect then correct password
+    When the user attempts to browse to the personal general settings page
+    Then the user should be redirected to a webUI page with the title "ownCloud"
+    When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
+    Then the user should be redirected to a webUI page with the title "ownCloud"
+    When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
+    Then the user should be redirected to a webUI page with the title "Settings - ownCloud"

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -1,39 +1,39 @@
 @webUI @insulated @disablePreviews @mailhog
 
 Feature: reset the password
-As a user
-I want to reset my password
-So that I can login to my account again after forgetting the password
+  As a user
+  I want to reset my password
+  So that I can login to my account again after forgetting the password
 
-	Background:
-		Given these users have been created but not initialized:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user logs in with username "user1" and invalid password "%alt3%" using the webUI
+  Background:
+    Given these users have been created but not initialized:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user logs in with username "user1" and invalid password "%alt3%" using the webUI
 
-	@smokeTest
-	Scenario: send password reset email
-		When the user requests the password reset link using the webUI
-		Then a message with this text should be displayed on the webUI:
+  @smokeTest
+  Scenario: send password reset email
+    When the user requests the password reset link using the webUI
+    Then a message with this text should be displayed on the webUI:
 			"""
 			The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
 			"""
-		And the email address "u1@oc.com.np" should have received an email with the body containing
+    And the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
 			Use the following link to reset your password: <a href=
 			"""
 
-	@skipOnEncryption
-	@smokeTest
-	Scenario: reset password for the ordinary (no encryption) case
-		When the user requests the password reset link using the webUI
-		And the user follows the password reset link from email address "u1@oc.com.np"
-		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user resets the password to "%alt1%" using the webUI
-		Then the email address "u1@oc.com.np" should have received an email with the body containing
+  @skipOnEncryption
+  @smokeTest
+  Scenario: reset password for the ordinary (no encryption) case
+    When the user requests the password reset link using the webUI
+    And the user follows the password reset link from email address "u1@oc.com.np"
+    Then the user should be redirected to a webUI page with the title "ownCloud"
+    When the user resets the password to "%alt1%" using the webUI
+    Then the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
 			Password changed successfully
 			"""
-		When the user logs in with username "user1" and password "%alt1%" using the webUI
-		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -1,40 +1,40 @@
 @webUI @insulated @disablePreviews @mailhog
 
 Feature: reset the password using an email address
-As a user
-I want to reset my password using an email address
-So that I can login to my account again after forgetting the password
+  As a user
+  I want to reset my password using an email address
+  So that I can login to my account again after forgetting the password
 
-	Background:
-		Given these users have been created but not initialized:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user logs in with email "u1@oc.com.np" and invalid password "%alt3%" using the webUI
+  Background:
+    Given these users have been created but not initialized:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user logs in with email "u1@oc.com.np" and invalid password "%alt3%" using the webUI
 
-	@smokeTest
-	Scenario: send password reset email
-		When the user requests the password reset link using the webUI
-		Then a message with this text should be displayed on the webUI:
+  @smokeTest
+  Scenario: send password reset email
+    When the user requests the password reset link using the webUI
+    Then a message with this text should be displayed on the webUI:
 			"""
 			The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
 			"""
-		And the email address "u1@oc.com.np" should have received an email with the body containing
+    And the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
 			Use the following link to reset your password: <a href=
 			"""
 
-	@skipOnEncryption
-	@smokeTest
-	@skip @issue-32868
-	Scenario: reset password for the ordinary (no encryption) case
-		When the user requests the password reset link using the webUI
-		And the user follows the password reset link from email address "u1@oc.com.np"
-		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user resets the password to "%alt1%" using the webUI
-		Then the email address "u1@oc.com.np" should have received an email with the body containing
+  @skipOnEncryption
+  @smokeTest
+  @skip @issue-32868
+  Scenario: reset password for the ordinary (no encryption) case
+    When the user requests the password reset link using the webUI
+    And the user follows the password reset link from email address "u1@oc.com.np"
+    Then the user should be redirected to a webUI page with the title "ownCloud"
+    When the user resets the password to "%alt1%" using the webUI
+    Then the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
 			Password changed successfully
 			"""
-		When the user logs in with username "user1" and password "%alt1%" using the webUI
-		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -1,87 +1,87 @@
 @webUI @insulated @disablePreviews
 Feature: move files
-As a user
-I want to move files
-So that I can organise my data structure
+  As a user
+  I want to move files
+  So that I can organise my data structure
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	Scenario: An attempt to move a file into a sub-folder using rename is not allowed
-		When the user renames the file "data.zip" to "simple-folder/data.zip" using the webUI
-		Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
+  Scenario: An attempt to move a file into a sub-folder using rename is not allowed
+    When the user renames the file "data.zip" to "simple-folder/data.zip" using the webUI
+    Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
-	@skipOnFIREFOX
-	@smokeTest
-	Scenario: move a file into a folder
-		When the user moves the file "data.zip" into the folder "simple-empty-folder" using the webUI
-		Then the file "data.zip" should not be listed on the webUI
-		But the file "data.zip" should be listed in the folder "simple-empty-folder" on the webUI
-		When the user browses to the files page
-		And the user moves the file "data.tar.gz" into the folder "strängé नेपाली folder empty" using the webUI
-		Then the file "data.tar.gz" should not be listed on the webUI
-		But the file "data.tar.gz" should be listed in the folder "strängé नेपाली folder empty" on the webUI
-		When the user browses to the files page
-		And the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder empty" using the webUI
-		Then the file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
-		But the file "strängé filename (duplicate #2 &).txt" should be listed in the folder "strängé नेपाली folder empty" on the webUI
+  @skipOnFIREFOX
+  @smokeTest
+  Scenario: move a file into a folder
+    When the user moves the file "data.zip" into the folder "simple-empty-folder" using the webUI
+    Then the file "data.zip" should not be listed on the webUI
+    But the file "data.zip" should be listed in the folder "simple-empty-folder" on the webUI
+    When the user browses to the files page
+    And the user moves the file "data.tar.gz" into the folder "strängé नेपाली folder empty" using the webUI
+    Then the file "data.tar.gz" should not be listed on the webUI
+    But the file "data.tar.gz" should be listed in the folder "strängé नेपाली folder empty" on the webUI
+    When the user browses to the files page
+    And the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder empty" using the webUI
+    Then the file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
+    But the file "strängé filename (duplicate #2 &).txt" should be listed in the folder "strängé नेपाली folder empty" on the webUI
 
-	@skipOnFIREFOX
-	Scenario: move a file into a folder where a file with the same name already exists
-		When the user moves the file "data.zip" into the folder "simple-folder" using the webUI
-		And the user moves the file "data.zip" into the folder "strängé नेपाली folder" using the webUI
-		Then notifications should be displayed on the webUI with the text
-			|Could not move "data.zip", target exists|
-			|Could not move "data.zip", target exists|
-		And the file "data.zip" should be listed on the webUI
+  @skipOnFIREFOX
+  Scenario: move a file into a folder where a file with the same name already exists
+    When the user moves the file "data.zip" into the folder "simple-folder" using the webUI
+    And the user moves the file "data.zip" into the folder "strängé नेपाली folder" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | Could not move "data.zip", target exists |
+      | Could not move "data.zip", target exists |
+    And the file "data.zip" should be listed on the webUI
 
-	@skipOnFIREFOX
-	Scenario: move a file into a folder where a file with the same name already exists
-		When the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder" using the webUI
-		Then notifications should be displayed on the webUI with the text
-			|Could not move "strängé filename (duplicate #2 &).txt", target exists|
-		And the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
+  @skipOnFIREFOX
+  Scenario: move a file into a folder where a file with the same name already exists
+    When the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | Could not move "strängé filename (duplicate #2 &).txt", target exists |
+    And the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 
-	@skipOnFIREFOX
-	@smokeTest
-	Scenario: Move multiple files at once
-		When the user batch moves these files into the folder "simple-empty-folder" using the webUI
-		| name        |
-		| data.zip    |
-		| lorem.txt   |
-		| testapp.zip |
-		Then the moved elements should not be listed on the webUI
-		And the moved elements should not be listed on the webUI after a page reload
-		But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
+  @skipOnFIREFOX
+  @smokeTest
+  Scenario: Move multiple files at once
+    When the user batch moves these files into the folder "simple-empty-folder" using the webUI
+      | name        |
+      | data.zip    |
+      | lorem.txt   |
+      | testapp.zip |
+    Then the moved elements should not be listed on the webUI
+    And the moved elements should not be listed on the webUI after a page reload
+    But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
 
-	@skipOnFIREFOX
-	Scenario: move a file into a folder (problematic characters)
-		When the user renames the following file using the webUI
-			| from-name-parts         | to-name-parts          |
-			| lorem.txt               | 'single'               |
-			|                         | "double" quotes        |
-			|                         | question?              |
-			|                         | &and#hash              |
-		And the user renames the following folder using the webUI
-			| from-name-parts         |to-name-parts           |
-			| simple-empty-folder     | folder-with'single'    |
-			|                         | "double" quotes        |
-			|                         | question?              |
-			|                         | &and#hash              |
-		And the user moves the following file using the webUI
-			| item-to-move-name-parts | destination-name-parts |
-			| 'single'                | folder-with'single'    |
-			| "double" quotes         | "double" quotes        |
-			| question?               | question?              |
-			| &and#hash               | &and#hash              |
-		Then the following item should be listed in the following folder on the webUI
-			| item-name-parts         | folder-name-parts      |
-			| 'single'                | folder-with'single'    |
-			| "double" quotes         | "double" quotes        |
-			| question?               | question?              |
-			| &and#hash               | &and#hash              |
+  @skipOnFIREFOX
+  Scenario: move a file into a folder (problematic characters)
+    When the user renames the following file using the webUI
+      | from-name-parts | to-name-parts   |
+      | lorem.txt       | 'single'        |
+      |                 | "double" quotes |
+      |                 | question?       |
+      |                 | &and#hash       |
+    And the user renames the following folder using the webUI
+      | from-name-parts     | to-name-parts       |
+      | simple-empty-folder | folder-with'single' |
+      |                     | "double" quotes     |
+      |                     | question?           |
+      |                     | &and#hash           |
+    And the user moves the following file using the webUI
+      | item-to-move-name-parts | destination-name-parts |
+      | 'single'                | folder-with'single'    |
+      | "double" quotes         | "double" quotes        |
+      | question?               | question?              |
+      | &and#hash               | &and#hash              |
+    Then the following item should be listed in the following folder on the webUI
+      | item-name-parts | folder-name-parts   |
+      | 'single'        | folder-with'single' |
+      | "double" quotes | "double" quotes     |
+      | question?       | question?           |
+      | &and#hash       | &and#hash           |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -1,71 +1,71 @@
 @webUI @insulated @disablePreviews
 Feature: move folders
-As a user
-I want to move folders
-So that I can organise my data structure
+  As a user
+  I want to move folders
+  So that I can organise my data structure
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	Scenario: An attempt to move a folder into a sub-folder using rename is not allowed
-		When the user renames the folder "simple-empty-folder" to "simple-folder/simple-empty-folder" using the webUI
-		Then near the folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
+  Scenario: An attempt to move a folder into a sub-folder using rename is not allowed
+    When the user renames the folder "simple-empty-folder" to "simple-folder/simple-empty-folder" using the webUI
+    Then near the folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
-	@skipOnFIREFOX
-	Scenario: move a folder into another folder
-		When the user moves the folder "simple-folder" into the folder "simple-empty-folder" using the webUI
-		Then the folder "simple-folder" should not be listed on the webUI
-		But the folder "simple-folder" should be listed in the folder "simple-empty-folder" on the webUI
-		When the user browses to the files page
-		And the user moves the folder "strängé नेपाली folder" into the folder "strängé नेपाली folder empty" using the webUI
-		Then the folder "strängé नेपाली folder" should not be listed on the webUI
-		But the folder "strängé नेपाली folder" should be listed in the folder "strängé नेपाली folder empty" on the webUI
+  @skipOnFIREFOX
+  Scenario: move a folder into another folder
+    When the user moves the folder "simple-folder" into the folder "simple-empty-folder" using the webUI
+    Then the folder "simple-folder" should not be listed on the webUI
+    But the folder "simple-folder" should be listed in the folder "simple-empty-folder" on the webUI
+    When the user browses to the files page
+    And the user moves the folder "strängé नेपाली folder" into the folder "strängé नेपाली folder empty" using the webUI
+    Then the folder "strängé नेपाली folder" should not be listed on the webUI
+    But the folder "strängé नेपाली folder" should be listed in the folder "strängé नेपाली folder empty" on the webUI
 
-	@skipOnFIREFOX
-	Scenario: move a folder into another folder where a folder with the same name already exists
-		When the user moves the folder "simple-empty-folder" into the folder "simple-folder" using the webUI
-		Then notifications should be displayed on the webUI with the text
-			|Could not move "simple-empty-folder", target exists|
-		And the folder "simple-empty-folder" should be listed on the webUI
+  @skipOnFIREFOX
+  Scenario: move a folder into another folder where a folder with the same name already exists
+    When the user moves the folder "simple-empty-folder" into the folder "simple-folder" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | Could not move "simple-empty-folder", target exists |
+    And the folder "simple-empty-folder" should be listed on the webUI
 
-	@skipOnFIREFOX
-	Scenario: Move multiple folders at once
-		When the user batch moves these folders into the folder "simple-empty-folder" using the webUI
-		| name               |
-		| simple-folder      |
-		| strängé नेपाली folder |
-		Then the moved elements should not be listed on the webUI
-		And the moved elements should not be listed on the webUI after a page reload
-		But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
+  @skipOnFIREFOX
+  Scenario: Move multiple folders at once
+    When the user batch moves these folders into the folder "simple-empty-folder" using the webUI
+      | name                  |
+      | simple-folder         |
+      | strängé नेपाली folder |
+    Then the moved elements should not be listed on the webUI
+    And the moved elements should not be listed on the webUI after a page reload
+    But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
 
-	@skipOnFIREFOX
-	Scenario: move a folder into another folder (problematic characters)
-		When the user renames the following folder using the webUI
-			| from-name-parts         | to-name-parts          |
-			| simple-folder           | 'single'               |
-			|                         | "double" quotes        |
-			|                         | question?              |
-			|                         | &and#hash              |
-		And the user renames the following folder using the webUI
-			| from-name-parts         |to-name-parts           |
-			| simple-empty-folder     | folder-with'single'    |
-			|                         | "double" quotes        |
-			|                         | question?              |
-			|                         | &and#hash              |
-		And the user moves the following folder using the webUI
-			| item-to-move-name-parts | destination-name-parts |
-			| 'single'                | folder-with'single'    |
-			| "double" quotes         | "double" quotes        |
-			| question?               | question?              |
-			| &and#hash               | &and#hash              |
-		Then the following item should be listed in the following folder on the webUI
-			| item-name-parts         | folder-name-parts      |
-			| 'single'                | folder-with'single'    |
-			| "double" quotes         | "double" quotes        |
-			| question?               | question?              |
-			| &and#hash               | &and#hash              |
+  @skipOnFIREFOX
+  Scenario: move a folder into another folder (problematic characters)
+    When the user renames the following folder using the webUI
+      | from-name-parts | to-name-parts   |
+      | simple-folder   | 'single'        |
+      |                 | "double" quotes |
+      |                 | question?       |
+      |                 | &and#hash       |
+    And the user renames the following folder using the webUI
+      | from-name-parts     | to-name-parts       |
+      | simple-empty-folder | folder-with'single' |
+      |                     | "double" quotes     |
+      |                     | question?           |
+      |                     | &and#hash           |
+    And the user moves the following folder using the webUI
+      | item-to-move-name-parts | destination-name-parts |
+      | 'single'                | folder-with'single'    |
+      | "double" quotes         | "double" quotes        |
+      | question?               | question?              |
+      | &and#hash               | &and#hash              |
+    Then the following item should be listed in the following folder on the webUI
+      | item-name-parts | folder-name-parts   |
+      | 'single'        | folder-with'single' |
+      | "double" quotes | "double" quotes     |
+      | question?       | question?           |
+      | &and#hash       | &and#hash           |

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -1,21 +1,21 @@
 @webUI @insulated @mailhog
 Feature: Change own email address on the personal settings page
-As a user
-I would like to change my own email address
-So that I can be reached by the owncloud server
+  As a user
+  I would like to change my own email address
+  So that I can be reached by the owncloud server
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the personal general settings page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the personal general settings page
 
-	@skip @issue-32385
-	@smokeTest
-	Scenario: Change email address 
-		When the user changes the email address to "new-address@owncloud.com" using the webUI
-		And the user follows the email change confirmation link received by "new-address@owncloud.com" using the webUI
-		Then the attributes of user "user1" returned by the API should include
-			| email | new-address@owncloud.com |
+  @skip @issue-32385
+  @smokeTest
+  Scenario: Change email address
+    When the user changes the email address to "new-address@owncloud.com" using the webUI
+    And the user follows the email change confirmation link received by "new-address@owncloud.com" using the webUI
+    Then the attributes of user "user1" returned by the API should include
+      | email | new-address@owncloud.com |

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -1,21 +1,21 @@
 @webUI @insulated
 Feature: Change own full name on the personal settings page
-As a user
-I would like to change my own full name
-So that other users can recognize me by it
+  As a user
+  I would like to change my own full name
+  So that other users can recognize me by it
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the personal general settings page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the personal general settings page
 
-	@smokeTest
-	Scenario: Change full name 
-		When the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
-		And the user reloads the current page of the webUI
-		Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
-		And the attributes of user "user1" returned by the API should include
-			| displayname | my#very&weird?नेपालि%name |
+  @smokeTest
+  Scenario: Change full name
+    When the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
+    And the user reloads the current page of the webUI
+    Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
+    And the attributes of user "user1" returned by the API should include
+      | displayname | my#very&weird?नेपालि%name |

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -1,27 +1,27 @@
 @webUI @insulated
 Feature: Change Login Password
-As a user
-I would like to change my login password
-So that I can login with my new password
+  As a user
+  I would like to change my login password
+  So that I can login with my new password
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the personal general settings page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the personal general settings page
 
-	@smokeTest
-	Scenario: Change password 
-		When the user changes the password to "%alt1%" using the webUI
-		And the user re-logs in with username "user1" and password "%alt1%" using the webUI
-		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+  @smokeTest
+  Scenario: Change password
+    When the user changes the password to "%alt1%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
-	Scenario: Password change with wrong current password
-		When the user changes the password to "%alt1%" entering the wrong current password "%alt2%" using the webUI
-		Then a password error message should be displayed on the webUI with the text "Wrong current password"
+  Scenario: Password change with wrong current password
+    When the user changes the password to "%alt1%" entering the wrong current password "%alt2%" using the webUI
+    Then a password error message should be displayed on the webUI with the text "Wrong current password"
 
-	Scenario: New password is same as current password
-		When the user changes the password to "%regular%" using the webUI
-		Then a password error message should be displayed on the webUI with the text "The new password cannot be the same as the previous one"
+  Scenario: New password is same as current password
+    When the user changes the password to "%regular%" using the webUI
+    Then a password error message should be displayed on the webUI with the text "The new password cannot be the same as the previous one"

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -1,25 +1,25 @@
 @webUI @insulated @disablePreviews
 Feature: personal general settings
-As a user
-I want to change the ownCloud User Interface to my preferred settings
-So that I can personalise the User Interface
+  As a user
+  I want to change the ownCloud User Interface to my preferred settings
+  So that I can personalise the User Interface
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the personal general settings page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the personal general settings page
 
-	@smokeTest
-	Scenario: change language
-		When the user changes the language to "Русский" using the webUI
-		Then the user should be redirected to a webUI page with the title "Настройки - ownCloud"
+  @smokeTest
+  Scenario: change language
+    When the user changes the language to "Русский" using the webUI
+    Then the user should be redirected to a webUI page with the title "Настройки - ownCloud"
 
-	Scenario: change language and check that file actions menu have been translated
-		When the user changes the language to "हिन्दी" using the webUI
-		And the user browses to the files page
-		And the user opens the file action menu of the folder "simple-folder" in the webUI
-		Then the user should see "Details" file action translated to "विवरण" in the webUI
-		And the user should see "Delete" file action translated to "हटाना" in the webUI
+  Scenario: change language and check that file actions menu have been translated
+    When the user changes the language to "हिन्दी" using the webUI
+    And the user browses to the files page
+    And the user opens the file action menu of the folder "simple-folder" in the webUI
+    Then the user should see "Details" file action translated to "विवरण" in the webUI
+    And the user should see "Delete" file action translated to "हटाना" in the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -1,26 +1,26 @@
 @webUI @insulated @disablePreviews
 Feature: personal security settings
-As a user
-I want to be able to manage security settings for my account
-So that I can enable, allow and deny access to and from other storage systems or resources
+  As a user
+  I want to be able to manage security settings for my account
+  So that I can enable, allow and deny access to and from other storage systems or resources
 
-	Background:
-			Given these users have been created but not initialized:
-				| username | password  | displayname | email        |
-				| user1    | %regular% | User One    | u1@oc.com.np |
-			And the user has browsed to the login page
-			And the user has logged in with username "user1" and password "%regular%" using the webUI
-			And the user has browsed to the personal security settings page
+  Background:
+    Given these users have been created but not initialized:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the personal security settings page
 
-	@smokeTest
-	Scenario: login with new app password
-		When the user creates a new App password using the webUI
-		And the user re-logs in with username "user1" and generated app password using the webUI
-		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+  @smokeTest
+  Scenario: login with new app password
+    When the user creates a new App password using the webUI
+    And the user re-logs in with username "user1" and generated app password using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
-	@smokeTest
-	Scenario: delete the app password 
-		When the user creates a new App password using the webUI
-		And the user deletes the app password
-		And the user re-logs in with username "user1" and deleted app password using the webUI
-		Then the user should be redirected to a webUI page with the title "ownCloud"
+  @smokeTest
+  Scenario: delete the app password
+    When the user creates a new App password using the webUI
+    And the user deletes the app password
+    And the user re-logs in with username "user1" and deleted app password using the webUI
+    Then the user should be redirected to a webUI page with the title "ownCloud"

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -1,127 +1,127 @@
 @webUI @insulated @disablePreviews
 Feature: rename files
-As a user
-I want to rename files
-So that I can organise my data structure
+  As a user
+  I want to rename files
+  So that I can organise my data structure
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@smokeTest
-	Scenario Outline: Rename a file using special characters
-		When the user renames the file "lorem.txt" to <to_file_name> using the webUI
-		Then the file <to_file_name> should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the file <to_file_name> should be listed on the webUI
-		Examples:
-		|to_file_name |
-		|'लोरेम।तयक्स्त? $%#&@' |
-		|'"quotes1"'  |
-		|"'quotes2'"  |
+  @smokeTest
+  Scenario Outline: Rename a file using special characters
+    When the user renames the file "lorem.txt" to <to_file_name> using the webUI
+    Then the file <to_file_name> should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the file <to_file_name> should be listed on the webUI
+    Examples:
+      | to_file_name           |
+      | 'लोरेम।तयक्स्त? $%#&@' |
+      | '"quotes1"'            |
+      | "'quotes2'"            |
 
-	Scenario Outline: Rename a file that has special characters in its name
-		When the user renames the file <from_name> to <to_name> using the webUI
-		Then the file <to_name> should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the file <to_name> should be listed on the webUI
-		Examples:
-		|from_name                            |to_name                              |
-		|"strängé filename (duplicate #2 &).txt"|"strängé filename (duplicate #3).txt"|
-		|"'single'quotes.txt"                 |"single-quotes.txt"                  |
+  Scenario Outline: Rename a file that has special characters in its name
+    When the user renames the file <from_name> to <to_name> using the webUI
+    Then the file <to_name> should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the file <to_name> should be listed on the webUI
+    Examples:
+      | from_name                               | to_name                               |
+      | "strängé filename (duplicate #2 &).txt" | "strängé filename (duplicate #3).txt" |
+      | "'single'quotes.txt"                    | "single-quotes.txt"                   |
 
-	@smokeTest
-	Scenario: Rename a file using special characters and check its existence after page reload
-		When the user renames the file "lorem.txt" to "लोरेम।तयक्स्त $%&" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "लोरेम।तयक्स्त $%&" should be listed on the webUI
-		When the user renames the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt' using the webUI
-		And the user reloads the current page of the webUI
-		Then the file '"double"quotes.txt' should be listed on the webUI
-		When the user renames the file '"double"quotes.txt' to "no-double-quotes.txt" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "no-double-quotes.txt" should be listed on the webUI
-		When the user renames the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed on the webUI
-		When the user renames the file 'zzzz-must-be-last-file-in-folder.txt' to "aaaaaa.txt" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "aaaaaa.txt" should be listed on the webUI
+  @smokeTest
+  Scenario: Rename a file using special characters and check its existence after page reload
+    When the user renames the file "lorem.txt" to "लोरेम।तयक्स्त $%&" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "लोरेम।तयक्स्त $%&" should be listed on the webUI
+    When the user renames the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt' using the webUI
+    And the user reloads the current page of the webUI
+    Then the file '"double"quotes.txt' should be listed on the webUI
+    When the user renames the file '"double"quotes.txt' to "no-double-quotes.txt" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "no-double-quotes.txt" should be listed on the webUI
+    When the user renames the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed on the webUI
+    When the user renames the file 'zzzz-must-be-last-file-in-folder.txt' to "aaaaaa.txt" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "aaaaaa.txt" should be listed on the webUI
 
-	Scenario: Rename a file using spaces at front and/or back of file name and type
-		When the user renames the file "lorem.txt" to " space at start" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file " space at start" should be listed on the webUI
-		When the user renames the file " space at start" to "space at end " using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "space at end " should be listed on the webUI
-		When the user renames the file "space at end " to "space at end .txt" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "space at end .txt" should be listed on the webUI
-		When the user renames the file "space at end .txt" to "space at end. lis" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "space at end. lis" should be listed on the webUI
-		When the user renames the file "space at end. lis" to "space at end.log " using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "space at end.log " should be listed on the webUI
-		When the user renames the file "space at end.log " to "  multiple   space    all     over   .  dat  " using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "  multiple   space    all     over   .  dat  " should be listed on the webUI
+  Scenario: Rename a file using spaces at front and/or back of file name and type
+    When the user renames the file "lorem.txt" to " space at start" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file " space at start" should be listed on the webUI
+    When the user renames the file " space at start" to "space at end " using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "space at end " should be listed on the webUI
+    When the user renames the file "space at end " to "space at end .txt" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "space at end .txt" should be listed on the webUI
+    When the user renames the file "space at end .txt" to "space at end. lis" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "space at end. lis" should be listed on the webUI
+    When the user renames the file "space at end. lis" to "space at end.log " using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "space at end.log " should be listed on the webUI
+    When the user renames the file "space at end.log " to "  multiple   space    all     over   .  dat  " using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "  multiple   space    all     over   .  dat  " should be listed on the webUI
 
-	Scenario: Rename a file using both double and single quotes
-		When the user renames the following file using the webUI
-			|from-name-parts |to-name-parts         |
-			|lorem.txt       |First 'single' quotes |
-			|                |-then "double".txt    |
-		And the user reloads the current page of the webUI
-		Then the following file should be listed on the webUI
-			|name-parts            |
-			|First 'single' quotes |
-			|-then "double".txt    |
-		When the user renames the following file using the webUI
-			|from-name-parts       |to-name-parts |
-			|First 'single' quotes |loremz.dat    |
-			|-then "double".txt    |              |
-		And the user reloads the current page of the webUI
-		Then the file "loremz.dat" should be listed on the webUI
+  Scenario: Rename a file using both double and single quotes
+    When the user renames the following file using the webUI
+      | from-name-parts | to-name-parts         |
+      | lorem.txt       | First 'single' quotes |
+      |                 | -then "double".txt    |
+    And the user reloads the current page of the webUI
+    Then the following file should be listed on the webUI
+      | name-parts            |
+      | First 'single' quotes |
+      | -then "double".txt    |
+    When the user renames the following file using the webUI
+      | from-name-parts       | to-name-parts |
+      | First 'single' quotes | loremz.dat    |
+      | -then "double".txt    |               |
+    And the user reloads the current page of the webUI
+    Then the file "loremz.dat" should be listed on the webUI
 
-	Scenario: Rename a file using forbidden characters
-		When the user renames the file "data.zip" to one of these names using the webUI
-		|lorem\txt  |
-		|\\.txt     |
-		|.htaccess  |
-		Then notifications should be displayed on the webUI with the text
-		|Could not rename "data.zip"|
-		|Could not rename "data.zip"|
-		|Could not rename "data.zip"|
-		And the file "data.zip" should be listed on the webUI
+  Scenario: Rename a file using forbidden characters
+    When the user renames the file "data.zip" to one of these names using the webUI
+      | lorem\txt |
+      | \\.txt    |
+      | .htaccess |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "data.zip" |
+      | Could not rename "data.zip" |
+      | Could not rename "data.zip" |
+    And the file "data.zip" should be listed on the webUI
 
-	Scenario: Rename the last file in a folder
-		When the user renames the file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "a-file.txt" should be listed on the webUI
+  Scenario: Rename the last file in a folder
+    When the user renames the file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "a-file.txt" should be listed on the webUI
 
-	Scenario: Rename a file to become the last file in a folder
-		When the user renames the file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt" using the webUI
-		And the user reloads the current page of the webUI
-		Then the file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
+  Scenario: Rename a file to become the last file in a folder
+    When the user renames the file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt" using the webUI
+    And the user reloads the current page of the webUI
+    Then the file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
 
-	Scenario: Rename a file putting a name of a file which already exists
-		When the user renames the file "data.zip" to "lorem.txt" using the webUI
-		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
+  Scenario: Rename a file putting a name of a file which already exists
+    When the user renames the file "data.zip" to "lorem.txt" using the webUI
+    Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
-	Scenario: Rename a file to ..
-		When the user renames the file "data.zip" to ".." using the webUI
-		Then near the file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
+  Scenario: Rename a file to ..
+    When the user renames the file "data.zip" to ".." using the webUI
+    Then near the file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
-	Scenario: Rename a file to .
-		When the user renames the file "data.zip" to "." using the webUI
-		Then near the file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
+  Scenario: Rename a file to .
+    When the user renames the file "data.zip" to "." using the webUI
+    Then near the file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
-	Scenario: Rename a file to .part
-		When the user renames the file "data.zip" to "data.part" using the webUI
-		Then near the file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI
+  Scenario: Rename a file to .part
+    When the user renames the file "data.zip" to "data.part" using the webUI
+    Then near the file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -1,24 +1,24 @@
 @webUI @insulated @disablePreviews
 Feature: Renaming files inside a folder with problematic name
-As a user
-I want to rename a file
-So that I can recognize my file easily
+  As a user
+  I want to rename a file
+  So that I can recognize my file easily
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
-	Scenario Outline: Rename the existing file inside a problematic folder
-		When the user opens the folder <folder> using the webUI
-		And the user renames the file "lorem.txt" to "???.txt" using the webUI
-		Then the file "???.txt" should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the file "???.txt" should be listed on the webUI
-		Examples:
-		|       folder       |
-		|         "0"        |
-		|  "'single'quotes"  |
-		|"strängé नेपाली folder"|
+  Scenario Outline: Rename the existing file inside a problematic folder
+    When the user opens the folder <folder> using the webUI
+    And the user renames the file "lorem.txt" to "???.txt" using the webUI
+    Then the file "???.txt" should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the file "???.txt" should be listed on the webUI
+    Examples:
+      | folder                  |
+      | "0"                     |
+      | "'single'quotes"        |
+      | "strängé नेपाली folder" |

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -1,103 +1,103 @@
 @webUI @insulated @disablePreviews
 Feature: rename folders
-As a user
-I want to rename folders
-So that I can organise my data structure
+  As a user
+  I want to rename folders
+  So that I can organise my data structure
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	Scenario Outline: Rename a folder using special characters
-		When the user renames the folder "simple-folder" to <to_folder_name> using the webUI
-		Then the folder <to_folder_name> should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the folder <to_folder_name> should be listed on the webUI
-		Examples:
-		|to_folder_name |
-		|'सिमप्ले फोल्देर$%#?&@' |
-		|'"quotes1"'    |
-		|"'quotes2'"    |
+  Scenario Outline: Rename a folder using special characters
+    When the user renames the folder "simple-folder" to <to_folder_name> using the webUI
+    Then the folder <to_folder_name> should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder <to_folder_name> should be listed on the webUI
+    Examples:
+      | to_folder_name          |
+      | 'सिमप्ले फोल्देर$%#?&@' |
+      | '"quotes1"'             |
+      | "'quotes2'"             |
 
-	Scenario Outline: Rename a folder that has special characters in its name
-		When the user renames the folder <from_name> to <to_name> using the webUI
-		Then the folder <to_name> should be listed on the webUI
-		When the user reloads the current page of the webUI
-		Then the folder <to_name> should be listed on the webUI
-		Examples:
-		|from_name           |to_name                 |
-		|"strängé नेपाली folder"|"strängé नेपाली folder-#?2"|
-		|"'single'quotes"    |"single-quotes"         |
+  Scenario Outline: Rename a folder that has special characters in its name
+    When the user renames the folder <from_name> to <to_name> using the webUI
+    Then the folder <to_name> should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder <to_name> should be listed on the webUI
+    Examples:
+      | from_name               | to_name                     |
+      | "strängé नेपाली folder" | "strängé नेपाली folder-#?2" |
+      | "'single'quotes"        | "single-quotes"             |
 
-	Scenario: Rename a folder using special characters and check its existence after page reload
-		When the user renames the folder "simple-folder" to "लोरेम।तयक्स्त $%&" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "लोरेम।तयक्स्त $%&" should be listed on the webUI
-		When the user renames the folder "लोरेम।तयक्स्त $%&" to '"double"quotes' using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder '"double"quotes' should be listed on the webUI
-		When the user renames the folder '"double"quotes' to "no-double-quotes" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "no-double-quotes" should be listed on the webUI
-		When the user renames the folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
+  Scenario: Rename a folder using special characters and check its existence after page reload
+    When the user renames the folder "simple-folder" to "लोरेम।तयक्स्त $%&" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "लोरेम।तयक्स्त $%&" should be listed on the webUI
+    When the user renames the folder "लोरेम।तयक्स्त $%&" to '"double"quotes' using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder '"double"quotes' should be listed on the webUI
+    When the user renames the folder '"double"quotes' to "no-double-quotes" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "no-double-quotes" should be listed on the webUI
+    When the user renames the folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
 
-	Scenario: Rename a folder using spaces at front and/or back of the name
-		When the user renames the folder "simple-folder" to " space at start" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder " space at start" should be listed on the webUI
-		When the user renames the folder " space at start" to "space at end " using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "space at end " should be listed on the webUI
-		When the user renames the folder "space at end " to "  multiple   spaces    all     over   " using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "  multiple   spaces    all     over   " should be listed on the webUI
+  Scenario: Rename a folder using spaces at front and/or back of the name
+    When the user renames the folder "simple-folder" to " space at start" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder " space at start" should be listed on the webUI
+    When the user renames the folder " space at start" to "space at end " using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "space at end " should be listed on the webUI
+    When the user renames the folder "space at end " to "  multiple   spaces    all     over   " using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "  multiple   spaces    all     over   " should be listed on the webUI
 
-	Scenario: Rename a folder using both double and single quotes
-		When the user renames the following folder using the webUI
-			|from-name-parts |to-name-parts        |
-			|simple-folder  |First 'single' quotes |
-			|               |-then "double"        |
-		And the user reloads the current page of the webUI
-		Then the following folder should be listed on the webUI
-			|name-parts            |
-			|First 'single' quotes |
-			|-then "double"        |
-		When the user renames the following folder using the webUI
-			|from-name-parts       |to-name-parts   |
-			|First 'single' quotes |a normal folder |
-			|-then "double"        |                |
-		And the user reloads the current page of the webUI
-		Then the folder "a normal folder" should be listed on the webUI
+  Scenario: Rename a folder using both double and single quotes
+    When the user renames the following folder using the webUI
+      | from-name-parts | to-name-parts         |
+      | simple-folder   | First 'single' quotes |
+      |                 | -then "double"        |
+    And the user reloads the current page of the webUI
+    Then the following folder should be listed on the webUI
+      | name-parts            |
+      | First 'single' quotes |
+      | -then "double"        |
+    When the user renames the following folder using the webUI
+      | from-name-parts       | to-name-parts   |
+      | First 'single' quotes | a normal folder |
+      | -then "double"        |                 |
+    And the user reloads the current page of the webUI
+    Then the folder "a normal folder" should be listed on the webUI
 
-	Scenario: Rename a folder using forbidden characters
-		When the user renames the folder "simple-folder" to one of these names using the webUI
-		|simple\folder   |
-		|\\simple-folder |
-		|.htaccess       |
-		Then notifications should be displayed on the webUI with the text
-		|Could not rename "simple-folder"|
-		|Could not rename "simple-folder"|
-		|Could not rename "simple-folder"|
-		And the folder "simple-folder" should be listed on the webUI
+  Scenario: Rename a folder using forbidden characters
+    When the user renames the folder "simple-folder" to one of these names using the webUI
+      | simple\folder   |
+      | \\simple-folder |
+      | .htaccess       |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "simple-folder" |
+      | Could not rename "simple-folder" |
+      | Could not rename "simple-folder" |
+    And the folder "simple-folder" should be listed on the webUI
 
-	Scenario: Rename a folder putting a name of a file which already exists
-		When the user renames the folder "simple-folder" to "lorem.txt" using the webUI
-		Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
+  Scenario: Rename a folder putting a name of a file which already exists
+    When the user renames the folder "simple-folder" to "lorem.txt" using the webUI
+    Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
-	Scenario: Rename a folder to ..
-		When the user renames the folder "simple-folder" to ".." using the webUI
-		Then near the folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
+  Scenario: Rename a folder to ..
+    When the user renames the folder "simple-folder" to ".." using the webUI
+    Then near the folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
-	Scenario: Rename a folder to .
-		When the user renames the folder "simple-folder" to "." using the webUI
-		Then near the folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
+  Scenario: Rename a folder to .
+    When the user renames the folder "simple-folder" to "." using the webUI
+    Then near the folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
-	Scenario: Rename a folder to .part
-		When the user renames the folder "simple-folder" to "simple.part" using the webUI
-		Then near the folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed on the webUI
+  Scenario: Rename a folder to .part
+    When the user renames the folder "simple-folder" to "simple.part" using the webUI
+    Then near the folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed on the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -1,18 +1,18 @@
 @webUI @insulated @disablePreviews
 Feature: disable sharing
-As an admin
-I want to be able to disable the sharing function
-So that users cannot share files
+  As an admin
+  I want to be able to disable the sharing function
+  So that users cannot share files
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: Users tries to share via WebUI when Sharing is disabled
-		Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
-		And the user has browsed to the login page
-		When the user logs in with username "user1" and password "%regular%" using the webUI
-		Then it should not be possible to share the folder "simple-folder" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: Users tries to share via WebUI when Sharing is disabled
+    Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
+    And the user has browsed to the login page
+    When the user logs in with username "user1" and password "%regular%" using the webUI
+    Then it should not be possible to share the folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -1,40 +1,40 @@
 @webUI @insulated @disablePreviews
 Feature: restrict resharing
-As an admin
-I want to be able to forbid the sharing of a received share globally
-As a user
-I want to be able to forbid a user that received a share from me to share it further
+  As an admin
+  I want to be able to forbid the sharing of a received share globally
+  As a user
+  I want to be able to forbid a user that received a share from me to share it further
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-			| user3    | %alt2%    | User Three  | u2@oc.com.np |
-		And these groups have been created:
-			| groupname |
-			| grp1      |
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "%alt1%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And the user has browsed to the login page
+    And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
-	@skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: share a folder with another internal user and prohibit resharing
-		Given the setting "Allow resharing" in the section "Sharing" has been enabled
-		And the user has browsed to the files page
-		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
-		| share | no |
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then it should not be possible to share the folder "simple-folder (2)" using the webUI
+  @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: share a folder with another internal user and prohibit resharing
+    Given the setting "Allow resharing" in the section "Sharing" has been enabled
+    And the user has browsed to the files page
+    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
+      | share | no |
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then it should not be possible to share the folder "simple-folder (2)" using the webUI
 
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: forbid resharing globally
-		Given the setting "Allow resharing" in the section "Sharing" has been disabled
-		And the user has browsed to the files page
-		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then it should not be possible to share the folder "simple-folder (2)" using the webUI
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: forbid resharing globally
+    Given the setting "Allow resharing" in the section "Sharing" has been disabled
+    And the user has browsed to the files page
+    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then it should not be possible to share the folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -1,60 +1,60 @@
 @webUI @insulated @disablePreviews
 Feature: restrict Sharing
-As an admin
-I want to be able to restrict the sharing function
-So that users can only share files with specific users and groups
+  As an admin
+  I want to be able to restrict the sharing function
+  So that users can only share files with specific users and groups
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-			| user3    | %alt2%    | User Three  | u2@oc.com.np |
-		And these groups have been created:
-			| groupname |
-			| grp1      |
-			| grp2      |
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And user "user3" has been added to group "grp2"
-		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "%alt1%" using the webUI
-	
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: Restrict users to only share with users in their groups
-		Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
-		When the user browses to the files page
-		Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
-		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user3" has been added to group "grp2"
+    And the user has browsed to the login page
+    And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: Restrict users to only share with groups they are member of
-		Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
-		When the user browses to the files page
-		Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
-		When the user shares the folder "simple-folder" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: Restrict users to only share with users in their groups
+    Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
+    When the user browses to the files page
+    Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
+    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
 
-	@TestAlsoOnExternalUserBackend
-	Scenario: Do not restrict users to only share with groups they are member of
-		Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
-		And the user browses to the files page
-		When the user shares the folder "simple-folder" with the group "grp2" using the webUI
-		And the user re-logs in with username "user3" and password "%alt2%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: Restrict users to only share with groups they are member of
+    Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
+    When the user browses to the files page
+    Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
+    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
 
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: Forbid sharing with groups
-		Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled
-		When the user browses to the files page
-		Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
-		And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
-		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
+  @TestAlsoOnExternalUserBackend
+  Scenario: Do not restrict users to only share with groups they are member of
+    Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
+    And the user browses to the files page
+    When the user shares the folder "simple-folder" with the group "grp2" using the webUI
+    And the user re-logs in with username "user3" and password "%alt2%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: Forbid sharing with groups
+    Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled
+    When the user browses to the files page
+    Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
+    And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
+    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -1,202 +1,202 @@
 @webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend
 Feature: Federation Sharing - sharing with users on other cloud storages
-As a user
-I want to share files with any users on other cloud storages
-So that other users have access to these files
+  As a user
+  I want to share files with any users on other cloud storages
+  So that other users have access to these files
 
-	Background:
-		Given using server "REMOTE"
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And using server "LOCAL"
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
+  Background:
+    Given using server "REMOTE"
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And using server "LOCAL"
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
-	Scenario: test the single steps of sharing a folder to a remote server
-		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user accepts the offered remote shares using the webUI
-		And using server "REMOTE"
-		Then as "user1" the folder "/simple-folder (2)" should exist
-		And as "user1" the file "/simple-folder (2)/lorem.txt" should exist
-		And as "user1" the folder "/simple-empty-folder (2)" should exist
+  Scenario: test the single steps of sharing a folder to a remote server
+    When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
+    And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    And using server "REMOTE"
+    Then as "user1" the folder "/simple-folder (2)" should exist
+    And as "user1" the file "/simple-folder (2)/lorem.txt" should exist
+    And as "user1" the folder "/simple-empty-folder (2)" should exist
 
-	Scenario: test the single steps of receiving a federation share
-		Given using server "REMOTE"
-		And these users have been created:
-			| username | password | displayname | email        |
-			| user2    | %alt1%   | User Two    | u2@oc.com.np |
-			| user3    | %alt2%   | User Two    | u2@oc.com.np |
-		And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-		And user "user2" from server "REMOTE" has shared "simple-empty-folder" with user "user1" from server "LOCAL"
-		And user "user3" from server "REMOTE" has shared "lorem.txt" with user "user1" from server "LOCAL"
-		And the user has reloaded the current page of the webUI
-		Then dialogs should be displayed on the webUI
-			| title        | content                                                                                              |
-			| Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%/?       |
-			| Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%/? |
-			| Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%/?           |
-		When the user accepts the offered remote shares using the webUI
-		Then the file "lorem (2).txt" should be listed on the webUI
-		And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"
-		And the folder "simple-folder (2)" should be listed on the webUI
-		And the file "lorem.txt" should be listed in the folder "simple-folder (2)" on the webUI
-		And the content of "lorem.txt" on the local server should be the same as the original "simple-folder/lorem.txt"
-		And the file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
-		And the folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
+  Scenario: test the single steps of receiving a federation share
+    Given using server "REMOTE"
+    And these users have been created:
+      | username | password | displayname | email        |
+      | user2    | %alt1%   | User Two    | u2@oc.com.np |
+      | user3    | %alt2%   | User Two    | u2@oc.com.np |
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And user "user2" from server "REMOTE" has shared "simple-empty-folder" with user "user1" from server "LOCAL"
+    And user "user3" from server "REMOTE" has shared "lorem.txt" with user "user1" from server "LOCAL"
+    And the user has reloaded the current page of the webUI
+    Then dialogs should be displayed on the webUI
+      | title        | content                                                                                              |
+      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%/?       |
+      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%/? |
+      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%/?           |
+    When the user accepts the offered remote shares using the webUI
+    Then the file "lorem (2).txt" should be listed on the webUI
+    And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"
+    And the folder "simple-folder (2)" should be listed on the webUI
+    And the file "lorem.txt" should be listed in the folder "simple-folder (2)" on the webUI
+    And the content of "lorem.txt" on the local server should be the same as the original "simple-folder/lorem.txt"
+    And the file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    And the folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
 
-	Scenario: declining a federation share on the webUI
-		Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-		And the user has reloaded the current page of the webUI
-		When the user declines the offered remote shares using the webUI
-		Then the file "lorem (2).txt" should not be listed on the webUI
-		And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+  Scenario: declining a federation share on the webUI
+    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    And the user has reloaded the current page of the webUI
+    When the user declines the offered remote shares using the webUI
+    Then the file "lorem (2).txt" should not be listed on the webUI
+    And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
-	@skipOnMICROSOFTEDGE
-	Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
-		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
-		| delete | no |
-		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user accepts the offered remote shares using the webUI
-		And the user opens the folder "simple-folder (2)" using the webUI
-		Then it should not be possible to delete the file "lorem.txt" using the webUI
+  @skipOnMICROSOFTEDGE
+  Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
+    When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
+    And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
+      | delete | no |
+    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    And the user opens the folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete the file "lorem.txt" using the webUI
 
-	@skipOnMICROSOFTEDGE
-	Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-		When the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user shares the folder "simple-folder" with the remote user "user1@%local_server_without_scheme%" using the webUI
-		And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
-		| delete | no |
-		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
-		And the user accepts the offered remote shares using the webUI
-		And the user opens the folder "simple-folder (2)" using the webUI
-		Then it should not be possible to delete the file "lorem.txt" using the webUI
+  @skipOnMICROSOFTEDGE
+  Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
+    When the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user shares the folder "simple-folder" with the remote user "user1@%local_server_without_scheme%" using the webUI
+    And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
+      | delete | no |
+    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    And the user opens the folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete the file "lorem.txt" using the webUI
 
-	Scenario: overwrite a file in a received share - local server shares - remote server receives
-		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" has accepted the last pending share
-		When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
-		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
+  Scenario: overwrite a file in a received share - local server shares - remote server receives
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
+    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
 
-	Scenario: overwrite a file in a received share - remote server shares - local server receives
-		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-		And the user has reloaded the current page of the webUI
-		When the user accepts the offered remote shares using the webUI
-		And the user opens the folder "simple-folder (2)" using the webUI
-		And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
+  Scenario: overwrite a file in a received share - remote server shares - local server receives
+    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And the user has reloaded the current page of the webUI
+    When the user accepts the offered remote shares using the webUI
+    And the user opens the folder "simple-folder (2)" using the webUI
+    And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
 
-	Scenario: upload a new file in a received share - local server shares - remote server receives
-		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" has accepted the last pending share
-		When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
-		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "new-lorem.txt" should be listed on the webUI
-		And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
+  Scenario: upload a new file in a received share - local server shares - remote server receives
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
+    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "new-lorem.txt" should be listed on the webUI
+    And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
 
-	Scenario: upload a new file in a received share - remote server shares - local server receives
-		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-		And the user has reloaded the current page of the webUI
-		When the user accepts the offered remote shares using the webUI
-		And the user opens the folder "simple-folder (2)" using the webUI
-		And the user uploads the file "new-lorem.txt" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "new-lorem.txt" should be listed on the webUI
-		And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
+  Scenario: upload a new file in a received share - remote server shares - local server receives
+    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And the user has reloaded the current page of the webUI
+    When the user accepts the offered remote shares using the webUI
+    And the user opens the folder "simple-folder (2)" using the webUI
+    And the user uploads the file "new-lorem.txt" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "new-lorem.txt" should be listed on the webUI
+    And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
 
-	Scenario: rename a file in a received share - local server shares - remote server receives
-		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" has accepted the last pending share
-		When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
-		When the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "renamed file.txt" should be listed on the webUI
-		But the file "lorem-big.txt" should not be listed on the webUI
-		And the content of "renamed file.txt" on the local server should be the same as the original "simple-folder/lorem-big.txt"
+  Scenario: rename a file in a received share - local server shares - remote server receives
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
+    When the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "renamed file.txt" should be listed on the webUI
+    But the file "lorem-big.txt" should not be listed on the webUI
+    And the content of "renamed file.txt" on the local server should be the same as the original "simple-folder/lorem-big.txt"
 
-	Scenario: rename a file in a received share - remote server shares - local server receives
-		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-		And the user has reloaded the current page of the webUI
-		When the user accepts the offered remote shares using the webUI
-		When the user opens the folder "simple-folder (2)" using the webUI
-		And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "renamed file.txt" should be listed on the webUI
-		And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
-		But the file "lorem-big.txt" should not be listed on the webUI
+  Scenario: rename a file in a received share - remote server shares - local server receives
+    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And the user has reloaded the current page of the webUI
+    When the user accepts the offered remote shares using the webUI
+    When the user opens the folder "simple-folder (2)" using the webUI
+    And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "renamed file.txt" should be listed on the webUI
+    And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
+    But the file "lorem-big.txt" should not be listed on the webUI
 
-	Scenario: delete a file in a received share - local server shares - remote server receives
-		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" has accepted the last pending share
-		When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
-		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "data.zip" should not be listed on the webUI
+  Scenario: delete a file in a received share - local server shares - remote server receives
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
+    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "data.zip" should not be listed on the webUI
 
-	Scenario: delete a file in a received share - remote server shares - local server receives
-		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-		And the user has reloaded the current page of the webUI
-		When the user accepts the offered remote shares using the webUI
-		And the user opens the folder "simple-folder (2)" using the webUI
-		And the user deletes the file "data.zip" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user opens the folder "simple-folder" using the webUI
-		Then the file "data.zip" should not be listed on the webUI
+  Scenario: delete a file in a received share - remote server shares - local server receives
+    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And the user has reloaded the current page of the webUI
+    When the user accepts the offered remote shares using the webUI
+    And the user opens the folder "simple-folder (2)" using the webUI
+    And the user deletes the file "data.zip" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    Then the file "data.zip" should not be listed on the webUI
 
-	Scenario: receive same name federation share from two users
-		Given using server "REMOTE"
-		And these users have been created:
-			| username | password | displayname | email        |
-			| user2    | %alt1%   | User Two    | u2@oc.com.np |
-		And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-		And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-		And the user has reloaded the current page of the webUI
-		When the user accepts the offered remote shares using the webUI
-		Then the file "lorem (2).txt" should be listed on the webUI
-		And the file "lorem (3).txt" should be listed on the webUI
-		And the file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
-		And the file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
+  Scenario: receive same name federation share from two users
+    Given using server "REMOTE"
+    And these users have been created:
+      | username | password | displayname | email        |
+      | user2    | %alt1%   | User Two    | u2@oc.com.np |
+    And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    And the user has reloaded the current page of the webUI
+    When the user accepts the offered remote shares using the webUI
+    Then the file "lorem (2).txt" should be listed on the webUI
+    And the file "lorem (3).txt" should be listed on the webUI
+    And the file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
+    And the file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
 
-	Scenario: unshare a federation share
-		Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		And the user has reloaded the current page of the webUI
-		When the user unshares the file "lorem (2).txt" using the webUI
-		Then the file "lorem (2).txt" should not be listed on the webUI
-		When the user has reloaded the current page of the webUI
-		Then the file "lorem (2).txt" should not be listed on the webUI
-		And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+  Scenario: unshare a federation share
+    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
+    When the user unshares the file "lorem (2).txt" using the webUI
+    Then the file "lorem (2).txt" should not be listed on the webUI
+    When the user has reloaded the current page of the webUI
+    Then the file "lorem (2).txt" should not be listed on the webUI
+    And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
-	Scenario: unshare a federation share from "share-with-you" page
-		Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-		And user "user1" from server "LOCAL" has accepted the last pending share
-		And the user has reloaded the current page of the webUI
-		When the user unshares the file "lorem (2).txt" using the webUI
-		Then the file "lorem (2).txt" should not be listed on the webUI
-		And the file "lorem (2).txt" should not be listed in the files page on the webUI
+  Scenario: unshare a federation share from "share-with-you" page
+    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
+    When the user unshares the file "lorem (2).txt" using the webUI
+    Then the file "lorem (2).txt" should not be listed on the webUI
+    And the file "lorem (2).txt" should not be listed in the files page on the webUI
 
-	@skip @issue-32732
-	Scenario: test sharing long file names with federation share
-		When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
-		And the user has reloaded the current page of the webUI
-		And the user shares the file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
-		And the user accepts the offered remote shares using the webUI
-		And using server "REMOTE"
-		Then as "user1" the file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
+  @skip @issue-32732
+  Scenario: test sharing long file names with federation share
+    When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
+    And the user has reloaded the current page of the webUI
+    And the user shares the file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with the remote user "user1@%remote_server_without_scheme%" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    And using server "REMOTE"
+    Then as "user1" the file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -1,230 +1,230 @@
 @webUI @insulated @disablePreviews @mailhog
 Feature: Share by public link
-As a user
-I want to share files through a publicly accessible link
-So that users who do not have an account on my ownCloud server can access them
+  As a user
+  I want to share files through a publicly accessible link
+  So that users who do not have an account on my ownCloud server can access them
 
-As an admin
-I want to limit the ability of a user to share files/folders through a publicly accessible link
-So that public sharing is limited according to organization policy
+  As an admin
+  I want to limit the ability of a user to share files/folders through a publicly accessible link
+  So that public sharing is limited according to organization policy
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
-	@smokeTest
-	Scenario: simple sharing by public link
-		When the user creates a new public link for the folder "simple-folder" using the webUI
-		And the public accesses the last created public link using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
+  @smokeTest
+  Scenario: simple sharing by public link
+    When the user creates a new public link for the folder "simple-folder" using the webUI
+    And the public accesses the last created public link using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
 
-	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
-	Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | read-write |
-		And the public accesses the last created public link using the webUI
-		And the user deletes the following elements using the webUI
-		| name                                 |
-		| simple-empty-folder                  |
-		| lorem.txt                            |
-		| strängé filename (duplicate #2 &).txt  |
-		| zzzz-must-be-last-file-in-folder.txt |
-		Then the deleted elements should not be listed on the webUI
-		And the deleted elements should not be listed on the webUI after a page reload
+  @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
+  Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    And the user deletes the following elements using the webUI
+      | name                                  |
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | strängé filename (duplicate #2 &).txt |
+      | zzzz-must-be-last-file-in-folder.txt  |
+    Then the deleted elements should not be listed on the webUI
+    And the deleted elements should not be listed on the webUI after a page reload
 
-	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
-	Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | read |
-		And the public accesses the last created public link using the webUI
-		Then it should not be possible to delete the file "lorem.txt" using the webUI
+  @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
+  Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | permission | read |
+    And the public accesses the last created public link using the webUI
+    Then it should not be possible to delete the file "lorem.txt" using the webUI
 
-	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
-	Scenario: mount public link
-		Given using server "REMOTE"
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user2    | %regular% | User One    | u1@oc.com.np |
-		When the user creates a new public link for the folder "simple-folder" using the webUI
-		And the user logs out of the webUI
-		And the public accesses the last created public link using the webUI
-		And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
-		And the user accepts the offered remote shares using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		When the user opens the folder "simple-folder (2)" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
-		And it should not be possible to delete the file "lorem.txt" using the webUI
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
+  Scenario: mount public link
+    Given using server "REMOTE"
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user2    | %regular% | User One    | u1@oc.com.np |
+    When the user creates a new public link for the folder "simple-folder" using the webUI
+    And the user logs out of the webUI
+    And the public accesses the last created public link using the webUI
+    And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    When the user opens the folder "simple-folder (2)" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
+    And it should not be possible to delete the file "lorem.txt" using the webUI
 
-	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
-	Scenario: mount public link and overwrite file
-		Given using server "REMOTE"
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user2    | %regular% | User One    | u1@oc.com.np |
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | read-write |
-		And the user logs out of the webUI
-		And the public accesses the last created public link using the webUI
-		And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
-		And the user accepts the offered remote shares using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		When the user opens the folder "simple-folder (2)" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
-		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
+  Scenario: mount public link and overwrite file
+    Given using server "REMOTE"
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user2    | %regular% | User One    | u1@oc.com.np |
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the user logs out of the webUI
+    And the public accesses the last created public link using the webUI
+    And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    When the user opens the folder "simple-folder (2)" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
+    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
 
-	Scenario: public should be able to access a public link with correct password
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| password | pass123 |
-		And the public accesses the last created public link with password "pass123" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
+  Scenario: public should be able to access a public link with correct password
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | password | pass123 |
+    And the public accesses the last created public link with password "pass123" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
 
-	Scenario: public should not be able to access a public link with wrong password
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| password | pass123 |
-		And the public tries to access the last created public link with wrong password "pass12" using the webUI
-		Then the public should not get access to the publicly shared file
+  Scenario: public should not be able to access a public link with wrong password
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | password | pass123 |
+    And the public tries to access the last created public link with wrong password "pass12" using the webUI
+    Then the public should not get access to the publicly shared file
 
-	Scenario: user tries to create a public link with name longer than 64 chars
-		Given user "user1" has moved file "/lorem.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
-		And the user has reloaded the current page of the webUI
-		When the user tries to create a new public link for the file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI
-		Then the user should see a error message on public dialog saying "Share name cannot be more than 64 characters"
-		And public link should not be generated
+  Scenario: user tries to create a public link with name longer than 64 chars
+    Given user "user1" has moved file "/lorem.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And the user has reloaded the current page of the webUI
+    When the user tries to create a new public link for the file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI
+    Then the user should see a error message on public dialog saying "Share name cannot be more than 64 characters"
+    And public link should not be generated
 
-	Scenario: user shares a public link with folder longer than 64 chars and shorter link name
-		Given user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
-		And the user has reloaded the current page of the webUI
-		When the user creates a new public link for the folder "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI with
-		|name | short_linkname |
-		And the public accesses the last created public link using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
+  Scenario: user shares a public link with folder longer than 64 chars and shorter link name
+    Given user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And the user has reloaded the current page of the webUI
+    When the user creates a new public link for the folder "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI with
+      | name | short_linkname |
+    And the public accesses the last created public link using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
 
-	Scenario: user tries to create a public link with read only permission without entering share password while enforce password on read only public share is enforced
-		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-		When the user tries to create a new public link for the folder "simple-folder" using the webUI
-		Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
-		And public link should not be generated
+  Scenario: user tries to create a public link with read only permission without entering share password while enforce password on read only public share is enforced
+    Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    When the user tries to create a new public link for the folder "simple-folder" using the webUI
+    Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
+    And public link should not be generated
 
-	Scenario: user tries to create a public link with read-write permission without entering share password while enforce password on read-write public share is enforced
-		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
-		When the user tries to create a new public link for the folder "simple-folder" using the webUI with
-			| permission | read-write |
-		Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
-		And public link should not be generated
+  Scenario: user tries to create a public link with read-write permission without entering share password while enforce password on read-write public share is enforced
+    Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
+    When the user tries to create a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
+    And public link should not be generated
 
-	Scenario: user tries to create a public link with write only permission without entering share password while enforce password on write only public share is enforced
-		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
-		When the user tries to create a new public link for the folder "simple-folder" using the webUI with
-			| permission | upload |
-		Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
-		And public link should not be generated
+  Scenario: user tries to create a public link with write only permission without entering share password while enforce password on write only public share is enforced
+    Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
+    When the user tries to create a new public link for the folder "simple-folder" using the webUI with
+      | permission | upload |
+    Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
+    And public link should not be generated
 
-	Scenario: user creates a public link with read-write permission without entering share password while enforce password on read only public share is enforced
-		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-			| permission | read-write |
-		And the public accesses the last created public link using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
+  Scenario: user creates a public link with read-write permission without entering share password while enforce password on read only public share is enforced
+    Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
 
-	Scenario: public should be able to access the shared file through public link
-		When the user creates a new public link for the file 'lorem.txt' using the webUI
-		And the public accesses the last created public link using the webUI
-		Then the text preview of the public link should contain "Lorem ipsum dolor sit amet, consectetur"
-		And the content of the file shared by last public link should be the same as "lorem.txt"
+  Scenario: public should be able to access the shared file through public link
+    When the user creates a new public link for the file 'lorem.txt' using the webUI
+    And the public accesses the last created public link using the webUI
+    Then the text preview of the public link should contain "Lorem ipsum dolor sit amet, consectetur"
+    And the content of the file shared by last public link should be the same as "lorem.txt"
 
-	Scenario: user shares a public link via email
-		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-		And the user has reloaded the current page of the webUI
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| email | foo@bar.co |
-		Then the email address "foo@bar.co" should have received an email with the body containing
+  Scenario: user shares a public link via email
+    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And the user has reloaded the current page of the webUI
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | email | foo@bar.co |
+    Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "foo@bar.co" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing last shared public link
 
-	Scenario: user shares a public link via email and sends a copy to self
-		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-		And the user has reloaded the current page of the webUI
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| email | foo@bar.co |
-		| emailToSelf | true |
-		Then the email address "foo@bar.co" should have received an email with the body containing
+  Scenario: user shares a public link via email and sends a copy to self
+    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And the user has reloaded the current page of the webUI
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | email       | foo@bar.co |
+      | emailToSelf | true       |
+    Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "u1@oc.com.np" should have received an email with the body containing
+    And the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "foo@bar.co" should have received an email containing last shared public link
-		And the email address "u1@oc.com.np" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing last shared public link
+    And the email address "u1@oc.com.np" should have received an email containing last shared public link
 
-	Scenario: user shares a public link via email with multiple addresses
-		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-		And the user has reloaded the current page of the webUI
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| email | foo@bar.co, foo@barr.co |
-		Then the email address "foo@bar.co" should have received an email with the body containing
+  Scenario: user shares a public link via email with multiple addresses
+    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And the user has reloaded the current page of the webUI
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | email | foo@bar.co, foo@barr.co |
+    Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "foo@barr.co" should have received an email with the body containing
+    And the email address "foo@barr.co" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "foo@bar.co" should have received an email containing last shared public link
-		And the email address "foo@barr.co" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing last shared public link
+    And the email address "foo@barr.co" should have received an email containing last shared public link
 
-	Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
-		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-		And the user has reloaded the current page of the webUI
-		When the user opens the share dialog for the folder "simple-folder"
-		And the user opens the public link share tab
-		And the user opens the create public link share popup
-		And the user adds the following email addresses using the webUI:
-		|email            |
-		| foo1234@bar.co  |
-		| foo5678@bar.co  |
-		| foo1234@barr.co |
-		| foo5678@barr.co |
-		And the user removes the following email addresses using the webUI:
-		| email            |
-		| foo1234@bar.co   |
-		| foo5678@barr.co  |
-		And the user creates the public link using the webUI
-		Then the email address "foo5678@bar.co" should have received an email with the body containing
+  Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
+    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And the user has reloaded the current page of the webUI
+    When the user opens the share dialog for the folder "simple-folder"
+    And the user opens the public link share tab
+    And the user opens the create public link share popup
+    And the user adds the following email addresses using the webUI:
+      | email           |
+      | foo1234@bar.co  |
+      | foo5678@bar.co  |
+      | foo1234@barr.co |
+      | foo5678@barr.co |
+    And the user removes the following email addresses using the webUI:
+      | email           |
+      | foo1234@bar.co  |
+      | foo5678@barr.co |
+    And the user creates the public link using the webUI
+    Then the email address "foo5678@bar.co" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "foo1234@barr.co" should have received an email with the body containing
+    And the email address "foo1234@barr.co" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "foo5678@bar.co" should have received an email containing last shared public link
-		And the email address "foo1234@barr.co" should have received an email containing last shared public link
-		But the email address "foo1234@bar.co" should not have received an email
-		And the email address "foo5678@barr.co" should not have received an email
+    And the email address "foo5678@bar.co" should have received an email containing last shared public link
+    And the email address "foo1234@barr.co" should have received an email containing last shared public link
+    But the email address "foo1234@bar.co" should not have received an email
+    And the email address "foo5678@barr.co" should not have received an email
 
-	Scenario: user shares a public link via email with a personal message
-		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-		And the user has reloaded the current page of the webUI
-		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| email | foo@bar.co |
-		| personalMessage | lorem ipsum |
-		Then the email address "foo@bar.co" should have received an email with the body containing
+  Scenario: user shares a public link via email with a personal message
+    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And the user has reloaded the current page of the webUI
+    When the user creates a new public link for the folder "simple-folder" using the webUI with
+      | email           | foo@bar.co  |
+      | personalMessage | lorem ipsum |
+    Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
-		And the email address "foo@bar.co" should have received an email with the body containing
+    And the email address "foo@bar.co" should have received an email with the body containing
 			"""
 			lorem ipsum
 			"""
-		And the email address "foo@bar.co" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing last shared public link

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -1,107 +1,107 @@
 @webUI @insulated @disablePreviews
 Feature: Sharing files and folders with internal groups
-As a user
-I want to share files and folders with groups
-So that those groups can access the files and folders
+  As a user
+  I want to share files and folders with groups
+  So that those groups can access the files and folders
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-			| user3    | %alt2%    | User Three  | u2@oc.com.np |
-		And these groups have been created:
-			|groupname|
-			|grp1     |
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And the user has browsed to the login page
-		And the user has logged in with username "user3" and password "%alt2%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And the user has browsed to the login page
+    And the user has logged in with username "user3" and password "%alt2%" using the webUI
 
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: share a folder with an internal group
-		When the user shares the folder "simple-folder" with the group "grp1" using the webUI
-		And the user shares the file "testimage.jpg" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
-		And the file "testimage (2).jpg" should be listed on the webUI
-		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
-		And the file "testimage (2).jpg" should be listed on the webUI
-		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: share a folder with an internal group
+    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    And the user shares the file "testimage.jpg" with the group "grp1" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
+    And the file "testimage (2).jpg" should be listed on the webUI
+    And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
+    And the file "testimage (2).jpg" should be listed on the webUI
+    And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
 
-	@TestAlsoOnExternalUserBackend
-	Scenario: share a file with an internal group a member overwrites and unshares the file
-		When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
-		And the user shares the file "new-lorem.txt" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
+  @TestAlsoOnExternalUserBackend
+  Scenario: share a file with an internal group a member overwrites and unshares the file
+    When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
+    And the user shares the file "new-lorem.txt" with the group "grp1" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-		When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
-		Then the file "new-lorem.txt" should be listed on the webUI
-		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
+    Then the file "new-lorem.txt" should be listed on the webUI
+    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
-		When the user unshares the file "new-lorem.txt" using the webUI
-		Then the file "new-lorem.txt" should not be listed on the webUI
+    When the user unshares the file "new-lorem.txt" using the webUI
+    Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that another group member can still see the file
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# check that the original file owner can still see the file
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-	@TestAlsoOnExternalUserBackend
-	Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
-		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-		And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		And the user opens the folder "new-simple-folder" using the webUI
-		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
+  @TestAlsoOnExternalUserBackend
+  Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
+    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+    And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user opens the folder "new-simple-folder" using the webUI
+    Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the local "lorem.txt"
+    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share
-		When the user uploads the file "new-lorem.txt" using the webUI
-		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    When the user uploads the file "new-lorem.txt" using the webUI
+    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# delete a file in the received share
-		When the user deletes the file "data.zip" using the webUI
-		Then the file "data.zip" should not be listed on the webUI
+    When the user deletes the file "data.zip" using the webUI
+    Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible to another group member
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		And the user opens the folder "new-simple-folder" using the webUI
-		Then the content of "lorem.txt" should be the same as the local "lorem.txt"
-		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-		And the file "data.zip" should not be listed on the webUI
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    And the user opens the folder "new-simple-folder" using the webUI
+    Then the content of "lorem.txt" should be the same as the local "lorem.txt"
+    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    And the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-		When the user re-logs in with username "user3" and password "%alt2%" using the webUI
-		And the user opens the folder "new-simple-folder" using the webUI
-		Then the content of "lorem.txt" should be the same as the local "lorem.txt"
-		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-		And the file "data.zip" should not be listed on the webUI
+    When the user re-logs in with username "user3" and password "%alt2%" using the webUI
+    And the user opens the folder "new-simple-folder" using the webUI
+    Then the content of "lorem.txt" should be the same as the local "lorem.txt"
+    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    And the file "data.zip" should not be listed on the webUI
 
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: share a folder with an internal group and a member unshares the folder
-		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-		And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: share a folder with an internal group and a member unshares the folder
+    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+    And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		And the user unshares the folder "new-simple-folder" using the webUI
-		Then the folder "new-simple-folder" should not be listed on the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user unshares the folder "new-simple-folder" using the webUI
+    Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible to another group member
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		Then the folder "new-simple-folder" should be listed on the webUI
-		When the user opens the folder "new-simple-folder" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    Then the folder "new-simple-folder" should be listed on the webUI
+    When the user opens the folder "new-simple-folder" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		# check that the folder is still visible for the share owner
-		When the user re-logs in with username "user3" and password "%alt2%" using the webUI
-		Then the folder "new-simple-folder" should be listed on the webUI
-		When the user opens the folder "new-simple-folder" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    When the user re-logs in with username "user3" and password "%alt2%" using the webUI
+    Then the folder "new-simple-folder" should be listed on the webUI
+    When the user opens the folder "new-simple-folder" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -1,36 +1,36 @@
 @webUI @insulated @disablePreviews
 Feature: Sharing files and folders with internal groups
-As a user
-I want to share files and folders with groups
-So that those groups can access the files and folders
+  As a user
+  I want to share files and folders with groups
+  So that those groups can access the files and folders
 
-	Scenario Outline: sharing  files and folder with an internal problematic group name
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-			| user3    | %alt2%    | User Three  | u2@oc.com.np |
-		And these groups have been created:
-			|groupname|
-			|<group>  |
-		And user "user1" has been added to group "<group>"
-		And user "user2" has been added to group "<group>"
-		And the user has browsed to the login page
-		And the user has logged in with username "user3" and password "%alt2%" using the webUI
-		When the user shares the folder "simple-folder" with the group "<group>" using the webUI
-		And the user shares the file "testimage.jpg" with the group "<group>" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
-		And the file "testimage (2).jpg" should be listed on the webUI
-		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
-		And the file "testimage (2).jpg" should be listed on the webUI
-		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
-		Examples:
-			| group     |
-			| ?\?@#%@,; |
-			| नेपाली    |
+  Scenario Outline: sharing  files and folder with an internal problematic group name
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+    And these groups have been created:
+      | groupname |
+      | <group>   |
+    And user "user1" has been added to group "<group>"
+    And user "user2" has been added to group "<group>"
+    And the user has browsed to the login page
+    And the user has logged in with username "user3" and password "%alt2%" using the webUI
+    When the user shares the folder "simple-folder" with the group "<group>" using the webUI
+    And the user shares the file "testimage.jpg" with the group "<group>" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
+    And the file "testimage (2).jpg" should be listed on the webUI
+    And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
+    And the file "testimage (2).jpg" should be listed on the webUI
+    And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+    Examples:
+      | group     |
+      | ?\?@#%@,; |
+      | नेपाली    |
 

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -1,240 +1,240 @@
 @webUI @insulated @disablePreviews
 Feature: accept/decline shares coming from internal users
-	As a user
-	I want to have control of which received shares I accept
-	So that I can keep my file system clean
+  As a user
+  I want to have control of which received shares I accept
+  So that I can keep my file system clean
 
-	Background:
-		Given these users have been created:
-          | username | password  | displayname | email        |
-          | user1    | %regular% | User One    | u1@oc.com.np |
-          | user2    | %alt1%    | User Two    | u2@oc.com.np |
-          | user3    | %alt2%    | User Three  | u2@oc.com.np |
-		And these groups have been created:
-			|groupname|
-			|grp1     |
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And the user has browsed to the login page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And the user has browsed to the login page
 
-	@smokeTest
-	Scenario: Auto-accept disabled results in "Pending" shares
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		When the user logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should not be listed on the webUI
-		And the file "testimage (2).jpg" should not be listed on the webUI
-		But the folder "simple-folder" should be listed in the shared-with-you page on the webUI
-		And the file "testimage.jpg" should be listed in the shared-with-you page on the webUI
-		And the folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
-		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+  @smokeTest
+  Scenario: Auto-accept disabled results in "Pending" shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with group "grp1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    When the user logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should not be listed on the webUI
+    And the file "testimage (2).jpg" should not be listed on the webUI
+    But the folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    And the file "testimage.jpg" should be listed in the shared-with-you page on the webUI
+    And the folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
+    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
 
-	Scenario: receive shares with same name from different users
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user3"
-		And user "user1" has shared folder "/simple-folder" with user "user3"
-		When the user logs in with username "user3" and password "%alt2%" using the webUI
-		Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
-		And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
+  Scenario: receive shares with same name from different users
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user3"
+    And user "user1" has shared folder "/simple-folder" with user "user3"
+    When the user logs in with username "user3" and password "%alt2%" using the webUI
+    Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
+    And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
-	Scenario: receive shares with same name from different users, accept one by one
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has created a folder "/simple-folder/from_user2"
-		And user "user2" has shared folder "/simple-folder" with user "user3"
-		And user "user1" has created a folder "/simple-folder/from_user1"
-		And user "user1" has shared folder "/simple-folder" with user "user3"
-		And the user has logged in with username "user3" and password "%alt2%" using the webUI
-		When the user accepts the share "simple-folder" offered by user "User One" using the webUI
-		And the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-		Then the folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
-		And the folder "simple-folder (3)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
-		And user "user3" should see the following elements
-			| /simple-folder%20(2)/from_user1/ |
-			| /simple-folder%20(3)/from_user2/ |
+  Scenario: receive shares with same name from different users, accept one by one
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has created a folder "/simple-folder/from_user2"
+    And user "user2" has shared folder "/simple-folder" with user "user3"
+    And user "user1" has created a folder "/simple-folder/from_user1"
+    And user "user1" has shared folder "/simple-folder" with user "user3"
+    And the user has logged in with username "user3" and password "%alt2%" using the webUI
+    When the user accepts the share "simple-folder" offered by user "User One" using the webUI
+    And the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    Then the folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
+    And the folder "simple-folder (3)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
+    And user "user3" should see the following elements
+      | /simple-folder%20(2)/from_user1/ |
+      | /simple-folder%20(3)/from_user2/ |
 
-	Scenario: receive shares with same name from different users
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user3"
-		And user "user1" has shared folder "/simple-folder" with user "user3"
-		When the user logs in with username "user3" and password "%alt2%" using the webUI
-		Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
-		And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
+  Scenario: receive shares with same name from different users
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user3"
+    And user "user1" has shared folder "/simple-folder" with user "user3"
+    When the user logs in with username "user3" and password "%alt2%" using the webUI
+    Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
+    And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
-	@smokeTest
-	Scenario: accept an offered share
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-		Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI after a page reload
-		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI after a page reload
-		And the folder "simple-folder (2)" should be listed in the files page on the webUI
-		And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+  @smokeTest
+  Scenario: accept an offered share
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI after a page reload
+    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI after a page reload
+    And the folder "simple-folder (2)" should be listed in the files page on the webUI
+    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
 
-	@smokeTest
-	Scenario: decline an offered (pending) share
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user declines the share "simple-folder" offered by user "User Two" using the webUI
-		Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should not be listed in the files page on the webUI
-		And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+  @smokeTest
+  Scenario: decline an offered (pending) share
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user declines the share "simple-folder" offered by user "User Two" using the webUI
+    Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
 
-	@smokeTest
-	Scenario: decline an accepted share (with page-reload in between)
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-		And the user reloads the current page of the webUI
-		And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
-		Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should not be listed in the files page on the webUI
-		And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+  @smokeTest
+  Scenario: decline an accepted share (with page-reload in between)
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    And the user reloads the current page of the webUI
+    And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
+    Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
 
-	Scenario: decline an accepted share (without any page-reload in between)
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-		And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
-		Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should not be listed in the files page on the webUI
-		And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+  Scenario: decline an accepted share (without any page-reload in between)
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
+    Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
 
-	Scenario: accept a previously declined share
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user declines the share "simple-folder" offered by user "User Two" using the webUI
-		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-		Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should be listed in the files page on the webUI
-		And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+  Scenario: accept a previously declined share
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user declines the share "simple-folder" offered by user "User Two" using the webUI
+    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should be listed in the files page on the webUI
+    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
 
-	Scenario: accept a share that you received as user and as group member
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should be listed in the files page on the webUI
+  Scenario: accept a share that you received as user and as group member
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared folder "/simple-folder" with group "grp1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should be listed in the files page on the webUI
 
-	Scenario: reject a share that you received as user and as group member
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user declines the share "simple-folder" offered by user "User Two" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should not be listed in the files page on the webUI
+  Scenario: reject a share that you received as user and as group member
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared folder "/simple-folder" with group "grp1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user declines the share "simple-folder" offered by user "User Two" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
 
-	Scenario: reshare a share that you received to a group that you are member of
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-		And the user has browsed to the files page
-		And the user shares the folder "simple-folder (2)" with the group "grp1" using the webUI
-		And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
-		And the user reloads the current page of the webUI
-		Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should not be listed in the files page on the webUI
+  Scenario: reshare a share that you received to a group that you are member of
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    And the user has browsed to the files page
+    And the user shares the folder "simple-folder (2)" with the group "grp1" using the webUI
+    And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
+    And the user reloads the current page of the webUI
+    Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
 
-	@smokeTest
-	Scenario: unshare an accepted share on the "All files" page
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user2" has shared folder "/testimage.jpg" with group "grp1"
-		And user "user1" has accepted the share "/simple-folder" offered by user "user2"
-		And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user unshares the folder "simple-folder (2)" using the webUI
-		And the user unshares the file "testimage (2).jpg" using the webUI
-		Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
-		And the file "testimage (2).jpg" should not be listed in the files page on the webUI 
-		And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-		And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+  @smokeTest
+  Scenario: unshare an accepted share on the "All files" page
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared folder "/testimage.jpg" with group "grp1"
+    And user "user1" has accepted the share "/simple-folder" offered by user "user2"
+    And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user unshares the folder "simple-folder (2)" using the webUI
+    And the user unshares the file "testimage (2).jpg" using the webUI
+    Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+    And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
-	@smokeTest
-	Scenario: Auto-accept shares
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And user "user2" has shared folder "/testimage.jpg" with user "user1"
-		When the user logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		And the file "testimage (2).jpg" should be listed on the webUI
-		And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
-		And the file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
-		And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-		And the file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI
+  @smokeTest
+  Scenario: Auto-accept shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user2" has shared folder "/simple-folder" with group "grp1"
+    And user "user2" has shared folder "/testimage.jpg" with user "user1"
+    When the user logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    And the file "testimage (2).jpg" should be listed on the webUI
+    And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    And the file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
+    And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And the file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI
 
-	Scenario: decline auto-accepted shares
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And user "user2" has shared folder "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
-		And the user declines the share "testimage (2).jpg" offered by user "User Two" using the webUI
-		And the user has browsed to the files page
-		Then the folder "simple-folder (2)" should not be listed on the webUI
-		And the file "testimage (2).jpg" should not be listed on the webUI
-		And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-		And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+  Scenario: decline auto-accepted shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user2" has shared folder "/simple-folder" with group "grp1"
+    And user "user2" has shared folder "/testimage.jpg" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
+    And the user declines the share "testimage (2).jpg" offered by user "User Two" using the webUI
+    And the user has browsed to the files page
+    Then the folder "simple-folder (2)" should not be listed on the webUI
+    And the file "testimage (2).jpg" should not be listed on the webUI
+    And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
-	Scenario: unshare auto-accepted shares
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And user "user2" has shared folder "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user unshares the folder "simple-folder (2)" using the webUI
-		And the user unshares the file "testimage (2).jpg" using the webUI
-		Then the folder "simple-folder (2)" should not be listed on the webUI
-		And the file "testimage (2).jpg" should not be listed on the webUI
-		And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-		And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+  Scenario: unshare auto-accepted shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user2" has shared folder "/simple-folder" with group "grp1"
+    And user "user2" has shared folder "/testimage.jpg" with user "user1"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user unshares the folder "simple-folder (2)" using the webUI
+    And the user unshares the file "testimage (2).jpg" using the webUI
+    Then the folder "simple-folder (2)" should not be listed on the webUI
+    And the file "testimage (2).jpg" should not be listed on the webUI
+    And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
-	Scenario: unshare renamed shares
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user unshares the folder "simple-folder-renamed" using the webUI
-		Then the folder "simple-folder-renamed" should not be listed on the webUI
-		And the folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
+  Scenario: unshare renamed shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user unshares the folder "simple-folder-renamed" using the webUI
+    Then the folder "simple-folder-renamed" should not be listed on the webUI
+    And the folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
 
-	Scenario: unshare moved shares
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder/shared"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user opens the folder "simple-folder" using the webUI
-		And the user unshares the folder "shared" using the webUI
-		Then the folder "shared" should not be listed on the webUI
-		And the folder "shared" should be in state "Declined" in the shared-with-you page on the webUI
+  Scenario: unshare moved shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder/shared"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user opens the folder "simple-folder" using the webUI
+    And the user unshares the folder "shared" using the webUI
+    Then the folder "shared" should not be listed on the webUI
+    And the folder "shared" should be in state "Declined" in the shared-with-you page on the webUI
 
-	Scenario: unshare renamed shares, accept it again
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		When the user unshares the folder "simple-folder-renamed" using the webUI
-		And the user accepts the share "simple-folder-renamed" offered by user "User Two" using the webUI
-		Then the folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
-		And the folder "simple-folder-renamed" should be listed in the files page on the webUI
+  Scenario: unshare renamed shares, accept it again
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    When the user unshares the folder "simple-folder-renamed" using the webUI
+    And the user accepts the share "simple-folder-renamed" offered by user "User Two" using the webUI
+    Then the folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
+    And the folder "simple-folder-renamed" should be listed in the files page on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -1,146 +1,146 @@
 @webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend
 Feature: Autocompletion of share-with names
-As a user
-I want to share files, with minimal typing, to the right people or groups
-So that I can efficiently share my files with other users or groups
+  As a user
+  I want to share files, with minimal typing, to the right people or groups
+  So that I can efficiently share my files with other users or groups
 
-	Background:
-		Given these users have been created but not initialized:
-			| username    | password  | displayname     | email                 |
-			| user1       | %regular% | User One        | u1@oc.com.np          |
-			| two         | %regular% | User Two        | u2@oc.com.np          |
-			| user3       | %regular% | Three           | u3@oc.com.np          |
-			| u444        | %regular% | Four            | u3@oc.com.np          |
-			| usergrp     | %regular% | User Ggg        | u@oc.com.np           |
-			| five        | %regular% | User Group      | five@oc.com.np        |
-			| regularuser | %regular% | User Regular    | regularuser@oc.com.np |
-			| usersmith   | %regular% | John Finn Smith | js@oc.com.np          |
-		And these groups have been created:
-			| groupname     |
-			| finance1      |
-			| finance2      |
-			| finance3      |
-			| users-finance |
-			| other         |
-		And the user has browsed to the login page
+  Background:
+    Given these users have been created but not initialized:
+      | username    | password  | displayname     | email                 |
+      | user1       | %regular% | User One        | u1@oc.com.np          |
+      | two         | %regular% | User Two        | u2@oc.com.np          |
+      | user3       | %regular% | Three           | u3@oc.com.np          |
+      | u444        | %regular% | Four            | u3@oc.com.np          |
+      | usergrp     | %regular% | User Ggg        | u@oc.com.np           |
+      | five        | %regular% | User Group      | five@oc.com.np        |
+      | regularuser | %regular% | User Regular    | regularuser@oc.com.np |
+      | usersmith   | %regular% | John Finn Smith | js@oc.com.np          |
+    And these groups have been created:
+      | groupname     |
+      | finance1      |
+      | finance2      |
+      | finance3      |
+      | users-finance |
+      | other         |
+    And the user has browsed to the login page
 
-	@skipOnLDAP @user_ldap-issue-175
-	@smokeTest
-	Scenario: autocompletion of regular existing users
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "us" in the share-with-field
-		Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
-		And the users own name should not be listed in the autocomplete list on the webUI
+  @skipOnLDAP @user_ldap-issue-175
+  @smokeTest
+  Scenario: autocompletion of regular existing users
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "us" in the share-with-field
+    Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP
-	@smokeTest
-	Scenario: autocompletion of regular existing groups
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "fi" in the share-with-field
-		Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
-		And the users own name should not be listed in the autocomplete list on the webUI
-		
-	Scenario: autocompletion for a pattern that does not match any user or group
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "doesnotexist" in the share-with-field
-		Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field on the webUI
-		And the autocomplete list should not be displayed on the webUI
+  @skipOnLDAP
+  @smokeTest
+  Scenario: autocompletion of regular existing groups
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "fi" in the share-with-field
+    Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP
-	Scenario: autocomplete short user/display names when completely typed
-		Given the administrator has set the minimum characters for sharing autocomplete to "4"
-		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And these users have been created but not initialized:
-			| username | password | displayname | email        |
-			| use      | %alt1%   | Use         | uz@oc.com.np |
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "Use" in the share-with-field
-		Then only "Use" should be listed in the autocomplete list on the webUI
+  Scenario: autocompletion for a pattern that does not match any user or group
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "doesnotexist" in the share-with-field
+    Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field on the webUI
+    And the autocomplete list should not be displayed on the webUI
 
-	@skipOnLDAP
-	Scenario: autocomplete short group names when completely typed
-		Given the administrator has set the minimum characters for sharing autocomplete to "3"
-		And these groups have been created:
-			| groupname |
-			| fi        |
-		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "fi" in the share-with-field
-		Then only "fi (group)" should be listed in the autocomplete list on the webUI
+  @skipOnLDAP
+  Scenario: autocomplete short user/display names when completely typed
+    Given the administrator has set the minimum characters for sharing autocomplete to "4"
+    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And these users have been created but not initialized:
+      | username | password | displayname | email        |
+      | use      | %alt1%   | Use         | uz@oc.com.np |
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "Use" in the share-with-field
+    Then only "Use" should be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP
-	Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "u" in the share-with-field
-		Then a tooltip with the text "No users or groups found for u. Please enter at least 2 characters for suggestions" should be shown near the share-with-field on the webUI
-		And the autocomplete list should not be displayed on the webUI
+  @skipOnLDAP
+  Scenario: autocomplete short group names when completely typed
+    Given the administrator has set the minimum characters for sharing autocomplete to "3"
+    And these groups have been created:
+      | groupname |
+      | fi        |
+    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "fi" in the share-with-field
+    Then only "fi (group)" should be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP
-	Scenario: autocompletion when minimum characters is increased and not enough characters are typed
-		Given the administrator has set the minimum characters for sharing autocomplete to "4"
-		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "use" in the share-with-field
-		Then a tooltip with the text "No users or groups found for use. Please enter at least 4 characters for suggestions" should be shown near the share-with-field on the webUI
-		And the autocomplete list should not be displayed on the webUI
+  @skipOnLDAP
+  Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "u" in the share-with-field
+    Then a tooltip with the text "No users or groups found for u. Please enter at least 2 characters for suggestions" should be shown near the share-with-field on the webUI
+    And the autocomplete list should not be displayed on the webUI
 
-	@skipOnLDAP
-	Scenario: autocompletion when increasing the minimum characters for sharing autocomplete
-		Given the administrator has set the minimum characters for sharing autocomplete to "3"
-		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "use" in the share-with-field
-		Then all users and groups that contain the string "use" in their name should be listed in the autocomplete list on the webUI
-		And the users own name should not be listed in the autocomplete list on the webUI
+  @skipOnLDAP
+  Scenario: autocompletion when minimum characters is increased and not enough characters are typed
+    Given the administrator has set the minimum characters for sharing autocomplete to "4"
+    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "use" in the share-with-field
+    Then a tooltip with the text "No users or groups found for use. Please enter at least 4 characters for suggestions" should be shown near the share-with-field on the webUI
+    And the autocomplete list should not be displayed on the webUI
 
-	@skipOnLDAP @user_ldap-issue-175
-	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has shared the folder "simple-folder" with the user "User One" using the webUI
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
-		And the users own name should not be listed in the autocomplete list on the webUI
+  @skipOnLDAP
+  Scenario: autocompletion when increasing the minimum characters for sharing autocomplete
+    Given the administrator has set the minimum characters for sharing autocomplete to "3"
+    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "use" in the share-with-field
+    Then all users and groups that contain the string "use" in their name should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP @user_ldap-issue-175
-	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user has shared the file "data.zip" with the user "User Ggg" using the webUI
-		And the user has opened the share dialog for the file "data.zip"
-		When the user types "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Ggg"
-		And the users own name should not be listed in the autocomplete list on the webUI
+  @skipOnLDAP @user_ldap-issue-175
+  Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has shared the folder "simple-folder" with the user "User One" using the webUI
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "user" in the share-with-field
+    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
+    And the users own name should not be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP
-	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user shares the folder "simple-folder" with the group "finance1" using the webUI
-		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "fi" in the share-with-field
-		Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
-		And the users own name should not be listed in the autocomplete list on the webUI
+  @skipOnLDAP @user_ldap-issue-175
+  Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user has shared the file "data.zip" with the user "User Ggg" using the webUI
+    And the user has opened the share dialog for the file "data.zip"
+    When the user types "user" in the share-with-field
+    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Ggg"
+    And the users own name should not be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP
-	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
-		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And the user shares the file "data.zip" with the group "finance1" using the webUI
-		And the user has opened the share dialog for the file "data.zip"
-		When the user types "fi" in the share-with-field
-		Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
-		And the users own name should not be listed in the autocomplete list on the webUI
+  @skipOnLDAP
+  Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user shares the folder "simple-folder" with the group "finance1" using the webUI
+    And the user has opened the share dialog for the folder "simple-folder"
+    When the user types "fi" in the share-with-field
+    Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
+    And the users own name should not be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
+    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And the user shares the file "data.zip" with the group "finance1" using the webUI
+    And the user has opened the share dialog for the file "data.zip"
+    When the user types "fi" in the share-with-field
+    Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
+    And the users own name should not be listed in the autocomplete list on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -1,94 +1,94 @@
 @webUI @insulated @disablePreviews
 Feature: Sharing files and folders with internal users
-As a user
-I want to share files and folders with other users
-So that those users can access the files and folders
+  As a user
+  I want to share files and folders with other users
+  So that those users can access the files and folders
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "%alt1%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
-	@TestAlsoOnExternalUserBackend
-	@smokeTest
-	Scenario: share a file & folder with another internal user
-		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user shares the file "testimage.jpg" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
-		And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
-		And the file "testimage (2).jpg" should be listed on the webUI
-		And the file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
-		When the user opens the folder "simple-folder (2)" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		But the folder "simple-folder (2)" should not be listed on the webUI
+  @TestAlsoOnExternalUserBackend
+  @smokeTest
+  Scenario: share a file & folder with another internal user
+    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    And the user shares the file "testimage.jpg" with the user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the folder "simple-folder (2)" should be listed on the webUI
+    And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
+    And the file "testimage (2).jpg" should be listed on the webUI
+    And the file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
+    When the user opens the folder "simple-folder (2)" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    But the folder "simple-folder (2)" should not be listed on the webUI
 
-	@TestAlsoOnExternalUserBackend
-	Scenario: share a file with another internal user who overwrites and unshares the file
-		When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
-		And the user shares the file "new-lorem.txt" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
+  @TestAlsoOnExternalUserBackend
+  Scenario: share a file with another internal user who overwrites and unshares the file
+    When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
+    And the user shares the file "new-lorem.txt" with the user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-		When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
-		Then the file "new-lorem.txt" should be listed on the webUI
-		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
+    Then the file "new-lorem.txt" should be listed on the webUI
+    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
-		When the user unshares the file "new-lorem.txt" using the webUI
-		Then the file "new-lorem.txt" should not be listed on the webUI
+    When the user unshares the file "new-lorem.txt" using the webUI
+    Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that the original file owner can still see the file
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-	@TestAlsoOnExternalUserBackend
-	Scenario: share a folder with another internal user who uploads, overwrites and deletes files
-		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-		And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		And the user opens the folder "new-simple-folder" using the webUI
-		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
+  @TestAlsoOnExternalUserBackend
+  Scenario: share a folder with another internal user who uploads, overwrites and deletes files
+    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+    And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user opens the folder "new-simple-folder" using the webUI
+    Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the local "lorem.txt"
+    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share
-		When the user uploads the file "new-lorem.txt" using the webUI
-		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    When the user uploads the file "new-lorem.txt" using the webUI
+    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# delete a file in the received share
-		When the user deletes the file "data.zip" using the webUI
-		Then the file "data.zip" should not be listed on the webUI
+    When the user deletes the file "data.zip" using the webUI
+    Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		And the user opens the folder "new-simple-folder" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the local "lorem.txt"
-		And the file "new-lorem.txt" should be listed on the webUI
-		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-		But the file "data.zip" should not be listed on the webUI
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    And the user opens the folder "new-simple-folder" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the local "lorem.txt"
+    And the file "new-lorem.txt" should be listed on the webUI
+    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    But the file "data.zip" should not be listed on the webUI
 
-	@TestAlsoOnExternalUserBackend
-	Scenario: share a folder with another internal user who unshares the folder
-		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-		And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
+  @TestAlsoOnExternalUserBackend
+  Scenario: share a folder with another internal user who unshares the folder
+    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+    And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		And the user unshares the folder "new-simple-folder" using the webUI
-		Then the folder "new-simple-folder" should not be listed on the webUI
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user unshares the folder "new-simple-folder" using the webUI
+    Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible for the share owner
-		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
-		Then the folder "new-simple-folder" should be listed on the webUI
-		When the user opens the folder "new-simple-folder" using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    Then the folder "new-simple-folder" should be listed on the webUI
+    When the user opens the folder "new-simple-folder" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
-	@skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
-	Scenario: share a folder with another internal user and prohibit deleting
-		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
-		| delete | no |
-		And the user re-logs in with username "user1" and password "%regular%" using the webUI
-		And the user opens the folder "simple-folder (2)" using the webUI
-		Then it should not be possible to delete the file "lorem.txt" using the webUI
+  @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
+  Scenario: share a folder with another internal user and prohibit deleting
+    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
+      | delete | no |
+    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user opens the folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete the file "lorem.txt" using the webUI

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -1,21 +1,21 @@
 @webUI @insulated @disablePreviews @app-required @notifications-app-required
 Feature: Display notifications when receiving a share and follow embedded links
-As a user
-I want to use the notification header as a link
-So that I will be redirected to the most appropriate screen
+  As a user
+  I want to use the notification header as a link
+  So that I will be redirected to the most appropriate screen
 
-	Background:
-		Given the app "notifications" has been enabled
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "%alt1%" using the webUI
+  Background:
+    Given the app "notifications" has been enabled
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
-	@smokeTest
-	Scenario: notification link redirection in case a share is pending
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user1" has shared folder "/simple-folder" with user "user2"
-		When the user follows the link of the first notification on the webUI
-		Then the user should be redirected to a webUI page with the title "Shared with you - ownCloud"
+  @smokeTest
+  Scenario: notification link redirection in case a share is pending
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user1" has shared folder "/simple-folder" with user "user2"
+    When the user follows the link of the first notification on the webUI
+    Then the user should be redirected to a webUI page with the title "Shared with you - ownCloud"

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -1,34 +1,34 @@
 @webUI @insulated @disablePreviews @app-required @notifications-app-required
 Feature: Sharing files and folders with internal groups
-As a user
-I want to share files and folders with groups
-So that those groups can access the files and folders
+  As a user
+  I want to share files and folders with groups
+  So that those groups can access the files and folders
 
-	Background:
-		Given the app "notifications" has been enabled
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-			| user3    | %alt2%    | User Three  | u2@oc.com.np |
-		And these groups have been created:
-			|groupname|
-			|grp1     |
-		And user "user1" has been added to group "grp1"
-		And user "user2" has been added to group "grp1"
-		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "%alt1%" using the webUI
+  Background:
+    Given the app "notifications" has been enabled
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And the user has browsed to the login page
+    And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
-	Scenario: notifications about new share is displayed
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		When user "user3" has shared folder "/simple-folder" with group "grp1"
-		And user "user3" has shared folder "/data.zip" with group "grp1"
-		Then the user should see 2 notifications on the webUI with these details
-			| title                                            |
-			| "User Three" shared "simple-folder" with you  |
-			| "User Three" shared "data.zip" with you       |
-		When the user re-logs in with username "user1" and password "%regular%" using the webUI
-		Then the user should see 2 notifications on the webUI with these details
-			| title                                            |
-			| "User Three" shared "simple-folder" with you  |
-			| "User Three" shared "data.zip" with you       |
+  Scenario: notifications about new share is displayed
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    When user "user3" has shared folder "/simple-folder" with group "grp1"
+    And user "user3" has shared folder "/data.zip" with group "grp1"
+    Then the user should see 2 notifications on the webUI with these details
+      | title                                        |
+      | "User Three" shared "simple-folder" with you |
+      | "User Three" shared "data.zip" with you      |
+    When the user re-logs in with username "user1" and password "%regular%" using the webUI
+    Then the user should see 2 notifications on the webUI with these details
+      | title                                        |
+      | "User Three" shared "simple-folder" with you |
+      | "User Three" shared "data.zip" with you      |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -1,55 +1,55 @@
 @webUI @insulated @disablePreviews @app-required @notifications-app-required
 Feature: Sharing files and folders with internal users
-As a user
-I want to share files and folders with other users
-So that those users can access the files and folders
+  As a user
+  I want to share files and folders with other users
+  So that those users can access the files and folders
 
-	Background:
-		Given the app "notifications" has been enabled
-		And these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-			| user2    | %alt1%    | User Two    | u2@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "%alt1%" using the webUI
+  Background:
+    Given the app "notifications" has been enabled
+    And these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
-	@smokeTest
-	Scenario: notifications about new share is displayed when autoacepting is disabled
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user1" has shared folder "/simple-folder" with user "user2"
-		And user "user1" has shared folder "/data.zip" with user "user2"
-		Then the user should see 2 notifications on the webUI with these details
-			| title                                          |
-			| "User One" shared "simple-folder" with you  |
-			| "User One" shared "data.zip" with you       |
+  @smokeTest
+  Scenario: notifications about new share is displayed when autoacepting is disabled
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user1" has shared folder "/simple-folder" with user "user2"
+    And user "user1" has shared folder "/data.zip" with user "user2"
+    Then the user should see 2 notifications on the webUI with these details
+      | title                                      |
+      | "User One" shared "simple-folder" with you |
+      | "User One" shared "data.zip" with you      |
 
-	@smokeTest
-	Scenario: Notification is gone after accepting a share
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user1" has shared folder "/simple-folder" with user "user2"
-		And user "user1" has shared folder "/simple-empty-folder" with user "user2"
-		When the user accepts all shares displayed in the notifications on the webUI
-		Then user "user2" should have 0 notifications
+  @smokeTest
+  Scenario: Notification is gone after accepting a share
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user1" has shared folder "/simple-folder" with user "user2"
+    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    When the user accepts all shares displayed in the notifications on the webUI
+    Then user "user2" should have 0 notifications
 
-	@smokeTest
-	Scenario: accept an offered share
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user1" has shared folder "/simple-folder" with user "user2"
-		And user "user1" has shared folder "/simple-empty-folder" with user "user2"
-		When the user accepts all shares displayed in the notifications on the webUI
-		Then the folder "simple-folder (2)" should be listed in the files page on the webUI
-		And the folder "simple-empty-folder (2)" should be listed in the files page on the webUI
-		And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-		And the folder "simple-empty-folder (2)" should be in state "" in the shared-with-you page on the webUI
+  @smokeTest
+  Scenario: accept an offered share
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user1" has shared folder "/simple-folder" with user "user2"
+    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    When the user accepts all shares displayed in the notifications on the webUI
+    Then the folder "simple-folder (2)" should be listed in the files page on the webUI
+    And the folder "simple-empty-folder (2)" should be listed in the files page on the webUI
+    And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And the folder "simple-empty-folder (2)" should be in state "" in the shared-with-you page on the webUI
 
-	@smokeTest
-	Scenario: reject an offered share
-		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-		And user "user1" has shared folder "/simple-folder" with user "user2"
-		And user "user1" has shared folder "/simple-empty-folder" with user "user2"
-		When the user declines all shares displayed in the notifications on the webUI
-		Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
-		And the folder "simple-empty-folder (2)" should not be listed in the files page on the webUI
-		And the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-		And the folder "simple-empty-folder" should be in state "Declined" in the shared-with-you page on the webUI
+  @smokeTest
+  Scenario: reject an offered share
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user1" has shared folder "/simple-folder" with user "user2"
+    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    When the user declines all shares displayed in the notifications on the webUI
+    Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And the folder "simple-empty-folder (2)" should not be listed in the files page on the webUI
+    And the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And the folder "simple-empty-folder" should be in state "Declined" in the shared-with-you page on the webUI
 

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -1,93 +1,93 @@
 @webUI @insulated @disablePreviews @files_trashbin-app-required
 Feature: Restore deleted files/folders
-As a user
-I would like to restore files/folders
-So that I can recover accidentally deleted files/folders in ownCloud
+  As a user
+  I would like to restore files/folders
+  So that I can recover accidentally deleted files/folders in ownCloud
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
 
-	@smokeTest
-	Scenario: Restore files
-		When the user deletes the file "data.zip" using the webUI
-		Then the file "data.zip" should be listed in the trashbin on the webUI
-		When the user restores the file "data.zip" from the trashbin using the webUI
-		Then the file "data.zip" should not be listed on the webUI
-		When the user browses to the files page
-		Then the file "data.zip" should be listed on the webUI
+  @smokeTest
+  Scenario: Restore files
+    When the user deletes the file "data.zip" using the webUI
+    Then the file "data.zip" should be listed in the trashbin on the webUI
+    When the user restores the file "data.zip" from the trashbin using the webUI
+    Then the file "data.zip" should not be listed on the webUI
+    When the user browses to the files page
+    Then the file "data.zip" should be listed on the webUI
 
-	Scenario: Restore folder
-		When the user deletes the folder "folder with space" using the webUI
-		Then the folder "folder with space" should be listed in the trashbin on the webUI
-		When the user restores the folder "folder with space" from the trashbin using the webUI
-		Then the file "folder with space" should not be listed on the webUI
-		When the user browses to the files page
-		Then the folder "folder with space" should be listed on the webUI
+  Scenario: Restore folder
+    When the user deletes the folder "folder with space" using the webUI
+    Then the folder "folder with space" should be listed in the trashbin on the webUI
+    When the user restores the folder "folder with space" from the trashbin using the webUI
+    Then the file "folder with space" should not be listed on the webUI
+    When the user browses to the files page
+    Then the folder "folder with space" should be listed on the webUI
 
-	@smokeTest
-	Scenario: Select some trashbin files and restore them in a batch
-		Given the following files have been deleted
-			| name          |
-			| data.zip      |
-			| lorem.txt     |
-			| lorem-big.txt |
-			| simple-folder |
-		And the user has browsed to the trashbin page
-		When the user marks these files for batch action using the webUI
-			| name          |
-			| lorem.txt     |
-			| lorem-big.txt |
-		And the user batch restores the marked files using the webUI
-		Then the file "data.zip" should be listed on the webUI
-		And the folder "simple-folder" should be listed on the webUI
-		But the file "lorem.txt" should not be listed on the webUI
-		And the file "lorem-big.txt" should not be listed on the webUI
-		And the file "lorem.txt" should be listed in the files page on the webUI
-		And the file "lorem-big.txt" should be listed in the files page on the webUI
-		But the file "data.zip" should not be listed in the files page on the webUI
-		And the folder "simple-folder" should not be listed in the files page on the webUI
+  @smokeTest
+  Scenario: Select some trashbin files and restore them in a batch
+    Given the following files have been deleted
+      | name          |
+      | data.zip      |
+      | lorem.txt     |
+      | lorem-big.txt |
+      | simple-folder |
+    And the user has browsed to the trashbin page
+    When the user marks these files for batch action using the webUI
+      | name          |
+      | lorem.txt     |
+      | lorem-big.txt |
+    And the user batch restores the marked files using the webUI
+    Then the file "data.zip" should be listed on the webUI
+    And the folder "simple-folder" should be listed on the webUI
+    But the file "lorem.txt" should not be listed on the webUI
+    And the file "lorem-big.txt" should not be listed on the webUI
+    And the file "lorem.txt" should be listed in the files page on the webUI
+    And the file "lorem-big.txt" should be listed in the files page on the webUI
+    But the file "data.zip" should not be listed in the files page on the webUI
+    And the folder "simple-folder" should not be listed in the files page on the webUI
 
-	Scenario: Select all except for some trashbin files and restore them in a batch
-		Given the following files have been deleted
-			| name          |
-			| data.zip      |
-			| lorem.txt     |
-			| lorem-big.txt |
-			| simple-folder |
-		And the user has browsed to the trashbin page
-		When the user marks all files for batch action using the webUI
-		And the user unmarks these files for batch action using the webUI
-			| name          |
-			| lorem.txt     |
-			| lorem-big.txt |
-		And the user batch restores the marked files using the webUI
-		Then the file "lorem.txt" should be listed on the webUI
-		And the file "lorem-big.txt" should be listed on the webUI
-		But the file "data.zip" should not be listed on the webUI
-		And the folder "simple-folder" should not be listed on the webUI
-		And the file "data.zip" should be listed in the files page on the webUI
-		And the folder "simple-folder" should be listed in the files page on the webUI
-		But the file "lorem.txt" should not be listed in the files page on the webUI
-		And the file "lorem-big.txt" should not be listed in the files page on the webUI
+  Scenario: Select all except for some trashbin files and restore them in a batch
+    Given the following files have been deleted
+      | name          |
+      | data.zip      |
+      | lorem.txt     |
+      | lorem-big.txt |
+      | simple-folder |
+    And the user has browsed to the trashbin page
+    When the user marks all files for batch action using the webUI
+    And the user unmarks these files for batch action using the webUI
+      | name          |
+      | lorem.txt     |
+      | lorem-big.txt |
+    And the user batch restores the marked files using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the file "lorem-big.txt" should be listed on the webUI
+    But the file "data.zip" should not be listed on the webUI
+    And the folder "simple-folder" should not be listed on the webUI
+    And the file "data.zip" should be listed in the files page on the webUI
+    And the folder "simple-folder" should be listed in the files page on the webUI
+    But the file "lorem.txt" should not be listed in the files page on the webUI
+    And the file "lorem-big.txt" should not be listed in the files page on the webUI
 
-	Scenario: Select all trashbin files and restore them in a batch
-		Given the following files have been deleted
-			| name          |
-			| data.zip      |
-			| lorem.txt     |
-			| lorem-big.txt |
-			| simple-folder |
-		And the user has browsed to the trashbin page
-		And the user marks all files for batch action using the webUI
-		And the user batch restores the marked files using the webUI
-		Then the folder should be empty on the webUI
-		When the user browses to the files page
-		Then the file "lorem.txt" should be listed on the webUI
-		And the file "lorem-big.txt" should be listed on the webUI
-		And the file "data.zip" should be listed on the webUI
-		And the folder "simple-folder" should be listed on the webUI
+  Scenario: Select all trashbin files and restore them in a batch
+    Given the following files have been deleted
+      | name          |
+      | data.zip      |
+      | lorem.txt     |
+      | lorem-big.txt |
+      | simple-folder |
+    And the user has browsed to the trashbin page
+    And the user marks all files for batch action using the webUI
+    And the user batch restores the marked files using the webUI
+    Then the folder should be empty on the webUI
+    When the user browses to the files page
+    Then the file "lorem.txt" should be listed on the webUI
+    And the file "lorem-big.txt" should be listed on the webUI
+    And the file "data.zip" should be listed on the webUI
+    And the folder "simple-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -15,10 +15,10 @@ Feature: files and folders exist in the trashbin after being deleted
   @smokeTest
   Scenario: Delete files & folders one by one and check that they are all in the trashbin
     When the user deletes the following elements using the webUI
-      | name                                |
-      | simple-folder                       |
-      | lorem.txt                           |
-      | strängé नेपाली folder                  |
+      | name                                  |
+      | simple-folder                         |
+      | lorem.txt                             |
+      | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
     Then the deleted elements should be listed in the trashbin on the webUI
     And the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
@@ -63,17 +63,17 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario: Delete multiple file with same filename and check they are in trashbin
     When the user deletes the following elements using the webUI
-    | name      |
-    | lorem.txt |
+      | name      |
+      | lorem.txt |
     And the user opens the folder "simple-folder" using the webUI
     And the user deletes the following elements using the webUI
-    | name      |
-    | lorem.txt |
+      | name      |
+      | lorem.txt |
     And the user browses to the files page
     And the user opens the folder "strängé नेपाली folder" using the webUI
     And the user deletes the following elements using the webUI
-    | name      |
-    | lorem.txt |
+      | name      |
+      | lorem.txt |
     Then the deleted elements should be listed in the trashbin on the webUI
     And the file "lorem.txt" with the path "./lorem.txt" should be listed in the trashbin on the webUI
     And the file "lorem.txt" with the path "simple-folder/lorem.txt" should be listed in the trashbin on the webUI

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -1,91 +1,91 @@
 @webUI @insulated @disablePreviews
 Feature: File Upload
 
-As a user
-I would like to be able to upload files via the WebUI
-So that I can store files in ownCloud
+  As a user
+  I would like to be able to upload files via the WebUI
+  So that I can store files in ownCloud
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
-	@smokeTest
-	Scenario: simple upload of a file that does not exist before
-		When the user uploads the file "new-lorem.txt" using the webUI
-		Then no notification should be displayed on the webUI
-		And the file "new-lorem.txt" should be listed on the webUI
-		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+  @smokeTest
+  Scenario: simple upload of a file that does not exist before
+    When the user uploads the file "new-lorem.txt" using the webUI
+    Then no notification should be displayed on the webUI
+    And the file "new-lorem.txt" should be listed on the webUI
+    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-	@smokeTest
-	Scenario: chunking upload
-		Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-		When the user uploads the file "big-video.mp4" using the webUI
-		Then no notification should be displayed on the webUI
-		And the file "big-video.mp4" should be listed on the webUI
-		And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
+  @smokeTest
+  Scenario: chunking upload
+    Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
+    When the user uploads the file "big-video.mp4" using the webUI
+    Then no notification should be displayed on the webUI
+    And the file "big-video.mp4" should be listed on the webUI
+    And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
-	Scenario: conflict with a chunked file
-		Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-		When the user renames the file "lorem.txt" to "big-video.mp4" using the webUI
-		And the user uploads overwriting the file "big-video.mp4" using the webUI and retries if the file is locked
-		Then the file "big-video.mp4" should be listed on the webUI
-		And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
+  Scenario: conflict with a chunked file
+    Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
+    When the user renames the file "lorem.txt" to "big-video.mp4" using the webUI
+    And the user uploads overwriting the file "big-video.mp4" using the webUI and retries if the file is locked
+    Then the file "big-video.mp4" should be listed on the webUI
+    And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
-	Scenario: upload a new file into a sub folder
-		When the user opens the folder "simple-folder" using the webUI
-		And the user uploads the file "new-lorem.txt" using the webUI
-		Then no notification should be displayed on the webUI
-		And the file "new-lorem.txt" should be listed on the webUI
-		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+  Scenario: upload a new file into a sub folder
+    When the user opens the folder "simple-folder" using the webUI
+    And the user uploads the file "new-lorem.txt" using the webUI
+    Then no notification should be displayed on the webUI
+    And the file "new-lorem.txt" should be listed on the webUI
+    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-	@smokeTest
-	Scenario: overwrite an existing file
-		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		Then no dialog should be displayed on the webUI
-		And the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the local "lorem.txt"
-		But the file "lorem (2).txt" should not be listed on the webUI
+  @smokeTest
+  Scenario: overwrite an existing file
+    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    Then no dialog should be displayed on the webUI
+    And the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the local "lorem.txt"
+    But the file "lorem (2).txt" should not be listed on the webUI
 
-	@smokeTest
-	Scenario: keep new and existing file
-		When the user uploads the file "lorem.txt" using the webUI
-		And the user chooses to keep the new files in the upload dialog
-		And the user chooses to keep the existing files in the upload dialog
-		And the user chooses "Continue" in the upload dialog
-		Then no dialog should be displayed on the webUI
-		And no notification should be displayed on the webUI
-		And the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should not have changed
-		And the file "lorem (2).txt" should be listed on the webUI
-		And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
-		
-	Scenario: cancel conflict dialog
-		When the user uploads the file "lorem.txt" using the webUI
-		And the user chooses "Cancel" in the upload dialog
-		Then no dialog should be displayed on the webUI
-		And no notification should be displayed on the webUI
-		And the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should not have changed
-		And the file "lorem (2).txt" should not be listed on the webUI
+  @smokeTest
+  Scenario: keep new and existing file
+    When the user uploads the file "lorem.txt" using the webUI
+    And the user chooses to keep the new files in the upload dialog
+    And the user chooses to keep the existing files in the upload dialog
+    And the user chooses "Continue" in the upload dialog
+    Then no dialog should be displayed on the webUI
+    And no notification should be displayed on the webUI
+    And the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should not have changed
+    And the file "lorem (2).txt" should be listed on the webUI
+    And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
 
-	Scenario: overwrite an existing file in a sub-folder
-		When the user opens the folder "simple-folder" using the webUI
-		And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		Then the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should be the same as the local "lorem.txt"
+  Scenario: cancel conflict dialog
+    When the user uploads the file "lorem.txt" using the webUI
+    And the user chooses "Cancel" in the upload dialog
+    Then no dialog should be displayed on the webUI
+    And no notification should be displayed on the webUI
+    And the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should not have changed
+    And the file "lorem (2).txt" should not be listed on the webUI
 
-	Scenario: keep new and existing file in a sub-folder
-		When the user opens the folder "simple-folder" using the webUI
-		And the user uploads the file "lorem.txt" using the webUI
-		And the user chooses to keep the new files in the upload dialog
-		And the user chooses to keep the existing files in the upload dialog
-		And the user chooses "Continue" in the upload dialog
-		Then no dialog should be displayed on the webUI
-		And no notification should be displayed on the webUI
-		And the file "lorem.txt" should be listed on the webUI
-		And the content of "lorem.txt" should not have changed
-		And the file "lorem (2).txt" should be listed on the webUI
-		And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
+  Scenario: overwrite an existing file in a sub-folder
+    When the user opens the folder "simple-folder" using the webUI
+    And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the local "lorem.txt"
+
+  Scenario: keep new and existing file in a sub-folder
+    When the user opens the folder "simple-folder" using the webUI
+    And the user uploads the file "lorem.txt" using the webUI
+    And the user chooses to keep the new files in the upload dialog
+    And the user chooses to keep the existing files in the upload dialog
+    And the user chooses "Continue" in the upload dialog
+    Then no dialog should be displayed on the webUI
+    And no notification should be displayed on the webUI
+    And the file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should not have changed
+    And the file "lorem (2).txt" should be listed on the webUI
+    And the content of "lorem (2).txt" should be the same as the local "lorem.txt"

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -1,105 +1,105 @@
 @webUI @insulated @disablePreviews
 Feature: File Upload
 
-As a QA engineer
-I would like to test uploads of all kind of funny filenames via the WebUI
+  As a QA engineer
+  I would like to test uploads of all kind of funny filenames via the WebUI
 
-These tests are written in a way that multiple file names are tested in one scenario
-that is not academically correct but saves a lot of time
+  These tests are written in a way that multiple file names are tested in one scenario
+  that is not academically correct but saves a lot of time
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
-	Scenario: simple upload of a file that does not exist before
-		When the user uploads the file "new-'single'quotes.txt" using the webUI
-		Then the file "new-'single'quotes.txt" should be listed on the webUI
-		And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
+  Scenario: simple upload of a file that does not exist before
+    When the user uploads the file "new-'single'quotes.txt" using the webUI
+    Then the file "new-'single'quotes.txt" should be listed on the webUI
+    And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
 
-		When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
-		Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
-		And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
+    When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
+    Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
 
-		When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
-		Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
-		And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
+    When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
+    Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
+    And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
 
-	@smokeTest
-	Scenario Outline: upload a new file into a sub folder
-		Given a file with the size of "3000" bytes and the name "0" has been created locally
-		When the user opens the folder <folder-to-upload-to> using the webUI
-		And the user uploads the file "0" using the webUI
-		Then the file "0" should be listed on the webUI
-		And the content of "0" should be the same as the local "0"
+  @smokeTest
+  Scenario Outline: upload a new file into a sub folder
+    Given a file with the size of "3000" bytes and the name "0" has been created locally
+    When the user opens the folder <folder-to-upload-to> using the webUI
+    And the user uploads the file "0" using the webUI
+    Then the file "0" should be listed on the webUI
+    And the content of "0" should be the same as the local "0"
 
-		When the user uploads the file "new-'single'quotes.txt" using the webUI
-		Then the file "new-'single'quotes.txt" should be listed on the webUI
-		And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
+    When the user uploads the file "new-'single'quotes.txt" using the webUI
+    Then the file "new-'single'quotes.txt" should be listed on the webUI
+    And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
 
-		When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
-		Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
-		And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
+    When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
+    Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
 
-		When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
-		Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
-		And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
-		Examples:
-		| folder-to-upload-to  |
-		| "0"                  |
-		| "'single'quotes"     |
-		| "strängé नेपाली folder" |
+    When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
+    Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
+    And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
+    Examples:
+      | folder-to-upload-to     |
+      | "0"                     |
+      | "'single'quotes"        |
+      | "strängé नेपाली folder" |
 
-	Scenario: overwrite an existing file
-		When the user uploads overwriting the file "'single'quotes.txt" using the webUI and retries if the file is locked
-		Then the file "'single'quotes.txt" should be listed on the webUI
-		And the content of "'single'quotes.txt" should be the same as the local "'single'quotes.txt"
+  Scenario: overwrite an existing file
+    When the user uploads overwriting the file "'single'quotes.txt" using the webUI and retries if the file is locked
+    Then the file "'single'quotes.txt" should be listed on the webUI
+    And the content of "'single'quotes.txt" should be the same as the local "'single'quotes.txt"
 
-		When the user uploads overwriting the file "strängé filename (duplicate #2 &).txt" using the webUI and retries if the file is locked
-		Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
-		And the content of "strängé filename (duplicate #2 &).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
+    When the user uploads overwriting the file "strängé filename (duplicate #2 &).txt" using the webUI and retries if the file is locked
+    Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    And the content of "strängé filename (duplicate #2 &).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
-		When the user uploads overwriting the file "zzzz-must-be-last-file-in-folder.txt" using the webUI and retries if the file is locked
-		Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
-		And the content of "zzzz-must-be-last-file-in-folder.txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
+    When the user uploads overwriting the file "zzzz-must-be-last-file-in-folder.txt" using the webUI and retries if the file is locked
+    Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
+    And the content of "zzzz-must-be-last-file-in-folder.txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
-	Scenario: keep new and existing file
-		When the user uploads the file "'single'quotes.txt" keeping both new and existing files using the webUI
-		Then the file "'single'quotes.txt" should be listed on the webUI
-		And the content of "'single'quotes.txt" should not have changed
-		And the file "'single'quotes (2).txt" should be listed on the webUI
-		And the content of "'single'quotes (2).txt" should be the same as the local "'single'quotes.txt"
+  Scenario: keep new and existing file
+    When the user uploads the file "'single'quotes.txt" keeping both new and existing files using the webUI
+    Then the file "'single'quotes.txt" should be listed on the webUI
+    And the content of "'single'quotes.txt" should not have changed
+    And the file "'single'quotes (2).txt" should be listed on the webUI
+    And the content of "'single'quotes (2).txt" should be the same as the local "'single'quotes.txt"
 
-		When the user uploads the file "strängé filename (duplicate #2 &).txt" keeping both new and existing files using the webUI
-		Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
-		And the content of "strängé filename (duplicate #2 &).txt" should not have changed
-		And the file "strängé filename (duplicate #2 &) (2).txt" should be listed on the webUI
-		And the content of "strängé filename (duplicate #2 &) (2).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
+    When the user uploads the file "strängé filename (duplicate #2 &).txt" keeping both new and existing files using the webUI
+    Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    And the content of "strängé filename (duplicate #2 &).txt" should not have changed
+    And the file "strängé filename (duplicate #2 &) (2).txt" should be listed on the webUI
+    And the content of "strängé filename (duplicate #2 &) (2).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
-		When the user uploads the file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files using the webUI
-		Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
-		And the content of "zzzz-must-be-last-file-in-folder.txt" should not have changed
-		And the file "zzzz-must-be-last-file-in-folder (2).txt" should be listed on the webUI
-		And the content of "zzzz-must-be-last-file-in-folder (2).txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
+    When the user uploads the file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files using the webUI
+    Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
+    And the content of "zzzz-must-be-last-file-in-folder.txt" should not have changed
+    And the file "zzzz-must-be-last-file-in-folder (2).txt" should be listed on the webUI
+    And the content of "zzzz-must-be-last-file-in-folder (2).txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
-	Scenario Outline: chunking upload using difficult names
-		Given a file with the size of "30000000" bytes and the name <file-name> has been created locally
-		When the user uploads the file <file-name> using the webUI
-		Then the file <file-name> should be listed on the webUI
-		And the content of <file-name> should be the same as the local <file-name>
-		Examples:
-		|file-name|
-		|"&#"     |
-		|"TIÄFÜ"  |
+  Scenario Outline: chunking upload using difficult names
+    Given a file with the size of "30000000" bytes and the name <file-name> has been created locally
+    When the user uploads the file <file-name> using the webUI
+    Then the file <file-name> should be listed on the webUI
+    And the content of <file-name> should be the same as the local <file-name>
+    Examples:
+      | file-name |
+      | "&#"      |
+      | "TIÄFÜ"   |
 		
 	#this test should be intergrated into the previous scenario after fixing the issue
 	#uploading into "simple-folder" because there is a folder called "0" in the root
-	@skip @issue-29599
-	Scenario: Upload a file called "0" using chunking
-		Given a file with the size of "30000000" bytes and the name "0" has been created locally
-		When the user opens the folder "simple-folder" using the webUI
-		And the user uploads the file "0" using the webUI
-		Then the file "0" should be listed on the webUI
-		And the content of "0" should be the same as the local "0"
+  @skip @issue-29599
+  Scenario: Upload a file called "0" using chunking
+    Given a file with the size of "30000000" bytes and the name "0" has been created locally
+    When the user opens the folder "simple-folder" using the webUI
+    And the user uploads the file "0" using the webUI
+    Then the file "0" should be listed on the webUI
+    And the content of "0" should be the same as the local "0"

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -1,23 +1,23 @@
 @webUI @insulated @disablePreviews
 Feature: Upload a file
 
-As a user
-I would like to upload a file
-So that I can store it in owncloud
+  As a user
+  I would like to upload a file
+  So that I can store it in owncloud
 
-	Background:
-		Given these users have been created:
-			| username | password  | displayname | email        |
-			| user1    | %regular% | User One    | u1@oc.com.np |
+  Background:
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
 
-	@smokeTest
-	Scenario: simple upload of a file with the size greater than the size of quota
-		Given the quota of user "user1" has been set to "10 MB"
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "%regular%" using the webUI
-		And the user has browsed to the files page
-		And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-		When the user uploads the file "big-video.mp4" using the webUI
-		Then the file "big-video.mp4" should not be listed on the webUI
-		And notifications should be displayed on the webUI with the text matching
-		|/^Not enough free space, you are uploading (\d+(.\d+)?) MB but only (\d+(.\d+)?) MB is left$/|
+  @smokeTest
+  Scenario: simple upload of a file with the size greater than the size of quota
+    Given the quota of user "user1" has been set to "10 MB"
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has browsed to the files page
+    And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
+    When the user uploads the file "big-video.mp4" using the webUI
+    Then the file "big-video.mp4" should not be listed on the webUI
+    And notifications should be displayed on the webUI with the text matching
+      | /^Not enough free space, you are uploading (\d+(.\d+)?) MB but only (\d+(.\d+)?) MB is left$/ |


### PR DESCRIPTION
The acceptance test feature files are a mix of 2-space and tab indent style. That is annoying when editing different feature files.

```
Either spaces or tabs may be used for indentation. The recommended indentation level is two spaces.
```
https://docs.cucumber.io/gherkin/reference/

Since we already have a mix, we might as well pick 2-space indent.