### PR TITLE
reset responseXml after receiving a new response

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -626,6 +626,8 @@ trait BasicStructure {
 	 */
 	public function setResponse($response) {
 		$this->response = $response;
+		//after a new response reset the response xml
+		$this->responseXml = [];
 	}
 
 	/**


### PR DESCRIPTION
## Description
when setting a new `$response` also the `$responseXml` (xml parsed response) is outdated

## Related Issue
https://github.com/owncloud/search_elastic/issues/35 

## Motivation and Context
when having multiple Requests in one test, we need to reset the values so we analyse the correct response

## How Has This Been Tested?
- written test-cases (seach_elastic) that send multiple requests and check the responses

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
