### PR TITLE
lookup in group principal backend as well

### DIFF
--- a/apps/dav/lib/Repair/RemoveInvalidShares.php
+++ b/apps/dav/lib/Repair/RemoveInvalidShares.php
@@ -22,6 +22,7 @@
 namespace OCA\DAV\Repair;
 
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\Migration\IOutput;
@@ -39,17 +40,22 @@ class RemoveInvalidShares implements IRepairStep {
 	private $connection;
 	/** @var Principal */
 	private $principalBackend;
+	/** @var GroupPrincipalBackend */
+	private $groupPrincipalBackend;
 
 	/**
 	 * RemoveInvalidShares constructor.
 	 *
 	 * @param IDBConnection $connection
 	 * @param Principal $principalBackend
+	 * @param GroupPrincipalBackend $groupPrincipalBackend
 	 */
 	public function __construct(IDBConnection $connection,
-								Principal $principalBackend) {
+								Principal $principalBackend,
+								GroupPrincipalBackend $groupPrincipalBackend) {
 		$this->connection = $connection;
 		$this->principalBackend = $principalBackend;
+		$this->groupPrincipalBackend = $groupPrincipalBackend;
 	}
 
 	/**
@@ -80,8 +86,11 @@ class RemoveInvalidShares implements IRepairStep {
 			$principaluri = $row['principaluri'];
 			$p = $this->principalBackend->getPrincipalByPath($principaluri);
 			if ($p === null) {
-				$output->info(" ... for principal '$principaluri'");
-				$this->deleteSharesForPrincipal($principaluri);
+				$p = $this->groupPrincipalBackend->getPrincipalByPath($principaluri);
+				if ($p === null) {
+					$output->info(" ... for principal '$principaluri'");
+					$this->deleteSharesForPrincipal($principaluri);
+				}
 			}
 		}
 

--- a/apps/dav/tests/unit/Repair/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Repair/RemoveInvalidSharesTest.php
@@ -22,6 +22,7 @@
 namespace OCA\DAV\Tests\Unit\Repair;
 
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCA\DAV\Repair\RemoveInvalidShares;
 use OCP\Migration\IOutput;
 use Test\TestCase;
@@ -45,16 +46,18 @@ class RemoveInvalidSharesTest extends TestCase {
 		]);
 	}
 
-	public function test() {
+	public function test(): void {
 		$db = \OC::$server->getDatabaseConnection();
 		/** @var Principal | \PHPUnit_Framework_MockObject_MockObject $principal */
 		$principal = $this->createMock(Principal::class);
+		/** @var GroupPrincipalBackend | \PHPUnit_Framework_MockObject_MockObject $groupPrincipal */
+		$groupPrincipal = $this->createMock(GroupPrincipalBackend::class);
 
 		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $output */
 		$output = $this->createMock(IOutput::class);
 
-		$repair = new RemoveInvalidShares($db, $principal);
-		$this->assertEquals("Remove invalid calendar and addressbook shares", $repair->getName());
+		$repair = new RemoveInvalidShares($db, $principal, $groupPrincipal);
+		$this->assertEquals('Remove invalid calendar and addressbook shares', $repair->getName());
 		$repair->run($output);
 
 		$query = $db->getQueryBuilder();
@@ -62,6 +65,6 @@ class RemoveInvalidSharesTest extends TestCase {
 			->where($query->expr()->eq('principaluri', $query->createNamedParameter('principal:unknown')))->execute();
 		$data = $result->fetchAll();
 		$result->closeCursor();
-		$this->assertEquals(0, \count($data));
+		$this->assertCount(0, $data);
 	}
 }


### PR DESCRIPTION
## Description
The repair step RemoveInvalidShares was not respecting group shares and deleted them.

## Related Issue
- fixes #33216

## Test Steps
- share calendar with a group
- run the repairstep (basically increase the version in version.php to trigger upgrade)
- ensure the calendar is still shared with the group

## How Has This Been Tested?
- unit test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
