### PR TITLE
Refactor edit and get user provisioning API acceptance tests

### DIFF
--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -113,6 +113,30 @@ class UserHelper {
 	 *
 	 * @return ResponseInterface
 	 */
+	public static function getUser(
+		$baseUrl, $userName, $adminUser, $adminPassword, $ocsApiVersion = 2
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUser,
+			$adminPassword,
+			"GET",
+			"/cloud/users/" . $userName,
+			[],
+			$ocsApiVersion
+		);
+	}
+
+	/**
+	 *
+	 * @param string $baseUrl
+	 * @param string $userName
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @param int $ocsApiVersion
+	 *
+	 * @return ResponseInterface
+	 */
 	public static function deleteUser(
 		$baseUrl, $userName, $adminUser, $adminPassword, $ocsApiVersion = 2
 	) {

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -1,24 +1,34 @@
 @api @provisioning_api-app-required
 Feature: edit users
-  As an admin
-  I want to be able to edit a user
-  So that I can change user information
+  As an admin, subadmin or as myself
+  I want to be able to edit user information
+  So that I can keep the user information up-to-date
 
   Background:
     Given using OCS API version "1"
 
   @smokeTest
-  Scenario: Edit a user email
+  Scenario: the administrator can edit a user email
     Given user "brand-new-user" has been created
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
-    And the HTTP status code should be "200"
+    Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And user "brand-new-user" should exist
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
   @smokeTest
-  Scenario: Edit a user quota
+  Scenario: the administrator can edit a user display name
+    Given user "brand-new-user" has been created
+    When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | displayname | A New User |
+
+  @smokeTest
+  Scenario: the administrator can edit a user quota
     Given user "brand-new-user" has been created
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
@@ -27,7 +37,7 @@ Feature: edit users
     And the user attributes returned by the API should include
       | quota definition | 12 MB |
 
-  Scenario: Override existing user email
+  Scenario: the administrator can override an existing user email
     Given user "brand-new-user" has been created
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "100"
@@ -35,38 +45,65 @@ Feature: edit users
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
   @smokeTest
-  Scenario: subadmin should be able to edit the user information in his group
+  Scenario: a subadmin should be able to edit the user information in their group
     Given user "subadmin" has been created
     And user "brand-new-user" has been created
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                      |
-      | value | brand-new-user@example.com |
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    And user "subadmin" has changed the quota of user "brand-new-user" to "12MB"
+    And user "subadmin" has changed the email of user "brand-new-user" to "brand-new-user@example.com"
+    And user "subadmin" has changed the display name of user "brand-new-user" to "Anne Brown"
+    When user "subadmin" retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | quota definition | 12 MB                      |
       | email            | brand-new-user@example.com |
+      | displayname      | Anne Brown                 |
 
-  Scenario: normal user should not be able to change their quota
+  Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created
-    When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
+    When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+
+  Scenario: a normal user should be able to change their display name
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+
+  Scenario: a normal user should not be able to change their quota
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | quota definition | default |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -1,8 +1,8 @@
 @api @provisioning_api-app-required
 Feature: get user
-  As an admin
-  I want to be able to get user
-  So that I can get information about user
+  As an admin, subadmin or as myself
+  I want to be able to retrieve user information
+  So that I can see the information
 
   Background:
     Given using OCS API version "1"
@@ -10,51 +10,51 @@ Feature: get user
   @smokeTest
   Scenario: admin gets existing user
     Given user "brand-new-user" has been created
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "brand-new-user"
 
   Scenario: admin tries to get a not existing user
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+    When the administrator retrieves the information of user "not-a-user" using the provisioning API
     Then the OCS status code should be "998"
     And the HTTP status code should be "200"
     And the API should not return any data
 
   @smokeTest
-  Scenario: subadmin gets information of a user in his group
+  Scenario: a subadmin gets information of a user in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
 
-  Scenario: subadmin tries to get information of a user not in his group
+  Scenario: a subadmin tries to get information of a user not in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  Scenario: normal user tries to get information of another user
+  Scenario: a normal user tries to get information of another user
     Given user "newuser" has been created
     And user "anotheruser" has been created
-    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "anotheruser" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 
   @smokeTest
-  Scenario: normal user gets his own information
+  Scenario: a normal user gets their own information
     Given user "newuser" has been created
-    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "newuser" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -1,69 +1,109 @@
 @api @provisioning_api-app-required
 Feature: edit users
-  As an admin
-  I want to be able to edit a user
-  So that I can change user information
+  As an admin, subadmin or as myself
+  I want to be able to edit user information
+  So that I can keep the user information up-to-date
 
   Background:
     Given using OCS API version "2"
 
   @smokeTest
-  Scenario: Edit a user
+  Scenario: the administrator can edit a user email
     Given user "brand-new-user" has been created
-    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota                    |
-      | value | 12MB                     |
-      | key   | email                    |
-      | value | brand-new-user@gmail.com |
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
+    When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
     And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | email | brand-new-user@example.com |
 
-  Scenario: Override existing user email
+  @smokeTest
+  Scenario: the administrator can edit a user display name
     Given user "brand-new-user" has been created
-    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                    |
-      | value | brand-new-user@gmail.com |
+    When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | displayname | A New User |
+
+  @smokeTest
+  Scenario: the administrator can edit a user quota
+    Given user "brand-new-user" has been created
+    When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | quota definition | 12 MB |
+
+  Scenario: the administrator can override existing user email
+    Given user "brand-new-user" has been created
+    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                      |
-      | value | brand-new-user@example.com |
+    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
   @smokeTest
-  Scenario: subadmin should be able to edit the user information in his group
+  Scenario: a subadmin should be able to edit the user information in their group
     Given user "subadmin" has been created
     And user "brand-new-user" has been created
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                      |
-      | value | brand-new-user@example.com |
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    And user "subadmin" has changed the quota of user "brand-new-user" to "12MB"
+    And user "subadmin" has changed the email of user "brand-new-user" to "brand-new-user@example.com"
+    And user "subadmin" has changed the display name of user "brand-new-user" to "Anne Brown"
+    When user "subadmin" retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | quota definition | 12 MB                      |
       | email            | brand-new-user@example.com |
+      | displayname      | Anne Brown                 |
 
-  @skip @issue-31276
-  Scenario: normal user should not be able to change their quota
+  Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created
-    When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
-    Then the OCS status code should be "401"
+    When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+
+  Scenario: a normal user should be able to change their display name
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+
+  Scenario: a normal user should not be able to change their quota
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
+    Then the OCS status code should be "997"
     And the HTTP status code should be "401"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | quota definition | default |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -1,8 +1,8 @@
 @api @provisioning_api-app-required
 Feature: get user
-  As an admin
-  I want to be able to get user
-  So that I can get information about user
+  As an admin, subadmin or as myself
+  I want to be able to retrieve user information
+  So that I can see the information
 
   Background:
     Given using OCS API version "2"
@@ -10,46 +10,44 @@ Feature: get user
   @smokeTest
   Scenario: admin gets an existing user
     Given user "brand-new-user" has been created
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "brand-new-user"
 
   Scenario: admin tries to get a not existing user
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+    When the administrator retrieves the information of user "not-a-user" using the provisioning API
     Then the OCS status code should be "404"
     And the HTTP status code should be "404"
     And the API should not return any data
 
   @smokeTest
-  Scenario: subadmin gets information of a user in his group
+  Scenario: a subadmin gets information of a user in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
 
-  @skip @issue-31276
-  Scenario: subadmin tries to get information of a user not in his group
+  Scenario: a subadmin tries to get information of a user not in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-    Then the OCS status code should be "401"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
+    Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @skip @issue-31276
-  Scenario: normal user tries to get information of another user
+  Scenario: a normal user tries to get information of another user
     Given user "newuser" has been created
     And user "anotheruser" has been created
-    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-    Then the OCS status code should be "401"
+    When user "anotheruser" retrieves the information of user "newuser" using the provisioning API
+    Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -534,6 +534,86 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" changes the email of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has changed the email of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $email
+	 *
+	 * @return void
+	 */
+	public function userChangesTheEmailOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser, $email
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			'email',
+			$email,
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
+	 * @When /^the administrator changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^the administrator has changed the display name of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $displayname
+	 *
+	 * @return void
+	 */
+	public function adminChangesTheDisplayNameOfTheUserUsingTheProvisioningApi(
+		$user, $displayname
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($user),
+			'display',
+			$displayname,
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+		if ($result->getStatusCode() !== 200) {
+			throw new \Exception(
+				"could not change display name of user. "
+				. $result->getStatusCode() . " " . $result->getBody()
+			);
+		}
+	}
+
+	/**
+	 * @When /^user "([^"]*)" changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has changed the display name of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $displayName
+	 *
+	 * @return void
+	 */
+	public function userChangesTheDisplayNameOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser, $displayName
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			'display',
+			$displayName,
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
 	 * @When /^the administrator changes the quota of user "([^"]*)" to "([^"]*)" using the provisioning API$/
 	 * @Given /^the administrator has changed the quota of user "([^"]*)" to "([^"]*)"$/
 	 *
@@ -561,6 +641,74 @@ trait Provisioning {
 				. $result->getStatusCode() . " " . $result->getBody()
 			);
 		}
+	}
+
+	/**
+	 * @When /^user "([^"]*)" changes the quota of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has changed the quota of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $quota
+	 *
+	 * @return void
+	 */
+	public function userChangesTheQuotaOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser, $quota
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			'quota',
+			$quota,
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
+	 * @When /^the administrator retrieves the information of user "([^"]*)" using the provisioning API$/
+	 * @Given /^the administrator has retrieved the information of user "([^"]*)"$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function adminRetrievesTheInformationOfUserUsingTheProvisioningApi(
+		$user
+	) {
+		$result = UserHelper::getUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($user),
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
+	 * @When /^user "([^"]*)" retrieves the information of user "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has retrieved the information of user "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 *
+	 * @return void
+	 */
+	public function userRetrievesTheInformationOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser
+	) {
+		$result = UserHelper::getUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) Add a ``getUser()`` method to ``UserHelper.php`` - somehow there was not one there yet, the scenarios were doing the gory ``sends HTTP method "GET" to OCS API endpoint`` thing.
2) Add step methods in ``Provisioning.php`` that say what it is that needs to happen, rather than how it happens - e.g. ``the administrator changes the display name of user...``
3) Use the steps in the ``editUser`` and ``getUser`` features.

## Motivation and Context
There are "magic" acceptance test steps like:
```
user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
```
These result in the knowledge about the gory details of the endpoint(s) being duplicated in many test scenarios. We should write scenario steps that say something closer to a higher-level requirement, rather than the detailed implementation of the API.

## How Has This Been Tested?
Local runs of the changed feature files.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
