### PR TITLE
return false if propfind result is empty

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2706,16 +2706,18 @@ trait WebDav {
 			$this->parseResponseIntoXml();
 		}
 		$multistatusResults = $this->responseXml["value"];
-		foreach ($multistatusResults as $multistatusResult) {
-			$filePath = $multistatusResult['value'][0]['value'];
-			$fullWebDavPath = \ltrim(
-				$this->getBasePath() . "/" . $this->getDavFilesPath($user) . "/",
-				"/"
-			);
-			$fileName = \str_replace($fullWebDavPath, "", $filePath);
-			$fileName = \rawurldecode($fileName);
-			if ($fileName === $fileNameToSearch) {
-				return $multistatusResult;
+		if ($multistatusResults !== null) {
+			foreach ($multistatusResults as $multistatusResult) {
+				$filePath = $multistatusResult['value'][0]['value'];
+				$fullWebDavPath = \ltrim(
+					$this->getBasePath() . "/" . $this->getDavFilesPath($user) . "/",
+					"/"
+				);
+				$fileName = \str_replace($fullWebDavPath, "", $filePath);
+				$fileName = \rawurldecode($fileName);
+				if ($fileName === $fileNameToSearch) {
+					return $multistatusResult;
+				}
 			}
 		}
 		return false;


### PR DESCRIPTION
## Description
if the PROPFIND result happens to be empty return `false` and do not crash with `Invalid argument supplied for foreach()`

## Related Issue
- https://github.com/owncloud/search_elastic/issues/35

## Motivation and Context
the search might return an empty result

## How Has This Been Tested?
- run search tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
