### PR TITLE
Allow remember login when external storage is disabled globally

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1042,11 +1042,11 @@ class OC_Util {
 
 		foreach ($apps as $app) {
 			$appInfo = OC_App::getAppInfo($app);
-			if (isset($appInfo['rememberlogin']) && $appInfo['rememberlogin'] === 'false') {
+			if (isset($appInfo['rememberlogin']) && $appInfo['rememberlogin'] === 'false' && $appInfo['id'] !== 'files_external') {
 				return false;
 			}
 		}
-		return true;
+		return \OC::$server->getAppConfig()->getValue('core', 'enable_external_storage', 'no') === 'no';
 	}
 
 	/**


### PR DESCRIPTION
#27051 and #15277 disable the feature "remember login". This means that `\OC_Util::rememberLoginAllowed()` returns `false` always. We can enable it when external storage is disabled globally.