### PR TITLE
[stable10] Fix PHP style in WebDav.php

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -300,6 +300,7 @@ trait WebDav {
 	 * @param string $enabledOrDisabled
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function triggerAsyncUpload($enabledOrDisabled) {
 		$switch = ($enabledOrDisabled !== "disabled");
@@ -343,6 +344,7 @@ trait WebDav {
 	 * @param string $method
 	 * @param int $seconds
 	 *
+	 * @throws Exception
 	 * @return void
 	 */
 	public function slowdownDavRequests($method, $seconds) {


### PR DESCRIPTION
Backport #33274 

That is a forward port from ``stable10``. But the forward port included these minor changes to ``WebDav.php`` which should be also applied in ``stable110`` just to keep the code the same.

The commits from #33274 called "Adjust async capabilities scenarios" and "Adjust downloadFileAsUserUsingPassword() makeDavRequest() call" are things that are already in ``stable10`` - so there is nothing from those to backport.

The commit from #33274 called "moveFileAsync.feature: adjust acceptance to new behavior" needs to be applied separately to the backport in PR #33266 which introduces the behavior changes to ``stable10``