### PR TITLE
extra checks for deleteFilesFolders.feature

### DIFF
--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -20,7 +20,11 @@ Feature: deleting files and folders
       | lorem.txt                             |
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
-    Then the deleted elements should not be listed on the webUI
+    Then as "user1" the folder "simple-folder" should not exist
+    And as "user1" the file "lorem.txt" should not exist
+    And as "user1" the folder "strängé नेपाली folder" should not exist
+    And as "user1" the file "strängé filename (duplicate #2 &).txt" should not exist
+    And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
   Scenario: Delete a file with problematic characters
@@ -64,13 +68,20 @@ Feature: deleting files and folders
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then the deleted elements should not be listed on the webUI
+    Then as "user1" the file "data.zip" should not exist
+    And as "user1" the file "lorem.txt" should not exist
+    And as "user1" the folder "simple-folder" should not exist
+    And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
   Scenario: Delete all files at once
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI
-    Then the folder should be empty on the webUI
+    # Check just some example files/folders that should not exist any more
+    Then as "user1" the file "data.zip" should not exist
+    And as "user1" the file "lorem.txt" should not exist
+    And as "user1" the folder "simple-folder" should not exist
+    And the folder should be empty on the webUI
     And the folder should be empty on the webUI after a page reload
 
   Scenario: Delete all except for a few files at once
@@ -80,21 +91,27 @@ Feature: deleting files and folders
       | lorem.txt     |
       | simple-folder |
     And the user batch deletes the marked files using the webUI
-    Then the folder "simple-folder" should be listed on the webUI
+    Then as "user1" the file "lorem.txt" should exist
+    And as "user1" the folder "simple-folder" should exist
+    And the folder "simple-folder" should be listed on the webUI
     And the file "lorem.txt" should be listed on the webUI
-		# Check just an example of a file that should not exist any more
-    But the file "data.zip" should not be listed on the webUI
+    # Check just an example of a file that should not exist any more
+    But as "user1" the file "data.zip" should not exist
+    And the file "data.zip" should not be listed on the webUI
 
   Scenario: Delete an empty folder
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
     And the user deletes the folder "my-empty-folder" using the webUI
-    Then the folder "my-other-empty-folder" should be listed on the webUI
-    But the folder "my-empty-folder" should not be listed on the webUI
+    Then as "user1" the folder "my-other-empty-folder" should exist
+    And the folder "my-other-empty-folder" should be listed on the webUI
+    But as "user1" the folder "my-empty-folder" should not exist
+    And the folder "my-empty-folder" should not be listed on the webUI
 
   Scenario: Delete the last file in a folder
     When the user deletes the file "zzzz-must-be-last-file-in-folder.txt" using the webUI
-    Then the file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
+    Then as "user1" the file "zzzz-must-be-last-file-in-folder.txt" should not exist
+    And the file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   Scenario: delete files from shared with others page
     Given the user has shared the file "lorem.txt" with the user "User Two" using the webUI
@@ -102,7 +119,9 @@ Feature: deleting files and folders
     And the user has browsed to the shared-with-others page
     When the user deletes the file "lorem.txt" using the webUI
     And the user deletes the folder "simple-folder" using the webUI
-    Then the file "lorem.txt" should not be listed on the webUI
+    Then as "user1" the file "lorem.txt" should not exist
+    And as "user1" the folder "simple-folder" should not exist
+    And the file "lorem.txt" should not be listed on the webUI
     And the folder "simple-folder" should not be listed on the webUI
     When the user browses to the files page
     Then the file "lorem.txt" should not be listed on the webUI
@@ -114,7 +133,8 @@ Feature: deleting files and folders
     And the user has browsed to the shared-by-link page
     Then the file "lorem.txt" should be listed on the webUI
     When the user deletes the file "lorem.txt" using the webUI
-    Then the file "lorem.txt" should not be listed on the webUI
+    Then as "user1" the file "lorem.txt" should not exist
+    And the file "lorem.txt" should not be listed on the webUI
     When the user browses to the files page
     Then the file "lorem.txt" should not be listed on the webUI
 
@@ -126,6 +146,7 @@ Feature: deleting files and folders
     And the user searches for tag "lorem" using the webUI
     Then the file "lorem.txt" should be listed on the webUI
     When the user deletes the file "lorem.txt" using the webUI
-    Then the file "lorem.txt" should not be listed on the webUI
+    Then as "user1" the file "lorem.txt" should not exist
+    And the file "lorem.txt" should not be listed on the webUI
     When the user browses to the files page
     Then the file "lorem.txt" should not be listed on the webUI


### PR DESCRIPTION
## Description
Add test steps to verify that deleted files are really gone via API requests.

As a side-effect, this will also help reliability of the webUI tests when run with the encryption app, where the webUI "response" seems slow, but not easy to reliably check for. The extra steps that do the API checks provide a small delay before checking the webUI. This should not be necessary! Some day that that needs more detailed investigation.

## Motivation and Context
When performing actions in the webUI, it is good to know that the effects of the actions can be seen via some other means also (API or CLI or...) Do this for the various webUI tests that delete files and folders.

## How Has This Been Tested?
Local webUI run:
```
make test-acceptance-webui BEHAT_FEATURE=tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
