### PR TITLE
[stable10] Backport of Fix re-encrypting encrypted files

### DIFF
--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -297,7 +297,10 @@ class EncryptAll {
 		$target = $path . '.encrypted.' . $this->getTimeStamp() . '.part';
 
 		try {
-			$this->keyManager->setVersion($source, 0, $this->rootView);
+			$version = $this->keyManager->getVersion($source, $this->rootView);
+			if ($version > 0)  {
+				return false;
+			}
 			$this->rootView->copy($source, $target);
 			$this->rootView->rename($target, $source);
 		} catch (DecryptionFailedException $e) {

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -673,4 +673,12 @@ class EncryptAllTest extends TestCase {
 		$result = $this->invokePrivate($encryptAll, 'getTimeStamp', []);
 		$this->assertGreaterThan(10000, $result);
 	}
+
+	public function testEncryptAlreadyEncryptedFile() {
+		$this->keyManager->method('getVersion')
+			->with('/user1/files/bar.txt', $this->view)
+			->willReturn(1);
+		$result = $this->invokePrivate($this->encryptAll, 'encryptFile', ['/user1/files/bar.txt']);
+		$this->assertFalse($result);
+	}
 }


### PR DESCRIPTION
When the files are already encrypted the
files need not be encrypted again.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
encrypt-all command should not re-encrypt again. It should skip the encrypted files.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/52

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
encrypt-all command should not re-encrypt again. It should skip the encrypted files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Below are the tests done to verify it. 
#### Master key encryption
- Create 2 users `admin` and `user1` and encrypt with masterkey.
- Decrypt `user1` files.
- Execute encrypt-all. Below are the console log to verify the result:
```
➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗ rm -fr config/config.php data; ./occ maintenance:install --admin-user "admin" --admin-pass "admin"; ./occ a:e encryption; ./occ encryption:enable; ./occ encryption:select-encryption-type masterkey -y; ./occ user:add user1            
Cannot load Xdebug - it was already loaded
creating sqlite db
ownCloud was successfully installed
Cannot load Xdebug - it was already loaded
encryption enabled
Cannot load Xdebug - it was already loaded
Encryption enabled

Default module: OC_DEFAULT_MODULE
Cannot load Xdebug - it was already loaded
Master key successfully enabled.
Cannot load Xdebug - it was already loaded
Enter password: 
Confirm password: 
The user "user1" was created successfully
➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗ ./occ encryption:decrypt-all user1               
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in user1's account.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

Do you really want to continue? (y/n) y
prepare encryption modules...

Prepare "Default encryption module"

Using master key for decryption
 done.


 decrypt files for user user1 (1 of 1): /user1/files/welcome.txt 
 [-->-------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
Server side encryption remains enabled
➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗ ./occ encryption:encrypt-all                                                                                       
Cannot load Xdebug - it was already loaded


You are about to encrypt all files stored in your ownCloud installation.
Depending on the number of available files, and their size, this may take quite some time.
Please ensure that no user accesses their files during this time!
Note: The encryption module you use determines which files get encrypted.

Do you really want to continue? (y/n) y


Encrypt all files with the Default encryption module
====================================================


Use master key to encrypt all files.


Start to encrypt users files
----------------------------



 all files encrypted 
 [============================]

➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗
```
- Was able to open the welcome.txt and read the contents from `user1` and `admin`.

#### Master key re-encryption
- Continuation of the above test
- Ran masterkey recreate command and below is the console log:
```
➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗ ./occ encryption:recreate-master-key -y          
Cannot load Xdebug - it was already loaded
Decryption started

    1 [->--------------------------]prepare encryption modules...
 done.


 decrypt files for user user1 (2 of 2): /user1/files/welcome.txt 
 [--->------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
    1 [============================]
Decryption completed

Encryption started

Waiting for creating new masterkey

New masterkey created successfully



Encrypt all files with the Default encryption module
====================================================


Use master key to encrypt all files.


Start to encrypt users files
----------------------------



 all files encrypted 
 [============================]


Encryption completed successfully

➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗
```
- Was able to read the welcome.txt file from both `user1` and `admin`.

#### User Keys encryption
- Create 2 users `admin` and `user1` with user-keys encrypted
- Login to both users
- Decrypt `user1` with decrypt-all command
- Execute `encrypt-all` on the file system. Below are the console logs to be verified:
```
➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗ rm -fr config/config.php data; ./occ maintenance:install --admin-user "admin" --admin-pass "admin"; ./occ a:e user_management; ./occ a:e encryption; ./occ encryption:enable; ./occ encryption:select-encryption-type user-keys -y; ./occ user:add user1
Cannot load Xdebug - it was already loaded
creating sqlite db
ownCloud was successfully installed
Cannot load Xdebug - it was already loaded
user_management enabled
Cannot load Xdebug - it was already loaded
encryption enabled
Cannot load Xdebug - it was already loaded
Encryption enabled

Default module: OC_DEFAULT_MODULE
Cannot load Xdebug - it was already loaded
User key successfully enabled.
Cannot load Xdebug - it was already loaded
Enter password: 
Confirm password: 
The user "user1" was created successfully
➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗ ./occ encryption:decrypt-all user1
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in user1's account.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

Do you really want to continue? (y/n) y
prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user user1 (1 of 1): /user1/files/welcome.txt 
 [-->-------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
Server side encryption remains enabled
➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗ ./occ encryption:encrypt-all      
Cannot load Xdebug - it was already loaded


You are about to encrypt all files stored in your ownCloud installation.
Depending on the number of available files, and their size, this may take quite some time.
Please ensure that no user accesses their files during this time!
Note: The encryption module you use determines which files get encrypted.

Do you really want to continue? (y/n) y


Encrypt all files with the Default encryption module
====================================================


Create key-pair for every user
------------------------------

This module will encrypt all files in the users files folder initially.
Already existing versions and files in the trash bin will not be encrypted.



 Key-pair created for all users 
 [>---------------------------]

Start to encrypt users files
----------------------------



 all files encrypted 
 [============================]

Generated encryption key passwords
----------------------------------


All users already had a key-pair, no further action needed.



➜  owncloud git:(fix-rencrypting-encryptedfiles) ✗
```
- Was able to read welcome.txt file from `user1` and `admin`


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
