### PR TITLE
Add webUI acceptance test for changing permissions in public link share

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -248,7 +248,25 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @throws ElementNotFoundException
 	 */
 	public function theUserChangesThePasswordOfThePublicLinkForTo($name, $newPassword) {
-		$this->publicShareTab->editLink($name, null, [], $newPassword);
+		$this->publicShareTab->editLink($name, null, null, $newPassword);
+		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($this->getSession());
+
+		$linkUrl = $this->publicShareTab->getLinkUrl($name);
+		$this->addToListOfCreatedPublicLinks($name, $linkUrl);
+	}
+
+	/**
+	 * @Given the user has changed the permission of the public link for :name to :newPermission
+	 * @When the user changes the permission of the public link for :name to :newPermission
+	 *
+	 * @param string $name
+	 * @param string $newPermission
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function theUserChangesThePermissionOfThePublicLinkForTo($name, $newPermission) {
+		$this->publicShareTab->editLink($name, null, $newPermission);
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($this->getSession());
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($name);

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -174,7 +174,7 @@ class PublicLinkTab extends OwncloudPage {
 	 *
 	 * @param string $name
 	 * @param string $newName
-	 * @param array $permissions
+	 * @param string $permissions
 	 * @param string $password
 	 * @param string $expirationDate
 	 * @param string $email
@@ -202,6 +202,9 @@ class PublicLinkTab extends OwncloudPage {
 		}
 		if ($password !== null) {
 			$this->editPublicLinkPopupPageObject->setLinkPassword($password);
+		}
+		if ($permissions !== null) {
+			$this->editPublicLinkPopupPageObject->setLinkPermissions($permissions);
 		}
 		$this->editPublicLinkPopupPageObject->save();
 	}

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -242,3 +242,30 @@ Feature: Share by public link
     When the user changes the password of the public link for "simple-folder link" to "pass1234"
     And the public accesses the last created public link with password "pass1234" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
+
+  Scenario: user edits the password of an already existing public link and tries to access with old password
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | password | pass123 |
+    When the user changes the password of the public link for "simple-folder link" to "pass1234"
+    And the public tries to access the last created public link with wrong password "pass123" using the webUI
+    Then the public should not get access to the publicly shared file
+
+  Scenario: user edits the permission of an already existing public link from read-write to read
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    When the user changes the permission of the public link for "simple-folder link" to "read"
+    And the public accesses the last created public link using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And it should not be possible to delete the file "lorem.txt" using the webUI
+
+  Scenario: user edits the permission of an already existing public link from read to read-write
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read |
+    When the user changes the permission of the public link for "simple-folder link" to "read-write"
+    And the public accesses the last created public link using the webUI
+    And the user deletes the following elements using the webUI
+      | name                                  |
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+    Then the deleted elements should not be listed on the webUI
+    And the deleted elements should not be listed on the webUI after a page reload


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added webUI acceptance test for checking change permission of public link share

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to #32845

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
