### PR TITLE
Add API checks for trashbinFilesFolders webUI scenarios

### DIFF
--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -17,7 +17,11 @@ Feature: files and folders exist in the trashbin after being deleted
       | lorem.txt                             |
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
-    Then the deleted elements should be listed in the trashbin on the webUI
+    Then as "user1" the folder "simple-folder" should exist in trash
+    And as "user1" the file "lorem.txt" should exist in trash
+    And as "user1" the folder "strängé नेपाली folder" should exist in trash
+    And as "user1" the file "strängé filename (duplicate #2 &).txt" should exist in trash
+    And the deleted elements should be listed in the trashbin on the webUI
     And the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
   Scenario: Delete a file with problematic characters and check it is in the trashbin
@@ -46,19 +50,25 @@ Feature: files and folders exist in the trashbin after being deleted
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then the deleted elements should be listed in the trashbin on the webUI
+    Then as "user1" the file "data.zip" should exist in trash
+    And as "user1" the file "lorem.txt" should exist in trash
+    And as "user1" the folder "simple-folder" should exist in trash
+    And as "user1" the file "simple-folder/lorem.txt" should exist in trash
+    And the deleted elements should be listed in the trashbin on the webUI
     And the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
   Scenario: Delete an empty folder and check it is in the trashbin
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
     And the user deletes the folder "my-empty-folder" using the webUI
-    Then the folder "my-empty-folder" should be listed in the trashbin on the webUI
+    Then as "user1" the folder "my-empty-folder" should exist in trash
+    But as "user1" the folder with original path "my-other-empty-folder" should not exist in trash
+    And the folder "my-empty-folder" should be listed in the trashbin on the webUI
     But the folder "my-other-empty-folder" should not be listed in the trashbin on the webUI
     When the user opens the trashbin folder "my-empty-folder" using the webUI
     Then there should be no files/folders listed on the webUI
 
-  Scenario: Delete multiple file with same filename and check they are in trashbin
+  Scenario: Delete multiple file with same filename and check they are in the trashbin
     When the user deletes the following elements using the webUI
       | name      |
       | lorem.txt |
@@ -71,6 +81,9 @@ Feature: files and folders exist in the trashbin after being deleted
     And the user deletes the following elements using the webUI
       | name      |
       | lorem.txt |
+    Then as "user1" the file with original path "lorem.txt" should exist in trash
+    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in trash
+    And as "user1" the file with original path "strängé नेपाली folder/lorem.txt" should exist in trash
     Then the deleted elements should be listed in the trashbin on the webUI
     And the file "lorem.txt" with the path "./lorem.txt" should be listed in the trashbin on the webUI
     And the file "lorem.txt" with the path "simple-folder/lorem.txt" should be listed in the trashbin on the webUI


### PR DESCRIPTION
## Description
Check that the trashbin API sees files that have been deleted in the webUI.

## Related Issue
#33300 

## Motivation and Context
- do more extensive checks that the trashbin "really works" from the POV of the trashbin API as well as the webUI trashbin page
- maybe reduce the intermittent timing issues (we will see)

## How Has This Been Tested?
Local run of ``tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature``

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
