### PR TITLE
Use both webDAV paths for share permission Acceptance tests

### DIFF
--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -3,26 +3,36 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And using old DAV path
     And user "user0" has been created
     And user "user1" has been created
 
   @smokeTest
-  Scenario: Correct webdav share-permissions for owned file
-    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+  Scenario Outline: Correct webdav share-permissions for owned file
+    Given using <dav-path> DAV path
+    And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     When user "user0" gets the following properties of file "/tmp.txt" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received file with edit and reshare permissions
-    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+  Scenario Outline: Correct webdav share-permissions for received file with edit and reshare permissions
+    Given using <dav-path> DAV path
+    And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has shared file "/tmp.txt" with user "user1"
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared file with edit and reshare permissions
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared file with edit and reshare permissions
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has created a share with settings
@@ -33,18 +43,28 @@ Feature: sharing
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
-    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+  Scenario Outline: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
+    Given using <dav-path> DAV path
+    And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has shared file "tmp.txt" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 3 |
     And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has created a share with settings
@@ -55,18 +75,28 @@ Feature: sharing
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
-    Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
+  Scenario Outline: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
+    Given using <dav-path> DAV path
+    And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has shared file "tmp.txt" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 17 |
     And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has created a share with settings
@@ -77,22 +107,37 @@ Feature: sharing
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for owned folder
-    Given user "user0" has created a folder "/tmp"
+  Scenario Outline: Correct webdav share-permissions for owned folder
+    Given using <dav-path> DAV path
+    And user "user0" has created a folder "/tmp"
     When user "user0" gets the following properties of folder "/" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received folder with all permissions
-    Given user "user0" has created a folder "/tmp"
+  Scenario Outline: Correct webdav share-permissions for received folder with all permissions
+    Given using <dav-path> DAV path
+    And user "user0" has created a folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared folder with all permissions
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a folder "/tmp"
     And user "user0" has created a share with settings
@@ -102,18 +147,28 @@ Feature: sharing
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received folder with all permissions but edit
-    Given user "user0" has created a folder "/tmp"
+  Scenario Outline: Correct webdav share-permissions for received folder with all permissions but edit
+    Given using <dav-path> DAV path
+    And user "user0" has created a folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 29 |
     And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but edit
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but edit
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a folder "/tmp"
     And user "user0" has created a share with settings
@@ -124,18 +179,28 @@ Feature: sharing
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received folder with all permissions but create
-    Given user "user0" has created a folder "/tmp"
+  Scenario Outline: Correct webdav share-permissions for received folder with all permissions but create
+    Given using <dav-path> DAV path
+    And user "user0" has created a folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 27 |
     And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but create
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but create
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a folder "/tmp"
     And user "user0" has created a share with settings
@@ -146,18 +211,28 @@ Feature: sharing
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received folder with all permissions but delete
-    Given user "user0" has created a folder "/tmp"
+  Scenario Outline: Correct webdav share-permissions for received folder with all permissions but delete
+    Given using <dav-path> DAV path
+    And user "user0" has created a folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 23 |
     And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but delete
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but delete
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a folder "/tmp"
     And user "user0" has created a share with settings
@@ -168,18 +243,28 @@ Feature: sharing
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received folder with all permissions but share
-    Given user "user0" has created a folder "/tmp"
+  Scenario Outline: Correct webdav share-permissions for received folder with all permissions but share
+    Given using <dav-path> DAV path
+    And user "user0" has created a folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 15 |
     And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
 
-  Scenario: Correct webdav share-permissions for received group shared folder with all permissions but share
-    Given group "grp1" has been created
+  Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but share
+    Given using <dav-path> DAV path
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a folder "/tmp"
     And user "user0" has created a share with settings
@@ -190,3 +275,7 @@ Feature: sharing
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
make tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature also work with new DAV path

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33348, Related to #32040

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
