### PR TITLE
Reword public link step text

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -325,23 +325,25 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the user should see a error message on public dialog saying :expectedWarningMessage
+	 * @Then the user should see an error message on the public link share dialog saying :expectedWarningMessage
 	 *
 	 * @param string $expectedWarningMessage
 	 *
 	 * @return void
 	 */
-	public function theUserShouldSeeAErrorMessageSaying($expectedWarningMessage) {
+	public function theUserShouldSeeAnErrorMessageOnThePublicLinkShareDialogSaying(
+		$expectedWarningMessage
+	) {
 		$warningMessage = $this->publicShareTab->getWarningMessage();
 		PHPUnit_Framework_Assert::assertEquals($expectedWarningMessage, $warningMessage);
 	}
 
 	/**
-	 * @Then public link should not be generated
+	 * @Then the public link should not have been generated
 	 *
 	 * @return void
 	 */
-	public function publicLinkShouldNotBeGenerated() {
+	public function thePublicLinkShouldNotHaveBeenGenerated() {
 		try {
 			$this->publicShareTab->getLinkUrl($this->linkName);
 		} catch (Exception $e) {

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -89,8 +89,8 @@ Feature: Share by public link
     Given user "user1" has moved file "/lorem.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And the user has reloaded the current page of the webUI
     When the user tries to create a new public link for the file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI
-    Then the user should see a error message on public dialog saying "Share name cannot be more than 64 characters"
-    And public link should not be generated
+    Then the user should see an error message on the public link share dialog saying "Share name cannot be more than 64 characters"
+    And the public link should not have been generated
 
   Scenario: user shares a public link with folder longer than 64 chars and shorter link name
     Given user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
@@ -103,22 +103,22 @@ Feature: Share by public link
   Scenario: user tries to create a public link with read only permission without entering share password while enforce password on read only public share is enforced
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the user tries to create a new public link for the folder "simple-folder" using the webUI
-    Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
-    And public link should not be generated
+    Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
+    And the public link should not have been generated
 
   Scenario: user tries to create a public link with read-write permission without entering share password while enforce password on read-write public share is enforced
     Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
     When the user tries to create a new public link for the folder "simple-folder" using the webUI with
       | permission | read-write |
-    Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
-    And public link should not be generated
+    Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
+    And the public link should not have been generated
 
   Scenario: user tries to create a public link with write only permission without entering share password while enforce password on write only public share is enforced
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
     When the user tries to create a new public link for the folder "simple-folder" using the webUI with
       | permission | upload |
-    Then the user should see a error message on public dialog saying "Passwords are enforced for link shares"
-    And public link should not be generated
+    Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
+    And the public link should not have been generated
 
   Scenario: user creates a public link with read-write permission without entering share password while enforce password on read only public share is enforced
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"


### PR DESCRIPTION
## Description
Reword some test steps related to public link sharing on the webUI.

## Motivation and Context
I noticed that the wording of some public link sharing steps is not quite correct or specific enough.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
