### PR TITLE
Fix from address on password set success email

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -713,7 +713,7 @@ class UsersController extends Controller {
 			$message->setTo([$email => $userId]);
 			$message->setSubject($this->l10n->t('%s password changed successfully', [$this->defaults->getName()]));
 			$message->setPlainBody($msg);
-			$message->setFrom([$email => $this->defaults->getName()]);
+			$message->setFrom([$this->fromMailAddress => $this->defaults->getName()]);
 			$this->mailer->send($message);
 		}
 	}

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -3180,6 +3180,8 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('getAppValue')
 			->willReturn(43200);
 
+		$fromMailAddress = $this->invokePrivate($usersController, 'fromMailAddress', []);
+
 		$message = $this->createMock(Message::class);
 		$message->expects($this->once())
 			->method('setTo')
@@ -3189,6 +3191,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->willReturn($message);
 		$message->expects($this->once())
 			->method('setFrom')
+			->with([$fromMailAddress => 'ownCloud'])
 			->willReturn($message);
 
 		$defaults->method('getName')
@@ -3204,6 +3207,8 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$result = $usersController->setPassword('fooBaZ1', 'foo', '123');
 		$this->assertEquals(new Http\JSONResponse(['status' => 'success']), $result);
+		$this->assertNotEquals($fromMailAddress, 'foo@bar.com');
+		$this->assertEquals($fromMailAddress, 'no-reply@foo.com');
 	}
 
 	public function testSetPasswordSendMailFailed() {

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -139,3 +139,14 @@ Feature: add users
     And the user sets the password to "%regular%" using the webUI
     And the user logs in with username "guiusr1" and password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+  Scenario: check if the sender email address is valid
+    When the administrator creates a user with the name "user1" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    And the user sets the password to "%regular%" using the webUI
+    Then the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    And the reset email to "guiusr1@owncloud" should be from "owncloud@foobar.com"


### PR DESCRIPTION
## Description
This fixes the from email on set password success email
Related issue: https://github.com/owncloud/user_management/issues/90


## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.