### PR TITLE
Relax tests for page title so they only check 'StringStartsWith'

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -430,7 +430,11 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function theUserShouldBeRedirectedToAWebUIPageWithTheTitle($title) {
 		$title = $this->replaceProductName($title);
 		$this->owncloudPage->waitForOutstandingAjaxCalls($this->getSession());
-		PHPUnit_Framework_Assert::assertEquals($title, $this->owncloudPage->getPageTitle());
+		// Just check that the actual title starts with the expected title.
+		// Theming can have other text following.
+		PHPUnit_Framework_Assert::assertStringStartsWith(
+			$title, $this->owncloudPage->getPageTitle()
+		);
 	}
 
 	/**
@@ -443,7 +447,9 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function theUserShouldBeRedirectedToGeneralErrorPage($title) {
 		$title = $this->replaceProductName($title);
 		$this->generalErrorPage->waitTillPageIsLoaded($this->getSession());
-		PHPUnit_Framework_Assert::assertEquals(
+		// Just check that the actual title starts with the expected title.
+		// Theming can have other text following.
+		PHPUnit_Framework_Assert::assertStringStartsWith(
 			$title, $this->generalErrorPage->getPageTitle()
 		);
 	}


### PR DESCRIPTION
## Description
Relax the webUI tests so they just check that the page title starts with the expected text.

## Motivation and Context
Some webUI tests check that the user has "arrived" at the correct page by checking for the expected page title in the browser. In some cases with theming there could be extra things after the page name and product name, e.g. ``Files - ownCloud`` - ``ownCloud`` can be branded and also have other things after it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
