### PR TITLE
Don't remove temp file on fail when creating office preview

### DIFF
--- a/lib/private/Preview/Office.php
+++ b/lib/private/Preview/Office.php
@@ -69,7 +69,6 @@ abstract class Office implements IProvider2 {
 			$pdf = new \imagick($pdfPreview . '[0]');
 			$pdf->setImageFormat('jpg');
 		} catch (\Exception $e) {
-			\unlink($absPath);
 			@\unlink($pdfPreview);
 			\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::ERROR);
 			return false;


### PR DESCRIPTION
## Description
Whenever an office file preview is created, in case of failure it would
try to delete the input path. In some cases the input path points to a
temporary file and in some other cases it's the original file. Deleting
the original file results in data loss in case the PDF processor had an
error.

The line that deletes the input file was removed now because there is no
need to remove temporary files because the TempManager will have all
temporary files cleant up in the shutdown handler at the end of the PHP
request.

## Related Issue
Fixes https://github.com/owncloud/core/issues/33160

## Motivation and Context
See issue

## How Has This Been Tested?
- [x] TEST: temporary file mode: verify that temp file is removed at the end
- [x] TEST: real file mode: verify that real file still exists
- [x] TEST: temporary file + PDF failure mode: verify that temp file is removed at the end and real file still exists
- [x] TEST: real file + PDF failure mode: verify that real file still exists

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added => not testable in unit tests
- [ ] Acceptance tests added => not worth it especially with code removal
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
