### PR TITLE
Remove string type-hints in Tags.php

### DIFF
--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -316,7 +316,7 @@ trait Tags {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFollowingTagsShouldNotExistForTheAdministrator(string $tagDisplayName) {
+	public function theFollowingTagsShouldNotExistForTheAdministrator($tagDisplayName) {
 		$this->tagShouldNotExistForUser($tagDisplayName, $this->getAdminUsername());
 	}
 
@@ -328,7 +328,7 @@ trait Tags {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFollowingTagsShouldNotExistForTheUser(string $tagDisplayName) {
+	public function theFollowingTagsShouldNotExistForTheUser($tagDisplayName) {
 		$this->tagShouldNotExistForUser($tagDisplayName, $this->getCurrentUser());
 	}
 


### PR DESCRIPTION
## Description
Remove ``string`` type-hints for now.

## Motivation and Context
Acceptance test code still needs to run in PHP 5.6 for a few more months.
Some code is using ``string`` type-hint that is PHP7-only.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
