### PR TITLE
[stable10] Add create user with email address to smoke test

### DIFF
--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -48,6 +48,7 @@ Feature: add users
       | "a"  | "%regular%" |
       | "a1" | "%alt1%"    |
 
+  @smokeTest
   Scenario: use the webUI to create a simple user with an Email address but without a password
     When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
@@ -58,6 +59,7 @@ Feature: add users
       Access it:
       """
 
+  @smokeTest
   Scenario Outline: user sets his own password after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI


### PR DESCRIPTION
## Description
Add 2 scenarios for creating a user with email address to the smoke tests.

## Motivation and Context
We should have some webUI user creation in smoke tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
