### PR TITLE
[stable10] Set versions to 10.1 for semver

### DIFF
--- a/apps/comments/appinfo/info.xml
+++ b/apps/comments/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<default_enable/>
 	<version>0.3.0</version>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<types>
 		<logging/>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -16,7 +16,7 @@
 		<webdav>appinfo/v1/publicwebdav.php</webdav>
 	</public>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\DAV\CardDAV\SyncJob</job>

--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -26,7 +26,7 @@
 	<use-migrations>true</use-migrations>
 	<dependencies>
 		<lib>openssl</lib>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<commands>
 		<command>OCA\Encryption\Command\SelectEncryptionType</command>

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -13,7 +13,7 @@
         <filesystem/>
     </types>
     <dependencies>
-		<owncloud min-version="10.0.2.4" max-version="10.0" />
+		<owncloud min-version="10.0.2.4" max-version="10.1" />
     </dependencies>
     <settings>
         <admin>OCA\FederatedFileSharing\AdminPanel</admin>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<namespace>Federation</namespace>
 	<category>other</category>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<default_enable/>
 	<types>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -11,7 +11,7 @@
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<documentation>
 		<user>user-files</user>

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -22,7 +22,7 @@
 	<namespace>Files_External</namespace>
 
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 
 	<commands>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -16,7 +16,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	</types>
 	<use-migrations>true</use-migrations>
 	<dependencies>
-		<owncloud min-version="10.0.2.4" max-version="10.0" />
+		<owncloud min-version="10.0.2.4" max-version="10.1" />
 	</dependencies>
 	<public>
 		<files>public.php</files>

--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -17,7 +17,7 @@ To prevent a user from running out of disk space, the ownCloud Deleted files app
 	<use-migrations>true</use-migrations>
 	<namespace>Files_Trashbin</namespace>
 	<dependencies>
-		<owncloud min-version="10.0.2.4" max-version="10.0" />
+		<owncloud min-version="10.0.2.4" max-version="10.1" />
 	</dependencies>
 	<documentation>
 		<user>user-trashbin</user>

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -15,7 +15,7 @@ In addition to the expiry of versions, ownCloud’s versions app makes certain n
 	</types>
 	<namespace>Files_Versions</namespace>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<documentation>
 		<user>user-versions</user>

--- a/apps/provisioning_api/appinfo/info.xml
+++ b/apps/provisioning_api/appinfo/info.xml
@@ -23,6 +23,6 @@
 		<prevent_group_restriction/>
 	</types>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 </info>

--- a/apps/systemtags/appinfo/info.xml
+++ b/apps/systemtags/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<default_enable/>
 	<version>0.3.0</version>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 	<namespace>SystemTags</namespace>
 	<types>

--- a/apps/updatenotification/appinfo/info.xml
+++ b/apps/updatenotification/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<namespace>UpdateNotification</namespace>
 	<default_enable/>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10.0" />
+		<owncloud min-version="10.0" max-version="10.1" />
 	</dependencies>
 
 	<background-jobs>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ownCloud",
-  "version": "10.0.0 beta",
+  "version": "10.1",
   "homepage": "https://www.owncloud.org",
   "license": "AGPL",
   "private": true,

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 0, 10, 4];
+$OC_Version = [10, 1, 0, 0];
 
 // The human readable string
-$OC_VersionString = '10.0.10';
+$OC_VersionString = '10.1.0 alpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
Simply sets the versions to 10.1 and adjust max-version for all core apps.
:warning: don't merge yet, this is to check CI. Will be merged when all other offical apps are ready :warning: 

## Related Issue
https://github.com/owncloud/enterprise/issues/2532

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
