### PR TITLE
[stable10] Email subject is already escaped, avoid double escaping

### DIFF
--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -160,10 +160,11 @@ class MailNotifications {
 				'file' => $filename,
 			]);
 
+			$unescapedFilename = $filename;
 			$filename = $filter->getFile();
 			$link = $filter->getLink();
 
-			$subject = (string) $this->l->t('%s shared »%s« with you', [$this->senderDisplayName, $filename]);
+			$subject = (string) $this->l->t('%s shared »%s« with you', [$this->senderDisplayName, $unescapedFilename]);
 			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, null, 'internal');
 
 			// send it out now

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -392,7 +392,7 @@ class MailNotificationsTest extends TestCase {
 	}
 
 	public function testSendInternalShareMail() {
-		$this->setupMailerMock('TestUser shared »&lt;welcome&gt;.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
+		$this->setupMailerMock('TestUser shared »<welcome>.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
 
 		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
 		$mailNotifications = $this->getMockBuilder('OC\Share\MailNotifications')
@@ -441,7 +441,7 @@ class MailNotificationsTest extends TestCase {
 	}
 
 	public function testSendInternalShareMailException() {
-		$this->setupMailerMock('TestUser shared »&lt;welcome&gt;.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
+		$this->setupMailerMock('TestUser shared »<welcome>.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
 
 		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
 		$mailNotifications = $this->getMockBuilder('OC\Share\MailNotifications')


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/33138 to stable10