### PR TITLE
Fix timing issue with adding tags

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -51,7 +51,9 @@ class DetailsDialog extends OwncloudPage {
 
 	private $tagsInputXpath = "//li[@class='select2-search-field']//input";
 
-	private $tagsSuggestDropDown = "//div[contains(@class, 'systemtags-select2-dropdown') and contains(@id, 'select2-drop')]";
+	private $tagsSuggestDropDownXpath = "//div[contains(@class, 'systemtags-select2-dropdown') and contains(@id, 'select2-drop')]";
+
+	private $tagsResultFromDropdownXpath = "//li[contains(@class, 'select2-result')]";
 
 	private $commentInputXpath = "//form[@class='newCommentForm']//textarea[@class='message']";
 	private $commentPostXpath = "//form[@class='newCommentForm']//input[@class='submit']";
@@ -299,7 +301,12 @@ class DetailsDialog extends OwncloudPage {
 		$inputField->focus();
 		$inputField->setValue($tagName);
 
-		$this->waitTillElementIsNotNull($this->tagsSuggestDropDown);
+		$this->waitTillElementIsNotNull($this->tagsSuggestDropDownXpath);
+
+		// select2 requires some time to display the results even though the dropdown has appeared.
+		// Until that, select2 shows `Searching...` in the dropdown.
+		// We are waiting here till a single result show up on the dropdown.
+		$this->waitTillElementIsNotNull($this->tagsSuggestDropDownXpath . $this->tagsResultFromDropdownXpath);
 
 		$tagSuggestions = $this->findAll("xpath", $this->getTagsDropDownResultsXpath());
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This fixes the timing issue when adding tags which had failed multiple tests.

This resulted due to the `select2` not showing up results even after showing the dropdown. I had only waited for the dropdown to appear, now I am also waiting for even a single result to appear. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Similar timing issues occurred with the checkbox for `Send a copy to self` on the `Public link sharing dialog` #32823 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Going green

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
