### PR TITLE
Get the default displayname and email when creating a user with the occ command

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -56,15 +56,22 @@ class OccContext implements Context {
 
 			if (isset($row['displayname'])) {
 				$displayName = $row['displayname'];
-				$cmd = "$cmd --display-name='$displayName'";
 			} else {
-				$displayName = null;
+				$displayName = $this->featureContext->getDisplayNameForUser($username);
 			}
+
+			if ($displayName !== null) {
+				$cmd = "$cmd --display-name='$displayName'";
+			}
+
 			if (isset($row['email'])) {
 				$email = $row['email'];
-				$cmd = "$cmd --email='$email'";
 			} else {
-				$email = null;
+				$email = $this->featureContext->getEmailAddressForUser($username);
+			}
+
+			if ($email !== null) {
+				$cmd = "$cmd --email='$email'";
 			}
 
 			if (isset($row['password'])) {


### PR DESCRIPTION
## Description
When the acceptance tests create a user using the ``occ`` command.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
