### PR TITLE
Skip password change email test on encryption

### DIFF
--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -16,13 +16,13 @@ Feature: reset the password
   Scenario: send password reset email
     When the user requests the password reset link using the webUI
     Then a message with this text should be displayed on the webUI:
-			"""
-			The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
-			"""
+      """
+      The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
+      """
     And the email address "user1@example.org" should have received an email with the body containing
-			"""
-			Use the following link to reset your password: <a href=
-			"""
+      """
+      Use the following link to reset your password: <a href=
+      """
 
   @skipOnEncryption
   @smokeTest
@@ -32,12 +32,13 @@ Feature: reset the password
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
-			"""
-			Password changed successfully
-			"""
+      """
+      Password changed successfully
+      """
     When the user logs in with username "user1" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
+  @skipOnEncryption
   Scenario: check if the sender email address is valid
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"


### PR DESCRIPTION
## Description
Skip ``resetPassword.feature`` Scenario: check if the sender email address is valid 
because that whole password reset workflow is not useful, specially for user-keys encryption.

## Motivation and Context
A new password reset email test scenario fails when encryption is enabled. The similar scenario above is already skipped.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
