### PR TITLE
Add tests for resetUserPassword

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -46,14 +46,19 @@ trait BasicStructure {
 	use CommandLine;
 
 	/**
-	 * @var array
+	 * @var string
 	 */
 	private $adminUsername = '';
 
 	/**
-	 * @var array
+	 * @var string
 	 */
 	private $adminPassword = '';
+
+	/**
+	 * @var string
+	 */
+	private $originalAdminPassword = '';
 
 	/**
 	 * @var string
@@ -303,6 +308,7 @@ trait BasicStructure {
 		if ($publicLinkSharePasswordFromEnvironment !== false) {
 			$this->publicLinkSharePassword = $publicLinkSharePasswordFromEnvironment;
 		}
+		$this->originalAdminPassword = $this->adminPassword;
 	}
 
 	/**
@@ -1382,6 +1388,15 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function rememberNewAdminPassword($password) {
+		$this->adminPassword = (string) $password;
+	}
+
+	/**
 	 * @param string $userName
 	 *
 	 * @return string
@@ -1898,6 +1913,21 @@ trait BasicStructure {
 				'true'
 			]
 		);
+	}
+
+	/**
+	 * @AfterScenario
+	 *
+	 * @return void
+	 */
+	public function restoreAdminPassword() {
+		if ($this->adminPassword !== $this->originalAdminPassword) {
+			$this->adminResetsPasswordOfUserUsingTheProvisioningApi(
+				$this->getAdminUsername(),
+				$this->originalAdminPassword
+			);
+			$this->adminPassword = $this->originalAdminPassword;
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -139,11 +139,16 @@ class OccContext implements Context {
 	 * @throws Exception
 	 */
 	public function resetUserPasswordUsingTheOccCommand($username, $password) {
+		$actualUsername = $this->featureContext->getActualUsername($username);
+		$password = $this->featureContext->getActualPassword($password);
 		$this->featureContext->invokingTheCommandWithEnvVariable(
-			"user:resetpassword $username  --password-from-env",
+			"user:resetpassword $actualUsername  --password-from-env",
 			'OC_PASS',
 			$password
 		);
+		if ($username === "%admin%") {
+			$this->featureContext->rememberNewAdminPassword($password);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -541,6 +541,8 @@ trait WebDav {
 	public function userUsingPasswordShouldNotBeAbleToDownloadFile(
 		$user, $password, $fileName
 	) {
+		$user = $this->getActualUsername($user);
+		$password = $this->getActualPassword($password);
 		$this->downloadFileAsUserUsingPassword($user, $fileName, $password);
 		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
 			400, $this->getResponse()->getStatusCode(), 'download must fail'
@@ -654,6 +656,8 @@ trait WebDav {
 	public function contentOfFileForUserUsingPasswordShouldBe(
 		$fileName, $user, $password, $content
 	) {
+		$user = $this->getActualUsername($user);
+		$password = $this->getActualPassword($password);
 		$this->downloadFileAsUserUsingPassword($user, $fileName, $password);
 		$this->downloadedContentShouldBe($content);
 	}

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -1,0 +1,29 @@
+@cli @skipOnLDAP
+Feature: reset user password
+  As an admin
+  I want to be able to reset a user's password
+  So that I can secure individual access to resources on the ownCloud server
+
+  Scenario: reset user password
+    Given these users have been created:
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    When the administrator resets the password of user "brand-new-user" to "%alt1%" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text "Successfully reset password for brand-new-user"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
+
+  Scenario: admin tries to reset the password of a user that does not exist
+    Given user "not-a-user" has been deleted
+    When the administrator resets the password of user "not-a-user" to "%alt1%" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'User does not exist'
+
+  Scenario: admin should be able to reset their own password
+    Given user "brand-new-user" has been created
+    When the administrator resets the password of user "%admin%" to "%alt1%" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text "Successfully reset password for admin"
+    When user "%admin%" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the display name returned by the API should be "brand-new-user"


### PR DESCRIPTION
## Description
This PR adds more tests for cliProvisioning resetUserPassword using occ commands.

Related issue: #33052

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.