### PR TITLE
Acceptance test tag public link share

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -56,7 +56,17 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
+
+  @files_trashbin-app-required
+  Scenario: getting trashbin app capability with admin user
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
       | files         | undelete                              | 1                 |
+
+  @files_versions-app-required
+  Scenario: getting versions app capability with admin user
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
       | files         | versioning                            | 1                 |
 
   Scenario: Changing public upload
@@ -80,8 +90,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Disabling share api
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
@@ -98,8 +106,6 @@ Feature: capabilities
       | files_sharing | federation@@@outgoing | 1                 |
       | files_sharing | federation@@@incoming | 1                 |
       | files         | bigfilechunking       | 1                 |
-      | files         | undelete              | 1                 |
-      | files         | versioning            | 1                 |
 
   Scenario: Disabling public links
     Given parameter "shareapi_allow_links" of app "core" has been set to "no"
@@ -120,8 +126,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing resharing
     Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
@@ -144,8 +148,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing federation outgoing
     Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
@@ -168,8 +170,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing federation incoming
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
@@ -192,8 +192,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing "password enforced for read-only public link shares"
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
@@ -219,8 +217,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled                     | 1                 |
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
-      | files         | undelete                                       | 1                 |
-      | files         | versioning                                     | 1                 |
 
   Scenario: Changing "password enforced for read-write public link shares"
     Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
@@ -246,8 +242,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled                     | 1                 |
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
-      | files         | undelete                                       | 1                 |
-      | files         | versioning                                     | 1                 |
 
   Scenario: Changing "password enforced for write-only public link shares"
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
@@ -273,8 +267,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled                     | 1                 |
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
-      | files         | undelete                                       | 1                 |
-      | files         | versioning                                     | 1                 |
 
   Scenario: Changing public notifications
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
@@ -297,8 +289,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing public social share
     Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
@@ -321,8 +311,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing expire date
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -346,8 +334,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing expire date enforcing
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -373,8 +359,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing group sharing allowed
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
@@ -397,8 +381,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing only share with group member
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -421,8 +403,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing allow share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
@@ -444,8 +424,6 @@ Feature: capabilities
       | files_sharing | share_with_group_members_only | EMPTY             |
       | files_sharing | user_enumeration@@@enabled    | EMPTY             |
       | files         | bigfilechunking               | 1                 |
-      | files         | undelete                      | 1                 |
-      | files         | versioning                    | 1                 |
 
   Scenario: Changing allow share dialog user enumeration for group members only
     Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
@@ -468,8 +446,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | 1                 |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: Changing exclude groups from sharing
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -496,8 +472,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -527,8 +501,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -558,8 +530,6 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |
 
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -590,5 +560,3 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
-      | files         | undelete                              | 1                 |
-      | files         | versioning                            | 1                 |

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -5,7 +5,8 @@ Feature: external-storage
     Given using OCS API version "1"
     And using old DAV path
 
-  Scenario: Share by link a file inside a local external storage
+  @public_link_share-feature-required
+  Scenario: Share by public link a file inside a local external storage
     Given user "user0" has been created
     And user "user1" has been created
     And user "user0" has created a folder "/local_storage/foo"

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -178,7 +178,7 @@ Feature: transfer-ownership
     Then the command should have been successful
     And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
-  @skipOnEncryptionType:user-keys
+  @skipOnEncryptionType:user-keys @public_link_share-feature-required
   Scenario: transferring ownership of folder shares which has public link
     Given user "user0" has been created
     And user "user1" has been created
@@ -245,7 +245,7 @@ Feature: transfer-ownership
     And using received transfer folder of "user1" as dav path
     And as "user1" the folder "/sub/test" should not exist
 
-  @skipOnEncryptionType:user-keys
+  @skipOnEncryptionType:user-keys @public_link_share-feature-required
   Scenario: transferring ownership of folder shared with transfer recipient and public link created of received share works
     Given user "user0" has been created
     And user "user1" has been created

--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -67,6 +67,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
@@ -79,7 +80,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest
+  @smokeTest @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file with password
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
@@ -93,6 +94,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
@@ -113,6 +115,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
@@ -152,6 +155,7 @@ Feature: sharing
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created a folder "/afolder"
@@ -168,6 +172,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -185,6 +190,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a link share with edit permissions keeps it
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created a folder "/afolder"
@@ -254,6 +260,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Do not allow public sharing of the root
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
@@ -264,6 +271,7 @@ Feature: sharing
       | 1               | 403             |
       | 2               | 403             |
 
