### PR TITLE
[stable10] Replace productname in expected email content

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -414,7 +414,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 *
 	 * @return string
 	 */
-	private function replaceProductName($text) {
+	public function replaceProductName($text) {
 		return \str_replace(
 			"%productname%", $this->getProductName(), $text
 		);

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -53,7 +53,7 @@ Feature: add users
     When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
       """
-      just letting you know that you now have an ownCloud account.
+      just letting you know that you now have an %productname% account.
       
       Your username: guiusr1
       Access it:


### PR DESCRIPTION
## Description
In ``EmailContext`` ``assertThatEmailContains()`` allow the product name to be substituted at run-time.

## Motivation and Context
Remove hard-coded"ownCloud" ``productname`` from acceptance tests.

## How Has This Been Tested?
Local run of the webUI acceptance test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
