### PR TITLE
Remove ambiguous adminLogsInUsingTheWebUI Gherkin

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -181,9 +181,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When user admin logs in using the webUI
-	 * @Given user admin has logged in using the webUI
-	 *
 	 * @return void
 	 * @throws \Exception
 	 */

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -181,6 +181,9 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the administrator logs in using the webUI
+	 * @Given the administrator has logged in using the webUI
+	 *
 	 * @return void
 	 * @throws \Exception
 	 */


### PR DESCRIPTION
## Description
Change the ambiguous acceptance test step forms ``When user admin logs in using the webUI`` and ``Given user admin has logged in using the webUI`` to talk about ``the administrator``. We alrready do that in other step text when we want to refer to the general idea off "administrator" rather than the specific username ``admin``

## Motivation and Context
Yesterday we added a general acceptance test step:
```
	/**
	 * @When user :username logs in using the webUI
	 * @Given user :username has logged in using the webUI
	 *
	 * @param string $username
	 *
	 * @return void
	 * @throws \Exception
	 */
	public function theUserLogsInUsingTheWebUI($username) {
		$this->theUserBrowsesToTheLoginPage();
		$this->theUserLogsInWithUsernameAndPasswordUsingTheWebUI(
			$username,
			$this->featureContext->getPasswordForUser($username)
		);
	}
```
and that works fine, but there is already a more specific step:
```
* @When user admin logs in using the webUI
* @Given user admin has logged in using the webUI
```
and that step becomes ambiguous.

The ambiguous form is not used in core master, so CI passed. But it is used in firewall and user_management apps, and now they fail some acceptance tests. Various user_management tests are also in core stable10, so there are acceptance test failures there, like:

```
  Background:                                           # /drone/src/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature:7
    Given user admin has logged in using the webUI
      Ambiguous match of "user admin has logged in using the webUI":
      to `user admin has logged in using the webUI` from WebUIGeneralContext::adminLogsInUsingTheWebUI()
      to `user :username has logged in using the webUI` from WebUILoginContext::theUserLogsInUsingTheWebUI()
And the administrator has browsed to the users page # WebUIUsersContext::theUserBrowsesToTheUsersPage()
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
