### PR TITLE
Revert "Revert "preLogin hook should use string UID not IUser""

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -986,7 +986,7 @@ class Session implements IUserSession, Emitter {
 				return false;
 			}
 
-			$this->manager->emit('\OC\User', 'preLogin', [$user, $password]);
+			$this->manager->emit('\OC\User', 'preLogin', [$user->getUID(), $password]);
 
 			if (!$user->isEnabled()) {
 				$message = \OC::$server->getL10N('lib')->t('User disabled');

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1582,8 +1582,7 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->once())
 			->method('isEnabled')
 			->willReturn(false);
-		$iUser->expects($this->exactly(2))
-			->method('getUID')
+		$iUser->method('getUID')
 			->willReturn('foo');
 
 		$failedEvent = new GenericEvent(null, ['user' => 'foo']);


### PR DESCRIPTION
Had a chat with @tomneedham and the actual workflow of this emitter is as follows:

1) the first time it had string UID
2) later on, it got changed to IUser by mistake when moving to Symfony. This got released in some version.
3) then @tomneedham noticed that and provided this PR to revert this back to stage 1)

When looking at this I wasn't aware that there was a time where the event was correct in the past.
Considering this, I think we can accept this change again as it will bring it back to its original intended state.

@sharidas can you do some research to identify what versions the stages 1) and 2) were in to confirm ?