### PR TITLE
[PoC] Run tests without the comments app

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -136,6 +136,33 @@ pipeline:
       matrix:
         INSTALL_SERVER: true
 
+  api-disable-comments:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+    - php occ a:d comments
+    when:
+      matrix:
+        TEST_SUITE: api
+
+  cli-disable-comments:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+    - php occ a:d comments
+    when:
+      matrix:
+        TEST_SUITE: cli
+
+  webui-disable-comments:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+    - php occ a:d comments
+    when:
+      matrix:
+        TEST_SUITE: selenium
+
   prepare-objectstore:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -354,7 +381,7 @@ pipeline:
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
-      - make test-acceptance-api TESTING_REMOTE_SYSTEM=true
+      - make test-acceptance-api TESTING_REMOTE_SYSTEM=true BEHAT_FILTER_TAGS=~comments-app-required
     when:
       matrix:
         TEST_SUITE: api
@@ -368,7 +395,7 @@ pipeline:
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
-      - make test-acceptance-cli TESTING_REMOTE_SYSTEM=true
+      - make test-acceptance-cli TESTING_REMOTE_SYSTEM=true BEHAT_FILTER_TAGS=~comments-app-required
     when:
       matrix:
         TEST_SUITE: cli
@@ -386,7 +413,7 @@ pipeline:
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
-      - make test-acceptance-webui TESTING_REMOTE_SYSTEM=true
+      - make test-acceptance-webui TESTING_REMOTE_SYSTEM=true BEHAT_FILTER_TAGS=~comments-app-required
     when:
       matrix:
         TEST_SUITE: selenium

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -7,7 +7,7 @@ Feature: get apps
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @comments-app-required @files_trashbin-app-required @files_versions-app-required @systemtags-app-required
   Scenario: admin gets enabled apps
     When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
     Then the OCS status code should be "100"
@@ -23,5 +23,18 @@ Feature: get apps
       | files_versions       |
       | provisioning_api     |
       | systemtags           |
+      | updatenotification   |
+      | files_external       |
+
+  Scenario: admin gets enabled apps - check for the minimal list of apps
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
       | updatenotification   |
       | files_external       |

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -7,7 +7,7 @@ Feature: get apps
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @comments-app-required @files_trashbin-app-required @files_versions-app-required @systemtags-app-required
   Scenario: admin gets enabled apps
     When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
     Then the OCS status code should be "200"
@@ -23,5 +23,18 @@ Feature: get apps
       | files_versions       |
       | provisioning_api     |
       | systemtags           |
+      | updatenotification   |
+      | files_external       |
+
+  Scenario: admin gets enabled apps - check for the minimal list of apps
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
       | updatenotification   |
       | files_external       |

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -28,7 +28,7 @@ Feature: get apps
 
   Scenario: admin gets enabled apps - check for the minimal list of apps
     When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the apps returned by the API should include
       | dav                  |

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -151,6 +151,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		$username, $password
 	) {
 		$this->filesPage = $this->webUIGeneralContext->loginAs($username, $password);
+		$this->webUIGeneralContext->setCurrentPageObject($this->filesPage);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -19,6 +19,7 @@ Feature: browse directly to details tab
       | /             |
       | simple-folder |
 
+  @comments-app-required
   Scenario Outline: Browse directly to the comments details of a file
     When the user browses directly to display the "comments" details of file "lorem.txt" in folder "<folder>"
     Then the thumbnail should be visible in the details panel
@@ -28,6 +29,7 @@ Feature: browse directly to details tab
       | /             |
       | simple-folder |
 
+  @files_versions-app-required
   Scenario Outline: Browse directly to the versions details of a file
     When the user browses directly to display the "versions" details of file "lorem.txt" in folder "<folder>"
     Then the thumbnail should be visible in the details panel

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -12,7 +12,7 @@ Feature: User can open the details panel for any file or folder
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @files_versions-app-required
+  @comments-app-required @files_versions-app-required
   Scenario: View different areas of the details panel in files page
     When the user opens the file action menu of the file "lorem.txt" in the webUI
     And the user clicks the details file action in the webUI
@@ -25,7 +25,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "versions" tab in details panel using the webUI
     Then the "versions" details panel should be visible
 
-  @files_versions-app-required
+  @comments-app-required @files_versions-app-required
   Scenario: View different areas of the details panel in favorites page
     When the user marks the file "lorem.txt" as favorite using the webUI
     And the user browses to the favorites page
@@ -40,7 +40,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "versions" tab in details panel using the webUI
     Then the "versions" details panel should be visible
 
-  @public_link_share-feature-required
+  @comments-app-required @public_link_share-feature-required
   Scenario: user shares a file through public link and then the details dialog should work in a Shared by link page
     Given the user has created a new public link for the folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page
@@ -54,6 +54,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "comments" tab in details panel using the webUI
     Then the "comments" details panel should be visible
 
+  @comments-app-required
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
     Given the user has shared the folder "simple-folder" with the user "User Two" using the webUI
     When the user browses to the shared-with-others page
@@ -67,6 +68,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "comments" tab in details panel using the webUI
     Then the "comments" details panel should be visible
 
+  @comments-app-required
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
     Given the user has shared the folder "simple-folder" with the user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
@@ -81,6 +83,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "comments" tab in details panel using the webUI
     Then the "comments" details panel should be visible
 
+  @comments-app-required
   Scenario: View different areas of details panel for the folder with given tag in Tags page
     Given user "user1" has created a "normal" tag with name "simple"
     And user "user1" has added the tag "simple" to "simple-folder"


### PR DESCRIPTION
- disable the comments app
- run the acceptance tests that do not test comments app behavior
- see what happens

Part of issue #33161 