### PR TITLE
Abstract edition productname version in API tests

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -3,7 +3,6 @@ Feature: capabilities
 
   Background:
     Given using OCS API version "1"
-    And as user "%admin%"
 
   @smokeTest
   Scenario: Check that the sharing API can be enabled
@@ -34,11 +33,15 @@ Feature: capabilities
 
   @smokeTest
   Scenario: getting capabilities with admin user
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
       | core          | webdav-root                           | remote.php/webdav |
+      | core          | status@@@edition                      | %edition%         |
+      | core          | status@@@productname                  | %productname%     |
+      | core          | status@@@version                      | %version%         |
+      | core          | status@@@versionstring                | %versionstring%   |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
       | files_sharing | public@@@enabled                      | 1                 |
@@ -58,7 +61,7 @@ Feature: capabilities
 
   Scenario: Changing public upload
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -82,7 +85,7 @@ Feature: capabilities
 
   Scenario: Disabling share api
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element       | value             |
       | core          | pollinterval          | 60                |
@@ -100,7 +103,7 @@ Feature: capabilities
 
   Scenario: Disabling public links
     Given parameter "shareapi_allow_links" of app "core" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -122,7 +125,7 @@ Feature: capabilities
 
   Scenario: Changing resharing
     Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -146,7 +149,7 @@ Feature: capabilities
 
   Scenario: Changing federation outgoing
     Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -170,7 +173,7 @@ Feature: capabilities
 
   Scenario: Changing federation incoming
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -194,7 +197,7 @@ Feature: capabilities
 
   Scenario: Changing "password enforced for read-only public link shares"
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                                | value             |
       | core          | pollinterval                                   | 60                |
@@ -221,7 +224,7 @@ Feature: capabilities
 
   Scenario: Changing "password enforced for read-write public link shares"
     Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                                | value             |
       | core          | pollinterval                                   | 60                |
@@ -248,7 +251,7 @@ Feature: capabilities
 
   Scenario: Changing "password enforced for write-only public link shares"
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                                | value             |
       | core          | pollinterval                                   | 60                |
@@ -275,7 +278,7 @@ Feature: capabilities
 
   Scenario: Changing public notifications
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -299,7 +302,7 @@ Feature: capabilities
 
   Scenario: Changing public social share
     Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -323,7 +326,7 @@ Feature: capabilities
 
   Scenario: Changing expire date
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -349,7 +352,7 @@ Feature: capabilities
   Scenario: Changing expire date enforcing
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -375,7 +378,7 @@ Feature: capabilities
 
   Scenario: Changing group sharing allowed
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -399,7 +402,7 @@ Feature: capabilities
 
   Scenario: Changing only share with group member
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -423,7 +426,7 @@ Feature: capabilities
 
   Scenario: Changing allow share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element               | value             |
       | core          | pollinterval                  | 60                |
@@ -446,7 +449,7 @@ Feature: capabilities
 
   Scenario: Changing allow share dialog user enumeration for group members only
     Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -474,7 +477,7 @@ Feature: capabilities
     And group "hash#group" has been created
     And group "group-3" has been created
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-    When the user retrieves the capabilities using the capabilities API
+    When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -505,8 +508,7 @@ Feature: capabilities
     And group "ordinary-group" has been created
     And user "user0" has been added to group "hash#group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-    And as user "user0"
-    When the user retrieves the capabilities using the capabilities API
+    When user "user0" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -537,8 +539,7 @@ Feature: capabilities
     And group "ordinary-group" has been created
     And user "user0" has been added to group "ordinary-group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-    And as user "user0"
-    When the user retrieves the capabilities using the capabilities API
+    When user "user0" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -570,8 +571,7 @@ Feature: capabilities
     And user "user0" has been added to group "hash#group"
     And user "user0" has been added to group "ordinary-group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-    And as user "user0"
-    When the user retrieves the capabilities using the capabilities API
+    When user "user0" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -1,9 +1,10 @@
 @api
 Feature: Status
 
+  @smokeTest
   Scenario: Status.php is correct
     When the administrator requests status.php
     Then the status.php response should match with
       """
-      {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"Community","productname":"ownCloud"}
+      {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"$EDITION","productname":"$PRODUCTNAME"}
       """

--- a/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
@@ -14,7 +14,7 @@ Feature: refuse access
     Then the HTTP status code should be "401"
     And there should be no duplicate headers
     And the following headers should be set
