### PR TITLE
Test acceptance cli infrastructure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -350,6 +350,19 @@ pipeline:
       matrix:
         TEST_SUITE: api
 
+  cli-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - TEST_SERVER_URL=https://server
+    commands:
+      - touch /drone/saved-settings.sh
+      - . /drone/saved-settings.sh
+      - make test-acceptance-cli TESTING_REMOTE_SYSTEM=true
+    when:
+      matrix:
+        TEST_SUITE: cli
+
   webui-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -785,6 +798,16 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavProperties
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+
+  # CLI Acceptance tests
+    - PHP_VERSION: 7.1
+      TEST_SUITE: cli
+      BEHAT_SUITE: cliProvisioning
       DB_TYPE: mariadb
       USE_SERVER: true
       INSTALL_SERVER: true

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ help:
 	@echo -e "make test-js\t\t\trun Javascript tests"
 	@echo -e "make test-js-debug\t\trun Javascript tests in debug mode (continuous)"
 	@echo -e "make test-acceptance-api\trun API acceptance tests"
+	@echo -e "make test-acceptance-cli\trun CLI acceptance tests"
 	@echo -e "make test-acceptance-webui\trun webUI acceptance tests"
 	@echo -e "make clean-test\t\t\tclean test results"
 	@echo
@@ -185,6 +186,10 @@ test-js-debug: $(nodejs_deps)
 test-acceptance-api: $(composer_dev_deps)
 	./tests/acceptance/run.sh --type api
 
+.PHONY: test-acceptance-cli
+test-acceptance-cli: $(composer_dev_deps)
+	./tests/acceptance/run.sh --type cli
+
 .PHONY: test-acceptance-webui
 test-acceptance-webui: $(composer_dev_deps)
 	./tests/acceptance/run.sh --type webUI
@@ -208,7 +213,7 @@ test-php-phan: $(PHAN_BIN)
 	php $(PHAN_BIN) --config-file .phan/config.php --require-config-exists -p
 
 .PHONY: test
