### PR TITLE
Fix error "does not comply with RFC 2822" in SMTP setup

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -149,7 +149,11 @@ class Mailer implements IMailer {
 		}
 
 		list($name, $domain) = \explode('@', $email, 2);
-		$domain = \idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+		if (\defined('INTL_IDNA_VARIANT_UTS46')) {
+			$domain = \idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+		} else {
+			$domain = \idn_to_ascii($domain);
+		}
 		return $name.'@'.$domain;
 	}
 

--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -57,11 +57,19 @@ class Message {
 		foreach ($addresses as $email => $readableName) {
 			if (!\is_numeric($email)) {
 				list($name, $domain) = \explode('@', $email, 2);
-				$domain = \idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+				if (\defined('INTL_IDNA_VARIANT_UTS46')) {
+					$domain = \idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+				} else {
+					$domain = \idn_to_ascii($domain);
+				}
 				$convertedAddresses[$name.'@'.$domain] = $readableName;
 			} else {
 				list($name, $domain) = \explode('@', $readableName, 2);
-				$domain = \idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+				if (\defined('INTL_IDNA_VARIANT_UTS46')) {
+					$domain = \idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+				} else {
+					$domain = \idn_to_ascii($domain);
+				}
 				$convertedAddresses[$email] = $name.'@'.$domain;
 			}
 		}


### PR DESCRIPTION
## Description
Two small extensions were made in [Message.php](https://github.com/owncloud/core/commit/b01de8519dc0872f4243f7763bb320309994a3d7) and [Mailer.php](https://github.com/owncloud/core/commit/af5a9634c7ce1039f6be9eb484f58b4ec64dfc55) to allow the conversion of the entered mail address to ASCII. There are PHP versions that expect this conversion. Especially RedHat distributions are affected by this.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/2818

## Motivation and Context
- This problem has been observed from time to time and should not occur again with my changes.

## How Has This Been Tested?
- Not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
