### PR TITLE
LOCAL_MAILHOG_HOST env variable

### DIFF
--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -30,13 +30,13 @@ require_once 'bootstrap.php';
  * context file for email related steps.
  */
 class EmailContext implements Context {
-	private $mailhogUrl = null;
-	
+	private $localMailhogUrl = null;
+
 	/**
 	 * @return string
 	 */
-	public function getMailhogUrl() {
-		return $this->mailhogUrl;
+	public function getLocalMailhogUrl() {
+		return $this->localMailhogUrl;
 	}
 
 	/**
@@ -52,7 +52,7 @@ class EmailContext implements Context {
 		$expectedContent = \str_replace("\r\n", "\n", $content->getRaw());
 		PHPUnit_Framework_Assert::assertContains(
 			$expectedContent,
-			EmailHelper::getBodyOfLastEmail($this->mailhogUrl, $address)
+			EmailHelper::getBodyOfLastEmail($this->localMailhogUrl, $address)
 		);
 	}
 
@@ -66,7 +66,7 @@ class EmailContext implements Context {
 	 */
 	public function assertThatEmailDoesntExistWithTheAddress($address) {
 		try {
-			EmailHelper::getBodyOfLastEmail($this->mailhogUrl, $address, 3);
+			EmailHelper::getBodyOfLastEmail($this->localMailhogUrl, $address, 3);
 		} catch (\Exception $err) {
 			PHPUnit_Framework_Assert::assertTrue(true);
 			return;
@@ -80,7 +80,7 @@ class EmailContext implements Context {
 	 * @return void
 	 */
 	public function setUpScenario() {
-		$this->mailhogUrl = EmailHelper::getMailhogUrl();
+		$this->localMailhogUrl = EmailHelper::getLocalMailhogUrl();
 		$this->clearMailHogMessages();
 	}
 
@@ -90,7 +90,7 @@ class EmailContext implements Context {
 	 */
 	protected function clearMailHogMessages() {
 		try {
-			EmailHelper::deleteAllMessages($this->getMailhogUrl());
+			EmailHelper::deleteAllMessages($this->getLocalMailhogUrl());
 		} catch (Exception $e) {
 			echo __METHOD__ .
 			" could not delete mailhog messages, is mailhog set up?\n" .

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -245,7 +245,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function followLinkFromEmail($emailAddress, $regexSearch, $errorMessage, $numEmails = 1) {
 		$content = EmailHelper::getBodyOfEmail(
-			EmailHelper::getMailhogUrl(), $emailAddress, $numEmails
+			EmailHelper::getLocalMailhogUrl(), $emailAddress, $numEmails
 		);
 		$matches = [];
 		\preg_match($regexSearch, $content, $matches);

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -213,7 +213,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theUserFollowsTheEmailChangeConfirmationLinkEmail($emailAddress) {
 		$content = EmailHelper::getBodyOfLastEmail(
-			EmailHelper::getMailhogUrl(), $emailAddress
+			EmailHelper::getLocalMailhogUrl(), $emailAddress
 		);
 		$matches = [];
 		\preg_match(

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1032,7 +1032,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theEmailAddressShouldHaveReceivedAnEmailContainingSharedPublicLink($address) {
 		$content = EmailHelper::getBodyOfLastEmail(
-			EmailHelper::getMailhogUrl(),
+			EmailHelper::getLocalMailhogUrl(),
 			$address
 		);
 		$lastCreatedPublicLink = \end($this->createdPublicLinks);

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -573,9 +573,20 @@ then
 	BEHAT_YML="${SCRIPT_PATH}/config/behat.yml"
 fi
 
+# MAILHOG_HOST defines where the system-under-test can find the MailHog server
+# for sending email.
 if [ -z "${MAILHOG_HOST}" ]
 then
 	MAILHOG_HOST="127.0.0.1"
+fi
+
+# LOCAL_MAILHOG_HOST defines where this test script can find the MailHog server
+# for sending email. When testing a remote system, the MailHog server somewhere
+# "in the middle" might have a different host name from the point of view of
+# the test script.
+if [ -z "${LOCAL_MAILHOG_HOST}" ]
+then
+	LOCAL_MAILHOG_HOST="${MAILHOG_HOST}"
 fi
 
 if [ -z "${MAILHOG_SMTP_PORT}" ]


### PR DESCRIPTION
## Description
Add support for environment variable ``LOCAL_MAILHOG_HOST``

``MAILHOG_HOST`` defines the host name or IP address that the system-under-test uses to access the Mailhog server.

``LOCAL_MAILHOG_HOST`` defines the host name or IP address that the test runner uses to access the Mailhog server. If undefined, then it default to the value of ``MAILHOG_HOST``

## Motivation and Context
The system-under-test and the test runner might have different network paths to get to the Mailhog server used for email tests. So we need to be able to separately specify the host (or address) from the point of view of the system-under-test and of the test runner.

## How Has This Been Tested?
CI will know

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