-      | WWW-Authenticate | Basic realm="ownCloud", charset="UTF-8" |
+      | WWW-Authenticate | Basic realm="%productname%", charset="UTF-8" |
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -127,7 +127,7 @@ trait AppConfiguration {
 	public function theCapabilitiesSettingOfAppParameterShouldBe(
 		$capabilitiesApp, $capabilitiesPath, $expectedValue
 	) {
-		$this->getCapabilitiesCheckResponse();
+		$this->theAdministratorGetsCapabilitiesCheckResponse();
 
 		PHPUnit_Framework_Assert::assertEquals(
 			$expectedValue,
@@ -152,15 +152,35 @@ trait AppConfiguration {
 	}
 
 	/**
+	 * @When user :username retrieves the capabilities using the capabilities API
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function userGetsCapabilitiesCheckResponse($username) {
+		$this->userSendsToOcsApiEndpoint($username, 'GET', '/cloud/capabilities');
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
+	}
+
+	/**
 	 * @When the user retrieves the capabilities using the capabilities API
 	 *
 	 * @return void
 	 */
 	public function getCapabilitiesCheckResponse() {
-		$this->theUserSendsToOcsApiEndpoint('GET', '/cloud/capabilities');
-		PHPUnit_Framework_Assert::assertEquals(
-			200, $this->response->getStatusCode()
-		);
+		$this->userGetsCapabilitiesCheckResponse($this->getCurrentUser());
+	}
+
+	/**
+	 * @When the administrator retrieves the capabilities using the capabilities API
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsCapabilitiesCheckResponse() {
+		$this->userGetsCapabilitiesCheckResponse($this->getAdminUsername());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1606,8 +1606,36 @@ trait BasicStructure {
 	 */
 	public function statusPhpRespondedShouldMatch(PyStringNode $jsonExpected) {
 		$jsonExpectedDecoded = \json_decode($jsonExpected->getRaw(), true);
-		$jsonRespondedEncoded
-			= \json_encode(\json_decode($this->response->getBody(), true));
+		$jsonRespondedEncoded = \json_encode($this->getJsonDecodedResponse());
+
+		$this->theAdministratorGetsCapabilitiesCheckResponse();
+		$edition = $this->getParameterValueFromXml(
+			$this->getCapabilitiesXml(),
+			'core',
+			'status@@@edition'
+		);
+
+		if (!\strlen($edition)) {
+			PHPUnit_Framework_Assert::fail(
+				"Cannot get edition from capabilities"
+			);
+		}
+
+		$productName = $this->getParameterValueFromXml(
+			$this->getCapabilitiesXml(),
+			'core',
+			'status@@@productname'
+		);
+
+		if (!\strlen($edition)) {
+			PHPUnit_Framework_Assert::fail(
+				"Cannot get productname from capabilities"
+			);
+		}
+
+		$jsonExpectedDecoded['edition'] = $edition;
+		$jsonExpectedDecoded['productname'] = $productName;
+
 		$runOccStatus = $this->runOcc(['status']);
 		if ($runOccStatus === 0) {
 			$output = \explode("- ", $this->lastStdOut);
@@ -1630,6 +1658,63 @@ trait BasicStructure {
 				"Cannot get version variables from occ - status $runOccStatus"
 			);
 		}
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getJsonDecodedResponse() {
+		return \json_decode(
+			$this->getResponse()->getBody(), true
+		);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEditionFromStatus() {
+		$this->getStatusPhp();
+		$decodedResponse = $this->getJsonDecodedResponse();
+		if (isset($decodedResponse['edition'])) {
+			return $decodedResponse['edition'];
+		}
+		return '';
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getProductNameFromStatus() {
+		$this->getStatusPhp();
+		$decodedResponse = $this->getJsonDecodedResponse();
+		if (isset($decodedResponse['productname'])) {
+			return $decodedResponse['productname'];
+		}
+		return '';
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getVersionFromStatus() {
+		$this->getStatusPhp();
+		$decodedResponse = $this->getJsonDecodedResponse();
+		if (isset($decodedResponse['version'])) {
+			return $decodedResponse['version'];
+		}
+		return '';
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getVersionStringFromStatus() {
+		$this->getStatusPhp();
+		$decodedResponse = $this->getJsonDecodedResponse();
+		if (isset($decodedResponse['versionstring'])) {
+			return $decodedResponse['versionstring'];
+		}
+		return '';
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -50,6 +50,18 @@ class CapabilitiesContext implements Context {
 		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
 
 		foreach ($formData->getHash() as $row) {
+			if ($row['value'] === "%edition%") {
+				$row['value'] = $this->featureContext->getEditionFromStatus();
+			}
+			if ($row['value'] === "%productname%") {
+				$row['value'] = $this->featureContext->getProductNameFromStatus();
+			}
+			if ($row['value'] === "%version%") {
+				$row['value'] = $this->featureContext->getVersionFromStatus();
+			}
+			if ($row['value'] === "%versionstring%") {
+				$row['value'] = $this->featureContext->getVersionStringFromStatus();
+			}
 			PHPUnit_Framework_Assert::assertEquals(
 				$row['value'] === "EMPTY" ? '' : $row['value'],
 				$this->featureContext->getParameterValueFromXml(

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -796,6 +796,12 @@ trait WebDav {
 			$headerName = $header[0];
 			$expectedHeaderValue = $header[1];
 			$returnedHeader = $this->response->getHeader($headerName);
+
+			if (\strpos($expectedHeaderValue, "%productname%") !== false) {
+				$productName = $this->getProductNameFromStatus();
+				$expectedHeaderValue = \str_replace("%productname%", $productName, $expectedHeaderValue);
+			}
+
 			if ($returnedHeader !== $expectedHeaderValue) {
 				throw new \Exception(
 					\sprintf(


### PR DESCRIPTION
## Description
1) Add methods to return the current product name, edition, version and version string extracted from what is reported by status.php.
2) Use those in capabilities tests to at least confirm that the values reported in capabilities are the same as was reported in status.php
3) Use that to abstract out the ``Basic realm="ownCloud"`` expectation in ``refuseAccess.feature``
4) For ``status.feature``, get the expected edition and product name from the capabilities to use in comparing the expected JSON returned by ``status.php``
5) Tag ``status.feature`` as ``smokeTest`` - the scenario is now generic and should pass against a variety of systems-under-test, and it is "a good thing" to know that the ``status.php`` end-point is working.
## Issue
Addresses #32872 

## Motivation and Context
Remove explicit mention of the product name "ownCloud" and the edition "Community" from API acceptance tests, so that they will run against a system-under-test with a different themed product name or edition "Enterprise".

## How Has This Been Tested?
Local runs of relevant acceptance tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
