### PR TITLE
Tag test scenarios that use the admin setttings pages with admin_settings-feature-required

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -1,4 +1,4 @@
-@webUI @comments-app-required
+@webUI @comments-app-required @admin_settings-feature-required
 Feature: admin apps settings
   As an admin
   I want to be able to manage apps settings on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog
+@webUI @mailhog @admin_settings-feature-required
 Feature: admin general settings
   As an admin
   I want to be able to manage general settings on the ownCloud server
@@ -32,13 +32,13 @@ Feature: admin general settings
     And the administrator logs out of the webUI
     Then the imprint url on the login page should link to "imprinturl.html"
 
-@smokeTest
+  @smokeTest
   Scenario: administrator sets legal URLs
     When the administrator sets the value of privacy policy url to "privacy_policy.html" using the webUI
     And the administrator logs out of the webUI
     Then the privacy policy url on the login page should link to "privacy_policy.html"
 
-@smokeTest
+  @smokeTest
   Scenario: administrator sets update channel
     Given the administrator has invoked occ command "config:app:set core OC_Channel --value git"
     When the user reloads the current page of the webUI
@@ -46,7 +46,7 @@ Feature: admin general settings
     And the administrator invokes occ command "config:app:get core OC_Channel"
     Then the command output should contain the text "daily"
 
-@smokeTest
+  @smokeTest
   Scenario: administrator changes the cron job
     Given the administrator has invoked occ command "config:app:set core backgroundjobs_mode --value ajax"
     When the user reloads the current page of the webUI
@@ -54,7 +54,7 @@ Feature: admin general settings
     And the administrator invokes occ command "config:app:get core backgroundjobs_mode"
     Then the command output should contain the text "webcron"
 
-@smokeTest
+  @smokeTest
   Scenario: administrator changes the log level
     Given the administrator has invoked occ command "config:system:set loglevel --value 0"
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI  @admin_settings-feature-required
 Feature: admin sharing settings
   As an admin
   I want to be able to manage sharing settings on the ownCloud server


### PR DESCRIPTION
## Description
Tag the relevant feature files with ``@admin_settings-feature-required``

## Motivation and Context
Allow easy skipping of scenarios that test stuff on the webUI admin settings pages (enable/disable apps, general settings like log-level..., and sharing settings), so that the test suite can be run in an environment where the admin is prevented from accessing these pages.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
