### PR TITLE
Run webUIComments acceptance test suite on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -682,25 +682,6 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
-      BEHAT_SUITE: apiMetadataApps
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: api
-      BEHAT_SUITE: apiSharingNotifications
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_NOTIFICATIONS-APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: api
       BEHAT_SUITE: apiCapabilities
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -715,6 +696,15 @@ matrix:
       USE_SERVER: true
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: api
+      BEHAT_SUITE: apiMetadataApps
+      DB_TYPE: mariadb
+      USE_SERVER: true
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -766,6 +756,16 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
+      BEHAT_SUITE: apiSharingNotifications
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_NOTIFICATIONS-APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: api
       BEHAT_SUITE: apiTrashbin
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -794,16 +794,6 @@ matrix:
   # UI Acceptance tests
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
-      BEHAT_SUITE: webUILogin
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
       BEHAT_SUITE: webUIAdminSettings
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -814,18 +804,35 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
-      BEHAT_SUITE: webUISharingNotifications
+      BEHAT_SUITE: webUIFavorites
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: webUIFiles
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: webUILogin
       DB_TYPE: mariadb
       USE_SERVER: true
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
       USE_EMAIL: true
-      INSTALL_NOTIFICATIONS-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
-      BEHAT_SUITE: webUIFavorites
+      BEHAT_SUITE: webUIMoveFilesFolders
       DB_TYPE: mariadb
       USE_SERVER: true
       INSTALL_SERVER: true
@@ -841,24 +848,6 @@ matrix:
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
       USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BEHAT_SUITE: webUIFiles
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BEHAT_SUITE: webUIMoveFilesFolders
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -880,12 +869,24 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
-      BEHAT_SUITE: webUITrashbin
+      BEHAT_SUITE: webUIRestrictSharing
       DB_TYPE: mariadb
       USE_SERVER: true
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: webUISharingExternal
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      USE_EMAIL: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -907,19 +908,18 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
-      BEHAT_SUITE: webUISharingExternal
+      BEHAT_SUITE: webUISharingNotifications
       DB_TYPE: mariadb
       USE_SERVER: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
       USE_EMAIL: true
+      INSTALL_NOTIFICATIONS-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
-      BEHAT_SUITE: webUIRestrictSharing
+      BEHAT_SUITE: webUITags
       DB_TYPE: mariadb
       USE_SERVER: true
       INSTALL_SERVER: true
@@ -928,7 +928,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
-      BEHAT_SUITE: webUITags
+      BEHAT_SUITE: webUITrashbin
       DB_TYPE: mariadb
       USE_SERVER: true
       INSTALL_SERVER: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -804,6 +804,15 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BEHAT_SUITE: webUIComments
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
       BEHAT_SUITE: webUIFavorites
       DB_TYPE: mariadb
       USE_SERVER: true

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -108,6 +108,16 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
 
+    webUIComments:
+      paths:
+        - %paths.base%/../features/webUIComments
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIFilesContext:
+        - WebUISharingContext:
+
     webUIFavorites:
       paths:
         - %paths.base%/../features/webUIFavorites
@@ -232,6 +242,15 @@ default:
         - WebUINotificationsContext:
         - WebUISharingContext:
 
+    webUITags:
+      paths:
+        - %paths.base%/../features/webUITags
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIFilesContext:
+
     webUITrashbin:
       paths:
         - %paths.base%/../features/webUITrashbin
@@ -249,25 +268,6 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-
-    webUIComments:
-      paths:
-        - %paths.base%/../features/webUIComments
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIFilesContext:
-        - WebUISharingContext:
-
-    webUITags:
-      paths:
-        - %paths.base%/../features/webUITags
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIFilesContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -1,4 +1,4 @@
-@webUI @insulated
+@webUI @insulated  @comments-app-required
 Feature: Add, delete and edit comments in files and folders
 
   As a user

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -43,6 +43,7 @@ Feature: Search
     And the file "lorem-big.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
     But the file "lorem.txt" with the path "/simple-folder" should not be listed in the search results in other folders section on the webUI
 
+  @systemtags-app-required
   Scenario: search for a file using a tag
     Given user "user1" has created a "normal" tag with name "ipsum"
     And user "user1" has added the tag "ipsum" to "/lorem.txt"
@@ -50,6 +51,7 @@ Feature: Search
     And the user searches for tag "ipsum" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
 
+  @systemtags-app-required
   Scenario: search for a file with multiple tags
     Given user "user1" has created a "normal" tag with name "lorem"
     And user "user1" has created a "normal" tag with name "ipsum"


### PR DESCRIPTION
## Description
1) Sort the suites into alphabetical order in ``.drone.yml`` and ``behat.yml`` so they are easier to compare.
2) Add ``webUIComments`` to drone.
3) Adds tags to recent scenarios that depend on the comments and systemtags apps.

## Motivation and Context
Suite ``webUIComments`` was recently created. But adding it to drone was forgotten :(

## How Has This Been Tested?
CI

## Types of changes- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
