### PR TITLE
[stable10] Deprecate Sharing 1.0 APIs

### DIFF
--- a/lib/public/Share.php
+++ b/lib/public/Share.php
@@ -48,6 +48,7 @@ namespace OCP;
  * It provides the following hooks:
  *  - post_shared
  * @since 5.0.0
+ * @deprecated since 10.0.11 and will be removed in 11.0, please use the share manager instead
  */
 class Share extends \OC\Share\Constants {
 

--- a/lib/public/Share_Backend.php
+++ b/lib/public/Share_Backend.php
@@ -29,6 +29,7 @@ namespace OCP;
 /**
  * Interface that apps must implement to share content.
  * @since 5.0.0
+ * @deprecated since 10.0.11 and will be removed in 11.0, please use the share manager instead
  */
 interface Share_Backend {
 

--- a/lib/public/Share_Backend_Collection.php
+++ b/lib/public/Share_Backend_Collection.php
@@ -28,6 +28,7 @@ namespace OCP;
  * Interface for collections of of items implemented by another share backend.
  * Extends the Share_Backend interface.
  * @since 5.0.0
+ * @deprecated since 10.0.11 and will be removed in 11.0, please use the share manager instead
  */
 interface Share_Backend_Collection extends Share_Backend {
 	/**

--- a/lib/public/Share_Backend_File_Dependent.php
+++ b/lib/public/Share_Backend_File_Dependent.php
@@ -28,6 +28,7 @@ namespace OCP;
  * Interface for share backends that share content that is dependent on files.
  * Extends the Share_Backend interface.
  * @since 5.0.0
+ * @deprecated since 10.0.11 and will be removed in 11.0, please use the share manager instead
  */
 interface Share_Backend_File_Dependent extends Share_Backend {
 	/**


### PR DESCRIPTION
They will be removed in ownCloud 11.0 as everyone should move to Sharing
2.0 API through the ShareManager service.

Some parts already removed in OC 11 in https://github.com/owncloud/core/pull/26608