### PR TITLE
phpcs style changes for master

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,6 +19,10 @@
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed" />
 	</rule>
 
+	<rule ref="Generic.Files.LineLength">
+		<exclude name="Generic.Files.LineLength.TooLong" />
+	</rule>
+
 	<rule ref="PEAR">
 		<exclude name="Generic.Commenting.DocComment.ShortNotCapital" />
 		<exclude name="Generic.Commenting.DocComment.SpacingAfter" />

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1657,7 +1657,7 @@ trait BasicStructure {
 				'local',
 				'null::null',
 				'-c',
-				'datadir=' . $this->getServerRoot(). '/' . LOCAL_STORAGE_DIR_ON_REMOTE_SERVER
+				'datadir=' . $this->getServerRoot() . '/' . LOCAL_STORAGE_DIR_ON_REMOTE_SERVER
 			]
 		);
 		// stdOut should have a string like "Storage created with id 65"

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -97,13 +97,13 @@ class DetailsDialog extends OwncloudPage {
 	 */
 	public function changeDetailsTab($tabName) {
 		$tabId = $this->getDetailsTabId($tabName);
-		$tabSwitchXpath = "//li[@data-tabid='".$tabId."']";
+		$tabSwitchXpath = "//li[@data-tabid='" . $tabId . "']";
 		$tabSwitch = $this->find("xpath", $tabSwitchXpath);
 		if ($tabSwitch === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" could not find tab switch with id $tabName"
-				);
+			);
 		}
 		$this->waitTillElementIsNotNull($tabSwitchXpath);
 		$tabSwitch->focus();

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -110,7 +110,7 @@ class FileActionsMenu extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" could not find action button with label $this->deleteActionLabel"
-				);
+			);
 		}
 		$detailsBtn->focus();
 		$detailsBtn->click();


### PR DESCRIPTION
A few more style issues that crept in. We need to implement the automation to stop this happening.

The phpcs warning for line length is just annoying noise, because actually there are many lines of Gherkin that exceed the length. And so we ignore those warnings anyway. The check is disabled.