### PR TITLE
No need to explode commands before passing to runOcc

### DIFF
--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -298,8 +298,7 @@ trait CommandLine {
 	 * @return void
 	 */
 	public function invokingTheCommand($cmd) {
-		$args = \explode(' ', $cmd);
-		$this->runOcc($args);
+		$this->runOcc([$cmd]);
 	}
 
 	/**
@@ -316,7 +315,7 @@ trait CommandLine {
 	public function invokingTheCommandWithEnvVariable(
 		$cmd, $envVariableName, $envVariableValue
 	) {
-		$args = \explode(' ', $cmd);
+		$args = [$cmd];
 		$this->runOccWithEnvVariables(
 			$args, [$envVariableName => $envVariableValue]
 		);


### PR DESCRIPTION
## Description
Pass whole command strings as-is to ``CommandLine.php`` ``runOcc()``.
There is no need to split them on spaces, that just looks scary.

## Motivation and Context
The testing app API for running an ``occ`` command takes a single string in the ``command`` key and executes that command.

``SetupHelper::runOcc()`` takes an array of the "words" as the command and puts them together into a single string to pass to the testing app:
```
$body['command'] = \implode(' ', $args);
```

Some functions in the path to calling ``SetupHelper::runOcc()`` actually ``\explode`` a string that they already have, putting it into space-separated pieces. This is unnecessary, and looks like it will break stuff when given command strings like ``--value='some words with spaces'``. Actually it ~~should~~ does work OK, but it looks scary, so remove that sort of thing.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
