### PR TITLE
Adjust PHPDocs to be aligned with the implementation

### DIFF
--- a/lib/private/Files/Node/File.php
+++ b/lib/private/Files/Node/File.php
@@ -57,7 +57,9 @@ class File extends Node implements \OCP\Files\File, IPreviewNode {
 	}
 
 	/**
-	 * @param string $data
+	 * Write the contents of data into this file node. It can be a whole
+	 * string or a stream resource
+	 * @param string|resource $data
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function putContent($data) {

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -56,7 +56,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 	/**
 	 * @param string $path
-	 * @return string
+	 * @return string|null the relative path from this folder to $path or
+	 * null if $path is outside of this folder
 	 */
 	public function getRelativePath($path) {
 		if ($this->path === '' or $this->path === '/') {

--- a/lib/public/Files/File.php
+++ b/lib/public/Files/File.php
@@ -48,9 +48,9 @@ interface File extends Node {
 	public function getContent();
 
 	/**
-	 * Write to the file from string data
+	 * Write to the file from string or resource data
 	 *
-	 * @param string $data
+	 * @param string|resource $data
 	 * @throws \OCP\Files\NotPermittedException
 	 * @return void
 	 * @since 6.0.0

--- a/lib/public/Files/Folder.php
+++ b/lib/public/Files/Folder.php
@@ -45,11 +45,12 @@ interface Folder extends Node {
 	public function getFullPath($path);
 
 	/**
-	 * Get the path of an item in the folder relative to the folder
+	 * Get the path of an item in the folder relative to the folder or null
+	 * if the path is outside of the folder
 	 *
 	 * @param string $path absolute path of an item in the folder
 	 * @throws \OCP\Files\NotFoundException
-	 * @return string
+	 * @return string|null
 	 * @since 6.0.0
 	 */
 	public function getRelativePath($path);

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -194,9 +194,9 @@ interface IShare {
 	public function setExpirationDate($expireDate);
 
 	/**
-	 * Get the expiration date
+	 * Get the expiration date or null if no expiration date has been set
 	 *
-	 * @return \DateTime
+	 * @return \DateTime|null
 	 * @since 9.0.0
 	 */
 	public function getExpirationDate();
@@ -247,11 +247,11 @@ interface IShare {
 	public function setPassword($password);
 
 	/**
-	 * Get the password of this share.
+	 * Get the password of this share or null if no password has been set.
 	 * If this share is obtained via a shareprovider the password is
 	 * hashed.
 	 *
-	 * @return string
+	 * @return string|null
 	 * @since 9.0.0
 	 */
 	public function getPassword();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
There are 3 changes:
* `getRelativePath` implementation returns null if the target path is outside of the folder. The interface docs has have been adjusted.
* `getExpirationDate` and `getPassword` can return null if the corresponding "set" method hasn't been called. Interface docs adjusted.
* `putContent` implementation relies on the `view->file_put_contents` which allows a stream to be passed as parameter. The docs have been adjusted to allow using a stream as parameter there.

    Due to problems of events not being triggered if we use the `$node->fopen('wb')` stream to write the contents, allowing the `putContent` method to be called with a stream is the easiest solution for the short term because the events trigger properly using that method.

## Related Issue
No opened issue

## Motivation and Context
Both phpstan and phan are complaining about those inconsistencies in the apps.

## How Has This Been Tested?
1. Run phpstan and phan with code targeting those methods. Check warnings
2. Apply these changes and run both tools again. No warnings shown.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
