### PR TITLE
webUI acceptance test for displaying group names, federated cloud id and version

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -171,6 +171,38 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
+	 * @Then the owncloud version should be displayed on the personal general settings page in the webUI
+	 *
+	 * @return void
+	 */
+	public function theOwncloudVersionShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui() {
+		PHPUnit_Framework_Assert::assertTrue($this->personalGeneralSettingsPage->isVersionDisplayed());
+	}
+
+	/**
+	 * @Then the federated cloud id for user :user should be displayed on the personal general settings page in the webUI
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theFederatedCloudIdForUserShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($user) {
+		$userFederatedCloudId = $user . "@" . $this->featureContext->getLocalBaseUrlWithoutScheme();
+		PHPUnit_Framework_Assert::assertEquals($this->personalGeneralSettingsPage->getFederatedCloudID(), $userFederatedCloudId);
+	}
+
+	/**
+	 * @Then the group :groupName should be displayed on the personal general settings page in the webUI
+	 *
+	 * @param string $groupName
+	 *
+	 * @return void
+	 */
+	public function theGroupShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($groupName) {
+		PHPUnit_Framework_Assert::assertTrue($this->personalGeneralSettingsPage->isGroupNameDisplayed($groupName));
+	}
+
+	/**
 	 * @When the user follows the email change confirmation link received by :emailAddress using the webUI
 	 * @Given the user has followed the email change confirmation link received by :emailAddress using the webUI
 	 *

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -24,6 +24,7 @@ namespace Page;
 
 use Behat\Mink\Session;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use TestHelpers\SetupHelper;
 
 /**
  * Personal General Settings page.
@@ -44,6 +45,10 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	protected $changeEmailButtonID = "emailbutton";
 	protected $changePasswordButtonID = "passwordbutton";
 	protected $passwordErrorMessageID = "password-error";
+
+	protected $versionSectionXpath = "//div[@id='OC\\Settings\\Panels\\Personal\\Version']";
+	protected $federatedCloudIDXpath = "//*[@id='fileSharingSettings']/p/strong";
+	protected $groupListXpath = "//div[@id='OC\\Settings\\Panels\\Personal\\Profile']/div[@id='groups']";
 
 	/**
 	 * @param string $language
@@ -157,5 +162,48 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 		}
 		
 		return $this->getTrimmedText($errorMessage);
+	}
+
+	/**
+	 * check if the version number displayed in the UI is correct
+	 *
+	 * @return bool
+	 */
+	public function isVersionDisplayed() {
+		$this->waitTillElementIsNotNull($this->versionSectionXpath);
+		$versionSection = $this->find("xpath", $this->versionSectionXpath);
+		$currentVersion = \trim(SetupHelper::runOcc(['-V'])['stdOut']);
+
+		if (\strpos($versionSection->getText(), $currentVersion) !== false) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * give federated cloud ID displayed in the UI
+	 *
+	 * @return string
+	 */
+	public function getFederatedCloudID() {
+		$this->waitTillElementIsNotNull($this->federatedCloudIDXpath);
+		return $this->find("xpath", $this->federatedCloudIDXpath)->getText();
+	}
+
+	/**
+	 * check if a group with given name is displayed in the UI
+	 *
+	 * @param string $groupName
+	 *
+	 * @return string
+	 */
+	public function isGroupNameDisplayed($groupName) {
+		$this->waitTillElementIsNotNull($this->groupListXpath);
+		$groupList = $this->find("xpath", $this->groupListXpath)->getText();
+
+		if (\strpos($groupList, $groupName) !== false) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -20,3 +20,14 @@ Feature: personal general settings
     And the user opens the file action menu of the folder "simple-folder" in the webUI
     Then the user should see "Details" file action translated to "विवरण" in the webUI
     And the user should see "Delete" file action translated to "हटाना" in the webUI
+
+  Scenario: user sees displayed version number, groupnames and federated cloud ID on the personal general settings page
+    Given group "new-group" has been created
+    And group "another-group" has been created
+    And user "user1" has been added to group "new-group"
+    And user "user1" has been added to group "another-group"
+    And the user has reloaded the current page of the webUI
+    Then the owncloud version should be displayed on the personal general settings page in the webUI
+    And the federated cloud id for user "user1" should be displayed on the personal general settings page in the webUI
+    And the group "new-group" should be displayed on the personal general settings page in the webUI
+    And the group "another-group" should be displayed on the personal general settings page in the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added webUI acceptance test for checking if correct version, group names and federated cloud id is displayed in the personal general settings page

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to #32850

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
