### PR TITLE
cliTest user settings

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -257,6 +257,22 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @When the administrator changes the language of user :username to :language using the occ command
+	 *
+	 * @param string $username
+	 * @param string $language
+	 *
+	 * @return void
+	 */
+	public function theAdministratorChangesTheLanguageOfUserToUsingTheOccCommand(
+		$username, $language
+	) {
+		$this->featureContext->invokingTheCommand(
+			"user:setting $username core lang --value='$language'"
+		);
+	}
+
+	/**
 	 * @When the administrator retrieves the user report using the occ command
 	 *
 	 * @return void
@@ -418,6 +434,22 @@ class OccContext implements Context {
 		$this->featureContext->invokingTheCommand(
 			"user:enable $username"
 		);
+	}
+
+	/**
+	 * @Then the language of the user :username returned by the occ command should be :language
+	 *
+	 * @param string $username
+	 * @param string $language
+	 *
+	 * @return void
+	 */
+	public function theLanguageOfTheUserReturnedByTheOccCommandShouldBe($username, $language) {
+		$this->featureContext->invokingTheCommand(
+			"user:setting $username core lang"
+		);
+		$responseLanguage = $this->featureContext->getStdOutOfOccCommand();
+		PHPUnit_Framework_Assert::assertEquals($language, \trim($responseLanguage));
 	}
 
 	/**

--- a/tests/acceptance/features/cliProvisioning/userSettings.feature
+++ b/tests/acceptance/features/cliProvisioning/userSettings.feature
@@ -1,0 +1,11 @@
+@cli @skipOnLDAP
+Feature: user settings
+  As an admin
+  I want to be able set user settings
+  So that I can set specific settings for a specific user
+
+  Scenario: admin changes user language 
+  Given user "brand-new-user" has been created
+  When the administrator changes the language of user "brand-new-user" to "fr" using the occ command
+  Then the command should have been successful
+  And the language of the user "brand-new-user" returned by the occ command should be "fr"


### PR DESCRIPTION
## Description
This PR adds more tests for cliProvisioning userSettings using occ commands.

Related issue: #33052

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.