### PR TITLE
Browse to files page after login for createFoldersEdgeCases

### DIFF
--- a/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
@@ -7,6 +7,7 @@ Feature: create folder
   Background:
     Given user "user1" has been created
     And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
 
   Scenario Outline: Create a folder using special characters
     When the user creates a folder with the name <folder_name> using the webUI

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -8,6 +8,7 @@ Feature: Search
   Background:
     Given user "user1" has been created
     And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
 
   @smokeTest
   Scenario: Simple search


### PR DESCRIPTION
## Description
Add the step:
```
    And the user has browsed to the files page
```
to ``createFoldersEdgeCases.feature`` and ``search.feature``

I don't have an explanation for why the current code works happily for ordinary test runs in core, and why it breaks when applied to another system-under-test - but maybe this will help.

## Motivation and Context
In some cases ``createFoldersEdgeCases.feature`` gets timeouts after reloading the files page to see if a sub-folder is really there.

``createFolders.feature`` works fine, and after login it explicitly does:
```
    And the user has browsed to the files page
```
That step browses to the files page (like it says!) and also remembers that it is on a files page - ``$currentPageObject`` gets definitely set to the files page object representing the page that has been browsed to.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
