### PR TITLE
Support global CORS domains for public pages

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -98,9 +98,9 @@ class CORSMiddleware extends Middleware {
 			$userId = $this->session->getUser()->getUID();
 		}
 
-		if ($this->request->getHeader("Origin") !== null &&
-			$this->reflector->hasAnnotation('CORS') && $userId !== null) {
-			$requesterDomain = $this->request->getHeader("Origin");
+		if ($this->request->getHeader('Origin') !== null &&
+			$this->reflector->hasAnnotation('CORS')) {
+			$requesterDomain = $this->request->getHeader('Origin');
 
 			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, $this->config);
 			foreach ($headers as $key => $value) {

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -289,7 +289,7 @@ class OC_Response {
 		// first check if any of the global CORS domains matches
 		$globalAllowedDomains = $config->getSystemValue('cors.allowed-domains', []);
 		$isCorsRequest = (\is_array($globalAllowedDomains) && \in_array($domain, $globalAllowedDomains));
-		if (!$isCorsRequest) {
+		if (!$isCorsRequest && $userId !== null) {
 			// check if any of the user specific CORS domains matches
 			$allowedDomains = \json_decode($config->getUserValue($userId, 'core', 'domains'));
 			$isCorsRequest = (\is_array($allowedDomains) && \in_array($domain, $allowedDomains));

--- a/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
@@ -20,13 +20,28 @@ use OCP\AppFramework\Http\Response;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Security\ISecureRandom;
+use OC\User\Session;
 
 /**
  * Class CORSMiddlewareTest
  */
 class CORSMiddlewareTest extends \Test\TestCase {
+	/** @var ControllerMethodReflector */
 	private $reflector;
+	/** @var Session */
 	private $session;
+	/** @var IConfig */
+	private $config;
+	/** @var IUserSession */
+	private $fakeSession;
+
+	public function providesConfigForPublicPageTest() {
+		return [
+			'no cors domain in system config' => [false, []],
+			'cors domain in system config' => [true, ['http://www.test.com']]
+		];
+	}
 
 	protected function setUp() {
 		parent::setUp();
@@ -37,7 +52,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 
 		$this->reflector = new ControllerMethodReflector();
 
-		$this->session = $this->getMockBuilder('\OC\User\Session')
+		$this->session = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -59,7 +74,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 					'HTTP_ORIGIN' => 'http://www.test.com'
 				]
 			],
-			$this->createMock('\OCP\Security\ISecureRandom'),
+			$this->createMock(ISecureRandom::class),
 			$this->config
 		);
 
@@ -76,6 +91,45 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		$this->assertEquals('http://www.test.com', $headers['Access-Control-Allow-Origin']);
 	}
 
+	/**
+	 * @dataProvider providesConfigForPublicPageTest
+	 * @CORS
+	 */
+	public function testCorsOnPublicPage($expected, $systemConfig) {
+		/** @var IUserSession $userSession */
+		$userSession = $this->createMock(IUserSession::class);
+		$config = $this->createMock(IConfig::class);
+		$config->method('getUserValue')->willReturn('');
+		$config->method('getSystemValue')->willReturn($systemConfig);
+
+		$request = new Request(
+			[
+				'server' => [
+					'HTTP_ORIGIN' => 'http://www.test.com'
+				]
+			],
+			$this->createMock(ISecureRandom::class),
+			$config
+		);
+
+		$this->reflector->reflect($this, __FUNCTION__);
+		$middleware = new CORSMiddleware(
+			$request,
+			$this->reflector,
+			$userSession,
+			$config
+		);
+
+		$response = $middleware->afterController($this, __FUNCTION__, new Response());
+		$headers = $response->getHeaders();
+		if ($expected) {
+			self::assertArrayHasKey('Access-Control-Allow-Origin', $headers);
+			self::assertEquals('http://www.test.com', $headers['Access-Control-Allow-Origin']);
+		} else {
+			self::assertArrayNotHasKey('Access-Control-Allow-Origin', $headers);
+		}
+	}
+
 	public function testNoAnnotationNoCORSHEADER() {
 		$request = new Request(
 			[
@@ -83,8 +137,8 @@ class CORSMiddlewareTest extends \Test\TestCase {
 					'HTTP_ORIGIN' => 'test'
 				]
 			],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$middleware = new CORSMiddleware(
 			$request,
@@ -104,8 +158,8 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	public function testNoOriginHeaderNoCORSHEADER() {
 		$request = new Request(
 			[],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
 		$middleware = new CORSMiddleware(
@@ -131,8 +185,8 @@ class CORSMiddlewareTest extends \Test\TestCase {
 					'HTTP_ORIGIN' => 'http://www.test.com',
 				]
 			],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
 		$middleware = new CORSMiddleware(
@@ -153,8 +207,8 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_USER' => 'user',
 				'PHP_AUTH_PW' => 'pass'
 			]],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$middleware = new CORSMiddleware(
 			$request,
@@ -174,8 +228,8 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_USER' => 'user',
 				'PHP_AUTH_PW' => 'pass'
 			]],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$middleware = new CORSMiddleware(
 			$request,
@@ -199,8 +253,8 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_USER' => 'user',
 				'PHP_AUTH_PW' => 'pass'
 			]],
-			$this->createMock('\OCP\Security\ISecureRandom'),
-			$this->createMock('\OCP\IConfig')
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$middleware = new CORSMiddleware(
 			$request,


### PR DESCRIPTION
## Description
CORS annotation on controller methods which are marked as public pages cannot use user specific cors domains. Only global cors domains can be used (set up via config.php)

As a result: no user specific domain can ever integrate via OAuth. 
Question: how to deal with this?

## Related Issue
- https://github.com/owncloud/phoenix/pull/258

## Motivation and Context
Integrate Phoenix with ownCloud via OAuth2 (later OpenID Connect)

## How Has This Been Tested?
- get new oauth app # linktocome
- get phoenix as per https://github.com/owncloud/phoenix/pull/258

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
