### PR TITLE
adjust 'has never logged in' text

### DIFF
--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -63,7 +63,7 @@ class LastSeen extends Command {
 		$lastLogin = $user->getLastLogin();
 		if ($lastLogin === 0) {
 			$output->writeln('User ' . $user->getUID() .
-				' has never logged in, yet.');
+				' has never logged in.');
 		} else {
 			$date = new \DateTime();
 			$date->setTimestamp($lastLogin);

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -539,7 +539,7 @@ class OccContext implements Context {
 	public function theCommandOutputOfUserLastSeenShouldBeNever() {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		PHPUnit_Framework_Assert::assertContains(
-			"has never logged in, yet.",
+			"has never logged in.",
 			$lastOutput
 		);
 	}

--- a/tests/acceptance/features/cliProvisioning/userLastSeen.feature
+++ b/tests/acceptance/features/cliProvisioning/userLastSeen.feature
@@ -2,7 +2,7 @@
 Feature: get user last seen
   As an admin
   I want to be able get user last seen
-  So that I can see when the user has last logged in the owncloud server
+  So that I can see when the user has last logged in to the owncloud server
 
   Scenario: admin gets last seen of a user
     Given user "brand-new-user" has been created


### PR DESCRIPTION
## Description
Change message:
```
User newuser has never logged in, yet.
```
to
```
User newuser has never logged in.
```


## Related Issue
#33268
Noticed when reviewing PR #33244 

## Motivation and Context
The words and punctuation of the "has never logged in" message are odd.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added (existing unit test is OK with this change)
- [x] Acceptance tests adjusted
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
