### PR TITLE
Allow env var BEHAT_RERUN_TIMES to be passed to acceptance tests

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -12,7 +12,6 @@ OCC=${OC_PATH}occ
 BEHAT=${OC_PATH}lib/composer/bin/behat
 
 BEHAT_TAGS_OPTION_FOUND=false
-BEHAT_RERUN_TIMES=1
 
 # The following environment variables can be specified:
 #
@@ -240,6 +239,11 @@ ADMIN_AUTH="${ADMIN_USERNAME}:${ADMIN_PASSWORD}"
 
 export ADMIN_USERNAME
 export ADMIN_PASSWORD
+
+if [ -z "${BEHAT_RERUN_TIMES}" ]
+then
+	BEHAT_RERUN_TIMES=1
+fi
 
 function env_alt_home_enable {
 	remote_occ ${ADMIN_AUTH} ${OCC_URL} "config:app:set testing enable_alt_user_backend --value yes"


### PR DESCRIPTION
## Description
Move the setting of ``BEHAT_RERUN_TIMES`` so it is only set to ``1`` if the env var is not provided externally or via ``--loop`` 

## Motivation and Context
When I want to run an acceptance test scenario locally multiple times when using the ``make test-acceptance-webui`` command.

I can do something like:
```
./tests/acceptance/run.sh --loop 5 tests/acceptance/features/webUIFiles/fileDetails.feature:57
```
But when I try to use the ``make`` target and pass the ``BEHAT_RERUN_TIMES`` env var, it is ignored:
```
make test-acceptance-webui BEHAT_RERUN_TIMES=5 BEHAT_FEATURE=tests/acceptance/features/webUIFiles/fileDetails.feature:57
```
because ``run.sh`` is first over-writing and setting ``BEHAT_RERUN_TIMES`` to 1.

## How Has This Been Tested?
Local webUI test runs like:
```
make test-acceptance-webui BEHAT_RERUN_TIMES=2 BEHAT_FEATURE=tests/acceptance/features/webUIFiles/fileDetails.feature:57
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
