### PR TITLE
ignore shared storages when listing versions

### DIFF
--- a/lib/private/Files/Meta/MetaVersionCollection.php
+++ b/lib/private/Files/Meta/MetaVersionCollection.php
@@ -71,7 +71,7 @@ class MetaVersionCollection extends AbstractFolder {
 	 */
 	public function getDirectoryListing() {
 		$view = new View();
-		$path = $view->getPath($this->fileId);
+		$path = $view->getPath($this->fileId, false);
 		/** @var Storage $storage */
 		list($storage, $internalPath) = $view->resolvePath($path);
 		if (!$storage->instanceOfStorage(IVersionedStorage::class)) {


### PR DESCRIPTION
otherwise the wrong storage might be used to look up the path, leading to an empty versions list. might also help a little with slow versions responses because it now skips shared storages
