### PR TITLE
Remove default is plain from occ command help

### DIFF
--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -47,7 +47,7 @@ class Base extends Command {
 				'output',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'The output format to use (plain, json or json_pretty, default is plain).',
+				'The output format to use (plain, json or json_pretty).',
 				$this->defaultOutputFormat
 			)
 		;


### PR DESCRIPTION
# Description
This PR removes the `default is plain` message from occ command help.
Related issue: #33168

After removing the text, the help message looks like this:
![image](https://user-images.githubusercontent.com/20378877/46851565-9c7ff000-ce17-11e8-9bd3-20820e5397ec.png)