+  @public_link_share-feature-required
   Scenario: Only allow 1 link share per file/folder
     Given using OCS API version "1"
     And as user "user0"
@@ -444,7 +452,8 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-Scenario Outline: user creates a public link share of a file with file name longer than 64 chars
+  @public_link_share-feature-required
+  Scenario Outline: user creates a public link share of a file with file name longer than 64 chars
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" creates a public link share using the sharing API with settings
@@ -457,7 +466,8 @@ Scenario Outline: user creates a public link share of a file with file name long
       | 1               | 100             |
       | 2               | 200             |
 
-Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars
+  @public_link_share-feature-required
+  Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created a folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"

--- a/tests/acceptance/features/apiShareManagement/multilinksharing.feature
+++ b/tests/acceptance/features/apiShareManagement/multilinksharing.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api @TestAlsoOnExternalUserBackend @public_link_share-feature-required
 Feature: multilinksharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -81,6 +81,7 @@ Feature: sharing
     And user "user3" downloads file "/textfile0_shared.txt" with range "bytes=1-7" using the WebDAV API
     Then the downloaded content should be "wnCloud"
 
+  @public_link_share-feature-required
   Scenario Outline: resharing using a public link with read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created a folder "/test"
@@ -95,6 +96,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
+  @public_link_share-feature-required
   Scenario Outline: resharing using a public link with read and write permissions only is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created a folder "/test"

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -22,6 +22,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
     Given using OCS API version "<ocs_api_version>"
     And as user "user0"
@@ -55,6 +56,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share with password and adding an expiration date
     Given using OCS API version "<ocs_api_version>"
     And as user "user0"
@@ -71,6 +73,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
     Given using OCS API version "<ocs_api_version>"
     And as user "user0"
@@ -104,6 +107,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share, updating its password and getting its info
     Given using OCS API version "<ocs_api_version>"
     And as user "user0"
@@ -136,6 +140,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share, updating its permissions and getting its info
     Given using OCS API version "<ocs_api_version>"
     And as user "user0"
@@ -168,6 +173,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Creating a new public link share, updating publicUpload option and getting its info
     Given using OCS API version "<ocs_api_version>"
     And as user "user0"
@@ -233,6 +239,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created
@@ -320,6 +327,7 @@ Feature: sharing
     And as "user0" the folder "/user0-folder/folder2" should not exist
     And as "user2" the folder "/user2-folder/folder2" should exist
 
+  @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created
@@ -338,6 +346,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created
@@ -356,6 +365,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
+  @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -6,7 +6,7 @@ Feature: sharing
     And using old DAV path
     And user "user0" has been created
 
-  @smokeTest
+  @smokeTest @public_link_share-feature-required
   Scenario: Downloading from upload-only share is forbidden
     Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
     When user "user0" creates a public link share using the sharing API with settings
@@ -51,7 +51,7 @@ Feature: sharing
     When user "user0" has shared folder "PARENT" with group "grp1"
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
-  @smokeTest
+  @smokeTest @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
@@ -78,6 +78,7 @@ Feature: sharing
       | permissions | 15     |
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
+  @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |
@@ -105,6 +106,7 @@ Feature: sharing
       | permissions | 1      |
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
+  @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -6,7 +6,7 @@ Feature: sharing
     And using old DAV path
     And user "user0" has been created
 
-  @smokeTest
+  @smokeTest @public_link_share-feature-required
   Scenario: Uploading same file to a public upload-only share multiple times
     Given as user "user0"
     And the user has created a public link share with settings
@@ -17,6 +17,7 @@ Feature: sharing
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
+  @public_link_share-feature-required
   Scenario: Uploading file to a public upload-only share that was deleted does not work
     Given user "user0" has created a public link share with settings
       | path        | FOLDER |
@@ -25,6 +26,7 @@ Feature: sharing
     Then publicly uploading a file should not work
     And the HTTP status code should be "404"
 
+  @public_link_share-feature-required
   Scenario: Uploading file to a public read-only share folder does not work
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -54,6 +56,7 @@ Feature: sharing
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
 
+  @public_link_share-feature-required
   Scenario: Uploading to a public upload-only share
     Given as user "user0"
     And the user has created a public link share with settings
