### PR TITLE
No max version check for apps when using release channel git or daily

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -400,8 +400,7 @@ class OC {
 		$tmpl->assign('isAppsOnlyUpgrade', $isAppsOnlyUpgrade);
 
 		// get third party apps
-		$ocVersion = \OCP\Util::getVersion();
-		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
+		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade());
 		$tmpl->assign('productName', 'ownCloud'); // for now
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -86,6 +86,8 @@ class AppManager implements IAppManager {
 	 * @var string[][]
 	 */
 	private $appDirs = [];
+	/** @var Platform */
+	private $platform;
 
 	/**
 	 * @param IUserSession $userSession
@@ -94,19 +96,22 @@ class AppManager implements IAppManager {
 	 * @param ICacheFactory $memCacheFactory
 	 * @param EventDispatcherInterface $dispatcher
 	 * @param IConfig $config
+	 * @param Platform $platform
 	 */
 	public function __construct(IUserSession $userSession = null,
 								IAppConfig $appConfig = null,
 								IGroupManager $groupManager = null,
 								ICacheFactory $memCacheFactory,
 								EventDispatcherInterface $dispatcher,
-								IConfig $config) {
+								IConfig $config,
+								Platform $platform) {
 		$this->userSession = $userSession;
 		$this->appConfig = $appConfig;
 		$this->groupManager = $groupManager;
 		$this->memCacheFactory = $memCacheFactory;
 		$this->dispatcher = $dispatcher;
 		$this->config = $config;
+		$this->platform = $platform;
 	}
 
 	/**
@@ -339,12 +344,11 @@ class AppManager implements IAppManager {
 	/**
 	 * Returns a list of apps that need upgrade
 	 *
-	 * @param array $ocVersion ownCloud version as array of version components
 	 * @return array list of app info from apps that need an upgrade
 	 *
 	 * @internal
 	 */
-	public function getAppsNeedingUpgrade($ocVersion) {
+	public function getAppsNeedingUpgrade() {
 		$appsToUpgrade = [];
 		$apps = $this->getInstalledApps();
 		foreach ($apps as $appId) {
@@ -353,7 +357,7 @@ class AppManager implements IAppManager {
 			if ($appDbVersion
 				&& isset($appInfo['version'])
 				&& \version_compare($appInfo['version'], $appDbVersion, '>')
-				&& \OC_App::isAppCompatible($ocVersion, $appInfo)
+				&& \OC_App::isAppCompatible($this->platform, $appInfo)
 			) {
 				$appsToUpgrade[] = $appInfo;
 			}
@@ -381,27 +385,6 @@ class AppManager implements IAppManager {
 			$appInfo['version'] = \OC_App::getAppVersion($appId);
 		}
 		return $appInfo;
-	}
-
-	/**
-	 * Returns a list of apps incompatible with the given version
-	 *
-	 * @param array $version ownCloud version as array of version components
-	 *
-	 * @return array list of app info from incompatible apps
-	 *
-	 * @internal
-	 */
-	public function getIncompatibleApps($version) {
-		$apps = $this->getInstalledApps();
-		$incompatibleApps = [];
-		foreach ($apps as $appId) {
-			$info = $this->getAppInfo($appId);
-			if (!\OC_App::isAppCompatible($version, $info)) {
-				$incompatibleApps[] = $info;
-			}
-		}
-		return $incompatibleApps;
 	}
 
 	/**

--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -176,8 +176,8 @@ class DependencyAnalyzer {
 			return $this->getValue($db);
 		}, $supportedDatabases);
 		$currentDatabase = $this->platform->getDatabase();
-		if (!\in_array($currentDatabase, $supportedDatabases)) {
-			$missing[] = (string)$this->l->t('Following databases are supported: %s', \join(', ', $supportedDatabases));
+		if (!\in_array($currentDatabase, $supportedDatabases, true)) {
+			$missing[] = (string)$this->l->t('Following databases are supported: %s', \implode(', ', $supportedDatabases));
 		}
 		return $missing;
 	}
@@ -279,8 +279,8 @@ class DependencyAnalyzer {
 			$oss = [$oss];
 		}
 		$currentOS = $this->platform->getOS();
-		if (!\in_array($currentOS, $oss)) {
-			$missing[] = (string)$this->l->t('Following platforms are supported: %s', \join(', ', $oss));
+		if (!\in_array($currentOS, $oss, true)) {
+			$missing[] = (string)$this->l->t('Following platforms are supported: %s', \implode(', ', $oss));
 		}
 		return $missing;
 	}
@@ -312,7 +312,7 @@ class DependencyAnalyzer {
 				$missing[] = (string)$this->l->t('ownCloud %s or higher is required.', $minVersion);
 			}
 		}
-		if ($maxVersion !== null) {
+		if ($maxVersion !== null && !\in_array($this->platform->getOcChannel(), ['git', 'daily'], true)) {
 			if ($this->compareBigger($this->platform->getOcVersion(), $maxVersion)) {
 				$missing[] = (string)$this->l->t('ownCloud %s or lower is required.', $maxVersion);
 			}

--- a/lib/private/App/Platform.php
+++ b/lib/private/App/Platform.php
@@ -46,29 +46,29 @@ class Platform {
 	/**
 	 * @return string
 	 */
-	public function getPhpVersion() {
+	public function getPhpVersion(): string {
 		return \phpversion();
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getIntSize() {
+	public function getIntSize(): int {
 		return PHP_INT_SIZE;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getOcVersion() {
+	public function getOcVersion(): string {
 		$v = \OCP\Util::getVersion();
-		return \join('.', $v);
+		return \implode('.', $v);
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDatabase() {
+	public function getDatabase(): string {
 		$dbType = $this->config->getSystemValue('dbtype', 'sqlite');
 		if ($dbType === 'sqlite3') {
 			$dbType = 'sqlite';
@@ -80,7 +80,7 @@ class Platform {
 	/**
 	 * @return string
 	 */
-	public function getOS() {
+	public function getOS(): string {
 		return \php_uname('s');
 	}
 
@@ -88,14 +88,17 @@ class Platform {
 	 * @param $command
 	 * @return bool
 	 */
-	public function isCommandKnown($command) {
+	public function isCommandKnown($command): bool {
 		$path = \OC_Helper::findBinaryPath($command);
 		return ($path !== null);
 	}
 
-	public function getLibraryVersion($name) {
+	public function getLibraryVersion($name): ?string {
 		$repo = new PlatformRepository();
-		$lib = $repo->findLibrary($name);
-		return $lib;
+		return $repo->findLibrary($name);
+	}
+
+	public function getOcChannel(): string {
+		return \OCP\Util::getChannel();
 	}
 }

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -39,6 +39,7 @@
 namespace OC;
 
 use Doctrine\DBAL\Exception\TableExistsException;
+use OC\App\Platform;
 use OC\DB\MigrationService;
 use OC_App;
 use OC_DB;
@@ -372,7 +373,7 @@ class Installer {
 		}
 
 		// check if the app is compatible with this version of ownCloud
-		if (!OC_App::isAppCompatible(\OCP\Util::getVersion(), $info)) {
+		if (!OC_App::isAppCompatible(new Platform(\OC::$server->getConfig()), $info)) {
 			OC_Helper::rmdirr($extractDir);
 			throw new \Exception($l->t("App can't be installed because it is not compatible with this version of ownCloud"));
 		}

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -23,6 +23,7 @@ namespace OC\Repair;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use OC\App\Platform;
 use OC\RepairException;
 use OC_App;
 use OCP\App\AppAlreadyInstalledException;
@@ -265,8 +266,7 @@ class Apps implements IRepairStep {
 				$appsToUpgrade[self::KEY_MISSING][] = $appId;
 				continue;
 			}
-			$version = Util::getVersion();
-			$key = (\OC_App::isAppCompatible($version, $info)) ? self::KEY_COMPATIBLE : self::KEY_INCOMPATIBLE;
+			$key = (\OC_App::isAppCompatible(new Platform($this->config), $info)) ? self::KEY_COMPATIBLE : self::KEY_INCOMPATIBLE;
 			$appsToUpgrade[$key][] = $appId;
 		}
 		return $appsToUpgrade;

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -41,6 +41,7 @@
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\App\Platform;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Db\Db;
 use OC\AppFramework\Utility\TimeFactory;
@@ -594,7 +595,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$groupManager,
 				$c->getMemCacheFactory(),
 				$c->getEventDispatcher(),
-				$c->getConfig()
+				$c->getConfig(),
+				new Platform($c->getConfig())
 			);
 		});
 		$this->registerService('DateTimeZone', function (Server $c) {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -98,6 +98,9 @@ class OC_App {
 	 * exists.
 	 *
 	 * if $types is set, only apps of those types will be loaded
+	 * @throws \OC\HintException
+	 * @throws \OC\NeedsUpdateException
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	public static function loadApps($types = null) {
 		if (\is_array($types) && !\array_diff($types, self::$loadedTypes)) {
@@ -123,7 +126,7 @@ class OC_App {
 		// prevent app.php from printing output
 		\ob_start();
 		foreach ($apps as $app) {
-			if (($types === null or self::isType($app, $types)) && !\in_array($app, self::$loadedApps)) {
+			if (($types === null or self::isType($app, $types)) && !\in_array($app, self::$loadedApps, true)) {
 				self::loadApp($app);
 			}
 		}
@@ -175,7 +178,9 @@ class OC_App {
 
 	/**
 	 * Enables the app as a theme if it has the type "theme"
+	 *
 	 * @param string $app
+	 * @throws \OCP\AppFramework\QueryException
 	 */
 	private static function enableThemeIfApplicable($app) {
 		if (self::isType($app, 'theme')) {
@@ -206,6 +211,7 @@ class OC_App {
 	 * Load app.php from the given app
 	 *
 	 * @param string $app app name
+	 * @throws Exception
 	 */
 	private static function requireAppFile($app) {
 		try {
@@ -214,7 +220,7 @@ class OC_App {
 		} catch (Exception $ex) {
 			\OC::$server->getLogger()->logException($ex);
 			$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
-			if (!\in_array($app, $blacklist)) {
+			if (!\in_array($app, $blacklist, true)) {
 				if (!self::isType($app, ['authentication', 'filesystem'])) {
 					\OC::$server->getLogger()->warning('Could not load app "' . $app . '", it will be disabled', ['app' => 'core']);
 					self::disable($app);
@@ -239,7 +245,7 @@ class OC_App {
 		}
 		$appTypes = self::getAppTypes($app);
 		foreach ($types as $type) {
-			if (\array_search($type, $appTypes) !== false) {
+			if (\in_array($type, $appTypes, true)) {
 				return true;
 			}
 		}
@@ -254,15 +260,15 @@ class OC_App {
 	 */
 	private static function getAppTypes($app) {
 		//load the cache
-		if (\count(self::$appTypes) == 0) {
+		if (\count(self::$appTypes) === 0) {
 			self::$appTypes = \OC::$server->getAppConfig()->getValues(false, 'types');
 		}
 
 		if (isset(self::$appTypes[$app])) {
 			return \explode(',', self::$appTypes[$app]);
-		} else {
-			return [];
 		}
+
+		return [];
 	}
 
 	/**
@@ -388,6 +394,7 @@ class OC_App {
 	/**
 	 * @param string $app
 	 * @return bool
+	 * @throws \OCP\App\AppAlreadyInstalledException
 	 */
 	public static function removeApp($app) {
 		if (self::isShipped($app)) {
@@ -413,9 +420,9 @@ class OC_App {
 		self::$enabledAppsCache = [];
 
 		// run uninstall steps
-		$appData = OC_App::getAppInfo($app);
+		$appData = self::getAppInfo($app);
 		if ($appData !== null) {
-			OC_App::executeRepairSteps($app, $appData['repair-steps']['uninstall']);
+			self::executeRepairSteps($app, $appData['repair-steps']['uninstall']);
 		}
 
 		// emit disable hook - needed anymore ?
@@ -445,11 +452,11 @@ class OC_App {
 		) {
 			$settings = [
 				[
-					"id" => "help",
-					"order" => 1000,
-					"href" => $urlGenerator->linkToRoute('settings_help'),
-					"name" => $l->t("Help"),
-					"icon" => $urlGenerator->imagePath("settings", "help.svg")
+					'id' => 'help',
+					'order' => 1000,
+					'href' => $urlGenerator->linkToRoute('settings_help'),
+					'name' => $l->t('Help'),
+					'icon' => $urlGenerator->imagePath('settings', 'help.svg')
 				]
 			];
 		}
@@ -458,11 +465,11 @@ class OC_App {
 		if (OC_User::isLoggedIn()) {
 			// personal menu
 			$settings[] = [
-				"id" => "settings",
-				"order" => 1,
-				"href" => $urlGenerator->linkToRoute('settings.SettingsPage.getPersonal'),
-				"name" => $l->t("Settings"),
-				"icon" => $urlGenerator->imagePath("settings", "admin.svg")
+				'id' => 'settings',
+				'order' => 1,
+				'href' => $urlGenerator->linkToRoute('settings.SettingsPage.getPersonal'),
+				'name' => $l->t('Settings'),
+				'icon' => $urlGenerator->imagePath('settings', 'admin.svg')
 			];
 		}
 
@@ -482,11 +489,11 @@ class OC_App {
 		unset($navEntry);
 
 		\usort($list, function ($a, $b) {
-			if ($a["order"] == $b["order"]) {
+			if ($a['order'] == $b['order']) {
 				return 0;
 			}
 
-			if ($a["order"] < $b["order"]) {
+			if ($a['order'] < $b['order']) {
 				return -1;
 			}
 
@@ -566,6 +573,7 @@ class OC_App {
 	 *
 	 * @param string $path
 	 * @return string
+	 * @throws Exception
 	 */
 	public static function getAppVersionByPath($path) {
 		$infoFile = $path . '/appinfo/info.xml';
@@ -579,6 +587,7 @@ class OC_App {
 	 * @param string $appId id of the app or the path of the info.xml file
 	 * @param boolean $path (optional)
 	 * @return array|null
+	 * @throws Exception
 	 * @note all data is read from info.xml, not just pre-defined fields
 	 */
 	public static function getAppInfo($appId, $path = false) {
@@ -604,7 +613,7 @@ class OC_App {
 		}
 
 		if (\is_array($data)) {
-			$data = OC_App::parseAppInfo($data);
+			$data = self::parseAppInfo($data);
 		}
 		if (isset($data['ocsid'])) {
 			$storedId = \OC::$server->getConfig()->getAppValue($appId, 'ocsid');
@@ -637,6 +646,7 @@ class OC_App {
 	 * get the id of loaded app
 	 *
 	 * @return string
+	 * @throws Exception
 	 */
 	public static function getCurrentApp() {
 		$request = \OC::$server->getRequest();
@@ -651,9 +661,9 @@ class OC_App {
 		if ($topFolder == 'apps') {
 			$length = \strlen($topFolder);
 			return \substr($script, $length + 1, \strpos($script, '/', $length + 1) - $length - 1);
-		} else {
-			return $topFolder;
 		}
+
+		return $topFolder;
 	}
 
 	/**
@@ -754,13 +764,11 @@ class OC_App {
 	/**
 	 * List all apps, this is used in apps.php
 	 *
-	 * @param bool $onlyLocal
-	 * @param bool $includeUpdateInfo Should we check whether there is an update
-	 *                                in the app store?
 	 * @return array
+	 * @throws Exception
 	 */
 	public static function listAllApps() {
-		$installedApps = OC_App::getAllApps();
+		$installedApps = self::getAllApps();
 
 		//TODO which apps do we want to blacklist and how do we integrate
 		// blacklisting with the multi apps folder feature?
@@ -771,8 +779,8 @@ class OC_App {
 		$urlGenerator = \OC::$server->getURLGenerator();
 
 		foreach ($installedApps as $app) {
-			if (\array_search($app, $blacklist) === false) {
-				$info = OC_App::getAppInfo($app);
+			if (!\in_array($app, $blacklist, true)) {
+				$info = self::getAppInfo($app);
 				if (!\is_array($info)) {
 					\OCP\Util::writeLog('core', 'Could not read app info file for app "' . $app . '"', \OCP\Util::ERROR);
 					continue;
@@ -838,7 +846,7 @@ class OC_App {
 					}
 				}
 
-				$info['version'] = OC_App::getAppVersion($app);
+				$info['version'] = self::getAppVersion($app);
 				$appList[] = $info;
 			}
 		}
@@ -854,8 +862,8 @@ class OC_App {
 	public static function getInternalAppIdByOcs($ocsID) {
 		if (\is_numeric($ocsID)) {
 			$idArray = \OC::$server->getAppConfig()->getValues(false, 'ocsid');
-			if (\array_search($ocsID, $idArray)) {
-				return \array_search($ocsID, $idArray);
+			if (\array_search($ocsID, $idArray, true)) {
+				return \array_search($ocsID, $idArray, true);
 			}
 		}
 		return false;
@@ -903,12 +911,12 @@ class OC_App {
 	 * This means that it's possible to specify "requiremin" => 6
 	 * and "requiremax" => 6 and it will still match ownCloud 6.0.3.
 	 *
-	 * @param string|array $ocVersion ownCloud version to check against
+	 * @param Platform $platform
 	 * @param array $appInfo app info (from xml)
 	 *
 	 * @return boolean true if compatible, otherwise false
 	 */
-	public static function isAppCompatible($ocVersion, $appInfo) {
+	public static function isAppCompatible(Platform $platform, $appInfo) {
 		$requireMin = '';
 		$requireMax = '';
 		if (isset($appInfo['dependencies']['owncloud']['@attributes']['min-version'])) {
@@ -925,10 +933,7 @@ class OC_App {
 			$requireMax = $appInfo['requiremax'];
 		}
 
-		if (\is_array($ocVersion)) {
-			$ocVersion = \implode('.', $ocVersion);
-		}
-
+		$ocVersion = $platform->getOcVersion();
 		if (!empty($requireMin)
 			&& \version_compare(self::adjustVersionParts($ocVersion, $requireMin), $requireMin, '<')
 		) {
@@ -936,6 +941,7 @@ class OC_App {
 		}
 
 		if (!empty($requireMax)
+			&& !\in_array($platform->getOcChannel(), ['git', 'daily'], true)
 			&& \version_compare(self::adjustVersionParts($ocVersion, $requireMax), $requireMax, '>')
 		) {
 			return false;
@@ -962,6 +968,7 @@ class OC_App {
 	 *
 	 * @param string $appId
 	 * @return bool
+	 * @throws \OC\NeedsUpdateException
 	 */
 	public static function updateApp($appId) {
 		$appPath = self::getAppPath($appId);
@@ -1003,7 +1010,7 @@ class OC_App {
 
 		self::setAppTypes($appId);
 
-		$version = \OC_App::getAppVersion($appId);
+		$version = self::getAppVersion($appId);
 		\OC::$server->getAppConfig()->setValue($appId, 'installed_version', $version);
 
 		return true;
@@ -1060,19 +1067,20 @@ class OC_App {
 	/**
 	 * @param string $appId
 	 * @return \OC\Files\View|false
+	 * @throws Exception
 	 */
 	public static function getStorage($appId) {
-		if (OC_App::isEnabled($appId)) { //sanity check
+		if (self::isEnabled($appId)) { //sanity check
 			if (OC_User::isLoggedIn()) {
 				$view = new \OC\Files\View('/' . OC_User::getUser());
 				if (!$view->file_exists($appId)) {
 					$view->mkdir($appId);
 				}
 				return new \OC\Files\View('/' . OC_User::getUser() . '/' . $appId);
-			} else {
-				\OCP\Util::writeLog('core', 'Can\'t get app storage, app ' . $appId . ', user not logged in', \OCP\Util::ERROR);
-				return false;
 			}
+
+			\OCP\Util::writeLog('core', 'Can\'t get app storage, app ' . $appId . ', user not logged in', \OCP\Util::ERROR);
+			return false;
 		} else {
 			\OCP\Util::writeLog('core', 'Can\'t get app storage, app ' . $appId . ' not enabled', \OCP\Util::ERROR);
 			return false;
@@ -1125,7 +1133,7 @@ class OC_App {
 		$dependencyAnalyzer = new DependencyAnalyzer(new Platform($config), $l);
 		$missing = $dependencyAnalyzer->analyze($info);
 		if (!empty($missing)) {
-			$missingMsg = \join(PHP_EOL, $missing);
+			$missingMsg = \implode(PHP_EOL, $missing);
 			throw new \Exception(
 				$l->t('App "%s" cannot be installed because the following dependencies are not fulfilled: %s',
 					[$info['name'], $missingMsg]

--- a/tests/Settings/Controller/AppSettingsControllerTest.php
+++ b/tests/Settings/Controller/AppSettingsControllerTest.php
@@ -60,6 +60,7 @@ class AppSettingsControllerTest extends TestCase {
 		$this->appManager = $this->getMockBuilder(IAppManager::class)
 			->disableOriginalConstructor()->getMock();
 
+		$this->config->method('getSystemValue')->willReturnArgument(1);
 		$this->appSettingsController = new AppSettingsController(
 			'settings',
 			$this->request,

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -29,39 +29,43 @@ class DependencyAnalyzerTest extends TestCase {
 		$this->platformMock = $this->getMockBuilder(Platform::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getPhpVersion')
 			->will($this->returnValue('5.4.3'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getIntSize')
 			->will($this->returnValue('4'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getDatabase')
 			->will($this->returnValue('mysql'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getOS')
 			->will($this->returnValue('Linux'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('isCommandKnown')
 			->will($this->returnCallback(function ($command) {
 				return ($command === 'grep');
 			}));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getLibraryVersion')
 			->will($this->returnCallback(function ($lib) {
 				if ($lib === 'curl') {
-					return "2.3.4";
+					return '2.3.4';
 				}
 				return null;
 			}));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getOcVersion')
 			->will($this->returnValue('8.0.2'));
 
-		$this->l10nMock = $this->getMockBuilder('\OCP\IL10N')
+		$this->platformMock
+			->method('getOcChannel')
+			->will($this->returnValue('production'));
+
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->l10nMock->expects($this->any())
+		$this->l10nMock
 			->method('t')
 			->will($this->returnCallback(function ($text, $parameters = []) {
 				return \vsprintf($text, $parameters);
@@ -78,7 +82,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param string $maxVersion
 	 * @param string $intSize
 	 */
-	public function testPhpVersion($expectedMissing, $minVersion, $maxVersion, $intSize) {
+	public function testPhpVersion($expectedMissing, $minVersion, $maxVersion, $intSize): void {
 		$app = [
 			'dependencies' => [
 				'php' => []
@@ -104,7 +108,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $databases
 	 */
-	public function testDatabases($expectedMissing, $databases) {
+	public function testDatabases($expectedMissing, $databases): void {
 		$app = [
 			'dependencies' => [
 			]
@@ -124,7 +128,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param string $expectedMissing
 	 * @param string|null $commands
 	 */
-	public function testCommand($expectedMissing, $commands) {
+	public function testCommand($expectedMissing, $commands): void {
 		$app = [
 			'dependencies' => [
 			]
@@ -143,7 +147,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $libs
 	 */
-	public function testLibs($expectedMissing, $libs) {
+	public function testLibs($expectedMissing, $libs): void {
 		$app = [
 			'dependencies' => [
 			]
@@ -163,7 +167,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $oss
 	 */
-	public function testOS($expectedMissing, $oss) {
+	public function testOS($expectedMissing, $oss): void {
 		$app = [
 			'dependencies' => []
 		];
@@ -182,7 +186,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $oc
 	 */
-	public function testOC($expectedMissing, $oc) {
+	public function testOC($expectedMissing, $oc): void {
 		$app = [
 			'dependencies' => []
 		];
@@ -199,7 +203,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesOC() {
+	public function providesOC(): array {
 		return [
 			// no version -> no missing dependency
 			[[], null],
@@ -215,7 +219,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesOS() {
+	public function providesOS(): array {
 		return [
 			[[], null],
 			[[], []],
@@ -227,7 +231,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesLibs() {
+	public function providesLibs(): array {
 		return [
 			// we expect curl to exist
 			[[], 'curl'],
@@ -257,7 +261,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesCommands() {
+	public function providesCommands(): array {
 		return [
 			[[], null],
 			// grep is known on linux
@@ -275,7 +279,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesDatabases() {
+	public function providesDatabases(): array {
 		return [
 			// non BC - in case on databases are defined -> all are supported
 			[[], null],
@@ -288,7 +292,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesPhpVersion() {
+	public function providesPhpVersion(): array {
 		return [
 			[[], null, null, null],
 			[[], '5.4', null, null],

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -8,6 +8,7 @@
  */
 
 namespace Test;
+use OC\App\Platform;
 use OCP\IAppConfig;
 use Test\Traits\UserTrait;
 
@@ -272,20 +273,10 @@ class AppTest extends \Test\TestCase {
 	 * @dataProvider appVersionsProvider
 	 */
 	public function testIsAppCompatible($ocVersion, $appInfo, $expectedResult) {
-		$this->assertEquals($expectedResult, \OC_App::isAppCompatible($ocVersion, $appInfo));
-	}
-
-	/**
-	 * Test that the isAppCompatible method also supports passing an array
-	 * as $ocVersion
-	 */
-	public function testIsAppCompatibleWithArray() {
-		$ocVersion = [6];
-		$appInfo = [
-			'requiremin' => '6',
-			'requiremax' => '6',
-		];
-		$this->assertTrue(\OC_App::isAppCompatible($ocVersion, $appInfo));
+		$platform = $this->createMock(Platform::class);
+		$platform->method('getOcChannel')->willReturn('production');
+		$platform->method('getOcVersion')->willReturn($ocVersion);
+		$this->assertEquals($expectedResult, \OC_App::isAppCompatible($platform, $appInfo));
 	}
 
 	/**
@@ -507,7 +498,7 @@ class AppTest extends \Test\TestCase {
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) use ($appConfig) {
 			return new \OC\App\AppManager($c->getUserSession(), $appConfig,
 				$c->getGroupManager(), $c->getMemCacheFactory(),
-				$c->getEventDispatcher(), $c->getConfig());
+				$c->getEventDispatcher(), $c->getConfig(), new Platform($c->getConfig()));
 		});
 	}
 
@@ -521,7 +512,7 @@ class AppTest extends \Test\TestCase {
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) {
 			return new \OC\App\AppManager($c->getUserSession(), $c->getAppConfig(),
 				$c->getGroupManager(), $c->getMemCacheFactory(),
-				$c->getEventDispatcher(), $c->getConfig());
+				$c->getEventDispatcher(), $c->getConfig(), new Platform($c->getConfig()));
 		});
 
 		// Remove the cache of the mocked apps list with a forceRefresh


### PR DESCRIPTION
## Description
When installing owncloud from git or the daily release tar ball the max version requirement is no longer checked when installing/enabling apps

This will help with the development and release of apps in general

@patrickjahns as discussed long time back - we did go for the release channel and no env variable.

## Related Issue
- fixes #31518 

## How Has This Been Tested?
- enable an app with max version lower then 11.0
- see if being enabled

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

