### PR TITLE
Flexible location of behat.yml

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -578,7 +578,22 @@ fi
 
 if [ -z "${BEHAT_YML}" ]
 then
-	BEHAT_YML="${SCRIPT_PATH}/config/behat.yml"
+	# Look for a behat.yml somewhere below the current working directory
+	# This saves app acceptance tests being forced to specify BEHAT_YML
+	BEHAT_YML="config/behat.yml"
+	if [ ! -f "${BEHAT_YML}" ]
+	then
+		BEHAT_YML="acceptance/config/behat.yml"
+	fi
+	if [ ! -f "${BEHAT_YML}" ]
+	then
+		BEHAT_YML="tests/acceptance/config/behat.yml"
+	fi
+	# If no luck above, then use the core behat.yml that should live below this script
+	if [ ! -f "${BEHAT_YML}" ]
+	then
+		BEHAT_YML="${SCRIPT_PATH}/config/behat.yml"
+	fi
 fi
 
 # MAILHOG_HOST defines where the system-under-test can find the MailHog server


### PR DESCRIPTION
## Description
In ``run.sh``, if the ``behat.yml`` is not explicitly passed in, go looking for one in paths like ``tests/acceptance/config/behat.yml`` under the current working directory. This lets you sit somewhere in an app directory and just:
```
	../../tests/acceptance/run.sh --type api
```
and have something sensible happen.
(where previously it would have used the core ``behat.yml`` and probably tried to run the core api tests)

## Motivation and Context
App acceptance tests always have to specify where to find their ``behat.yml``, e.g. from the app root folder:
```
	../../tests/acceptance/run.sh --config tests/acceptance/config/behat.yml --type api
```

We can make ``run.sh`` smarter so it can go looking for a ``behat.yml`` somewhere under the current working directory.

## How Has This Been Tested?
Local ``make test-acceptance-api`` from core or apps 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
