### PR TITLE
Extend DBAL comparator to allow text field length changes

### DIFF
--- a/lib/private/DB/Comparator.php
+++ b/lib/private/DB/Comparator.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author martin-rueegg <martin.rueegg@metaworx.ch>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author tbelau666 <thomas.belau@gmx.de>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\DB;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Types\Type;
+
+class Comparator extends \Doctrine\DBAL\Schema\Comparator {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function diffColumn(Column $column1, Column $column2) {
+		$changedProperties = parent::diffColumn($column1, $column2);
+
+		// Remove once https://github.com/doctrine/dbal/pull/3182 is merged and
+		// DBAL is updated to a version containing this fix.
+		if ($column1->getType()->getName() === Type::TEXT) {
+			if ($column1->getLength() !== $column2->getLength()) {
+				$changedProperties[] = 'length';
+			}
+		}
+		return array_unique($changedProperties);
+	}
+}

--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -31,7 +31,6 @@ use \Doctrine\DBAL\DBALException;
 use \Doctrine\DBAL\Schema\Index;
 use \Doctrine\DBAL\Schema\Table;
 use \Doctrine\DBAL\Schema\Schema;
-use \Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\Type;
 use OCP\IConfig;

--- a/lib/private/DB/OracleMigrator.php
+++ b/lib/private/DB/OracleMigrator.php
@@ -145,10 +145,11 @@ class OracleMigrator extends Migrator {
 				return $this->quoteColumn($column);
 			}, $tableDiff->addedColumns);
 
-			foreach ($tableDiff->changedColumns as $column) {
-				$column->oldColumnName = $this->connection->quoteIdentifier($column->oldColumnName);
+			foreach ($tableDiff->changedColumns as $columnDiff) {
+				$columnDiff->column = $this->quoteColumn($columnDiff->column);
+				$columnDiff->oldColumnName = $this->connection->quoteIdentifier($columnDiff->oldColumnName);
 				// auto increment is not relevant for oracle and can anyhow not be applied on change
-				$column->changedProperties = \array_diff($column->changedProperties, ['autoincrement', 'unsigned']);
+				$columnDiff->changedProperties = \array_diff($columnDiff->changedProperties, ['autoincrement', 'unsigned']);
 			}
 			// remove columns that no longer have changed (because autoincrement and unsigned are not supported)
 			$tableDiff->changedColumns = \array_filter($tableDiff->changedColumns, function (ColumnDiff $column) {


### PR DESCRIPTION
## Description
Extend DBAL comparator to allow text field length changes

## Related Issue
See motivation section

## Motivation and Context
For until https://github.com/doctrine/dbal/pull/3182 is merged.
Required for https://github.com/owncloud/activity/pull/654

## How Has This Been Tested?
### Manual test
Manual test on https://github.com/owncloud/activity/pull/654:
1. Setup OC from scratch with Mariadb 10.2.17
1. Change the column to be "text": `alter table oc_activity modify column subjectparams text;`
1. Run the activity migration that convers it to "longtext": `occ migrations:execute activity 20181019151118`

Before the fix: the column stayed "text"
After this fix: the column properly changes to "longtext"

### Unit test
Unit test cannot work because DBAL doesn't populate the "length" attribute when reading schema from the DB, see https://github.com/doctrine/dbal/pull/3182#issuecomment-396004745 which is also a blocker for that upstream PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
