### PR TITLE
Added delay in search

### DIFF
--- a/core/search/js/search.js
+++ b/core/search/js/search.js
@@ -86,6 +86,8 @@
 			var lastSize = 30;
 			var lastResults = [];
 			var timeoutID = null;
+			/* For delaying search*/
+			var timeout = null;                                    
 
 			this.getLastQuery = function() {
 				return lastQuery;
@@ -319,18 +321,24 @@
 						renderCurrent();
 					}
 				} else {
-					var query = $searchBox.val();
-					if (lastQuery !== query) {
-						currentResult = -1;
-						if (query.length > 2) {
-							self.search(query);
-						} else {
-							self.hideResults();
+					/**
+			 		* Search begins 500 millisoconds after the user stops typing
+			 		*/
+					clearTimeout(timeout);
+					timeout = setTimeout(function () {
+						var query = $searchBox.val();
+						if (lastQuery !== query) {
+							currentResult = -1;
+							if (query.length > 2) {
+								self.search(query);
+							} else {
+								self.hideResults();
+							}
+							if(self.hasFilter(getCurrentApp())) {
+								self.getFilter(getCurrentApp())(query);
+							}
 						}
-						if(self.hasFilter(getCurrentApp())) {
-							self.getFilter(getCurrentApp())(query);
-						}
-					}
+    					}, 500);
 				}
 			});
 			$(document).keyup(function(event) {


### PR DESCRIPTION
## Description
Issue  #31305 (To add delay to search operation)
I've added a delay of 500 milliseconds before the search results are showed in function $searchBox.keyup() .

## Motivation and Context
We don't want for the search results to be generated on every single keystroke .
That is why a wait (delay) is required to ascertain the user has stopped typing.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
