### PR TITLE
Explicitly set display name for API search acceptance tests

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -5,7 +5,9 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "user0" has been created
+    Given these users have been created:
+      | username | password  | displayname | email        |
+      | user0    | %regular% | User Zero   | u1@oc.com.np |
     And user "user0" has created a folder "/just-a-folder"
     And user "user0" has created a folder "/फनी näme"
     And user "user0" has uploaded file with content "does-not-matter" to "/upload.txt"
@@ -82,7 +84,7 @@ Feature: Search
       | {DAV:}getcontenttype                       | text\/plain                                                                                       |
       | {http://owncloud.org/ns}size               | 15                                                                                                |
       | {http://owncloud.org/ns}owner-id           | user0                                                                                             |
-      | {http://owncloud.org/ns}owner-display-name | user0                                                                                             |
+      | {http://owncloud.org/ns}owner-display-name | User Zero                                                                                         |
     Examples:
       | dav_version |
       | old         |


### PR DESCRIPTION
## Description
In ``search.feature`` explicitly set the display name of ``user0``

## Motivation and Context
When ``user_ldap`` runs the core acceptance tests it fails on getting the display name attribute of ``user0``. The ``user_ldap`` environment has the display name of ``user0`` already set to ``User Zero``

So in core tests we need to be careful to expect the same thing.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
