### PR TITLE
Tag systemtags-related acceptance tests

### DIFF
--- a/tests/acceptance/features/apiMetadataApps/tags.feature
+++ b/tests/acceptance/features/apiMetadataApps/tags.feature
@@ -1,4 +1,4 @@
-@api
+@api @systemtags-app-required
 Feature: tags
 
   @smokeTest


### PR DESCRIPTION
The other day we tagged acceptance test features/scenarios that depended on a "core bundled" app being installed+enabled.

The tests for the ``systemtags`` app were missed. So here is the 1-line tag that is needed on the feature.