### PR TITLE
Deprecate Sharing 1.0 APIs

### DIFF
--- a/lib/public/Share.php
+++ b/lib/public/Share.php
@@ -47,6 +47,7 @@ namespace OCP;
  * It provides the following hooks:
  *  - post_shared
  * @since 5.0.0
+ * @deprecated since 10.0.11 and will be removed in 11.0, please use the share manager instead
  */
 class Share extends \OC\Share\Constants {
 	/**


### PR DESCRIPTION
Just to make sure we also have the deprecation warning in OC 11, in case we don't manage to fully kill this class with https://github.com/owncloud/core/issues/33219 in time.