### PR TITLE
Parse product name in webUI acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -33,8 +33,6 @@ require_once 'bootstrap.php';
  * WebUI Login context.
  */
 class WebUILoginContext extends RawMinkContext implements Context {
-	private $loginFailedPageTitle = "ownCloud";
-	private $loginSuccessPageTitle = "Files - ownCloud";
 	private $loginPage;
 	private $filesPage;
 	private $expectedPage;
@@ -58,6 +56,23 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	public function __construct(LoginPage $loginPage) {
 		$this->loginPage = $loginPage;
+	}
+
+	/**
+	 * @return string
+	 */
+	private function getLoginSuccessPageTitle() {
+		// When the login succeeds, we end up on the Files page
+		return "Files - " . $this->webUIGeneralContext->getProductName();
+	}
+
+	/**
+	 * @return string
+	 */
+	private function getLoginFailedPageTitle() {
+		// When the login fails, we end up at a page with a title that is the
+		// themed product name, e.g. "ownCloud"
+		return $this->webUIGeneralContext->getProductName();
 	}
 
 	/**
@@ -332,14 +347,14 @@ class WebUILoginContext extends RawMinkContext implements Context {
 				$username, $password
 			);
 			$this->webUIGeneralContext->theUserShouldBeRedirectedToAWebUIPageWithTheTitle(
-				$this->loginSuccessPageTitle
+				$this->getLoginSuccessPageTitle()
 			);
 		} else {
 			$this->theUserLogsInWithUsernameAndInvalidPasswordUsingTheWebUI(
 				$username, $password
 			);
 			$this->webUIGeneralContext->theUserShouldBeRedirectedToAWebUIPageWithTheTitle(
-				$this->loginFailedPageTitle
+				$this->getLoginFailedPageTitle()
 			);
 		}
 	}

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -14,29 +14,29 @@ Feature: login users
       | username |
       | user1    |
     When user "user1" logs in using the webUI
-    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   @smokeTest
   Scenario: admin login
     When user "%admin%" logs in using the webUI
-    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   @smokeTest
   Scenario: admin login with invalid password
     Given the user has browsed to the login page
     When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
-    Then the user should be redirected to a webUI page with the title "ownCloud"
+    Then the user should be redirected to a webUI page with the title "%productname%"
 
   Scenario: access the personal general settings page when not logged in
     When the user attempts to browse to the personal general settings page
-    Then the user should be redirected to a webUI page with the title "ownCloud"
+    Then the user should be redirected to a webUI page with the title "%productname%"
     When user "%admin%" logs in using the webUI after a redirect from the "personal general settings" page
-    Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Settings - %productname%"
 
   Scenario: access the personal general settings page when not logged in using incorrect then correct password
     When the user attempts to browse to the personal general settings page
-    Then the user should be redirected to a webUI page with the title "ownCloud"
+    Then the user should be redirected to a webUI page with the title "%productname%"
     When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
-    Then the user should be redirected to a webUI page with the title "ownCloud"
+    Then the user should be redirected to a webUI page with the title "%productname%"
     When user "%admin%" logs in using the webUI after a redirect from the "personal general settings" page
-    Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Settings - %productname%"

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -29,11 +29,11 @@ Feature: reset the password
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
-    Then the user should be redirected to a webUI page with the title "ownCloud"
+    Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
 			"""
 			Password changed successfully
 			"""
     When the user logs in with username "user1" and password "%alt3%" using the webUI
-    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -30,11 +30,11 @@ Feature: reset the password using an email address
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
-    Then the user should be redirected to a webUI page with the title "ownCloud"
+    Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
 			"""
 			Password changed successfully
 			"""
     When the user logs in with username "user1" and password "%alt3%" using the webUI
-    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -13,7 +13,7 @@ Feature: Change Login Password
   Scenario: Change password
     When the user changes the password to "%alt3%" using the webUI
     And the user re-logs in with username "user1" and password "%alt3%" using the webUI
-    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   Scenario: Password change with wrong current password
     When the user changes the password to "%alt3%" entering the wrong current password "%alt2%" using the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -12,7 +12,7 @@ Feature: personal general settings
   @smokeTest
   Scenario: change language
     When the user changes the language to "Русский" using the webUI
-    Then the user should be redirected to a webUI page with the title "Настройки - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Настройки - %productname%"
 
   Scenario: change language and check that file actions menu have been translated
     When the user changes the language to "हिन्दी" using the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -13,11 +13,11 @@ Feature: personal security settings
   Scenario: login with new app password
     When the user creates a new App password using the webUI
     And the user re-logs in with username "user1" and generated app password using the webUI
-    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   @smokeTest
   Scenario: delete the app password
     When the user creates a new App password using the webUI
     And the user deletes the app password
     And the user re-logs in with username "user1" and deleted app password using the webUI
-    Then the user should be redirected to a webUI page with the title "ownCloud"
+    Then the user should be redirected to a webUI page with the title "%productname%"

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -17,4 +17,4 @@ Feature: Display notifications when receiving a share and follow embedded links
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user1" has shared folder "/simple-folder" with user "user2"
     When the user follows the link of the first notification on the webUI
-    Then the user should be redirected to a webUI page with the title "Shared with you - ownCloud"
+    Then the user should be redirected to a webUI page with the title "Shared with you - %productname%"


### PR DESCRIPTION
## Description
At the start of webUI scenarios, when we are already getting the capabilities, save the product name.
Substitute it in steps that expect some string containing the product name, e.g. the files page has title "Files - ownCloud" = "Files - %productname%"

## Motivation and Context
Be able to run acceptance tests on a system that has a different product name defined.

## How Has This Been Tested?
Local run of login.feature tests.
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
