### PR TITLE
Collaborative tags new category work

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagNode.php
+++ b/apps/dav/lib/SystemTag/SystemTagNode.php
@@ -111,11 +111,12 @@ class SystemTagNode implements \Sabre\DAV\INode {
 	 * @param string $name new tag name
 	 * @param bool $userVisible user visible
 	 * @param bool $userAssignable user assignable
+	 * @param bool $userEditable user editable
 	 * @throws NotFound whenever the given tag id does not exist
 	 * @throws Forbidden whenever there is no permission to update said tag
 	 * @throws Conflict whenever a tag already exists with the given attributes
 	 */
-	public function update($name, $userVisible, $userAssignable) {
+	public function update($name, $userVisible, $userAssignable, $userEditable = false) {
 		try {
 			if (!$this->tagManager->canUserSeeTag($this->tag, $this->user)) {
 				throw new NotFound('Tag with id ' . $this->tag->getId() . ' does not exist');
@@ -134,7 +135,7 @@ class SystemTagNode implements \Sabre\DAV\INode {
 				}
 			}
 
-			$this->tagManager->updateTag($this->tag->getId(), $name, $userVisible, $userAssignable);
+			$this->tagManager->updateTag($this->tag->getId(), $name, $userVisible, $userAssignable, $userEditable);
 		} catch (TagNotFoundException $e) {
 			throw new NotFound('Tag with id ' . $this->tag->getId() . ' does not exist');
 		} catch (TagAlreadyExistsException $e) {

--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -50,9 +50,11 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 	const ID_PROPERTYNAME = '{http://owncloud.org/ns}id';
 	const DISPLAYNAME_PROPERTYNAME = '{http://owncloud.org/ns}display-name';
 	const USERVISIBLE_PROPERTYNAME = '{http://owncloud.org/ns}user-visible';
+	const USEREDITABLE_PROPERTYNAME = '{http://owncloud.org/ns}user-editable';
 	const USERASSIGNABLE_PROPERTYNAME = '{http://owncloud.org/ns}user-assignable';
 	const GROUPS_PROPERTYNAME = '{http://owncloud.org/ns}groups';
 	const CANASSIGN_PROPERTYNAME = '{http://owncloud.org/ns}can-assign';
+	const WHITELISTEDINGROUP = '{http://owncloud.org/ns}editable-in-group';
 
 	/**
 	 * @var \Sabre\DAV\Server $server
@@ -172,6 +174,7 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 		$tagName = $data['name'];
 		$userVisible = true;
 		$userAssignable = true;
+		$userEditable = false;
 
 		if (isset($data['userVisible'])) {
 			$userVisible = (bool)$data['userVisible'];
@@ -179,6 +182,10 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 
 		if (isset($data['userAssignable'])) {
 			$userAssignable = (bool)$data['userAssignable'];
+		}
+
+		if (isset($data['userEditable'])) {
+			$userEditable = (bool)$data['userEditable'];
 		}
 
 		$groups = [];
@@ -196,7 +203,7 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 		}
 
 		try {
-			$tag = $this->tagManager->createTag($tagName, $userVisible, $userAssignable);
+			$tag = $this->tagManager->createTag($tagName, $userVisible, $userAssignable, $userEditable);
 			if (!empty($groups)) {
 				$this->tagManager->setTagGroups($tag, $groups);
 			}
@@ -232,6 +239,11 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			return $node->getSystemTag()->isUserVisible() ? 'true' : 'false';
 		});
 
+		$propFind->handle(self::USEREDITABLE_PROPERTYNAME, function () use ($node) {
+			// this is the tag's inherent property "is user editable"
+			return $node->getSystemTag()->isUserEditable() ? 'true' : 'false';
+		});
+
 		$propFind->handle(self::USERASSIGNABLE_PROPERTYNAME, function () use ($node) {
 			// this is the tag's inherent property "is user assignable"
 			return $node->getSystemTag()->isUserAssignable() ? 'true' : 'false';
@@ -249,10 +261,19 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 			$groups = [];
 			// no need to retrieve groups for namespaces that don't qualify
-			if ($node->getSystemTag()->isUserVisible() && !$node->getSystemTag()->isUserAssignable()) {
+			$restrictedTagCondition = $node->getSystemTag()->isUserVisible() &&
+				(!$node->getSystemTag()->isUserAssignable());
+			$editableTagCondition = $node->getSystemTag()->isUserVisible() &&
+				$node->getSystemTag()->isUserAssignable() &&
+				(!$node->getSystemTag()->isUserEditable());
+			if ($restrictedTagCondition || $editableTagCondition) {
 				$groups = $this->tagManager->getTagGroups($node->getSystemTag());
 			}
 			return \implode('|', $groups);
+		});
+
+		$propFind->handle(self::WHITELISTEDINGROUP, function () use ($node) {
+			return $this->tagManager->canUserUseStaticTagInGroup($node->getSystemTag(), $this->userSession->getUser()) ? 'true' : 'false';
 		});
 	}
 
@@ -273,12 +294,14 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 		$propPatch->handle([
 			self::DISPLAYNAME_PROPERTYNAME,
 			self::USERVISIBLE_PROPERTYNAME,
+			self::USEREDITABLE_PROPERTYNAME,
 			self::USERASSIGNABLE_PROPERTYNAME,
 			self::GROUPS_PROPERTYNAME,
 		], function ($props) use ($node) {
 			$tag = $node->getSystemTag();
 			$name = $tag->getName();
 			$userVisible = $tag->isUserVisible();
+			$userEditable = $tag->isUserEditable();
 			$userAssignable = $tag->isUserAssignable();
 
 			$updateTag = false;
@@ -291,6 +314,12 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			if (isset($props[self::USERVISIBLE_PROPERTYNAME])) {
 				$propValue = $props[self::USERVISIBLE_PROPERTYNAME];
 				$userVisible = ($propValue !== 'false' && $propValue !== '0');
+				$updateTag = true;
+			}
+
+			if (isset($props[self::USEREDITABLE_PROPERTYNAME])) {
+				$propValue = $props[self::USEREDITABLE_PROPERTYNAME];
+				$userEditable = ($propValue !== 'true' && $propValue !== '1');
 				$updateTag = true;
 			}
 
@@ -312,7 +341,7 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 
 			if ($updateTag) {
-				$node->update($name, $userVisible, $userAssignable);
+				$node->update($name, $userVisible, $userAssignable, $userEditable);
 			}
 
 			return true;

--- a/apps/dav/lib/SystemTag/SystemTagsByIdCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsByIdCollection.php
@@ -119,7 +119,7 @@ class SystemTagsByIdCollection implements ICollection {
 			$visibilityFilter = null;
 		}
 
-		$tags = $this->tagManager->getAllTags($visibilityFilter);
+		$tags = $this->tagManager->getAllTags($visibilityFilter, null);
 		return \array_map(function ($tag) {
 			return $this->makeNode($tag);
 		}, $tags);

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -39,6 +39,8 @@ class SystemTagPluginTest extends \Test\TestCase {
 	const USERASSIGNABLE_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::USERASSIGNABLE_PROPERTYNAME;
 	const CANASSIGN_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::CANASSIGN_PROPERTYNAME;
 	const GROUPS_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::GROUPS_PROPERTYNAME;
+	const USEREDITABLE_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::USEREDITABLE_PROPERTYNAME;
+	const WHITELISTEDINGROUP = \OCA\DAV\SystemTag\SystemTagPlugin::WHITELISTEDINGROUP;
 
 	/**
 	 * @var \Sabre\DAV\Server
@@ -114,7 +116,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 					self::DISPLAYNAME_PROPERTYNAME,
 					self::USERVISIBLE_PROPERTYNAME,
 					self::USERASSIGNABLE_PROPERTYNAME,
-					self::CANASSIGN_PROPERTYNAME,
+					self::CANASSIGN_PROPERTYNAME
 				],
 				[
 					self::ID_PROPERTYNAME => '1',
@@ -155,16 +157,20 @@ class SystemTagPluginTest extends \Test\TestCase {
 				]
 			],
 			[
-				new SystemTag(1, 'Test', true, true),
+				new SystemTag(1, 'Test', true, true, true),
 				['group1', 'group2'],
 				[
 					self::ID_PROPERTYNAME,
 					self::GROUPS_PROPERTYNAME,
+					self::USEREDITABLE_PROPERTYNAME,
+					self::WHITELISTEDINGROUP,
 				],
 				[
 					self::ID_PROPERTYNAME => '1',
 					// groups only returned when userAssignable is false
 					self::GROUPS_PROPERTYNAME => '',
+					self::USEREDITABLE_PROPERTYNAME => 'true',
+					self::WHITELISTEDINGROUP => 'false'
 				]
 			],
 		];
@@ -297,6 +303,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$propPatch = new \Sabre\DAV\PropPatch([
 			self::DISPLAYNAME_PROPERTYNAME => 'Test changed',
 			self::USERVISIBLE_PROPERTYNAME => 'false',
+			self::USEREDITABLE_PROPERTYNAME => 'true',
 			self::USERASSIGNABLE_PROPERTYNAME => 'true',
 			self::GROUPS_PROPERTYNAME => 'group1|group2',
 		]);
@@ -315,6 +322,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$this->assertEquals(200, $result[self::DISPLAYNAME_PROPERTYNAME]);
 		$this->assertEquals(200, $result[self::USERASSIGNABLE_PROPERTYNAME]);
 		$this->assertEquals(200, $result[self::USERVISIBLE_PROPERTYNAME]);
+		$this->assertEquals(200, $result[self::USEREDITABLE_PROPERTYNAME]);
 	}
 
 	/**

--- a/core/Migrations/Version20181017105216.php
+++ b/core/Migrations/Version20181017105216.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+class Version20181017105216 implements ISchemaMigration {
+
+	/** @var string */
+	private $prefix;
+
+	public function changeSchema(Schema $schema, array $options) {
+		$this->prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$this->prefix}systemtag");
+		if ($schema->hasTable("{$this->prefix}systemtag")) {
+			if (!$table->hasColumn('assignable')) {
+				$table->addColumn('assignable', 'integer');
+				$assignableColumn = $table->getColumn('assignable');
+				$assignableColumn->setDefault(0);
+			}
+		}
+	}
+}

--- a/core/Migrations/Version20181017120818.php
+++ b/core/Migrations/Version20181017120818.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migrations;
+
+use OCP\IDBConnection;
+use OCP\Migration\ISqlMigration;
+
+/**
+ * Added extra column assignable to systemtag table, post 10.0.10.1 version
+ * this is required to identify editable tag. It is only
+ * set to "1" for visible and editable tags.
+ */
+class Version20181017120818 implements ISqlMigration {
+	public function sql(IDBConnection $connection) {
+		$valueToUpdate = 1;
+		$qb = $connection->getQueryBuilder();
+		$qb->update('systemtag')
+			->set(
+				'assignable',
+				$qb->expr()->literal($valueToUpdate)
+			)
+			->where(
+				$qb->expr()->eq(
+					'visibility',
+					$qb->expr()->literal($valueToUpdate)
+				)
+			)
+			->andWhere(
+				$qb->expr()->eq(
+					'editable',
+					$qb->expr()->literal($valueToUpdate)
+				)
+			);
+		return [$qb->getSQL()];
+	}
+}

--- a/core/js/systemtags/systemtagmodel.js
+++ b/core/js/systemtags/systemtagmodel.js
@@ -15,7 +15,9 @@
 		PROPERTY_CAN_ASSIGN:'{' + OC.Files.Client.NS_OWNCLOUD + '}can-assign',
 		PROPERTY_DISPLAYNAME:	'{' + OC.Files.Client.NS_OWNCLOUD + '}display-name',
 		PROPERTY_USERVISIBLE:	'{' + OC.Files.Client.NS_OWNCLOUD + '}user-visible',
+		PROPERTY_USEREDITABLE:'{' + OC.Files.Client.NS_OWNCLOUD + '}user-editable',
 		PROPERTY_USERASSIGNABLE:'{' + OC.Files.Client.NS_OWNCLOUD + '}user-assignable',
+		PROPERTY_WHITELISTEDINGROUP:'{' + OC.Files.Client.NS_OWNCLOUD + '}editable-in-group'
 	});
 
 	/**
@@ -39,18 +41,29 @@
 			'id':	OC.Files.Client.PROPERTY_FILEID,
 			'name': OC.Files.Client.PROPERTY_DISPLAYNAME,
 			'userVisible': 	OC.Files.Client.PROPERTY_USERVISIBLE,
+			'userEditable':  OC.Files.Client.PROPERTY_USEREDITABLE,
 			'userAssignable': 	OC.Files.Client.PROPERTY_USERASSIGNABLE,
+			'editableInGroup':	OC.Files.Client.PROPERTY_WHITELISTEDINGROUP,
 			// read-only, effective permissions computed by the server,
 			'canAssign': OC.Files.Client.PROPERTY_CAN_ASSIGN
 		},
 
 		parse: function(data) {
+			var userEditable;
+			//If assignable is false, just set editable to false
+			if (data.userAssignable === false) {
+				userEditable = false;
+			} else {
+				userEditable = (data.userEditable === true || data.userEditable === 'true');
+			}
 			return {
 				id: data.id,
 				name: data.name,
 				userVisible: data.userVisible === true || data.userVisible === 'true',
+				userEditable: userEditable,
 				userAssignable: data.userAssignable === true || data.userAssignable === 'true',
-				canAssign: data.canAssign === true || data.canAssign === 'true'
+				canAssign: data.canAssign === true || data.canAssign === 'true',
+				editableInGroup: data.editableInGroup === true || data.editableInGroup === 'true'
 			};
 		}
 	});

--- a/core/js/systemtags/systemtags.js
+++ b/core/js/systemtags/systemtags.js
@@ -42,6 +42,13 @@
 				// invisible also implicitly means not assignable
 				scope = t('core', 'invisible');
 			}
+			if (tag.userVisible === true && tag.userEditable === false && tag.userAssignable === true) {
+				/**
+				 * Users can edit the tag, if they are admin or belong to whitelisted
+				 * group by the edit tag.
+				 */
+				scope = t('core', 'Static')
+			}
 			if (scope) {
 				var $tag = $('<em>').text(' ' +
 					t('core', '({scope})', {

--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -207,6 +207,7 @@
 					name: e.object.name.trim(),
 					userVisible: true,
 					userAssignable: true,
+					userEditable: true,
 					canAssign: true
 				}, {
 					success: function(model) {
@@ -279,6 +280,16 @@
 		},
 
 		/**
+		 * Returns true if tag is static tag else false
+		 *
+		 * @param data
+		 * @returns {boolean}
+		 */
+		_isStaticTag: function(data) {
+			return data.userEditable === false && data.userAssignable === true;
+		},
+
+		/**
 		 * Formats a single dropdown result
 		 *
 		 * @param {Object} data data to format
@@ -288,6 +299,25 @@
 			if (!this._resultTemplate) {
 				this._resultTemplate = Handlebars.compile(RESULT_TEMPLATE);
 			}
+
+			/**
+			 * Static tags are shown if the user belongs to group which is
+			 * whitelisted in the tag. Else the tag is not seen. If the tag
+			 * is visible, then no edit options are availbe to users. Admin user
+			 * is the only exception here. Admin user can edit, delete, assign or
+			 * unassign the tag.
+			 *
+			 */
+			this._allowActions = true;
+			if (data.editableInGroup === false && this._isStaticTag(data)) {
+				//No need to show the static tag as it is not viewable for the user
+				return;
+			}
+			if (this._isStaticTag(data)) {
+				//Show the name of the static tag, rename and delete actions are forbidden for the user
+				this._allowActions = false;
+			}
+
 			return this._resultTemplate(_.extend({
 				renameTooltip: t('core', 'Rename'),
 				allowActions: this._allowActions,

--- a/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
+++ b/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
@@ -113,6 +113,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 					name: 'newname',
 					userVisible: true,
 					userAssignable: true,
+					userEditable: true,
 					canAssign: true
 				});
 
@@ -191,6 +192,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 					name: 'newname',
 					userVisible: true,
 					userAssignable: true,
+					userEditable: true,
 					canAssign: true
 				});
 
@@ -369,6 +371,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 					new OC.SystemTags.SystemTagModel({id: '2', name: 'def'}),
 					new OC.SystemTags.SystemTagModel({id: '3', name: 'abd', userAssignable: false, canAssign: false}),
 					new OC.SystemTags.SystemTagModel({id: '4', name: 'Deg'}),
+					new OC.SystemTags.SystemTagModel({id: '5', name: 'staticTag', editableInGroup: true, canAssign: true, userAssignable: true, userEditable: false, userVisible: true})
 				]);
 			});
 			afterEach(function() {
@@ -399,6 +402,28 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 						userVisible: true,
 						userAssignable: false,
 						canAssign: false
+					}
+				]);
+			});
+			it('check static tag result', function () {
+				var callback = sinon.stub();
+				opts.query({
+					term: 'sta',
+					callback: callback
+				});
+				expect(fetchStub.calledOnce).toEqual(true);
+
+				fetchStub.yieldTo('success', view.collection);
+
+				expect(callback.getCall(0).args[0].results).toEqual([
+					{
+						id: '5',
+						name: 'staticTag',
+						editableInGroup: true,
+						canAssign: true,
+						userAssignable: true,
+						userEditable: false,
+						userVisible: true
 					}
 				]);
 			});
