### PR TITLE
Use correct user and password when finding fileid in tag tests

### DIFF
--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -38,10 +38,12 @@ class TagsHelper {
 	 * @param string $password
 	 * @param string $tagName
 	 * @param string $fileName
-	 * @param string $fileOwner
+	 * @param string|null $fileOwner
+	 * @param string|null $fileOwnerPassword
 	 * @param int $davPathVersionToUse (1|2)
 	 *
 	 * @return ResponseInterface
+	 * @throws \Exception
 	 */
 	public static function tag(
 		$baseUrl,
@@ -49,11 +51,20 @@ class TagsHelper {
 		$password,
 		$tagName,
 		$fileName,
-		$fileOwner,
+		$fileOwner = null,
+		$fileOwnerPassword = null,
 		$davPathVersionToUse = 1
 	) {
+		if ($fileOwner === null) {
+			$fileOwner = $taggingUser;
+		}
+
+		if ($fileOwnerPassword === null) {
+			$fileOwnerPassword = $password;
+		}
+
 		$fileID = WebDavHelper::getFileIdForPath(
-			$baseUrl, $fileOwner, $password, $fileName
+			$baseUrl, $fileOwner, $fileOwnerPassword, $fileName
 		);
 
 		$tag = self::requestTagByDisplayName(

--- a/tests/acceptance/features/apiMetadataApps/tags.feature
+++ b/tests/acceptance/features/apiMetadataApps/tags.feature
@@ -92,7 +92,7 @@ Feature: tags
     Given user "user0" has been created
     And user "user0" has created a "normal" tag with name "JustARegularTagName"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
+    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt"
     When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "%admin%"
@@ -133,7 +133,7 @@ Feature: tags
     And user "%admin%" has created a "normal" tag with name "JustARegularTagName"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | JustARegularTagName | normal |
@@ -144,7 +144,7 @@ Feature: tags
     And user "%admin%" has created a "normal" tag with name "MyFirstTag"
     And user "%admin%" has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
     And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" owned by "user0" should have the following tags
@@ -157,8 +157,8 @@ Feature: tags
     And user "%admin%" has created a "not user-assignable" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | MyFirstTag | normal |
@@ -171,7 +171,7 @@ Feature: tags
     And user "%admin%" has created a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | JustARegularTagName | not user-assignable |
@@ -183,8 +183,8 @@ Feature: tags
     And user "%admin%" has created a "not user-visible" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "412"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | MyFirstTag | normal |
@@ -197,8 +197,8 @@ Feature: tags
     And user "another_admin" has created a "not user-visible" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
-    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
+    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" should have the following tags for user "another_admin"
       | MyFirstTag  | normal           |
@@ -214,8 +214,8 @@ Feature: tags
     And user "another_admin" has created a "not user-assignable" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
-    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
+    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" should have the following tags for user "another_admin"
       | MyFirstTag  | normal              |
@@ -232,8 +232,8 @@ Feature: tags
     And user "%admin%" has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0"
+    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
@@ -245,8 +245,8 @@ Feature: tags
     And user "%admin%" has created a "normal" tag with name "MyFirstTag"
     And user "%admin%" has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
@@ -263,8 +263,8 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
@@ -283,8 +283,8 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
@@ -302,8 +302,8 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     And user "user0" has removed all shares from the file named "/myFileToTag.txt"
     When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
@@ -318,8 +318,8 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
@@ -339,8 +339,8 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
@@ -358,8 +358,8 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt"
     And user "user0" has removed all shares from the file named "/myFileToTag.txt"
     When user "%admin%" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
@@ -385,7 +385,7 @@ Feature: tags
     And user "user1" has been created
     And user "%admin%" has created a "normal" tag with name "MyFirstTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
     Then file "/myFileToTag.txt" should have the following tags for user "user0"
       | MyFirstTag | normal |
     And the HTTP status when user "user1" requests tags for file "/myFileToTag.txt" owned by "user0" should be "404"

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -374,11 +374,17 @@ trait Tags {
 	 * @param string $taggingUser
 	 * @param string $tagName
 	 * @param string $fileName
-	 * @param string $fileOwner
+	 * @param string|null $fileOwner
 	 *
 	 * @return void
 	 */
-	private function tag($taggingUser, $tagName, $fileName, $fileOwner) {
+	private function tag(
+		$taggingUser, $tagName, $fileName, $fileOwner = null
+	) {
+		if ($fileOwner === null) {
+			$fileOwner = $taggingUser;
+		}
+
 		$this->response = TagsHelper::tag(
 			$this->getBaseUrl(),
 			$taggingUser,
@@ -386,6 +392,7 @@ trait Tags {
 			$tagName,
 			$fileName,
 			$fileOwner,
+			$this->getPasswordForUser($fileOwner),
 			$this->getDavPathVersion('systemtags')
 		);
 	}
@@ -421,6 +428,22 @@ trait Tags {
 		}
 		$this->response = $response;
 		return $response;
+	}
+
+	/**
+	 * @When /^user "([^"]*)" adds the tag "([^"]*)" to "([^"]*)" using the WebDAV API$/
+	 * @Given /^user "([^"]*)" has added the tag "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $taggingUser
+	 * @param string $tagName
+	 * @param string $fileName
+	 *
+	 * @return void
+	 */
+	public function addsTheTagTo(
+		$taggingUser, $tagName, $fileName
+	) {
+		$this->tag($taggingUser, $tagName, $fileName);
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) Enhance ``TagsHelper`` so it can be passed the password of the file owner.
2) Use that password when the file owner is specified, otherwise use the tagging user name and password. (Because the tagging user could already be the file owner also)
3) Adjust calls in ``Tags.php`` trait.
4) Adjust Gherkin steps for tagging - when a user is tagging a file that they have proper access to, then they do not need to know/mention the UID and password of the file owner.

## Related Issue
- Fixes #32912 

## Motivation and Context
See issue description.

## How Has This Been Tested?
Local run of ``tags.feature``

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
