### PR TITLE
Email subject is already escaped, avoid double escaping

### DIFF
--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -176,10 +176,11 @@ class MailNotifications {
 				'file' => $filename,
 			]);
 
+			$unescapedFilename = $filename;
 			$filename = $filter->getFile();
 			$link = $filter->getLink();
 
-			$subject = (string) $this->l->t('%s shared »%s« with you', [$this->senderDisplayName, $filename]);
+			$subject = (string) $this->l->t('%s shared »%s« with you', [$this->senderDisplayName, $unescapedFilename]);
 			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, null, 'internal');
 
 			// send it out now

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -353,7 +353,7 @@ class MailNotificationsTest extends TestCase {
 	}
 
 	public function testSendInternalShareMail() {
-		$this->setupMailerMock('TestUser shared »&lt;welcome&gt;.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
+		$this->setupMailerMock('TestUser shared »<welcome>.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
 
 		$shareMock = $this->getShareMock(
 			['file_target' => '/<welcome>.txt', 'item_source' => 123, 'expiration' => '2017-01-01T15:03:01.012345Z']
@@ -385,14 +385,14 @@ class MailNotificationsTest extends TestCase {
 	}
 
 	public function testSendInternalShareMailException() {
-		$this->setupMailerMock('TestUser shared »&lt;welcome&gt;.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
+		$this->setupMailerMock('TestUser shared »<welcome>.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
 
 		$share = $this->getShareMock(
 			['file_target' => '/<welcome>.txt', 'item_source' => 123, 'expiration' => 'foo']
 		);
 		$this->shareManager->method('getSharedWith')
 			->withAnyParameters()
-			->willReturn([$share]);
+			->willreturn([$share]);
 
 		$recipient = $this->createMock(IUser::class);
 		$recipient


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Otherwise file names are double escaped in the email subject.

## Related Issue


## Motivation and Context
Annoying double escaped email subjects with filesnames.

## How Has This Been Tested?
Create a file called `!@£$%^&*()_.txt` and share it, notify by email. Check escaping in email.

## Screenshots (if appropriate):
Before: 
<img width="586" alt="screenshot 2018-10-10 at 15 14 09" src="https://user-images.githubusercontent.com/660805/46742576-36705d00-cc9f-11e8-9a38-3d934853659d.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