@@ -450,6 +475,30 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 			var opts = select2Stub.getCall(0).args[0];
 			var $el = $(opts.formatSelection({id: '1', name: 'test'}));
 			expect($el.text().trim()).toEqual('test');
+		});
+		it('formatSelection renders visibleTag', function () {
+			var opts = select2Stub.getCall(0).args[0];
+			var $el = $(opts.formatResult({id: '1', name: 'visibleTag', userAssignable: true, userEditable: true, userVisible: true, canAssign: true, editableInGroup: false}));
+			expect($el.find('.label').text()).toEqual('visibleTag');
+			expect($el.find('.rename').length).toEqual(1);
+		});
+		it('formatSelection renders restrictedTag', function () {
+			var opts = select2Stub.getCall(0).args[0];
+			var $el = $(opts.formatResult({id: '1', name: 'restrictTag', userAssignable: false, userEditable: false, userVisible: true, canAssign: true, editableInGroup: true}));
+			expect($el.find('.label').text()).toEqual('restrictTag');
+			expect($el.find('.rename').length).toEqual(1);
+		});
+		it('formatSelection renders staticTag', function () {
+			var opts = select2Stub.getCall(0).args[0];
+			var $el = $(opts.formatResult({id: '1', name: 'staticTag', userAssignable: true, userEditable: false, userVisible: true, canAssign: true, editableInGroup: true}));
+			expect($el.find('.label').text()).toEqual('staticTag');
+			expect($el.find('.rename').length).toEqual(0);
+		});
+		it('formatSelection renders staticTag should not showup', function () {
+			var opts = select2Stub.getCall(0).args[0];
+			var $el = $(opts.formatResult({id: '1', name: 'staticTag', userAssignable: true, userEditable: false, userVisible: true, canAssign: true, editableInGroup: false}));
+			expect($el.find('.label').text()).toEqual('');
+			expect($el.find('.rename').length).toEqual(0);
 		});
 		describe('initSelection', function() {
 			var fetchStub;

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1084,6 +1084,15 @@
 				<length>1</length>
 			</field>
 
+			<!-- Assignable: 0 user-not-assignable, 1 user-assignable -->
+			<field>
+				<name>assignable</name>
+				<type>integer</type>
+				<default>1</default>
+				<notnull>true</notnull>
+				<length>1</length>
+			</field>
+
 			<index>
 				<name>tag_ident</name>
 				<unique>true</unique>
@@ -1097,6 +1106,10 @@
 				</field>
 				<field>
 					<name>editable</name>
+					<sorting>ascending</sorting>
+				</field>
+				<field>
+					<name>assignable</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/lib/private/SystemTag/SystemTag.php
+++ b/lib/private/SystemTag/SystemTag.php
@@ -44,6 +44,11 @@ class SystemTag implements ISystemTag {
 	/**
 	 * @var bool
 	 */
+	private $userEditable;
+
+	/**
+	 * @var bool
+	 */
 	private $userAssignable;
 
 	/**
@@ -53,11 +58,13 @@ class SystemTag implements ISystemTag {
 	 * @param string $name tag name
 	 * @param bool $userVisible whether the tag is user visible
 	 * @param bool $userAssignable whether the tag is user assignable
+	 * @param bool $userEditable whether the tag is user assignable
 	 */
-	public function __construct($id, $name, $userVisible, $userAssignable) {
+	public function __construct($id, $name, $userVisible, $userAssignable, $userEditable = false) {
 		$this->id = $id;
 		$this->name = $name;
 		$this->userVisible = $userVisible;
+		$this->userEditable = $userEditable;
 		$this->userAssignable = $userAssignable;
 	}
 
@@ -87,5 +94,12 @@ class SystemTag implements ISystemTag {
 	 */
 	public function isUserAssignable() {
 		return $this->userAssignable;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isUserEditable() {
+		return $this->userEditable;
 	}
 }

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -77,7 +77,8 @@ class SystemTagManager implements ISystemTagManager {
 			->from(self::TAG_TABLE)
 			->where($query->expr()->eq('name', $query->createParameter('name')))
 			->andWhere($query->expr()->eq('visibility', $query->createParameter('visibility')))
-			->andWhere($query->expr()->eq('editable', $query->createParameter('editable')));
+			->andWhere($query->expr()->eq('editable', $query->createParameter('editable')))
+			->andWhere($query->expr()->eq('assignable', $query->createParameter('assignable')));
 	}
 
 	/**
@@ -104,6 +105,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('name', 'ASC')
 			->addOrderBy('visibility', 'ASC')
 			->addOrderBy('editable', 'ASC')
+			->addOrderBy('assignable', 'ASC')
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY);
 
 		$result = $query->execute();
@@ -148,7 +150,8 @@ class SystemTagManager implements ISystemTagManager {
 		$query
 			->addOrderBy('name', 'ASC')
 			->addOrderBy('visibility', 'ASC')
-			->addOrderBy('editable', 'ASC');
+			->addOrderBy('editable', 'ASC')
+			->addOrderBy('assignable', 'ASC');
 
 		$result = $query->execute();
 		while ($row = $result->fetch()) {
@@ -163,14 +166,16 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getTag($tagName, $userVisible, $userAssignable) {
+	public function getTag($tagName, $userVisible, $userAssignable, $userEditable = false) {
 		$userVisible = (int)$userVisible;
 		$userAssignable = (int)$userAssignable;
+		$userEditable = (int)$userEditable;
 
 		$result = $this->selectTagQuery
 			->setParameter('name', $tagName)
 			->setParameter('visibility', $userVisible)
 			->setParameter('editable', $userAssignable)
+			->setParameter('assignable', $userEditable)
 			->execute();
 
 		$row = $result->fetch();
@@ -187,16 +192,25 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function createTag($tagName, $userVisible, $userAssignable) {
+	public function createTag($tagName, $userVisible, $userAssignable, $userEditable = false) {
 		$userVisible = (int)$userVisible;
 		$userAssignable = (int)$userAssignable;
+		$userEditable = (int)$userEditable;
+
+		if ($userEditable === 1) {
+			$editable = $userAssignable;
+		} else {
+			$editable = 0;
+			$userAssignable = 1;
+		}
 
 		$query = $this->connection->getQueryBuilder();
 		$query->insert(self::TAG_TABLE)
 			->values([
 				'name' => $query->createNamedParameter($tagName),
 				'visibility' => $query->createNamedParameter($userVisible),
-				'editable' => $query->createNamedParameter($userAssignable),
+				'editable' => $query->createNamedParameter($editable),
+				'assignable' => $query->createNamedParameter($userAssignable)
 			]);
 
 		try {
@@ -215,7 +229,8 @@ class SystemTagManager implements ISystemTagManager {
 			(int)$tagId,
 			$tagName,
 			(bool)$userVisible,
-			(bool)$userAssignable
+			(bool)$userAssignable,
+			(bool)$editable
 		);
 
 		$this->dispatcher->dispatch(ManagerEvent::EVENT_CREATE, new ManagerEvent(
@@ -228,9 +243,10 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function updateTag($tagId, $tagName, $userVisible, $userAssignable) {
+	public function updateTag($tagId, $tagName, $userVisible, $userAssignable, $userEditable = false) {
 		$userVisible = (int)$userVisible;
 		$userAssignable = (int)$userAssignable;
+		$userEditable = (int)$userEditable;
 
 		try {
 			$tags = $this->getTagsByIds($tagId);
@@ -245,7 +261,8 @@ class SystemTagManager implements ISystemTagManager {
 			(int) $tagId,
 			$tagName,
 			(bool) $userVisible,
-			(bool) $userAssignable
+			(bool) $userAssignable,
+			(bool) $userEditable
 		);
 
 		$query = $this->connection->getQueryBuilder();
@@ -253,10 +270,12 @@ class SystemTagManager implements ISystemTagManager {
 			->set('name', $query->createParameter('name'))
 			->set('visibility', $query->createParameter('visibility'))
 			->set('editable', $query->createParameter('editable'))
+			->set('assignable', $query->createParameter('assignable'))
 			->where($query->expr()->eq('id', $query->createParameter('tagid')))
 			->setParameter('name', $tagName)
 			->setParameter('visibility', $userVisible)
-			->setParameter('editable', $userAssignable)
+			->setParameter('editable', $userEditable)
+			->setParameter('assignable', $userAssignable)
 			->setParameter('tagid', $tagId);
 
 		try {
@@ -374,7 +393,7 @@ class SystemTagManager implements ISystemTagManager {
 	}
 
 	private function createSystemTagFromRow($row) {
-		return new SystemTag((int)$row['id'], $row['name'], (bool)$row['visibility'], (bool)$row['editable']);
+		return new SystemTag((int)$row['id'], $row['name'], (bool)$row['visibility'], (bool)$row['assignable'], (bool)$row['editable']);
 	}
 
 	/**
@@ -430,5 +449,24 @@ class SystemTagManager implements ISystemTagManager {
 		$result->closeCursor();
 
 		return $groupIds;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function canUserUseStaticTagInGroup(ISystemTag $tag, IUser $user) {
+		if ($this->groupManager->isAdmin($user->getUID())) {
+			return true;
+		}
+		if ($tag->isUserEditable() === false) {
+			$groupIds = $this->groupManager->getUserGroupIds($user);
+			if (!empty($groupIds)) {
+				$matchingGroups = \array_intersect($groupIds, $this->getTagGroups($tag));
+				if (!empty($matchingGroups)) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/lib/public/SystemTag/ISystemTag.php
+++ b/lib/public/SystemTag/ISystemTag.php
@@ -63,4 +63,13 @@ interface ISystemTag {
 	 * @since 9.0.0
 	 */
 	public function isUserAssignable();
+
+	/**
+	 * Returns whether the tag can be assigned to objects by regular users
+	 *
+	 * @return bool true if editable, false otherwise
+	 *
+	 * @since 10.0.11
+	 */
+	public function isUserEditable();
 }

--- a/lib/public/SystemTag/ISystemTagManager.php
+++ b/lib/public/SystemTag/ISystemTagManager.php
@@ -59,7 +59,7 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 */
-	public function getTag($tagName, $userVisible, $userAssignable);
+	public function getTag($tagName, $userVisible, $userAssignable, $userEditable = false);
 
 	/**
 	 * Creates the tag object using the given attributes.
@@ -67,6 +67,7 @@ interface ISystemTagManager {
 	 * @param string $tagName tag name
 	 * @param bool $userVisible whether the tag is visible by users
 	 * @param bool $userAssignable whether the tag is assignable by users
+	 * @param bool $userEditable whether the tag is editable by users
 	 *
 	 * @return \OCP\SystemTag\ISystemTag system tag
 	 *
@@ -74,7 +75,7 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 */
-	public function createTag($tagName, $userVisible, $userAssignable);
+	public function createTag($tagName, $userVisible, $userAssignable, $userEditable = false);
 
 	/**
 	 * Returns all known tags, optionally filtered by visibility.
@@ -95,6 +96,7 @@ interface ISystemTagManager {
 	 * @param string $newName the new tag name
 	 * @param bool $userVisible whether the tag is visible by users
 	 * @param bool $userAssignable whether the tag is assignable by users
+	 * @param bool $userEditable whether the tag is assignable by users
 	 *
 	 * @throws \OCP\SystemTag\TagNotFoundException if tag with the given id does not exist
 	 * @throws \OCP\SystemTag\TagAlreadyExistsException if there is already another tag
@@ -102,7 +104,7 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 */
-	public function updateTag($tagId, $newName, $userVisible, $userAssignable);
+	public function updateTag($tagId, $newName, $userVisible, $userAssignable, $userEditable = false);
 
 	/**
 	 * Delete the given tags from the database and all their relationships.
@@ -160,4 +162,14 @@ interface ISystemTagManager {
 	 * @since 9.1.0
 	 */
 	public function getTagGroups(ISystemTag $tag);
+
+	/**
+	 * Verify if users of group can use static tags
+	 *
+	 * @param ISystemTag $tag
+	 * @param IUser $user
+	 * @return bool, true if user of group can use staic tags, else false
+	 * @since 10.0.11
+	 */
+	public function canUserUseStaticTagInGroup(ISystemTag $tag, Iuser $user);
 }

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -164,6 +164,7 @@ class TagsHelper {
 		$name,
 		$userVisible = true,
 		$userAssignable = true,
+		$userEditable = false,
 		$groups = null,
 		$davPathVersionToUse = 2
 	) {
@@ -172,6 +173,7 @@ class TagsHelper {
 			'name' => $name,
 			'userVisible' => $userVisible,
 			'userAssignable' => $userAssignable,
+			'userEditable' => $userEditable
 		];
 
 		if ($groups !== null) {
@@ -225,21 +227,22 @@ class TagsHelper {
 	 * @return boolean[]
 	 */
 	public static function validateTypeOfTag($type) {
-		$userVisible = true;
-		$userAssignable = true;
+		$userVisible = "1";
+		$userAssignable = "1";
+		$userEditable = "1";
 		switch ($type) {
 			case 'normal':
 				break;
 			case 'not user-assignable':
-				$userAssignable = false;
+				$userAssignable = "0";
 				break;
 			case 'not user-visible':
-				$userVisible = false;
+				$userVisible = "0";
 				break;
 			default:
 				throw new \Exception('Unsupported type');
 		}
 
-		return [$userVisible, $userAssignable];
+		return [$userVisible, $userAssignable, $userEditable];
 	}
 }

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -40,19 +40,20 @@ trait Tags {
 	 * @param string $user
 	 * @param bool $userVisible
 	 * @param bool $userAssignable
+	 * @param bool$userEditable
 	 * @param string $name
 	 * @param string $groups
 	 *
 	 * @return void
 	 */
 	private function createTag(
-		$user, $userVisible, $userAssignable, $name, $groups = null
+		$user, $userVisible, $userAssignable, $userEditable, $name, $groups = null
 	) {
 		$this->response = TagsHelper::createTag(
 			$this->getBaseUrl(),
 			$this->getActualUsername($user),
 			$this->getPasswordForUser($user),
-			$name, $userVisible, $userAssignable, $groups,
+			$name, $userVisible, $userAssignable, $userEditable, $groups,
 			$this->getDavPathVersion('systemtags')
 		);
 		$responseHeaders = $this->response->getHeaders();
@@ -153,6 +154,7 @@ trait Tags {
 			$user,
 			TagsHelper::validateTypeOfTag($type)[0],
 			TagsHelper::validateTypeOfTag($type)[1],
+			TagsHelper::validateTypeOfTag($type)[2],
 			$name
 		);
 	}
@@ -204,6 +206,7 @@ trait Tags {
 			$user,
 			TagsHelper::validateTypeOfTag($type)[0],
 			TagsHelper::validateTypeOfTag($type)[1],
+			TagsHelper::validateTypeOfTag($type)[2],
 			$name,
 			$groups
 		);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Adding a new tag which is same as restricted tag except it is not editable by users.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding a new tag which is same as restricted tag except it is not editable by users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a new tag `Editable` with name lets say , `editableTag`, by enabling systemtag_management app by navigating to admin page -> `Workflow & tags`
- Create groups `group1`, `group2` under users page ( by enabling user_management app)
- Create users `user1`, `user2`. Add them to `group1`
- Create user `user3` and add it to `group2`.
- Now try to update the `editableTag` in the `Workflow & tags` page, by adding 2 groups `group1` and `group2`.
- Login to `user1`, now the user will see that `editableTag` is editable. It can also be assigned/unassigned.
- Login to `user3`, now the user will see that `editableTag` is not editable. Its only assignable/unassignable.
- Similarly create `visibleTag` under `Visible`, `invisibleTag` under `Invisible`, and `restrictedTag` under `Restricted`. The `editableTag` behaves the same way as it was before.
- Add `group1` to `restrictedTag`.
- Now when logged in as `user3` , `restrictedTag` is not visible. Only `visibleTag` and `editableTag` are visible.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Requires: https://github.com/owncloud/systemtags_management/pull/30

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
