### PR TITLE
search function in acceptance tests is on FilesPage

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
@@ -169,7 +169,6 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 	 */
 	protected function openNotificationsDialog() {
 		$this->getSession()->reload();
-		$this->owncloudPage->waitTillPageIsLoaded($this->getSession());
 		$this->owncloudPage->waitForNotifications();
 		return $this->owncloudPage->openNotifications();
 	}

--- a/tests/acceptance/features/bootstrap/WebUISearchContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISearchContext.php
@@ -23,8 +23,8 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
+use Page\FilesPage;
 use Page\SearchResultInOtherFoldersPage;
-use Page\OwncloudPage;
 
 require_once 'bootstrap.php';
 
@@ -39,9 +39,9 @@ class WebUISearchContext extends RawMinkContext implements Context {
 	private $searchResultInOtherFoldersPage;
 	/**
 	 *
-	 * @var OwncloudPage
+	 * @var FilesPage
 	 */
-	private $ownCloudPage;
+	private $filesPage;
 
 	/**
 	 *
@@ -58,14 +58,14 @@ class WebUISearchContext extends RawMinkContext implements Context {
 	/**
 	 * WebUILoginContext constructor.
 	 *
-	 * @param OwncloudPage $ownCloudPage
+	 * @param FilesPage $filesPage
 	 * @param SearchResultInOtherFoldersPage $searchResultInOtherFoldersPage
 	 */
 	public function __construct(
-		OwncloudPage $ownCloudPage,
+		FilesPage $filesPage,
 		SearchResultInOtherFoldersPage $searchResultInOtherFoldersPage
 	) {
-		$this->ownCloudPage = $ownCloudPage;
+		$this->filesPage = $filesPage;
 		$this->searchResultInOtherFoldersPage = $searchResultInOtherFoldersPage;
 	}
 
@@ -78,8 +78,8 @@ class WebUISearchContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function theUserSearchesUsingTheWebUI($searchTerm) {
-		$this->ownCloudPage->waitTillPageIsLoaded($this->getSession());
-		$this->ownCloudPage->search($this->getSession(), $searchTerm);
+		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$this->filesPage->search($this->getSession(), $searchTerm);
 	}
 
 	/**


### PR DESCRIPTION
## Description
The search that is carried out by the steps in ``WebUISearchContext.php`` is the search button/box on the files page. But ``WebUISearchContext.php`` is just instantiating an basic ``OwncloudPage``. This means that when ``theUserSearchesUsingTheWebUI()`` does ``waitTillPageIsLoaded()``, it uses the method in ``OwncloudPage``. That method looks for a loading indicator to exist and become not visible. But a files page does not have that.

In default core, the comments panel of the details dialog has a loading indicator! The wait in core is finding that, and "waiting" for it. In the other system-under-test the comments app is disabled - that means that there is no loading indicator, and the wait times out!

## Motivation and Context
In core the ``webUIFiles/search.feature`` scenarios are passing. But when running against some other themed system-under-test they fail, e.g. ``search.feature:14`` gets a "timeout waiting for page to load".

## How Has This Been Tested?
With comments app disabled:
Run ``search.feature`` locally.
Run ``notificationLink.feature`` locally.
Run ``shareWithUsers.feature`` locally.

Before the change there are "wait for page to load" timeouts.
After the change, the tests pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
