### PR TITLE
Provisioning api edit displayname

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -245,6 +245,7 @@ class Users {
 		if ($targetUserId === $currentLoggedInUser->getUID()) {
 			// Editing self (display, email)
 			$permittedFields[] = 'display';
+			$permittedFields[] = 'displayname';
 			$permittedFields[] = 'email';
 			$permittedFields[] = 'password';
 			$permittedFields[] = 'two_factor_auth_enabled';
@@ -259,6 +260,7 @@ class Users {
 			|| $this->groupManager->isAdmin($currentLoggedInUser->getUID())) {
 				// They have permissions over the user
 				$permittedFields[] = 'display';
+				$permittedFields[] = 'displayname';
 				$permittedFields[] = 'quota';
 				$permittedFields[] = 'password';
 				$permittedFields[] = 'email';
@@ -275,6 +277,7 @@ class Users {
 		// Process the edit
 		switch ($parameters['_put']['key']) {
 			case 'display':
+			case 'displayname':
 				$targetUser->setDisplayName($parameters['_put']['value']);
 				break;
 			case 'quota':

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -914,7 +914,7 @@ class UsersTest extends OriginalTest {
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit']));
 	}
 
-	public function testEditUserRegularUserSelfEditChangeDisplayName() {
+	public function testEditUserRegularUserSelfEditChangeDisplay() {
 		$loggedInUser = $this->createMock(IUser::class);
 		$loggedInUser
 			->expects($this->any())
@@ -937,6 +937,31 @@ class UsersTest extends OriginalTest {
 
 		$expected = new Result(null, 100);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'display', 'value' => 'NewDisplayName']]));
+	}
+
+	public function testEditUserRegularUserSelfEditChangeDisplayName() {
+		$loggedInUser = $this->createMock(IUser::class);
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('UserToEdit'));
+		$targetUser = $this->createMock(IUser::class);
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($loggedInUser));
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->will($this->returnValue($targetUser));
+		$targetUser
+			->expects($this->once())
+			->method('setDisplayName')
+			->with('NewDisplayName');
+
+		$expected = new Result(null, 100);
+		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'displayname', 'value' => 'NewDisplayName']]));
 	}
 
 	public function testEditUserRegularUserSelfEditChangeEmailValid() {

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -573,7 +573,7 @@ trait Provisioning {
 		$result = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$this->getActualUsername($user),
-			'display',
+			'displayname',
 			$displayname,
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
@@ -604,7 +604,7 @@ trait Provisioning {
 		$result = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$this->getActualUsername($targetUser),
-			'display',
+			'displayname',
 			$displayName,
 			$this->getActualUsername($requestingUser),
 			$this->getPasswordForUser($requestingUser),


### PR DESCRIPTION
## Description
1) Allow ``displayname`` (in addition to the existing ``display``) as a key for modifying the display name of a user via the provisioning API.
2) Adjust the acceptance tests  to use ``displayname``

## Related Issue
- Fixes #33039 

## Motivation and Context
Make modify and get of display name via the provisioning API both use ``displayname`` as the key.

## How Has This Been Tested?
Run acceptance test scenarios.
Run ``curl`` commands like:
```
curl -X PUT http://admin:admin@172.17.0.1:8080/ocs/v1.php/cloud/users/zzz -d key="display" -d value="Me"
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
