### PR TITLE
Simplify 'When the user logs in' steps

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -71,6 +71,22 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user re-logs in as :username using the webUI
+	 * @Given the user has re-logged in as :username using the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theUserRelogsInUsingTheWebUI($username) {
+		$this->theUserRelogsInWithUsernameAndPasswordUsingTheWebUI(
+			$username,
+			$this->featureContext->getPasswordForUser($username)
+		);
+	}
+
+	/**
 	 * @When the user re-logs in with username :username and password :password using the webUI
 	 * @Given the user has re-logged in with username :username and password :password using the webUI
 	 *
@@ -86,6 +102,23 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
 		$this->theUserLogsInWithUsernameAndPasswordUsingTheWebUI(
 			$username, $password
+		);
+	}
+
+	/**
+	 * @When user :username logs in using the webUI
+	 * @Given user :username has logged in using the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theUserLogsInUsingTheWebUI($username) {
+		$this->theUserBrowsesToTheLoginPage();
+		$this->theUserLogsInWithUsernameAndPasswordUsingTheWebUI(
+			$username,
+			$this->featureContext->getPasswordForUser($username)
 		);
 	}
 
@@ -121,6 +154,26 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When user :username re-logs in to :server using the webUI
+	 * @Given user :username has re-logged in to :server using the webUI
+	 *
+	 * @param string $username
+	 * @param string $server
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theUserRelogsInToUsingTheWebUI(
+		$username, $server
+	) {
+		$this->theUserRelogsInWithUsernameAndPasswordToUsingTheWebUI(
+			$username,
+			$this->featureContext->getPasswordForUser($username),
+			$server
+		);
+	}
+
+	/**
 	 * @When the user re-logs in with username :username and password :password to :server using the webUI
 	 * @Given the user has re-logged in with username :username and password :password to :server using the webUI
 	 *
@@ -137,6 +190,26 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
 		$this->theUserLogsInWithUsernameAndPasswordToUsingTheWebUI(
 			$username, $password, $server
+		);
+	}
+
+	/**
+	 * @When user :username logs in to :server using the webUI
+	 * @Given user :username has logged in to :server using the webUI
+	 *
+	 * @param string $username
+	 * @param string $server
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theUserLogsInToUsingTheWebUI(
+		$username, $server
+	) {
+		$this->theUserLogsInWithUsernameAndPasswordToUsingTheWebUI(
+			$username,
+			$this->featureContext->getPasswordForUser($username),
+			$server
 		);
 	}
 
@@ -186,6 +259,27 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		$password = $this->featureContext->getActualPassword($password);
 		$this->loginPage->loginAs($username, $password, 'LoginPage');
 		$this->loginPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
+	 * @When user :username logs in using the webUI after a redirect from the :page page
+	 * @Given user :username has logged in using the webUI after a redirect from the :page page
+	 *
+	 * @param string $username
+	 * @param string $page text name of a page that I expect to be taken to
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theUserLogsInAfterRedirectFromThePage(
+		$username,
+		$page
+	) {
+		$this->theUserLogsInWithUsernameAndPasswordAfterRedirectFromThePage(
+			$username,
+			$this->featureContext->getPasswordForUser($username),
+			$page
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -10,8 +10,7 @@ Feature: Add, delete and edit comments in files and folders
       | username |
       | user1    |
       | user2    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario: user adds and deletes comment for a file/folder
@@ -26,6 +25,6 @@ Feature: Add, delete and edit comments in files and folders
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
     And the user comments with content "lorem ipsum" using the webUI
     And the user shares the file "new-lorem.txt" with the user "User Two" using the webUI
-    And the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    And the user re-logs in as "user2" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
     Then the comment "lorem ipsum" should be listed in the comments tab in details dialog

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -7,8 +7,7 @@ Feature: Mark file as favorite
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -7,8 +7,7 @@ Feature: Unmark file/folder as favorite
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -6,8 +6,7 @@ Feature: browse directly to details tab
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   @smokeTest
   Scenario Outline: Browse directly to the sharing details of a file

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -6,8 +6,7 @@ Feature: create folders
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
@@ -6,8 +6,7 @@ Feature: create folder
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   Scenario Outline: Create a folder using special characters
     When the user creates a folder with the name <folder_name> using the webUI

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -6,8 +6,7 @@ Feature: deleting files and folders
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -6,8 +6,7 @@ Feature: User can open the details panel for any file or folder
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario: View different areas of the details panel in files page

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -7,8 +7,7 @@ Feature: Hide file/folders
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -6,8 +6,7 @@ Feature: scroll menu of actions that can be done on a file into view
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @skipOnINTERNETEXPLORER

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -7,8 +7,7 @@ Feature: Search
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   @smokeTest
   Scenario: Simple search

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -13,14 +13,12 @@ Feature: login users
     Given these users have been created but not initialized:
       | username |
       | user1    |
-    And the user has browsed to the login page
-    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    When user "user1" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
   @smokeTest
   Scenario: admin login
-    Given the user has browsed to the login page
-    When the user logs in with username "%admin%" and password "%admin%" using the webUI
+    When user "%admin%" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
   @smokeTest
@@ -32,7 +30,7 @@ Feature: login users
   Scenario: access the personal general settings page when not logged in
     When the user attempts to browse to the personal general settings page
     Then the user should be redirected to a webUI page with the title "ownCloud"
-    When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
+    When user "%admin%" logs in using the webUI after a redirect from the "personal general settings" page
     Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
 
   Scenario: access the personal general settings page when not logged in using incorrect then correct password
@@ -40,5 +38,5 @@ Feature: login users
     Then the user should be redirected to a webUI page with the title "ownCloud"
     When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "ownCloud"
-    When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
+    When user "%admin%" logs in using the webUI after a redirect from the "personal general settings" page
     Then the user should be redirected to a webUI page with the title "Settings - ownCloud"

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -6,8 +6,7 @@ Feature: move files
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario: An attempt to move a file into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -6,8 +6,7 @@ Feature: move folders
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario: An attempt to move a folder into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -6,8 +6,7 @@ Feature: Change own email address on the personal settings page
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @skip @issue-32385

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -6,8 +6,7 @@ Feature: Change own full name on the personal settings page
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -6,18 +6,17 @@ Feature: Change Login Password
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest
   Scenario: Change password
-    When the user changes the password to "%alt1%" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    When the user changes the password to "%alt3%" using the webUI
+    And the user re-logs in with username "user1" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
   Scenario: Password change with wrong current password
-    When the user changes the password to "%alt1%" entering the wrong current password "%alt2%" using the webUI
+    When the user changes the password to "%alt3%" entering the wrong current password "%alt2%" using the webUI
     Then a password error message should be displayed on the webUI with the text "Wrong current password"
 
   Scenario: New password is same as current password

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -6,8 +6,7 @@ Feature: personal general settings
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -6,8 +6,7 @@ Feature: personal security settings
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the personal security settings page
 
   @smokeTest

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -6,8 +6,7 @@ Feature: rename files
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -6,8 +6,7 @@ Feature: Renaming files inside a folder with problematic name
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   Scenario Outline: Rename the existing file inside a problematic folder
     When the user opens the folder <folder> using the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -6,8 +6,7 @@ Feature: rename folders
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario Outline: Rename a folder using special characters

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -11,6 +11,5 @@ Feature: disable sharing
   @smokeTest
   Scenario: Users tries to share via WebUI when Sharing is disabled
     Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
-    And the user has browsed to the login page
-    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    When user "user1" logs in using the webUI
     Then it should not be possible to share the folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -16,8 +16,7 @@ Feature: restrict resharing
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
-    And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt2%" using the webUI
+    And user "user2" has logged in using the webUI
 
   @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
   @smokeTest
@@ -27,7 +26,7 @@ Feature: restrict resharing
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | share | no |
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then it should not be possible to share the folder "simple-folder (2)" using the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -36,5 +35,5 @@ Feature: restrict resharing
     Given the setting "Allow resharing" in the section "Sharing" has been disabled
     And the user has browsed to the files page
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then it should not be possible to share the folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -17,8 +17,7 @@ Feature: restrict Sharing
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And user "user3" has been added to group "grp2"
-    And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt2%" using the webUI
+    And user "user2" has logged in using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
@@ -27,7 +26,7 @@ Feature: restrict Sharing
     When the user browses to the files page
     Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -37,7 +36,7 @@ Feature: restrict Sharing
     When the user browses to the files page
     Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
     When the user shares the folder "simple-folder" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -45,7 +44,7 @@ Feature: restrict Sharing
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
     And the user browses to the files page
     When the user shares the folder "simple-folder" with the group "grp2" using the webUI
-    And the user re-logs in with username "user3" and password "%alt3%" using the webUI
+    And the user re-logs in as "user3" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -56,5 +55,5 @@ Feature: restrict Sharing
     Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
     And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -9,13 +9,12 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" has been created
     And using server "LOCAL"
     And user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   Scenario: test the single steps of sharing a folder to a remote server
     When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
     And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
     Then as "user1" the folder "/simple-folder (2)" should exist
@@ -59,18 +58,18 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
     And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
       | delete | no |
-    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete the file "lorem.txt" using the webUI
 
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-    When the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    When user "user1" re-logs in to "%remote_server%" using the webUI
     And the user shares the folder "simple-folder" with the remote user "user1@%local_server_without_scheme%" using the webUI
     And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
       | delete | no |
-    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
+    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete the file "lorem.txt" using the webUI
@@ -79,7 +78,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
-    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
+    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
@@ -90,7 +89,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
@@ -99,7 +98,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
-    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
+    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
@@ -110,7 +109,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     And the user uploads the file "new-lorem.txt" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
@@ -119,7 +118,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
-    When the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
+    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "renamed file.txt" should be listed on the webUI
     But the file "lorem-big.txt" should not be listed on the webUI
@@ -131,7 +130,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     When the user opens the folder "simple-folder (2)" using the webUI
     And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "renamed file.txt" should be listed on the webUI
     And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
@@ -141,7 +140,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
-    And the user re-logs in with username "user1" and password "%alt1%" to "%local_server%" using the webUI
+    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 
@@ -151,7 +150,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     And the user deletes the file "data.zip" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user opens the folder "simple-folder" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 
@@ -190,7 +189,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI
     And the user shares the file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" to "%remote_server%" using the webUI
+    And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
     Then as "user1" the file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -10,8 +10,7 @@ Feature: Share by public link
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   @smokeTest
   Scenario: simple sharing by public link

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -15,20 +15,19 @@ Feature: Sharing files and folders with internal groups
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
-    And the user has browsed to the login page
-    And the user has logged in with username "user3" and password "%alt3%" using the webUI
+    And user "user3" has logged in using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a folder with an internal group
     When the user shares the folder "simple-folder" with the group "grp1" using the webUI
     And the user shares the file "testimage.jpg" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
     And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
@@ -38,7 +37,7 @@ Feature: Sharing files and folders with internal groups
   Scenario: share a file with an internal group a member overwrites and unshares the file
     When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares the file "new-lorem.txt" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
     When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -48,17 +47,17 @@ Feature: Sharing files and folders with internal groups
     When the user unshares the file "new-lorem.txt" using the webUI
     Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that another group member can still see the file
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# check that the original file owner can still see the file
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user3" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -72,13 +71,13 @@ Feature: Sharing files and folders with internal groups
     When the user deletes the file "data.zip" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible to another group member
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
     And the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-    When the user re-logs in with username "user3" and password "%alt3%" using the webUI
+    When the user re-logs in as "user3" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
@@ -90,17 +89,17 @@ Feature: Sharing files and folders with internal groups
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    When the user re-logs in as "user1" using the webUI
     And the user unshares the folder "new-simple-folder" using the webUI
     Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible to another group member
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then the folder "new-simple-folder" should be listed on the webUI
     When the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		# check that the folder is still visible for the share owner
-    When the user re-logs in with username "user3" and password "%alt3%" using the webUI
+    When the user re-logs in as "user3" using the webUI
     Then the folder "new-simple-folder" should be listed on the webUI
     When the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -15,16 +15,15 @@ Feature: Sharing files and folders with internal groups
       | <group>   |
     And user "user1" has been added to group "<group>"
     And user "user2" has been added to group "<group>"
-    And the user has browsed to the login page
-    And the user has logged in with username "user3" and password "%alt3%" using the webUI
+    And user "user3" has logged in using the webUI
     When the user shares the folder "simple-folder" with the group "<group>" using the webUI
     And the user shares the file "testimage.jpg" with the group "<group>" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
     And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -15,14 +15,13 @@ Feature: accept/decline shares coming from internal users
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
-    And the user has browsed to the login page
 
   @smokeTest
   Scenario: Auto-accept disabled results in "Pending" shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    When user "user1" logs in using the webUI
     Then the folder "simple-folder (2)" should not be listed on the webUI
     And the file "testimage (2).jpg" should not be listed on the webUI
     But the folder "simple-folder" should be listed in the shared-with-you page on the webUI
@@ -34,7 +33,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
-    When the user logs in with username "user3" and password "%alt3%" using the webUI
+    When user "user3" logs in using the webUI
     Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
     And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
@@ -44,7 +43,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has created a folder "/simple-folder/from_user1"
     And user "user1" has shared folder "/simple-folder" with user "user3"
-    And the user has logged in with username "user3" and password "%alt3%" using the webUI
+    And user "user3" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User One" using the webUI
     And the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
@@ -57,7 +56,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
-    When the user logs in with username "user3" and password "%alt3%" using the webUI
+    When user "user3" logs in using the webUI
     Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
     And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
@@ -66,7 +65,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
     And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
@@ -80,7 +79,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user declines the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
@@ -92,7 +91,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
@@ -105,7 +104,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
@@ -117,7 +116,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user declines the share "simple-folder" offered by user "User Two" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
@@ -129,7 +128,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
@@ -139,7 +138,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user declines the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
@@ -148,7 +147,7 @@ Feature: accept/decline shares coming from internal users
   Scenario: reshare a share that you received to a group that you are member of
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user has browsed to the files page
     And the user shares the folder "simple-folder (2)" with the group "grp1" using the webUI
@@ -164,7 +163,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/testimage.jpg" with group "grp1"
     And user "user1" has accepted the share "/simple-folder" offered by user "user2"
     And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user unshares the folder "simple-folder (2)" using the webUI
     And the user unshares the file "testimage (2).jpg" using the webUI
     Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -177,7 +176,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    When the user logs in with username "user1" and password "%alt1%" using the webUI
+    When user "user1" logs in using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
     And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
@@ -189,7 +188,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
     And the user declines the share "testimage (2).jpg" offered by user "User Two" using the webUI
     And the user has browsed to the files page
@@ -202,7 +201,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user unshares the folder "simple-folder (2)" using the webUI
     And the user unshares the file "testimage (2).jpg" using the webUI
     Then the folder "simple-folder (2)" should not be listed on the webUI
@@ -214,7 +213,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user unshares the folder "simple-folder-renamed" using the webUI
     Then the folder "simple-folder-renamed" should not be listed on the webUI
     And the folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
@@ -223,7 +222,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder/shared"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user opens the folder "simple-folder" using the webUI
     And the user unshares the folder "shared" using the webUI
     Then the folder "shared" should not be listed on the webUI
@@ -233,7 +232,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     When the user unshares the folder "simple-folder-renamed" using the webUI
     And the user accepts the share "simple-folder-renamed" offered by user "User Two" using the webUI
     Then the folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -26,12 +26,11 @@ Feature: Autocompletion of share-with names
       | finance3      |
       | users-finance |
       | other         |
-    And the user has browsed to the login page
 
   @skipOnLDAP @user_ldap-issue-175
   @smokeTest
   Scenario: autocompletion of regular existing users
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "us" in the share-with-field
@@ -41,7 +40,7 @@ Feature: Autocompletion of share-with names
   @skipOnLDAP
   @smokeTest
   Scenario: autocompletion of regular existing groups
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "fi" in the share-with-field
@@ -49,7 +48,7 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion for a pattern that does not match any user or group
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "doesnotexist" in the share-with-field
@@ -59,7 +58,7 @@ Feature: Autocompletion of share-with names
   @skipOnLDAP
   Scenario: autocomplete short user/display names when completely typed
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
-    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And these users have been created but not initialized:
       | username | password | displayname | email        |
@@ -74,7 +73,7 @@ Feature: Autocompletion of share-with names
     And these groups have been created:
       | groupname |
       | fi        |
-    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "fi" in the share-with-field
@@ -82,7 +81,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "u" in the share-with-field
@@ -92,7 +91,7 @@ Feature: Autocompletion of share-with names
   @skipOnLDAP
   Scenario: autocompletion when minimum characters is increased and not enough characters are typed
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
-    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "use" in the share-with-field
@@ -102,7 +101,7 @@ Feature: Autocompletion of share-with names
   @skipOnLDAP
   Scenario: autocompletion when increasing the minimum characters for sharing autocomplete
     Given the administrator has set the minimum characters for sharing autocomplete to "3"
-    And the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "use" in the share-with-field
@@ -111,7 +110,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has shared the folder "simple-folder" with the user "User One" using the webUI
     And the user has opened the share dialog for the folder "simple-folder"
@@ -121,7 +120,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has shared the file "data.zip" with the user "User Grp" using the webUI
     And the user has opened the share dialog for the file "data.zip"
@@ -131,7 +130,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user shares the folder "simple-folder" with the group "finance1" using the webUI
     And the user has opened the share dialog for the folder "simple-folder"
@@ -141,7 +140,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
-    Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user shares the file "data.zip" with the group "finance1" using the webUI
     And the user has opened the share dialog for the file "data.zip"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -9,15 +9,14 @@ Feature: Sharing files and folders with internal users
       | username |
       | user1    |
       | user2    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt2%" using the webUI
+    And user "user2" has logged in using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a file & folder with another internal user
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
     And the user shares the file "testimage.jpg" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
     And the file "testimage (2).jpg" should be listed on the webUI
@@ -30,7 +29,7 @@ Feature: Sharing files and folders with internal users
   Scenario: share a file with another internal user who overwrites and unshares the file
     When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares the file "new-lorem.txt" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
     When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -40,14 +39,14 @@ Feature: Sharing files and folders with internal users
     When the user unshares the file "new-lorem.txt" using the webUI
     Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that the original file owner can still see the file
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -61,7 +60,7 @@ Feature: Sharing files and folders with internal users
     When the user deletes the file "data.zip" using the webUI
     Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
@@ -74,11 +73,11 @@ Feature: Sharing files and folders with internal users
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user unshares the folder "new-simple-folder" using the webUI
     Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible for the share owner
-    When the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then the folder "new-simple-folder" should be listed on the webUI
     When the user opens the folder "new-simple-folder" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
@@ -89,6 +88,6 @@ Feature: Sharing files and folders with internal users
     When the user shares the folder "simple-folder" with the user "User One" using the webUI
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | delete | no |
-    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user opens the folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete the file "lorem.txt" using the webUI

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -10,8 +10,7 @@ Feature: Display notifications when receiving a share and follow embedded links
       | username |
       | user1    |
       | user2    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt2%" using the webUI
+    And user "user2" has logged in using the webUI
 
   @smokeTest
   Scenario: notification link redirection in case a share is pending

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -16,8 +16,7 @@ Feature: Sharing files and folders with internal groups
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
-    And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt2%" using the webUI
+    And user "user2" has logged in using the webUI
 
   Scenario: notifications about new share is displayed
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -27,7 +26,7 @@ Feature: Sharing files and folders with internal groups
       | title                                        |
       | "User Three" shared "simple-folder" with you |
       | "User Three" shared "data.zip" with you      |
-    When the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    When the user re-logs in as "user1" using the webUI
     Then the user should see 2 notifications on the webUI with these details
       | title                                        |
       | "User Three" shared "simple-folder" with you |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -10,8 +10,7 @@ Feature: Sharing files and folders with internal users
       | username |
       | user1    |
       | user2    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user2" and password "%alt2%" using the webUI
+    And user "user2" has logged in using the webUI
 
   @smokeTest
   Scenario: notifications about new share is displayed when autoacepting is disabled

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -6,8 +6,7 @@ Feature: Restore deleted files/folders
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -6,8 +6,7 @@ Feature: files and folders can be deleted from the trashbin
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the following files have been deleted
       | name          |
       | data.zip      |

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -6,8 +6,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -7,8 +7,7 @@ Feature: File Upload
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   @smokeTest
   Scenario: simple upload of a file that does not exist before

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -9,8 +9,7 @@ Feature: File Upload
 
   Background:
     Given user "user1" has been created
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
 
   Scenario: simple upload of a file that does not exist before
     When the user uploads the file "new-'single'quotes.txt" using the webUI

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -11,8 +11,7 @@ Feature: Upload a file
   @smokeTest
   Scenario: simple upload of a file with the size greater than the size of quota
     Given the quota of user "user1" has been set to "10 MB"
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user uploads the file "big-video.mp4" using the webUI


### PR DESCRIPTION
## Description
Add webUI acceptance test steps that let the user login without the step text having to mention the password.
Make the underlying code use the password it already knows to fill in the login page.

## Motivation and Context
Some test steps have the form:
```
the user has logged in with username "user1" and password "%alt1%" using the webUI
```

For 98% of these cases, the user is expected to be logging in with their correct password.
The underlying code already knows the password that the user was created with.
We do not need to have all the repetition of the password, and the potential for mistakes.

## How Has This Been Tested?
Local test runs and CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