-test: test-php-lint test-php-style test-php test-js test-acceptance-api test-acceptance-webui
+test: test-php-lint test-php-style test-php test-js test-acceptance-api test-acceptance-cli test-acceptance-webui
 
 .PHONY: clean-test-acceptance
 clean-test-acceptance:

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -113,6 +113,30 @@ class UserHelper {
 	 *
 	 * @return ResponseInterface
 	 */
+	public static function getUser(
+		$baseUrl, $userName, $adminUser, $adminPassword, $ocsApiVersion = 2
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUser,
+			$adminPassword,
+			"GET",
+			"/cloud/users/" . $userName,
+			[],
+			$ocsApiVersion
+		);
+	}
+
+	/**
+	 *
+	 * @param string $baseUrl
+	 * @param string $userName
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @param int $ocsApiVersion
+	 *
+	 * @return ResponseInterface
+	 */
 	public static function deleteUser(
 		$baseUrl, $userName, $adminUser, $adminPassword, $ocsApiVersion = 2
 	) {

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -95,6 +95,13 @@ default:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
 
+    cliProvisioning:
+      paths:
+        - %paths.base%/../features/cliProvisioning
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+
     webUIAdminSettings:
       paths:
         - %paths.base%/../features/webUIAdminSettings

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -1,24 +1,34 @@
 @api @provisioning_api-app-required
 Feature: edit users
-  As an admin
-  I want to be able to edit a user
-  So that I can change user information
+  As an admin, subadmin or as myself
+  I want to be able to edit user information
+  So that I can keep the user information up-to-date
 
   Background:
     Given using OCS API version "1"
 
   @smokeTest
-  Scenario: Edit a user email
+  Scenario: the administrator can edit a user email
     Given user "brand-new-user" has been created
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
-    And the HTTP status code should be "200"
+    Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And user "brand-new-user" should exist
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
   @smokeTest
-  Scenario: Edit a user quota
+  Scenario: the administrator can edit a user display name
+    Given user "brand-new-user" has been created
+    When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | displayname | A New User |
+
+  @smokeTest
+  Scenario: the administrator can edit a user quota
     Given user "brand-new-user" has been created
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
@@ -27,7 +37,7 @@ Feature: edit users
     And the user attributes returned by the API should include
       | quota definition | 12 MB |
 
-  Scenario: Override existing user email
+  Scenario: the administrator can override an existing user email
     Given user "brand-new-user" has been created
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "100"
@@ -35,38 +45,65 @@ Feature: edit users
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
   @smokeTest
-  Scenario: subadmin should be able to edit the user information in his group
+  Scenario: a subadmin should be able to edit the user information in their group
     Given user "subadmin" has been created
     And user "brand-new-user" has been created
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                      |
-      | value | brand-new-user@example.com |
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    And user "subadmin" has changed the quota of user "brand-new-user" to "12MB"
+    And user "subadmin" has changed the email of user "brand-new-user" to "brand-new-user@example.com"
+    And user "subadmin" has changed the display name of user "brand-new-user" to "Anne Brown"
+    When user "subadmin" retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | quota definition | 12 MB                      |
       | email            | brand-new-user@example.com |
+      | displayname      | Anne Brown                 |
 
-  Scenario: normal user should not be able to change their quota
+  Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created
-    When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
+    When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+
+  Scenario: a normal user should be able to change their display name
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+
+  Scenario: a normal user should not be able to change their quota
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | quota definition | default |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -1,8 +1,8 @@
 @api @provisioning_api-app-required
 Feature: get user
-  As an admin
-  I want to be able to get user
-  So that I can get information about user
+  As an admin, subadmin or as myself
+  I want to be able to retrieve user information
+  So that I can see the information
 
   Background:
     Given using OCS API version "1"
@@ -10,51 +10,51 @@ Feature: get user
   @smokeTest
   Scenario: admin gets existing user
     Given user "brand-new-user" has been created
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "brand-new-user"
 
   Scenario: admin tries to get a not existing user
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+    When the administrator retrieves the information of user "not-a-user" using the provisioning API
     Then the OCS status code should be "998"
     And the HTTP status code should be "200"
     And the API should not return any data
 
   @smokeTest
-  Scenario: subadmin gets information of a user in his group
+  Scenario: a subadmin gets information of a user in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
 
-  Scenario: subadmin tries to get information of a user not in his group
+  Scenario: a subadmin tries to get information of a user not in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  Scenario: normal user tries to get information of another user
+  Scenario: a normal user tries to get information of another user
     Given user "newuser" has been created
     And user "anotheruser" has been created
-    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "anotheruser" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 
   @smokeTest
-  Scenario: normal user gets his own information
+  Scenario: a normal user gets their own information
     Given user "newuser" has been created
-    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "newuser" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -1,69 +1,109 @@
 @api @provisioning_api-app-required
 Feature: edit users
-  As an admin
-  I want to be able to edit a user
-  So that I can change user information
+  As an admin, subadmin or as myself
+  I want to be able to edit user information
+  So that I can keep the user information up-to-date
 
   Background:
     Given using OCS API version "2"
 
   @smokeTest
-  Scenario: Edit a user
+  Scenario: the administrator can edit a user email
     Given user "brand-new-user" has been created
-    When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota                    |
-      | value | 12MB                     |
-      | key   | email                    |
-      | value | brand-new-user@gmail.com |
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
+    When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
     And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | email | brand-new-user@example.com |
 
-  Scenario: Override existing user email
+  @smokeTest
+  Scenario: the administrator can edit a user display name
     Given user "brand-new-user" has been created
-    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                    |
-      | value | brand-new-user@gmail.com |
+    When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | displayname | A New User |
+
+  @smokeTest
+  Scenario: the administrator can edit a user quota
+    Given user "brand-new-user" has been created
+    When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | quota definition | 12 MB |
+
+  Scenario: the administrator can override existing user email
+    Given user "brand-new-user" has been created
+    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                      |
-      | value | brand-new-user@example.com |
+    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
   @smokeTest
-  Scenario: subadmin should be able to edit the user information in his group
+  Scenario: a subadmin should be able to edit the user information in their group
     Given user "subadmin" has been created
     And user "brand-new-user" has been created
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
-    And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | email                      |
-      | value | brand-new-user@example.com |
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    And user "subadmin" has changed the quota of user "brand-new-user" to "12MB"
+    And user "subadmin" has changed the email of user "brand-new-user" to "brand-new-user@example.com"
+    And user "subadmin" has changed the display name of user "brand-new-user" to "Anne Brown"
+    When user "subadmin" retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the user attributes returned by the API should include
       | quota definition | 12 MB                      |
       | email            | brand-new-user@example.com |
+      | displayname      | Anne Brown                 |
 
-  @skip @issue-31276
-  Scenario: normal user should not be able to change their quota
+  Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created
-    When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
-      | key   | quota |
-      | value | 12MB  |
-    Then the OCS status code should be "401"
+    When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | email | brand-new-user@example.com |
+
+  Scenario: a normal user should be able to change their display name
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | displayname | Alan Border |
+
+  Scenario: a normal user should not be able to change their quota
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
+    Then the OCS status code should be "997"
     And the HTTP status code should be "401"
+    And the attributes of user "brand-new-user" returned by the API should include
+      | quota definition | default |
+    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -1,8 +1,8 @@
 @api @provisioning_api-app-required
 Feature: get user
-  As an admin
-  I want to be able to get user
-  So that I can get information about user
+  As an admin, subadmin or as myself
+  I want to be able to retrieve user information
+  So that I can see the information
 
   Background:
     Given using OCS API version "2"
@@ -10,46 +10,44 @@ Feature: get user
   @smokeTest
   Scenario: admin gets an existing user
     Given user "brand-new-user" has been created
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "brand-new-user"
 
   Scenario: admin tries to get a not existing user
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+    When the administrator retrieves the information of user "not-a-user" using the provisioning API
     Then the OCS status code should be "404"
     And the HTTP status code should be "404"
     And the API should not return any data
 
   @smokeTest
-  Scenario: subadmin gets information of a user in his group
+  Scenario: a subadmin gets information of a user in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
 
-  @skip @issue-31276
-  Scenario: subadmin tries to get information of a user not in his group
+  Scenario: a subadmin tries to get information of a user not in their group
     Given user "subadmin" has been created
     And user "newuser" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-    Then the OCS status code should be "401"
+    When user "subadmin" retrieves the information of user "newuser" using the provisioning API
+    Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @skip @issue-31276
-  Scenario: normal user tries to get information of another user
+  Scenario: a normal user tries to get information of another user
     Given user "newuser" has been created
     And user "anotheruser" has been created
-    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
-    Then the OCS status code should be "401"
+    When user "anotheruser" retrieves the information of user "newuser" using the provisioning API
+    Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -277,13 +277,13 @@ trait CommandLine {
 		// end of the captured string, so trim them.
 		$text = \trim($text, $text[0]);
 		$lines = $this->findLines($this->lastStdOut, $text);
-		if (empty($lines)) {
-			throw new \Exception(
-				"The command output did not contain the expected text on stdout '$text'\n" .
-				"The command output on stdout was:\n" .
-				$this->lastStdOut
-			);
-		}
+		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+			1,
+			\count($lines),
+			"The command output did not contain the expected text on stdout '$text'\n" .
+			"The command output on stdout was:\n" .
+			$this->lastStdOut
+		);
 	}
 
 	/**
@@ -299,13 +299,13 @@ trait CommandLine {
 		// end of the captured string, so trim them.
 		$text = \trim($text, $text[0]);
 		$lines = $this->findLines($this->lastStdErr, $text);
-		if (empty($lines)) {
-			throw new \Exception(
-				"The command output did not contain the expected text on stderr '$text'\n" .
-				"The command output on stderr was:\n" .
-				$this->lastStdOut
-			);
-		}
+		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+			1,
+			\count($lines),
+			"The command output did not contain the expected text on stderr '$text'\n" .
+			"The command output on stderr was:\n" .
+			$this->lastStdErr
+		);
 	}
 
 	private $lastTransferPath;

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -534,6 +534,86 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" changes the email of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has changed the email of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $email
+	 *
+	 * @return void
+	 */
+	public function userChangesTheEmailOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser, $email
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			'email',
+			$email,
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
+	 * @When /^the administrator changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^the administrator has changed the display name of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $displayname
+	 *
+	 * @return void
+	 */
+	public function adminChangesTheDisplayNameOfTheUserUsingTheProvisioningApi(
+		$user, $displayname
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($user),
+			'display',
+			$displayname,
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+		if ($result->getStatusCode() !== 200) {
+			throw new \Exception(
+				"could not change display name of user. "
+				. $result->getStatusCode() . " " . $result->getBody()
+			);
+		}
+	}
+
+	/**
+	 * @When /^user "([^"]*)" changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has changed the display name of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $displayName
+	 *
+	 * @return void
+	 */
+	public function userChangesTheDisplayNameOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser, $displayName
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			'display',
+			$displayName,
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
 	 * @When /^the administrator changes the quota of user "([^"]*)" to "([^"]*)" using the provisioning API$/
 	 * @Given /^the administrator has changed the quota of user "([^"]*)" to "([^"]*)"$/
 	 *
@@ -561,6 +641,74 @@ trait Provisioning {
 				. $result->getStatusCode() . " " . $result->getBody()
 			);
 		}
+	}
+
+	/**
+	 * @When /^user "([^"]*)" changes the quota of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has changed the quota of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $quota
+	 *
+	 * @return void
+	 */
+	public function userChangesTheQuotaOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser, $quota
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			'quota',
+			$quota,
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
+	 * @When /^the administrator retrieves the information of user "([^"]*)" using the provisioning API$/
+	 * @Given /^the administrator has retrieved the information of user "([^"]*)"$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function adminRetrievesTheInformationOfUserUsingTheProvisioningApi(
+		$user
+	) {
+		$result = UserHelper::getUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($user),
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
+	}
+
+	/**
+	 * @When /^user "([^"]*)" retrieves the information of user "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has retrieved the information of user "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 *
+	 * @return void
+	 */
+	public function userRetrievesTheInformationOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser
+	) {
+		$result = UserHelper::getUser(
+			$this->getBaseUrl(),
+			$this->getActualUsername($targetUser),
+			$this->getActualUsername($requestingUser),
+			$this->getPasswordForUser($requestingUser),
+			$this->ocsApiVersion
+		);
+		$this->response = $result;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -526,6 +526,19 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" should be able to access a skeleton file$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userShouldBeAbleToAccessASkeletonFile($user) {
+		$this->contentOfFileForUserShouldBePlusEndOfLine(
+			"textfile0.txt", $user, "ownCloud test text file 0"
+		);
+	}
+
+	/**
 	 * @Then /^the downloaded content should be "([^"]*)"$/
 	 *
 	 * @param string $content

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -1,0 +1,31 @@
+@cli @skipOnLDAP
+Feature: add a user using the using the occ command
+
+  As an administrator
+  I want to be able to add users via the command line
+  So that I can give people controlled individual access to resources on the ownCloud server and
+  So that I can write scripts to add users
+
+  Scenario: admin creates an ordinary user using the occ command
+    When the administrator creates this user using the occ command:
+      | username  |
+      | justauser |
+    Then the command should have been successful
+    And the command output should contain the text 'The user "justauser" was created successfully'
+    And user "justauser" should exist
+    And user "justauser" should be able to access a skeleton file
+
+  Scenario: admin creates an ordinary user sspecifying attributes using the occ command
+    When the administrator creates this user using the occ command:
+      | username  | displayname | email                 |
+      | justauser | Just A User | justauser@example.com |
+    Then the command should have been successful
+    And the command output should contain the text 'The user "justauser" was created successfully'
+    And the command output should contain the text 'Display name set to "Just A User"'
+    And the command output should contain the text 'Email address set to "justauser@example.com"'
+    And user "justauser" should exist
+    And user "justauser" should be able to access a skeleton file
+    When the administrator retrieves the information of user "justauser" using the provisioning API
+    Then the user attributes returned by the API should include
+      | displayname      | Just A User           |
+      | email            | justauser@example.com |


### PR DESCRIPTION
## Description
1) Add a ``make test-acceptance-cli`` Makefile target.
2) Implement the pieces in ``.drone.yml`` ``behat.yml`` ``run.sh`` to know about the ``cli`` acceptance test suite type.
3) Make a ``cliProvisioning`` suite to get started.
4) Make ``addUser.feature`` with a couple of "easy" scenarios

## Related Issue
- Implements https://github.com/owncloud/QA/issues/570

## Motivation and Context
See issue, we need acceptance tests that test ``occ`` command behaviour.

## How Has This Been Tested?
```
make test-acceptance-cli
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: https://github.com/owncloud/docs/issues/140

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
