### PR TITLE
Refactor getProductName and related acceptance test code

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -410,6 +410,17 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @param string $text
+	 *
+	 * @return string
+	 */
+	public function replaceProductName($text) {
+		return \str_replace(
+			"%productname%", $this->getProductNameFromStatus(), $text
+		);
+	}
+
+	/**
 	 * @return string
 	 */
 	public function getOcPath() {
@@ -1553,9 +1564,17 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
+	public function theAdministratorRequestsStatusPhp() {
+		$this->response = $this->getStatusPhp();
+	}
+
+	/**
+	 *
+	 * @return ResponseInterface
+	 */
 	public function getStatusPhp() {
 		$fullUrl = $this->getBaseUrl() . "/status.php";
-		
+
 		$config = null;
 		if ($this->sourceIpAddress !== null) {
 			$config = [
@@ -1565,7 +1584,7 @@ trait BasicStructure {
 			];
 		}
 
-		$this->response = HttpRequestHelper::get(
+		return HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(),
 			$this->getAdminPassword(), $this->guzzleClientHeaders, null, $config
 		);
@@ -1650,11 +1669,26 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @return string|null
+	 * @param ResponseInterface|null $response
+	 *
+	 * @return array
 	 */
-	public function getJsonDecodedResponse() {
+	public function getJsonDecodedResponse($response = null) {
+		if ($response === null) {
+			$response = $this->getResponse();
+		}
 		return \json_decode(
-			$this->getResponse()->getBody(), true
+			$response->getBody(), true
+		);
+	}
+
+	/**
+	 *
+	 * @return array
+	 */
+	public function getJsonDecodedStatusPhp() {
+		return $this->getJsonDecodedResponse(
+			$this->getStatusPhp()
 		);
 	}
 
@@ -1662,8 +1696,7 @@ trait BasicStructure {
 	 * @return string
 	 */
 	public function getEditionFromStatus() {
-		$this->getStatusPhp();
-		$decodedResponse = $this->getJsonDecodedResponse();
+		$decodedResponse = $this->getJsonDecodedStatusPhp();
 		if (isset($decodedResponse['edition'])) {
 			return $decodedResponse['edition'];
 		}
@@ -1674,8 +1707,7 @@ trait BasicStructure {
 	 * @return string|null
 	 */
 	public function getProductNameFromStatus() {
-		$this->getStatusPhp();
-		$decodedResponse = $this->getJsonDecodedResponse();
+		$decodedResponse = $this->getJsonDecodedStatusPhp();
 		if (isset($decodedResponse['productname'])) {
 			return $decodedResponse['productname'];
 		}
@@ -1686,8 +1718,7 @@ trait BasicStructure {
 	 * @return string|null
 	 */
 	public function getVersionFromStatus() {
-		$this->getStatusPhp();
-		$decodedResponse = $this->getJsonDecodedResponse();
+		$decodedResponse = $this->getJsonDecodedStatusPhp();
 		if (isset($decodedResponse['version'])) {
 			return $decodedResponse['version'];
 		}
@@ -1698,8 +1729,7 @@ trait BasicStructure {
 	 * @return string|null
 	 */
 	public function getVersionStringFromStatus() {
-		$this->getStatusPhp();
-		$decodedResponse = $this->getJsonDecodedResponse();
+		$decodedResponse = $this->getJsonDecodedStatusPhp();
 		if (isset($decodedResponse['versionstring'])) {
 			return $decodedResponse['versionstring'];
 		}

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -35,9 +35,9 @@ class EmailContext implements Context {
 
 	/**
 	 *
-	 * @var WebUIGeneralContext
+	 * @var FeatureContext
 	 */
-	private $webUIGeneralContext;
+	private $featureContext;
 
 	/**
 	 * @return string
@@ -57,7 +57,7 @@ class EmailContext implements Context {
 	 */
 	public function assertThatEmailContains($address, PyStringNode $content) {
 		$expectedContent = \str_replace("\r\n", "\n", $content->getRaw());
-		$expectedContent = $this->webUIGeneralContext->replaceProductName(
+		$expectedContent = $this->featureContext->replaceProductName(
 			$expectedContent
 		);
 		PHPUnit_Framework_Assert::assertContains(
@@ -95,7 +95,7 @@ class EmailContext implements Context {
 		// Get the environment
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
-		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
+		$this->featureContext = $environment->getContext('FeatureContext');
 		$this->localMailhogUrl = EmailHelper::getLocalMailhogUrl();
 		$this->clearMailHogMessages();
 	}


### PR DESCRIPTION
## Description
Clean it up - make a ``replaceProductName()`` in ``BasicStructure``. Call it from ``EmailContext``.

## Motivation and Context
CI  started failing in guests and notifications apps because ``EmailContext`` in core started calling:
```
$this->webUIGeneralContext->replaceProductName(
```

That requires ``WebUIGeneralContext`` to be mentioned in ``behat.yml`` whenever ``EmailContext``.

But some API acceptance tests make use of ``EmailContext`` (quite rightly). We do not want them to be crossing over to use ``webUI`` code. And anyway it does not work because the ``BeforeScenario`` of ``WebUIGeneralContext`` only gets run for ``webUI``, and so the product name stuff does not work for API  code.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
