### PR TITLE
Sort behat.yml

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -12,9 +12,9 @@ default:
             adminPassword: admin
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
-        - CardDavContext:
-        - CalDavContext:
         - AppManagementContext:
+        - CalDavContext:
+        - CardDavContext:
 
     apiCapabilities:
       paths:
@@ -67,18 +67,18 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
 
-    apiTrashbin:
-      paths:
-        - %paths.base%/../features/apiTrashbin
-      contexts:
-        - FeatureContext: *common_feature_context_params
-
     apiSharingNotifications:
       paths:
         - %paths.base%/../features/apiSharingNotifications
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
+
+    apiTrashbin:
+      paths:
+        - %paths.base%/../features/apiTrashbin
+      contexts:
+        - FeatureContext: *common_feature_context_params
 
     apiWebdavOperations:
       paths:
@@ -95,92 +95,95 @@ default:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
 
-    webUILogin:
-      paths:
-        - %paths.base%/../features/webUILogin
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIFilesContext:
-        - WebUIPersonalGeneralSettingsContext:
-        - EmailContext:
-
     webUIAdminSettings:
       paths:
         - %paths.base%/../features/webUIAdminSettings
       contexts:
         - FeatureContext: *common_feature_context_params
-        - WebUIAdminSharingSettingsContext:
+        - CapabilitiesContext:
         - WebUIAdminAppsSettingsContext:
+        - WebUIAdminSharingSettingsContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - CapabilitiesContext:
+
+    webUIFavorites:
+      paths:
+        - %paths.base%/../features/webUIFavorites
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
+        - WebUIGeneralContext:
+        - WebUILoginContext:
 
     webUIFiles:
       paths:
         - %paths.base%/../features/webUIFiles
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
         - WebUISearchContext:
+
+    webUILogin:
+      paths:
+        - %paths.base%/../features/webUILogin
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - EmailContext:
+        - WebUIFilesContext:
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIPersonalGeneralSettingsContext:
 
     webUIMoveFilesFolders:
       paths:
         - %paths.base%/../features/webUIMoveFilesFolders
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+
+    webUIPersonalSettings:
+      paths:
+        - %paths.base%/../features/webUIPersonalSettings
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - EmailContext:
         - WebUIFilesContext:
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIPersonalGeneralSettingsContext:
+        - WebUIPersonalSecuritySettingsContext:
+        - WebUIUserContext:
 
     webUIRenameFiles:
       paths:
         - %paths.base%/../features/webUIRenameFiles
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
 
     webUIRenameFolders:
       paths:
         - %paths.base%/../features/webUIRenameFolders
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
 
-    webUITrashbin:
+    webUIRestrictSharing:
       paths:
-        - %paths.base%/../features/webUITrashbin
+        - %paths.base%/../features/webUIRestrictSharing
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
-
-    webUISharingInternalGroups:
-      paths:
-        - %paths.base%/../features/webUISharingInternalGroups
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIFilesContext:
-        - WebUISharingContext:
-
-    webUISharingInternalUsers:
-      paths:
-        - %paths.base%/../features/webUISharingInternalUsers
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIFilesContext:
         - WebUISharingContext:
 
     webUISharingExternal:
@@ -188,53 +191,32 @@ default:
         - %paths.base%/../features/webUISharingExternal
       contexts:
         - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIFilesContext:
-        - WebUISharingContext:
+        - EmailContext:
         - FederationContext:
-        - EmailContext:
-
-    webUIUpload:
-      paths:
-        - %paths.base%/../features/webUIUpload
-      contexts:
-        - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
-
-    webUIRestrictSharing:
-      paths:
-        - %paths.base%/../features/webUIRestrictSharing
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIFilesContext:
         - WebUISharingContext:
 
-    webUIFavorites:
+    webUISharingInternalGroups:
       paths:
-        - %paths.base%/../features/webUIFavorites
+        - %paths.base%/../features/webUISharingInternalGroups
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
+        - WebUISharingContext:
 
-    webUIPersonalSettings:
+    webUISharingInternalUsers:
       paths:
-        - %paths.base%/../features/webUIPersonalSettings
+        - %paths.base%/../features/webUISharingInternalUsers
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
-        - WebUIPersonalSecuritySettingsContext:
-        - WebUIPersonalGeneralSettingsContext:
-        - WebUIUserContext:
-        - EmailContext:
+        - WebUISharingContext:
 
     webUISharingNotifications:
       paths:
@@ -242,11 +224,29 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
-        - WebUISharingContext:
         - WebUINotificationsContext:
+        - WebUISharingContext:
+
+    webUITrashbin:
+      paths:
+        - %paths.base%/../features/webUITrashbin
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+
+    webUIUpload:
+      paths:
+        - %paths.base%/../features/webUIUpload
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
+        - WebUIGeneralContext:
+        - WebUILoginContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:


### PR DESCRIPTION
## Description
Sort the acceptance test ``behat.yml`` suites and contexts into alphabetical order, except that ``FeatureContext`` and ``apiMain`` get priority at the top.

## Motivation and Context
It is annoying to compare suites and contexts in other apps with what is in core.
Sort the list in core so it is easy to scan through it.

## How Has This Been Tested?
CI will know if I broke it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
