### PR TITLE
29873 read only mount

### DIFF
--- a/apps/files_external/appinfo/Migrations/Version20190109104110.php
+++ b/apps/files_external/appinfo/Migrations/Version20190109104110.php
@@ -55,7 +55,7 @@ class Version20190109104110 implements ISimpleMigration {
 			} catch (\Exception $exception) {
 				$out->warning(
 					'There has been an error migrating an external storage from mount.json to the database. The affected mount point is "' .
-					$legacyStorage->getMountPoint() . '" and the type is "' . $legacyStorage->getBackend()->getIdentifier() . '"'
+					$legacyStorage->getMountPoint() . '" and is of type "' . $legacyStorage->getBackend()->getIdentifier() . '"'
 				);
 			}
 		}

--- a/apps/files_external/appinfo/Migrations/Version20190109104110.php
+++ b/apps/files_external/appinfo/Migrations/Version20190109104110.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Philipp Schaffrath <pschaffrath@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Migrations;
+
+use OC\Files\External\Service\GlobalStoragesService;
+use OC\Files\External\Service\LegacyStoragesService;
+use OCP\Migration\IOutput;
+use OCP\Migration\ISimpleMigration;
+
+/**
+ * migrate mount.json mounts into the database
+ */
+class Version20190109104110 implements ISimpleMigration {
+
+	/**
+	 * @param IOutput $out
+	 */
+	public function run(IOutput $out) {
+
+		/** @var GlobalStoragesService $globalStoragesService */
+		$globalStoragesService = \OC::$server->query('GlobalStoragesService');
+		$legacyStoragesService = new LegacyStoragesService(\OC::$server->getStoragesBackendService());
+
+		$legacyStorages = $legacyStoragesService->getAllStorages();
+
+		foreach ($legacyStorages as $legacyStorage) {
+			try {
+				$mountOptions = $legacyStorage->getMountOptions();
+				if (!empty($mountOptions) && !isset($mountOptions['read_only'])) {
+					// existing mounts must have read_only disabled by default to avoid surprises
+					$mountOptions['read_only'] = false;
+					$legacyStorage->setMountOptions($mountOptions);
+				}
+				$globalStoragesService->addStorage($legacyStorage);
+			} catch (\Exception $exception) {
+				$out->warning(
+					'There has been an error migrating an external storage from mount.json to the database. The affected mount point is "' .
+					$legacyStorage->getMountPoint() . '" and the type is "' . $legacyStorage->getBackend()->getIdentifier() . '"'
+				);
+			}
+		}
+	}
+}

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -6,6 +6,7 @@
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Ross Nicoll <jrn@jrn.me.uk>
+ * @author Tjeerd Jan Heeringa <Heeringa@protonmail.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
  *

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -19,7 +19,7 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'		<label for="mountOptionsEncrypt">{{t "files_external" "Enable encryption"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
-	'		<input id="mountOptionsPreviews" name="read_only" type="checkbox" value="false" checked="checked"/>' +
+	'		<input id="mountOptionsPreviews" name="read_only" type="checkbox" value="true"/>' +
 	'		<label for="mountOptionsPreviews">{{t "files_external" "Set read-only"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -19,6 +19,10 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'		<label for="mountOptionsEncrypt">{{t "files_external" "Enable encryption"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
+	'		<input id="mountOptionsPreviews" name="read_only" type="checkbox" value="false" checked="checked"/>' +
+	'		<label for="mountOptionsPreviews">{{t "files_external" "Set read-only"}}</label>' +
+	'	</div>' +
+	'	<div class="optionRow">' +
 	'		<input id="mountOptionsPreviews" name="previews" type="checkbox" value="true" checked="checked"/>' +
 	'		<label for="mountOptionsPreviews">{{t "files_external" "Enable previews"}}</label>' +
 	'	</div>' +
@@ -960,6 +964,7 @@ MountConfigListView.prototype = _.extend({
 			// FIXME default backend mount options
 			$tr.find('input.mountOptions').val(JSON.stringify({
 				'encrypt': true,
+				'read_only': false,
 				'previews': true,
 				'enable_sharing': false,
 				'filesystem_check_changes': 1,
@@ -1342,6 +1347,7 @@ MountConfigListView.prototype = _.extend({
 		var $toggle = $tr.find('.mountOptionsToggle');
 		var dropDown = new MountOptionsDropdown();
 		var visibleOptions = [
+			'read_only',
 			'previews',
 			'filesystem_check_changes',
 			'encoding_compatibility'

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Robin Appelman <icewind@owncloud.com>
+ * @author Tjeerd Jan Heeringa <heeringa@protonmail.ch>
  * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
@@ -218,6 +219,7 @@ class ListCommand extends Base {
 				'encrypt' => true,
 				'previews' => true,
 				'filesystem_check_changes' => 1,
+				'read_only' => false,
 				'enable_sharing' => false,
 				'encoding_compatibility' => false
 			];

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -5,6 +5,7 @@
 	use OCP\Files\External\IStoragesBackendService;
 
 	$l->t("Enable encryption");
+	$l->t("Set read-only");
 	$l->t("Enable previews");
 	$l->t("Enable sharing");
 	$l->t("Check for changes");

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -371,6 +371,7 @@ describe('OCA.External.Settings tests', function() {
 				expect(JSON.parse($tr.find('input.mountOptions').val())).toEqual({
 					encrypt: true,
 					previews: true,
+					read_only: false,
 					enable_sharing: false,
 					filesystem_check_changes: 0,
 					encoding_compatibility: false

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -33,6 +33,7 @@
  * @author Roeland Jago Douma <rullzer@owncloud.com>
  * @author Stefan Rado <owncloud@sradonia.net>
  * @author Stefan Weil <sw@weilnetz.de>
+ * @author Tjeerd Jan Heeringa <heeringa@protonmail.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Thomas Tanghus <thomas@tanghus.net>
  * @author Victor Dubiniuk <dubiniuk@owncloud.com>
@@ -168,6 +169,16 @@ class OC_Util {
 				return new \OC\Files\Storage\Wrapper\PermissionsMask([
 					'storage' => $storage,
 					'mask' => \OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_SHARE
+				]);
+			}
+			return $storage;
+		});
+
+		\OC\Files\Filesystem::addStorageWrapper('read_only', function ($mountPoint, IStorage $storage, \OCP\Files\Mount\IMountPoint $mount) {
+			if ($mount->getOption('read_only', true) && !$storage->instanceOfStorage('\OC\Files\Storage\Home')) {
+				return new \OC\Files\Storage\Wrapper\PermissionsMask([
+					'storage' => $storage,
+					'mask' => \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE
 				]);
 			}
 			return $storage;

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -175,7 +175,7 @@ class OC_Util {
 		});
 
 		\OC\Files\Filesystem::addStorageWrapper('read_only', function ($mountPoint, IStorage $storage, \OCP\Files\Mount\IMountPoint $mount) {
-			if ($mount->getOption('read_only', true) && !$storage->instanceOfStorage('\OC\Files\Storage\Home')) {
+			if ($mount->getOption('read_only', false)) {
 				return new \OC\Files\Storage\Wrapper\PermissionsMask([
 					'storage' => $storage,
 					'mask' => \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
TL;DR: Made a read only option for external storages

I added a extra option in the advanced settings menu when mounting an external storage. This causes an extra row to be added in the database, when saving the mount, with whether an the mount is read only or not. A storagewrapper is added that checks the option and if the mount has the read only option the storagewrapper adds an permissionmask that makes the mount read only.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/29873

## Motivation and Context
Sometimes you want to have a group only to be able to read a certain map. Currently no option exists to do this. Extra info can be found in:
https://github.com/owncloud/user_management/issues/23
https://github.com/owncloud/core/issues/29873

## How Has This Been Tested?
Currently tested it by making a external share called 'Local' and setting the option `read_only` that I made. Haven't figured out how to write proper tests.

## Screenshots (if appropriate):
![capture](https://user-images.githubusercontent.com/16029718/46557054-e7b27400-c8e8-11e8-8aeb-119a245238c8.PNG)

![capture_2](https://user-images.githubusercontent.com/16029718/46557028-d10c1d00-c8e8-11e8-9b9c-e689a2ab9948.PNG)

![capture_3](https://user-images.githubusercontent.com/16029718/46557103-19c3d600-c8e9-11e8-9655-bf296681014a.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
 - [ ] Write tests
 - [x] Figure out why `!$storage->instanceOfStorage('\OC\Files\Storage\Home'))` is required in the line `if ($mount->getOption('read_only', true) && !$storage->instanceOfStorage('\OC\Files\Storage\Home'))` on `lib/private/legacy/util.php` line 178