### PR TITLE
Consolidate acceptance test knowledge about known users

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -25,7 +25,7 @@ Feature: federated
       | mail_send              | 0              |
       | uid_owner              | user1          |
       | file_parent            | A_NUMBER       |
-      | displayname_owner      | user1          |
+      | displayname_owner      | User One       |
       | share_with             | user0@REMOTE   |
       | share_with_displayname | user0@REMOTE   |
 
@@ -46,7 +46,7 @@ Feature: federated
       | mail_send              | 0              |
       | uid_owner              | user0          |
       | file_parent            | A_NUMBER       |
-      | displayname_owner      | user0          |
+      | displayname_owner      | User Zero      |
       | share_with             | user1@LOCAL    |
       | share_with_displayname | user1@LOCAL    |
 
@@ -97,9 +97,9 @@ Feature: federated
       | mail_send              | 0                  |
       | uid_owner              | user1              |
       | file_parent            | A_NUMBER           |
-      | displayname_owner      | user1              |
+      | displayname_owner      | User One           |
       | share_with             | user2              |
-      | share_with_displayname | user2              |
+      | share_with_displayname | User Two           |
 
   Scenario: Overwrite a federated shared file as recipient - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "/textfile0.txt" with user "user0" from server "REMOTE"

--- a/tests/acceptance/features/apiMain/tokenAuth.feature
+++ b/tests/acceptance/features/apiMain/tokenAuth.feature
@@ -3,9 +3,7 @@ Feature: tokenAuth
 
   Background:
     Given using OCS API version "1"
-    And these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    And user "user1" has been created
     And token auth has been enforced
 
   Scenario: creating a user with basic auth should be blocked when token auth is enforced

--- a/tests/acceptance/features/apiShareManagement/multilinksharing.feature
+++ b/tests/acceptance/features/apiShareManagement/multilinksharing.feature
@@ -93,7 +93,7 @@ Feature: multilinksharing
       | permissions  | 15          |
       | name         | sharedlink2 |
     When the user updates the last share using the sharing API with
-      | password | newpassword |
+      | password | %alt1% |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as user "user0" the public shares of folder "/FOLDER" should be

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -4,9 +4,7 @@ Feature: sharing
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And these users have been created:
-      | username | displayname |
-      | user0    | User Zero   |
+    And user "user0" has been created
 
   @smokeTest
   Scenario Outline: Allow modification of reshare
@@ -267,10 +265,8 @@ Feature: sharing
       | 2               | 400              |
 
   Scenario: Share ownership change after moving a shared file outside of an outer share
-    Given these users have been created:
-      | username | displayname |
-      | user1    | User One    |
-      | user2    | User Two    |
+    Given user "user1" has been created
+    And user "user2" has been created
     And user "user0" has created a folder "/folder1"
     And user "user0" has created a folder "/folder1/folder2"
     And user "user1" has created a folder "/moved-out"
@@ -297,10 +293,8 @@ Feature: sharing
     And as "user2" the folder "/folder2" should exist
 
   Scenario: Share ownership change after moving a shared file to another share
-    Given these users have been created:
-      | username | displayname |
-      | user1    | User One    |
-      | user2    | User Two    |
+    Given user "user1" has been created
+    And user "user2" has been created
     And user "user0" has created a folder "/user0-folder"
     And user "user0" has created a folder "/user0-folder/folder2"
     And user "user2" has created a folder "/user2-folder"

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -3,10 +3,8 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And these users have been created:
-      | username | displayname |
-      | user0    | User Zero   |
-      | user1    | User One    |
+    And user "user0" has been created
+    And user "user1" has been created
 
   @smokeTest
   Scenario Outline: getting all shares of a user using that user

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -4,9 +4,9 @@ Feature: sharees
   Background:
     Given using OCS API version "1"
     And these users have been created:
-      | username | displayname |
-      | user1    | User One    |
-      | sharee1  | Sharee One  |
+      | username |
+      | user1    |
+      | sharee1  |
     And group "ShareeGroup" has been created
     And group "ShareeGroup2" has been created
     And user "user1" has been added to group "ShareeGroup2"

--- a/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
+++ b/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
@@ -4,9 +4,9 @@ Feature: sharees_provisioningapiv2
   Background:
     Given using OCS API version "2"
     And these users have been created:
-      | username | displayname |
-      | user1    | User One    |
-      | sharee1  | Sharee One  |
+      | username |
+      | user1    |
+      | sharee1  |
     And group "ShareeGroup" has been created
     And group "ShareeGroup2" has been created
     And user "user1" has been added to group "ShareeGroup2"

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -9,10 +9,10 @@ Feature: Display notifications when receiving a share
     And using OCS API version "1"
     And using new DAV path
     And these users have been created:
