### PR TITLE
Refactor acceptance test get-set-delete system config

### DIFF
--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -51,9 +51,9 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function prepareParameters() {
-		$value = SetupHelper::runOcc(
-			['config:system:get', 'apps_paths', '--output', 'json']
-		)['stdOut'];
+		$value = $this->featureContext->getSystemConfigValue(
+			'apps_paths', 'json'
+		);
 
 		if ($value === '') {
 			$this->oldAppsPaths = null;
@@ -72,7 +72,7 @@ class AppManagementContext implements Context {
 	 */
 	public function undoChangingParameters() {
 		if ($this->oldAppsPaths === null) {
-			SetupHelper::runOcc(['config:system:delete', 'apps_paths']);
+			$this->featureContext->deleteSystemConfig('apps_paths');
 		} else {
 			$this->setAppsPaths($this->oldAppsPaths);
 		}
@@ -86,15 +86,10 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function setAppsPaths($appsPaths) {
-		return SetupHelper::runOcc(
-			[
-				'config:system:set',
-				'apps_paths',
-				'--type',
-				'json',
-				'--value',
-				\json_encode($appsPaths)
-			]
+		return $this->featureContext->setSystemConfig(
+			'apps_paths',
+			\json_encode($appsPaths),
+			'json'
 		);
 	}
 
@@ -132,9 +127,7 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function appHasBeenPutInDir($appId, $version, $dir) {
-		$ocVersion = SetupHelper::runOcc(
-			['config:system:get', 'version']
-		)['stdOut'];
+		$ocVersion = $this->featureContext->getSystemConfigValue('version');
 		$appInfo = \sprintf(
 			'<?xml version="1.0"?>
 			<info>

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -43,42 +43,6 @@ class AppManagementContext implements Context {
 	private $cmdOutput;
 
 	/**
-	 * @BeforeScenario
-	 *
-	 * Remember the config values before each scenario
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function prepareParameters() {
-		$value = $this->featureContext->getSystemConfigValue(
-			'apps_paths', 'json'
-		);
-
-		if ($value === '') {
-			$this->oldAppsPaths = null;
-		} else {
-			$this->oldAppsPaths = \json_decode($value, true);
-		}
-	}
-
-	/**
-	 * @AfterScenario
-	 *
-	 * Reset the config values after each scenario
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function undoChangingParameters() {
-		if ($this->oldAppsPaths === null) {
-			$this->featureContext->deleteSystemConfig('apps_paths');
-		} else {
-			$this->setAppsPaths($this->oldAppsPaths);
-		}
-	}
-
-	/**
 	 *
 	 * @param array $appsPaths of apps_paths entries
 	 *
@@ -196,10 +160,36 @@ class AppManagementContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function before(BeforeScenarioScope $scope) {
+	public function prepareParameters(BeforeScenarioScope $scope) {
 		// Get the environment
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
+
+		$value = $this->featureContext->getSystemConfigValue(
+			'apps_paths', 'json'
+		);
+
+		if ($value === '') {
+			$this->oldAppsPaths = null;
+		} else {
+			$this->oldAppsPaths = \json_decode($value, true);
+		}
+	}
+
+	/**
+	 * @AfterScenario
+	 *
+	 * Reset the config values after each scenario
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function undoChangingParameters() {
+		if ($this->oldAppsPaths === null) {
+			$this->featureContext->deleteSystemConfig('apps_paths');
+		} else {
+			$this->setAppsPaths($this->oldAppsPaths);
+		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -294,15 +294,10 @@ trait Auth {
 		} else {
 			$value = 'false';
 		}
-		$this->runOcc(
-			[
-				'config:system:set',
-				'token_auth_enforced',
-				'--type',
-				'boolean',
-				'--value',
-				$value
-			]
+		$this->setSystemConfig(
+			'token_auth_enforced',
+			$value,
+			'boolean'
 		);
 
 		// Remember that we set this value, so it can be removed after the scenario
@@ -329,11 +324,8 @@ trait Auth {
 			} else {
 				$appTokenForOccCommand = null;
 			}
-			$this->runOcc(
-				[
-					'config:system:delete',
-					'token_auth_enforced'
-				],
+			$this->deleteSystemConfig(
+				'token_auth_enforced',
 				null,
 				$appTokenForOccCommand,
 				null,

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -659,23 +659,12 @@ trait BasicStructure {
 	 * @return string the previous setting of csrf.disabled
 	 */
 	public function setCSRFDotDisabled($setting) {
-		$oldCSRFSetting = SetupHelper::runOcc(
-			['config:system:get', 'csrf.disabled']
-		)['stdOut'];
+		$oldCSRFSetting = $this->getSystemConfigValue('csrf.disabled');
 
 		if ($setting === "") {
-			SetupHelper::runOcc(['config:system:delete', 'csrf.disabled']);
+			$this->deleteSystemConfig('csrf.disabled');
 		} elseif (($setting === 'true') || ($setting === 'false')) {
-			SetupHelper::runOcc(
-				[
-					'config:system:set',
-					'csrf.disabled',
-					'--type',
-					'boolean',
-					'--value',
-					$setting
-				]
-			);
+			$this->setSystemConfig('csrf.disabled', $setting, 'boolean');
 		} else {
 			throw new \http\Exception\InvalidArgumentException(
 				'setting must be "true", "false" or ""'

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -71,6 +71,165 @@ trait CommandLine {
 	}
 
 	/**
+	 * Set a system config setting
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @param string|null $type e.g. boolean or json
+	 * @param string|null $output e.g. json
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 * @param string|null $baseUrl
+	 * @param string|null $ocPath
+	 *
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 * @throws Exception if parameters have not been provided yet or the testing app is not enabled
+	 */
+	public function setSystemConfig(
+		$key,
+		$value,
+		$type = null,
+		$output = null,
+		$adminUsername = null,
+		$adminPassword = null,
+		$baseUrl = null,
+		$ocPath = null
+	) {
+		$args = [];
+		$args[] = 'config:system:set';
+		$args[] = $key;
+		$args[] = '--value';
+		$args[] = $value;
+
+		if ($type !== null) {
+			$args[] = '--type';
+			$args[] = $type;
+		}
+
+		if ($output !== null) {
+			$args[] = '--output';
+			$args[] = $output;
+		}
+
+		$args[] = '--no-ansi';
+
+		return SetupHelper::runOcc(
+			$args,
+			$adminUsername,
+			$adminPassword,
+			$baseUrl,
+			$ocPath
+		);
+	}
+
+	/**
+	 * Get a system config setting, including status code, output and standard
+	 * error output.
+	 *
+	 * @param string $key
+	 * @param string|null $output e.g. json
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 * @param string|null $baseUrl
+	 * @param string|null $ocPath
+	 *
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 * @throws Exception if parameters have not been provided yet or the testing app is not enabled
+	 */
+	public function getSystemConfig(
+		$key,
+		$output = null,
+		$adminUsername = null,
+		$adminPassword = null,
+		$baseUrl = null,
+		$ocPath = null
+	) {
+		$args = [];
+		$args[] = 'config:system:get';
+		$args[] = $key;
+
+		if ($output !== null) {
+			$args[] = '--output';
+			$args[] = $output;
+		}
+
+		$args[] = '--no-ansi';
+
+		return SetupHelper::runOcc(
+			$args,
+			$adminUsername,
+			$adminPassword,
+			$baseUrl,
+			$ocPath
+		);
+	}
+
+	/**
+	 * Get the value of a system config setting
+	 *
+	 * @param string $key
+	 * @param string|null $output e.g. json
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 * @param string|null $baseUrl
+	 * @param string|null $ocPath
+	 *
+	 * @return string
+	 * @throws Exception if parameters have not been provided yet or the testing app is not enabled
+	 */
+	public function getSystemConfigValue(
+		$key,
+		$output = null,
+		$adminUsername = null,
+		$adminPassword = null,
+		$baseUrl = null,
+		$ocPath = null
+	) {
+		return $this->getSystemConfig(
+			$key,
+			$output,
+			$adminUsername,
+			$adminPassword,
+			$baseUrl,
+			$ocPath
+		)['stdOut'];
+	}
+
+	/**
+	 * Delete a system config setting
+	 *
+	 * @param string $key
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 * @param string|null $baseUrl
+	 * @param string|null $ocPath
+	 *
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 * @throws Exception if parameters have not been provided yet or the testing app is not enabled
+	 */
+	public function deleteSystemConfig(
+		$key,
+		$adminUsername = null,
+		$adminPassword = null,
+		$baseUrl = null,
+		$ocPath = null
+	) {
+		$args = [];
+		$args[] = 'config:system:delete';
+		$args[] = $key;
+
+		$args[] = '--no-ansi';
+
+		return SetupHelper::runOcc(
+			$args,
+			$adminUsername,
+			$adminPassword,
+			$baseUrl,
+			$ocPath
+		);
+	}
+
+	/**
 	 * Invokes an OCC command
 	 *
 	 * @param array $args of the occ command

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -194,7 +194,9 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 			}
 			// Save the app configs
 			$this->appParameterValues = $results;
-			$this->logLevelValue = SetupHelper::runOcc(["config:system:get loglevel"])['stdOut'];
+			$this->logLevelValue = $this->featureContext->getSystemConfigValue(
+				"loglevel"
+			);
 		}
 	}
 
@@ -205,7 +207,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	 */
 	public function theVersionOfOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
 		$actualVersion = $this->adminGeneralSettingsPage->getOwncloudVersion();
-		$expectedVersion = SetupHelper::runOcc(['config:system:get version'])['stdOut'];
+		$expectedVersion = $this->featureContext->getSystemConfigValue('version');
 		PHPUnit_Framework_Assert::assertEquals(\trim($expectedVersion), $actualVersion);
 	}
 
@@ -237,6 +239,8 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 			$this->featureContext->getAdminPassword(),
 			$this->appParameterValues
 		);
-		SetupHelper::runOcc(["config:system:set loglevel --value $this->logLevelValue"]);
+		$this->featureContext->setSystemConfig(
+			"loglevel", $this->logLevelValue
+		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -616,20 +616,15 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		);
 
 		if ($this->oldCSRFSetting === null) {
-			$oldCSRFSetting = SetupHelper::runOcc(
-				['config:system:get', 'csrf.disabled']
-			)['stdOut'];
+			$oldCSRFSetting = $this->featureContext->getSystemConfigValue(
+				'csrf.disabled'
+			);
 			$this->oldCSRFSetting = \trim($oldCSRFSetting);
 		}
-		SetupHelper::runOcc(
-			[
-				'config:system:set',
-				'csrf.disabled',
-				'--type',
-				'boolean',
-				'--value',
-				'true'
-			]
+		$this->featureContext->setSystemConfig(
+			'csrf.disabled',
+			'true',
+			'boolean'
 		);
 
 		//TODO make it smarter to be able also to work with other backends
@@ -658,20 +653,13 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function disablePreviewBeforeScenario() {
 		if ($this->oldPreviewSetting === null) {
-			$oldPreviewSetting = SetupHelper::runOcc(
-				['config:system:get', 'enable_previews']
-			)['stdOut'];
+			$oldPreviewSetting = $this->featureContext->getSystemConfigValue(
+				'enable_previews'
+			);
 			$this->oldPreviewSetting = \trim($oldPreviewSetting);
 		}
-		SetupHelper::runOcc(
-			[
-				'config:system:set',
-				'enable_previews',
-				'--type',
-				'boolean',
-				'--value',
-				'false'
-			]
+		$this->featureContext->setSystemConfig(
+			'enable_previews', 'false', 'boolean'
 		);
 	}
 
@@ -689,20 +677,13 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function enablePreviewBeforeScenario() {
 		if ($this->oldPreviewSetting === null) {
-			$oldPreviewSetting = SetupHelper::runOcc(
-				['config:system:get', 'enable_previews']
-			)['stdOut'];
+			$oldPreviewSetting = $this->featureContext->getSystemConfigValue(
+				'enable_previews'
+			);
 			$this->oldPreviewSetting = \trim($oldPreviewSetting);
 		}
-		SetupHelper::runOcc(
-			[
-				'config:system:set',
-				'enable_previews',
-				'--type',
-				'boolean',
-				'--value',
-				'true'
-			]
+		$this->featureContext->setSystemConfig(
+			'enable_previews', 'true', 'boolean'
 		);
 	}
 
@@ -733,32 +714,18 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		);
 
 		if ($this->oldPreviewSetting === "") {
-			SetupHelper::runOcc(['config:system:delete', 'enable_previews']);
+			$this->featureContext->deleteSystemConfig('enable_previews');
 		} elseif ($this->oldPreviewSetting !== null) {
-			SetupHelper::runOcc(
-				[
-					'config:system:set',
-					'enable_previews',
-					'--type',
-					'boolean',
-					'--value',
-					$this->oldPreviewSetting
-				]
+			$this->featureContext->setSystemConfig(
+				'enable_previews', $this->oldPreviewSetting, 'boolean'
 			);
 		}
 		
 		if ($this->oldCSRFSetting === "") {
-			SetupHelper::runOcc(['config:system:delete', 'csrf.disabled']);
+			$this->featureContext->deleteSystemConfig('csrf.disabled');
 		} elseif ($this->oldCSRFSetting !== null) {
-			SetupHelper::runOcc(
-				[
-					'config:system:set',
-					'csrf.disabled',
-					'--type',
-					'boolean',
-					'--value',
-					$this->oldCSRFSetting
-				]
+			$this->featureContext->setSystemConfig(
+				'csrf.disabled', $this->oldCSRFSetting, 'boolean'
 			);
 		}
 		

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -482,21 +482,17 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function setMinCharactersForAutocomplete($minCharacters) {
 		if ($this->oldMinCharactersForAutocomplete === null) {
-			$oldMinCharactersForAutocomplete = SetupHelper::runOcc(
-				['config:system:get', 'user.search_min_length']
-			)['stdOut'];
+			$oldMinCharactersForAutocomplete
+				= $this->featureContext->getSystemConfigValue(
+					'user.search_min_length'
+				);
 			$this->oldMinCharactersForAutocomplete = \trim(
 				$oldMinCharactersForAutocomplete
 			);
 		}
 		$minCharacters = (int) $minCharacters;
-		SetupHelper::runOcc(
-			[
-				'config:system:set',
-				'user.search_min_length',
-				'--value',
-				$minCharacters
-			]
+		$this->featureContext->setSystemConfig(
+			'user.search_min_length', $minCharacters
 		);
 	}
 
@@ -508,20 +504,16 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function allowHttpFallbackForFedSharing() {
 		if ($this->oldFedSharingFallbackSetting === null) {
-			$oldFedSharingFallbackSetting = SetupHelper::runOcc(
-				['config:system:get', 'sharing.federation.allowHttpFallback']
-			)['stdOut'];
+			$oldFedSharingFallbackSetting
+				= $this->featureContext->getSystemConfigValue(
+					'sharing.federation.allowHttpFallback'
+				);
 			$this->oldFedSharingFallbackSetting = \trim(
 				$oldFedSharingFallbackSetting
 			);
 		}
-		SetupHelper::runOcc(
-			[
-				'config:system:set',
-				'sharing.federation.allowHttpFallback',
-				'--type boolean',
-				'--value true',
-			]
+		$this->featureContext->setSystemConfig(
+			'sharing.federation.allowHttpFallback', 'true', 'boolean'
 		);
 	}
 
@@ -1106,31 +1098,23 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function tearDownScenario() {
 		//TODO make a function that can be used for different settings
 		if ($this->oldMinCharactersForAutocomplete === "") {
-			SetupHelper::runOcc(['config:system:delete', 'user.search_min_length']);
+			$this->featureContext->deleteSystemConfig('user.search_min_length');
 		} elseif ($this->oldMinCharactersForAutocomplete !== null) {
-			SetupHelper::runOcc(
-				[
-					'config:system:set',
-					'user.search_min_length',
-					'--value',
-					$this->oldMinCharactersForAutocomplete
-				]
+			$this->featureContext->setSystemConfig(
+				'user.search_min_length',
+				$this->oldMinCharactersForAutocomplete
 			);
 		}
 
 		if ($this->oldFedSharingFallbackSetting === "") {
-			SetupHelper::runOcc(
-				['config:system:delete', 'sharing.federation.allowHttpFallback']
+			$this->featureContext->deleteSystemConfig(
+				'sharing.federation.allowHttpFallback'
 			);
 		} elseif ($this->oldFedSharingFallbackSetting !== null) {
-			SetupHelper::runOcc(
-				[
-					'config:system:set',
-					'sharing.federation.allowHttpFallback',
-					'--type boolean',
-					'--value',
-					$this->oldFedSharingFallbackSetting
-				]
+			$this->featureContext->setSystemConfig(
+				'sharing.federation.allowHttpFallback',
+				$this->oldFedSharingFallbackSetting,
+				'boolean'
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Add new convenience methods to ``CommandLine.php`` to set/get/delete system configs.
Call them.

## Related Issue
- Fixes #32666 

## Motivation and Context
See issue

## How Has This Been Tested?
Local runs of some acceptance test feature files

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