@@ -62,6 +65,7 @@ Feature: sharing
     When the public uploads file "test.txt" with content "test" using the old WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
+  @public_link_share-feature-required
   Scenario: Uploading to a public upload-only share with password
     Given as user "user0"
     And the user has created a public link share with settings
@@ -93,6 +97,7 @@ Feature: sharing
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
 
+  @public_link_share-feature-required
   Scenario: Uploading to a public read/write share with password
     Given as user "user0"
     And the user has created a public link share with settings
@@ -134,7 +139,7 @@ Feature: sharing
     When user "user1" uploads file "data/textfile.txt" to "/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
 
-  @smokeTest
+  @smokeTest @public_link_share-feature-required
   Scenario: Uploading to a public read/write share with password
     Given as user "user0"
     And the user has created a public link share with settings
@@ -168,6 +173,7 @@ Feature: sharing
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
 
+  @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder with read/write permission when the sharer has unsufficient quota does not work
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -200,6 +206,7 @@ Feature: sharing
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
 
+  @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has unsufficient quota does not work
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -208,6 +215,7 @@ Feature: sharing
     Then publicly uploading a file should not work
     And the HTTP status code should be "507"
 
+  @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
     Given user "user0" has created a public link share with settings
       | path        | FOLDER |
@@ -216,6 +224,7 @@ Feature: sharing
     Then publicly uploading a file should not work
     And the HTTP status code should be "403"
 
+  @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "user0" has created a public link share with settings
@@ -225,6 +234,7 @@ Feature: sharing
     Then publicly uploading a file should not work
     And the HTTP status code should be "403"
 
+  @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
     Given user "user0" has created a public link share with settings
       | path        | FOLDER |

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -27,6 +27,7 @@ Feature: download file
       | old         |
       | new         |
 
+  @public_link_share-feature-required
   Scenario Outline: download a public shared file with range
     Given using <dav_version> DAV path
     When user "user0" creates a public link share using the sharing API with settings
@@ -38,6 +39,7 @@ Feature: download file
       | old         |
       | new         |
 
+  @public_link_share-feature-required
   Scenario Outline: download a public shared file inside a folder with range
     Given using <dav_version> DAV path
     When user "user0" creates a public link share using the sharing API with settings

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -105,6 +105,7 @@ Feature: get file properties
       | old         |
       | new         |
 
+  @public_link_share-feature-required
   Scenario Outline: A file that is shared by link has a share-types property
     Given using <dav_version> DAV path
     And user "user0" has created a folder "/test"
@@ -120,7 +121,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnLDAP @user_ldap-issue-268
+  @skipOnLDAP @user_ldap-issue-268 @public_link_share-feature-required
   Scenario Outline: A file that is shared by user,group and link has a share-types property
     Given using <dav_version> DAV path
     And user "user1" has been created

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -108,6 +108,7 @@ Feature: deleting files and folders
     Then the file "lorem.txt" should not be listed on the webUI
     And the folder "simple-folder" should not be listed on the webUI
 
+  @public_link_share-feature-required
   Scenario: delete files from shared by link page
     Given the user has created a new public link for the file "lorem.txt" using the webUI
     And the user has browsed to the shared-by-link page

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -40,6 +40,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "versions" tab in details panel using the webUI
     Then the "versions" details panel should be visible
 
+  @public_link_share-feature-required
   Scenario: user shares a file through public link and then the details dialog should work in a Shared by link page
     Given the user has created a new public link for the folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @mailhog
+@webUI @insulated @disablePreviews @mailhog @public_link_share-feature-required
 Feature: Share by public link
   As a user
   I want to share files through a publicly accessible link


### PR DESCRIPTION
## Description
1) capabilities acceptance tests - extract out the test parts that rely on having the trashbin or versions app enabled. Tag those scenarios so they can be skipped easily if required.
2) public link sharing - add a tag ``public_link_share-feature-required`` - this will allow easily skipping tests related to public link sharing, if the system-under-test does not do/allow public link sharing.

Note: the acceptance test infrastructure supports setting an environment variable to define the public link share password to be used in tests: ``PUBLIC_LINK_SHARE_PASSWORD``
If the system-under-test has some password policy settings that require some complexity in the public link share password, then a  suitable password can be provided via this env var.

## Motivation and Context
Make acceptance tests run in flexible environments.

## How Has This Been Tested?
Local runs of some acceptance test scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