-      | username | displayname |
-      | user0    | User Zero   |
-      | user1    | User One    |
-      | user2    | User Two    |
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
     And these groups have been created:
       | groupname |
       | grp1      |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -5,9 +5,7 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user0    | %regular% | User Zero   | u1@oc.com.np |
+    Given user "user0" has been created
     And user "user0" has created a folder "/just-a-folder"
     And user "user0" has created a folder "/फनी näme"
     And user "user0" has uploaded file with content "does-not-matter" to "/upload.txt"

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -76,6 +76,11 @@ trait BasicStructure {
 	private $alt3UserPassword = '';
 
 	/**
+	 * @var string
+	 */
+	private $alt4UserPassword = '';
+
+	/**
 	 * The password to use in tests that create a sub-admin user
 	 *
 	 * @var string
@@ -217,6 +222,7 @@ trait BasicStructure {
 		$this->alt1UserPassword = "1234";
 		$this->alt2UserPassword = "AaBb2Cc3Dd4";
 		$this->alt3UserPassword = "aVeryLongPassword42TheMeaningOfLife";
+		$this->alt4UserPassword = "ThisIsThe4thAlternatePwd";
 		$this->subAdminPassword = "IamAJuniorAdmin42";
 		$this->alternateAdminPassword = "IHave99LotsOfPriv";
 		$this->publicLinkSharePassword = "publicPwd1";
@@ -272,6 +278,12 @@ trait BasicStructure {
 		$alt3UserPasswordFromEnvironment = $this->getAlt3UserPasswordFromEnvironment();
 		if ($alt3UserPasswordFromEnvironment !== false) {
 			$this->alt3UserPassword = $alt3UserPasswordFromEnvironment;
+		}
+
+		// get the alternate(4) user password from the environment (if defined)
+		$alt4UserPasswordFromEnvironment = $this->getAlt4UserPasswordFromEnvironment();
+		if ($alt4UserPasswordFromEnvironment !== false) {
+			$this->alt4UserPassword = $alt4UserPasswordFromEnvironment;
 		}
 
 		// get the sub-admin password from the environment (if defined)
@@ -345,6 +357,15 @@ trait BasicStructure {
 	 */
 	private static function getAlt3UserPasswordFromEnvironment() {
 		return \getenv('ALT3_USER_PASSWORD');
+	}
+
+	/**
+	 * Get the externally-defined alternate(4) user password, if any
+	 *
+	 * @return string|false
+	 */
+	private static function getAlt4UserPasswordFromEnvironment() {
+		return \getenv('ALT4_USER_PASSWORD');
 	}
 
 	/**
@@ -1373,10 +1394,110 @@ trait BasicStructure {
 			return (string) $this->createdUsers[$userName]['password'];
 		} elseif (\array_key_exists($userName, $this->createdRemoteUsers)) {
 			return (string) $this->createdRemoteUsers[$userName]['password'];
-		} else {
-			// The user has not been created yet, let the caller have the
-			// default password.
+		} elseif ($userName === 'regularuser') {
 			return (string) $this->regularUserPassword;
+		} elseif ($userName === 'user0') {
+			return (string) $this->regularUserPassword;
+		} elseif ($userName === 'user1') {
+			return (string) $this->alt1UserPassword;
+		} elseif ($userName === 'user2') {
+			return (string) $this->alt2UserPassword;
+		} elseif ($userName === 'user3') {
+			return (string) $this->alt3UserPassword;
+		} elseif ($userName === 'user4') {
+			return (string) $this->alt4UserPassword;
+		} elseif ($userName === 'usergrp') {
+			return (string) $this->regularUserPassword;
+		} elseif ($userName === 'sharee1') {
+			return (string) $this->regularUserPassword;
+		} else {
+			// The user has not been created yet and is not one of the pre-known
+			// users. So let the caller have the default password.
+			return (string) $this->regularUserPassword;
+		}
+	}
+
+	/**
+	 * Get the display name of the user.
+	 *
+	 * For users that have already been created, return their display name.
+	 * For special known user names, return the display name that is also used by LDAP tests.
+	 * For other users, return null. They will not be assigned any particular
+	 * display name by this function.
+	 *
+	 * @param string $userName
+	 *
+	 * @return string|null
+	 */
+	public function getDisplayNameForUser($userName) {
+		$userName = $this->getActualUsername($userName);
+		// The hard-coded user names and display names are also in ldap-users.ldif
+		// for testing in an LDAP environment. The mapping must be kept the
+		// same in both places.
+		if (\array_key_exists($userName, $this->createdUsers)) {
+			return (string) $this->createdUsers[$userName]['displayname'];
+		} elseif (\array_key_exists($userName, $this->createdRemoteUsers)) {
+			return (string)$this->createdRemoteUsers[$userName]['displayname'];
+		} elseif ($userName === 'regularuser') {
+			return 'Regular User';
+		} elseif ($userName === 'user0') {
+			return 'User Zero';
+		} elseif ($userName === 'user1') {
+			return 'User One';
+		} elseif ($userName === 'user2') {
+			return 'User Two';
+		} elseif ($userName === 'user3') {
+			return 'User Three';
+		} elseif ($userName === 'user4') {
+			return 'User Four';
+		} elseif ($userName === 'usergrp') {
+			return 'User Grp';
+		} elseif ($userName === 'sharee1') {
+			return 'Sharee One';
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Get the email address of the user.
+	 *
+	 * For users that have already been created, return their email address.
+	 * For special known user names, return the email address that is also used by LDAP tests.
+	 * For other users, return null. They will not be assigned any particular
+	 * email address by this function.
+	 *
+	 * @param string $userName
+	 *
+	 * @return string|null
+	 */
+	public function getEmailAddressForUser($userName) {
+		$userName = $this->getActualUsername($userName);
+		// The hard-coded user names and email addresses are also in ldap-users.ldif
+		// for testing in an LDAP environment. The mapping must be kept the
+		// same in both places.
+		if (\array_key_exists($userName, $this->createdUsers)) {
+			return (string) $this->createdUsers[$userName]['email'];
+		} elseif (\array_key_exists($userName, $this->createdRemoteUsers)) {
+			return (string)$this->createdRemoteUsers[$userName]['email'];
+		} elseif ($userName === 'regularuser') {
+			return 'regularuser@example.org';
+		} elseif ($userName === 'user0') {
+			return 'user0@example.org';
+		} elseif ($userName === 'user1') {
+			return 'user1@example.org';
+		} elseif ($userName === 'user2') {
+			return 'user2@example.org';
+		} elseif ($userName === 'user3') {
+			return 'user3@example.org';
+		} elseif ($userName === 'user4') {
+			return 'user4@example.org';
+		} elseif ($userName === 'usergrp') {
+			return 'usergrp@example.org';
+		} elseif ($userName === 'sharee1') {
+			return 'sharee1@example.org';
+		} else {
+			return null;
 		}
 	}
 
@@ -1407,6 +1528,8 @@ trait BasicStructure {
 			return (string) $this->alt2UserPassword;
 		} elseif ($functionalPassword === "%alt3%") {
 			return (string) $this->alt3UserPassword;
+		} elseif ($functionalPassword === "%alt4%") {
+			return (string) $this->alt4UserPassword;
 		} elseif ($functionalPassword === "%subadmin%") {
 			return (string) $this->subAdminPassword;
 		} elseif ($functionalPassword === "%admin%") {

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -632,6 +632,9 @@ trait Sharing {
 				$dateModification = $fd['expireDate'];
 				$fd['expireDate'] = \date('Y-m-d', \strtotime($dateModification));
 			}
+			if (\array_key_exists('password', $fd)) {
+				$fd['password'] = $this->getActualPassword($fd['password']);
+			}
 		}
 
 		$this->response = HttpRequestHelper::put(

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -6,11 +6,9 @@ Feature: Mark file as favorite
   So that I can find my favorite file/folder easily
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -6,11 +6,9 @@ Feature: Unmark file/folder as favorite
   So that I can remove my favorite file/folder from favorite page
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -5,11 +5,9 @@ Feature: browse directly to details tab
   So that I can see the details immediately without needing to click in the UI
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   @smokeTest
   Scenario Outline: Browse directly to the sharing details of a file

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -5,11 +5,9 @@ Feature: create folders
   So that I can organise my data structure
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
@@ -5,11 +5,9 @@ Feature: create folder
   So that I can organise my data structure
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   Scenario Outline: Create a folder using special characters
     When the user creates a folder with the name <folder_name> using the webUI

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -5,11 +5,9 @@ Feature: deleting files and folders
   So that I can keep my filing system clean and tidy
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -4,12 +4,10 @@ Feature: User can open the details panel for any file or folder
   I want to be able to open the details panel of any file or folder
   So that the details of the file or folder are visible to me
 
-  Background: 
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+  Background:
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   Scenario: View different areas of the details panel in files page

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -6,11 +6,9 @@ Feature: Hide file/folders
   So that I can choose to see the files that I want.
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,11 +5,9 @@ Feature: scroll menu of actions that can be done on a file into view
   So that I can manage and work with my files
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @skipOnINTERNETEXPLORER

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -6,11 +6,9 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   @smokeTest
   Scenario: Simple search

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -11,10 +11,10 @@ Feature: login users
   @TestAlsoOnExternalUserBackend
   Scenario: simple user login
     Given these users have been created but not initialized:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+      | username |
+      | user1    |
     And the user has browsed to the login page
-    When the user logs in with username "user1" and password "%regular%" using the webUI
+    When the user logs in with username "user1" and password "%alt1%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
   @smokeTest

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -7,10 +7,10 @@ Feature: reset the password
 
   Background:
     Given these users have been created but not initialized:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+      | username |
+      | user1    |
     And the user has browsed to the login page
-    And the user logs in with username "user1" and invalid password "%alt3%" using the webUI
+    And the user logs in with username "user1" and invalid password "%alt2%" using the webUI
 
   @smokeTest
   Scenario: send password reset email
@@ -19,7 +19,7 @@ Feature: reset the password
 			"""
 			The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
 			"""
-    And the email address "u1@oc.com.np" should have received an email with the body containing
+    And the email address "user1@example.org" should have received an email with the body containing
 			"""
 			Use the following link to reset your password: <a href=
 			"""
@@ -28,12 +28,12 @@ Feature: reset the password
   @smokeTest
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "u1@oc.com.np"
+    And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "ownCloud"
-    When the user resets the password to "%alt1%" using the webUI
-    Then the email address "u1@oc.com.np" should have received an email with the body containing
+    When the user resets the password to "%alt3%" using the webUI
+    Then the email address "user1@example.org" should have received an email with the body containing
 			"""
 			Password changed successfully
 			"""
-    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    When the user logs in with username "user1" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - ownCloud"

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -7,10 +7,10 @@ Feature: reset the password using an email address
 
   Background:
     Given these users have been created but not initialized:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+      | username |
+      | user1    |
     And the user has browsed to the login page
-    And the user logs in with email "u1@oc.com.np" and invalid password "%alt3%" using the webUI
+    And the user logs in with email "user1@example.org" and invalid password "%alt2%" using the webUI
 
   @smokeTest
   Scenario: send password reset email
@@ -19,7 +19,7 @@ Feature: reset the password using an email address
 			"""
 			The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
 			"""
-    And the email address "u1@oc.com.np" should have received an email with the body containing
+    And the email address "user1@example.org" should have received an email with the body containing
 			"""
 			Use the following link to reset your password: <a href=
 			"""
@@ -29,12 +29,12 @@ Feature: reset the password using an email address
   @skip @issue-32868
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "u1@oc.com.np"
+    And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "ownCloud"
-    When the user resets the password to "%alt1%" using the webUI
-    Then the email address "u1@oc.com.np" should have received an email with the body containing
+    When the user resets the password to "%alt3%" using the webUI
+    Then the email address "user1@example.org" should have received an email with the body containing
 			"""
 			Password changed successfully
 			"""
-    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    When the user logs in with username "user1" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - ownCloud"

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -5,11 +5,9 @@ Feature: move files
   So that I can organise my data structure
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   Scenario: An attempt to move a file into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -5,11 +5,9 @@ Feature: move folders
   So that I can organise my data structure
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   Scenario: An attempt to move a folder into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -5,11 +5,9 @@ Feature: Change own email address on the personal settings page
   So that I can be reached by the owncloud server
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the personal general settings page
 
   @skip @issue-32385

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -5,11 +5,9 @@ Feature: Change own full name on the personal settings page
   So that other users can recognize me by it
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -5,11 +5,9 @@ Feature: Change Login Password
   So that I can login with my new password
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest
@@ -23,5 +21,5 @@ Feature: Change Login Password
     Then a password error message should be displayed on the webUI with the text "Wrong current password"
 
   Scenario: New password is same as current password
-    When the user changes the password to "%regular%" using the webUI
+    When the user changes the password to "%alt1%" using the webUI
     Then a password error message should be displayed on the webUI with the text "The new password cannot be the same as the previous one"

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -5,11 +5,9 @@ Feature: personal general settings
   So that I can personalise the User Interface
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -5,11 +5,9 @@ Feature: personal security settings
   So that I can enable, allow and deny access to and from other storage systems or resources
 
   Background:
-    Given these users have been created but not initialized:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the personal security settings page
 
   @smokeTest

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -5,11 +5,9 @@ Feature: rename files
   So that I can organise my data structure
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -5,11 +5,9 @@ Feature: Renaming files inside a folder with problematic name
   So that I can recognize my file easily
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   Scenario Outline: Rename the existing file inside a problematic folder
     When the user opens the folder <folder> using the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -5,11 +5,9 @@ Feature: rename folders
   So that I can organise my data structure
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   Scenario Outline: Rename a folder using special characters

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -5,14 +5,12 @@ Feature: disable sharing
   So that users cannot share files
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Users tries to share via WebUI when Sharing is disabled
     Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
     And the user has browsed to the login page
-    When the user logs in with username "user1" and password "%regular%" using the webUI
+    When the user logs in with username "user1" and password "%alt1%" using the webUI
     Then it should not be possible to share the folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -7,17 +7,17 @@ Feature: restrict resharing
 
   Background:
     Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
-      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt1%" using the webUI
+    And the user has logged in with username "user2" and password "%alt2%" using the webUI
 
   @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
   @smokeTest
@@ -27,7 +27,7 @@ Feature: restrict resharing
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | share | no |
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then it should not be possible to share the folder "simple-folder (2)" using the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -36,5 +36,5 @@ Feature: restrict resharing
     Given the setting "Allow resharing" in the section "Sharing" has been disabled
     And the user has browsed to the files page
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then it should not be possible to share the folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -6,10 +6,10 @@ Feature: restrict Sharing
 
   Background:
     Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
-      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -18,7 +18,7 @@ Feature: restrict Sharing
     And user "user2" has been added to group "grp1"
     And user "user3" has been added to group "grp2"
     And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt1%" using the webUI
+    And the user has logged in with username "user2" and password "%alt2%" using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
@@ -27,7 +27,7 @@ Feature: restrict Sharing
     When the user browses to the files page
     Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -37,7 +37,7 @@ Feature: restrict Sharing
     When the user browses to the files page
     Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
     When the user shares the folder "simple-folder" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -45,7 +45,7 @@ Feature: restrict Sharing
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
     And the user browses to the files page
     When the user shares the folder "simple-folder" with the group "grp2" using the webUI
-    And the user re-logs in with username "user3" and password "%alt2%" using the webUI
+    And the user re-logs in with username "user3" and password "%alt3%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -56,5 +56,5 @@ Feature: restrict Sharing
     Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
     And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -6,20 +6,16 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Background:
     Given using server "REMOTE"
-    And these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    And user "user1" has been created
     And using server "LOCAL"
-    And these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    And user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   Scenario: test the single steps of sharing a folder to a remote server
     When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
     And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
     Then as "user1" the folder "/simple-folder (2)" should exist
@@ -29,9 +25,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: test the single steps of receiving a federation share
     Given using server "REMOTE"
     And these users have been created:
-      | username | password | displayname | email        |
-      | user2    | %alt1%   | User Two    | u2@oc.com.np |
-      | user3    | %alt2%   | User Two    | u2@oc.com.np |
+      | username |
+      | user2    |
+      | user3    |
     And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And user "user2" from server "REMOTE" has shared "simple-empty-folder" with user "user1" from server "LOCAL"
     And user "user3" from server "REMOTE" has shared "lorem.txt" with user "user1" from server "LOCAL"
@@ -63,18 +59,18 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
     And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
       | delete | no |
-    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete the file "lorem.txt" using the webUI
 
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-    When the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    When the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user shares the folder "simple-folder" with the remote user "user1@%local_server_without_scheme%" using the webUI
     And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
       | delete | no |
-    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete the file "lorem.txt" using the webUI
@@ -83,7 +79,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
-    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
@@ -94,7 +90,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
@@ -103,7 +99,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
-    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
@@ -114,7 +110,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     And the user uploads the file "new-lorem.txt" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
@@ -123,7 +119,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
-    When the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    When the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "renamed file.txt" should be listed on the webUI
     But the file "lorem-big.txt" should not be listed on the webUI
@@ -135,7 +131,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     When the user opens the folder "simple-folder (2)" using the webUI
     And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "renamed file.txt" should be listed on the webUI
     And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
@@ -145,7 +141,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
-    And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 
@@ -155,15 +151,13 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     And the user deletes the file "data.zip" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 
   Scenario: receive same name federation share from two users
     Given using server "REMOTE"
-    And these users have been created:
-      | username | password | displayname | email        |
-      | user2    | %alt1%   | User Two    | u2@oc.com.np |
+    And user "user2" has been created
     And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
@@ -196,7 +190,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI
     And the user shares the file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
     Then as "user1" the file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -9,11 +9,9 @@ Feature: Share by public link
   So that public sharing is limited according to organization policy
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   @smokeTest
   Scenario: simple sharing by public link
@@ -45,13 +43,11 @@ Feature: Share by public link
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link
     Given using server "REMOTE"
-    And these users have been created:
-      | username | password  | displayname | email        |
-      | user2    | %regular% | User One    | u1@oc.com.np |
+    And user "user2" has been created
     When the user creates a new public link for the folder "simple-folder" using the webUI
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
-    And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
+    And the public adds the public link to "%remote_server%" as user "user2" with the password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     When the user opens the folder "simple-folder (2)" using the webUI
@@ -62,14 +58,12 @@ Feature: Share by public link
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
-    And these users have been created:
-      | username | password  | displayname | email        |
-      | user2    | %regular% | User One    | u1@oc.com.np |
+    And user "user2" has been created
     When the user creates a new public link for the folder "simple-folder" using the webUI with
       | permission | read-write |
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
-    And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
+    And the public adds the public link to "%remote_server%" as user "user2" with the password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     When the user opens the folder "simple-folder (2)" using the webUI
@@ -160,12 +154,12 @@ Feature: Share by public link
 			"""
 			User One shared simple-folder with you
 			"""
-    And the email address "u1@oc.com.np" should have received an email with the body containing
+    And the email address "user1@example.org" should have received an email with the body containing
 			"""
 			User One shared simple-folder with you
 			"""
     And the email address "foo@bar.co" should have received an email containing last shared public link
-    And the email address "u1@oc.com.np" should have received an email containing last shared public link
+    And the email address "user1@example.org" should have received an email containing last shared public link
 
   Scenario: user shares a public link via email with multiple addresses
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -6,29 +6,29 @@ Feature: Sharing files and folders with internal groups
 
   Background:
     Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
-      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And the user has browsed to the login page
-    And the user has logged in with username "user3" and password "%alt2%" using the webUI
+    And the user has logged in with username "user3" and password "%alt3%" using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a folder with an internal group
     When the user shares the folder "simple-folder" with the group "grp1" using the webUI
     And the user shares the file "testimage.jpg" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
     And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
@@ -38,7 +38,7 @@ Feature: Sharing files and folders with internal groups
   Scenario: share a file with an internal group a member overwrites and unshares the file
     When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares the file "new-lorem.txt" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
     When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -48,17 +48,17 @@ Feature: Sharing files and folders with internal groups
     When the user unshares the file "new-lorem.txt" using the webUI
     Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that another group member can still see the file
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# check that the original file owner can still see the file
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -72,13 +72,13 @@ Feature: Sharing files and folders with internal groups
     When the user deletes the file "data.zip" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible to another group member
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
     And the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-    When the user re-logs in with username "user3" and password "%alt2%" using the webUI
+    When the user re-logs in with username "user3" and password "%alt3%" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
@@ -90,17 +90,17 @@ Feature: Sharing files and folders with internal groups
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     And the user unshares the folder "new-simple-folder" using the webUI
     Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible to another group member
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then the folder "new-simple-folder" should be listed on the webUI
     When the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		# check that the folder is still visible for the share owner
-    When the user re-logs in with username "user3" and password "%alt2%" using the webUI
+    When the user re-logs in with username "user3" and password "%alt3%" using the webUI
     Then the folder "new-simple-folder" should be listed on the webUI
     When the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -6,25 +6,25 @@ Feature: Sharing files and folders with internal groups
 
   Scenario Outline: sharing  files and folder with an internal problematic group name
     Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
-      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
     And these groups have been created:
       | groupname |
       | <group>   |
     And user "user1" has been added to group "<group>"
     And user "user2" has been added to group "<group>"
     And the user has browsed to the login page
-    And the user has logged in with username "user3" and password "%alt2%" using the webUI
+    And the user has logged in with username "user3" and password "%alt3%" using the webUI
     When the user shares the folder "simple-folder" with the group "<group>" using the webUI
     And the user shares the file "testimage.jpg" with the group "<group>" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
     And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
@@ -33,4 +33,3 @@ Feature: Sharing files and folders with internal groups
       | group     |
       | ?\?@#%@,; |
       | नेपाली    |
-

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -6,10 +6,10 @@ Feature: accept/decline shares coming from internal users
 
   Background:
     Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
-      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -22,7 +22,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    When the user logs in with username "user1" and password "%regular%" using the webUI
+    When the user logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should not be listed on the webUI
     And the file "testimage (2).jpg" should not be listed on the webUI
     But the folder "simple-folder" should be listed in the shared-with-you page on the webUI
@@ -34,7 +34,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
-    When the user logs in with username "user3" and password "%alt2%" using the webUI
+    When the user logs in with username "user3" and password "%alt3%" using the webUI
     Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
     And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
@@ -44,7 +44,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has created a folder "/simple-folder/from_user1"
     And user "user1" has shared folder "/simple-folder" with user "user3"
-    And the user has logged in with username "user3" and password "%alt2%" using the webUI
+    And the user has logged in with username "user3" and password "%alt3%" using the webUI
     When the user accepts the share "simple-folder" offered by user "User One" using the webUI
     And the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
@@ -57,7 +57,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
-    When the user logs in with username "user3" and password "%alt2%" using the webUI
+    When the user logs in with username "user3" and password "%alt3%" using the webUI
     Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
     And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
@@ -66,7 +66,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
     And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
@@ -80,7 +80,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user declines the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
@@ -92,7 +92,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
@@ -105,7 +105,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
@@ -117,7 +117,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user declines the share "simple-folder" offered by user "User Two" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
@@ -129,7 +129,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
@@ -139,7 +139,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user declines the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
@@ -148,7 +148,7 @@ Feature: accept/decline shares coming from internal users
   Scenario: reshare a share that you received to a group that you are member of
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user has browsed to the files page
     And the user shares the folder "simple-folder (2)" with the group "grp1" using the webUI
@@ -164,7 +164,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/testimage.jpg" with group "grp1"
     And user "user1" has accepted the share "/simple-folder" offered by user "user2"
     And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user unshares the folder "simple-folder (2)" using the webUI
     And the user unshares the file "testimage (2).jpg" using the webUI
     Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -177,7 +177,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    When the user logs in with username "user1" and password "%regular%" using the webUI
+    When the user logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
     And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
@@ -189,7 +189,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
     And the user declines the share "testimage (2).jpg" offered by user "User Two" using the webUI
     And the user has browsed to the files page
@@ -202,7 +202,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user unshares the folder "simple-folder (2)" using the webUI
     And the user unshares the file "testimage (2).jpg" using the webUI
     Then the folder "simple-folder (2)" should not be listed on the webUI
@@ -214,7 +214,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user unshares the folder "simple-folder-renamed" using the webUI
     Then the folder "simple-folder-renamed" should not be listed on the webUI
     And the folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
@@ -223,7 +223,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder/shared"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user opens the folder "simple-folder" using the webUI
     And the user unshares the folder "shared" using the webUI
     Then the folder "shared" should not be listed on the webUI
@@ -233,7 +233,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     When the user unshares the folder "simple-folder-renamed" using the webUI
     And the user accepts the share "simple-folder-renamed" offered by user "User Two" using the webUI
     Then the folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -5,15 +5,19 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
+    # Users that are in the special known users already
+    Given these users have been created but not initialized:
+      | username    |
+      | user1       |
+      | user3       |
+      | usergrp     |
+      | regularuser |
+    # Some extra users to make the share autocompletion interesting
     Given these users have been created but not initialized:
       | username    | password  | displayname     | email                 |
-      | user1       | %regular% | User One        | u1@oc.com.np          |
       | two         | %regular% | User Two        | u2@oc.com.np          |
-      | user3       | %regular% | Three           | u3@oc.com.np          |
       | u444        | %regular% | Four            | u3@oc.com.np          |
-      | usergrp     | %regular% | User Ggg        | u@oc.com.np           |
       | five        | %regular% | User Group      | five@oc.com.np        |
-      | regularuser | %regular% | User Regular    | regularuser@oc.com.np |
       | usersmith   | %regular% | John Finn Smith | js@oc.com.np          |
     And these groups have been created:
       | groupname     |
@@ -119,10 +123,10 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
     Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
     And the user has browsed to the files page
-    And the user has shared the file "data.zip" with the user "User Ggg" using the webUI
+    And the user has shared the file "data.zip" with the user "User Grp" using the webUI
     And the user has opened the share dialog for the file "data.zip"
     When the user types "user" in the share-with-field
-    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Ggg"
+    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
     And the users own name should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -6,18 +6,18 @@ Feature: Sharing files and folders with internal users
 
   Background:
     Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
     And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt1%" using the webUI
+    And the user has logged in with username "user2" and password "%alt2%" using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a file & folder with another internal user
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
     And the user shares the file "testimage.jpg" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
@@ -30,7 +30,7 @@ Feature: Sharing files and folders with internal users
   Scenario: share a file with another internal user who overwrites and unshares the file
     When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares the file "new-lorem.txt" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
     When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -40,14 +40,14 @@ Feature: Sharing files and folders with internal users
     When the user unshares the file "new-lorem.txt" using the webUI
     Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that the original file owner can still see the file
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -61,7 +61,7 @@ Feature: Sharing files and folders with internal users
     When the user deletes the file "data.zip" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
@@ -74,11 +74,11 @@ Feature: Sharing files and folders with internal users
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     And the user unshares the folder "new-simple-folder" using the webUI
     Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible for the share owner
-    When the user re-logs in with username "user2" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then the folder "new-simple-folder" should be listed on the webUI
     When the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
@@ -89,6 +89,6 @@ Feature: Sharing files and folders with internal users
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | delete | no |
-    And the user re-logs in with username "user1" and password "%regular%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete the file "lorem.txt" using the webUI

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -7,11 +7,11 @@ Feature: Display notifications when receiving a share and follow embedded links
   Background:
     Given the app "notifications" has been enabled
     And these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
     And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt1%" using the webUI
+    And the user has logged in with username "user2" and password "%alt2%" using the webUI
 
   @smokeTest
   Scenario: notification link redirection in case a share is pending

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -7,17 +7,17 @@ Feature: Sharing files and folders with internal groups
   Background:
     Given the app "notifications" has been enabled
     And these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
-      | user3    | %alt2%    | User Three  | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt1%" using the webUI
+    And the user has logged in with username "user2" and password "%alt2%" using the webUI
 
   Scenario: notifications about new share is displayed
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -27,7 +27,7 @@ Feature: Sharing files and folders with internal groups
       | title                                        |
       | "User Three" shared "simple-folder" with you |
       | "User Three" shared "data.zip" with you      |
-    When the user re-logs in with username "user1" and password "%regular%" using the webUI
+    When the user re-logs in with username "user1" and password "%alt1%" using the webUI
     Then the user should see 2 notifications on the webUI with these details
       | title                                        |
       | "User Three" shared "simple-folder" with you |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -7,11 +7,11 @@ Feature: Sharing files and folders with internal users
   Background:
     Given the app "notifications" has been enabled
     And these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %alt1%    | User Two    | u2@oc.com.np |
+      | username |
+      | user1    |
+      | user2    |
     And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt1%" using the webUI
+    And the user has logged in with username "user2" and password "%alt2%" using the webUI
 
   @smokeTest
   Scenario: notifications about new share is displayed when autoacepting is disabled

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -5,11 +5,9 @@ Feature: Restore deleted files/folders
   So that I can recover accidentally deleted files/folders in ownCloud
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -5,11 +5,9 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the following files have been deleted
       | name          |
       | data.zip      |

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -5,11 +5,9 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -6,11 +6,9 @@ Feature: File Upload
   So that I can store files in ownCloud
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   @smokeTest
   Scenario: simple upload of a file that does not exist before

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -8,11 +8,9 @@ Feature: File Upload
   that is not academically correct but saves a lot of time
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
   Scenario: simple upload of a file that does not exist before
     When the user uploads the file "new-'single'quotes.txt" using the webUI

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -6,15 +6,13 @@ Feature: Upload a file
   So that I can store it in owncloud
 
   Background:
-    Given these users have been created:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
+    Given user "user1" has been created
 
   @smokeTest
   Scenario: simple upload of a file with the size greater than the size of quota
     Given the quota of user "user1" has been set to "10 MB"
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%regular%" using the webUI
+    And the user has logged in with username "user1" and password "%alt1%" using the webUI
     And the user has browsed to the files page
     And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user uploads the file "big-video.mp4" using the webUI


### PR DESCRIPTION
## Description
1) Make the core acceptance test code know what is the password, display name, and email address of each of the "fixed" users that are setup in user_ldap testing.
2) "Just create" these users in Gherkin steps without specifying the password, display name, and email address. Leave it to the code underneath to fill in that information. This reduces the duplication of password, display name and email address throughout the feature files.

## Motivation and Context
Acceptance tests in user_ldap app run tests from core with a known set of users already setup in LDAP. We have problems when we change or add acceptance tests in core. We have to remember not to "break the rules" of what will work for user_ldap.

e.g. ``apiWebdavOperations/search.feature`` was recently added. It created a "default" ``user0`` and then the test expected the display name of ``user0`` to be just ``user0``. But in LDAP that user has a display name of ``User Zero``. We can fixup just the core test, like in PR #32910 but it would be nice to try and avoid this as much as reasonable for the future.

## How Has This Been Tested?
Some local acceptance test runs. CI will run the complete suites.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
