### PR TITLE
[stable10] Backport of Blacklist the method setPassword while logging

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -110,7 +110,10 @@ class Log implements ILogger {
 		'invokeLDAPMethod',
 
 		//User_LDAP\Access
-		'areCredentialsValid'
+		'areCredentialsValid',
+
+		//UserManagement\Controller\UsersController
+		'setPassword'
 
 	];
 


### PR DESCRIPTION
Blacklist the setPassword method to prevent
writing function args info to the log file.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Blacklist the method setPassword while logging

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Blacklist the method setPassword while logging

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a user `user1` with email id using users page.
- Click the link from the email received which will land user to the page to set password.
- Add a line throw new \Exception('Wrong password'); in UsersController::setPassword ( in settings/Controller/UsersController.php )
- Now set the password and click the password button in the page
- User should see a trace in the log file as below:
```
{
"reqId":"RfW3ioRNLIeSlDVtaEp6","level":3,"time":"2018-10-12T13:32:35+00:00","remoteAddr":"::1","user":"--","app":"index","method":"POST","url":"\/testing2\/index.php\/setpassword\/844470806693509342706\/user1","message":"Exception: {\"Exception\":\"Exception\",\"Message\":\"wrong\",\"Code\":0,\"Trace\":\"
#0 /home/sujith/test/owncloud2/lib/private/AppFramework/Http/Dispatcher.php(153): OC\Settings\Controller\UsersController->setPassword(*** sensitive parameters replaced ***)
#1 /home/sujith/test/owncloud2/lib/private/AppFramework/Http/Dispatcher.php(85): OC\AppFramework\Http\Dispatcher->executeController(Object(OC\Settings\Controller\UsersController), 'setPassword')
#2 /home/sujith/test/owncloud2/lib/private/AppFramework/App.php(100): OC\AppFramework\Http\Dispatcher->dispatch(Object(OC\Settings\Controller\UsersController), 'setPassword')
#3 /home/sujith/test/owncloud2/lib/private/AppFramework/Routing/RouteActionHandler.php(46): OC\AppFramework\App::main('UsersController', 'setPassword', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#4 /home/sujith/test/owncloud2/lib/private/Route/Router.php(342): OC\AppFramework\Routing\RouteActionHandler->__invoke(Array)
#5 /home/sujith/test/owncloud2/lib/base.php(909): OC\Route\Router->match('/setpassword/84...')
#6 /home/sujith/test/owncloud2/index.php(54): OC::handleRequest()
#7 {main}\",\"File\":\"/home/sujith/test/owncloud2/settings/Controller/UsersController.php\",\"Line\":659}"
}
```
- Note the `*** sensitive parameters replaced ***` in the log for the function argument.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Requires https://github.com/owncloud/user_management/pull/89

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
