### PR TITLE
fix upload avatar for LDAP users

### DIFF
--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -131,7 +131,7 @@ if ($_['passwordChangeSupported']) {
 <?php
 	}
 ?>
-<form class="section">
+<form id="language" class="section">
 	<h2>
 		<label><?php p($l->t('Language'));?></label>
 	</h2>


### PR DESCRIPTION
## Description

Readd ```id="language"``` to the form

## Related Issue

- Fixes https://github.com/owncloud/enterprise/issues/2553#issuecomment-434390467

## Motivation and Context

LDAP users can upload an avatar via webUI

## How Has This Been Tested?

Locally applying this PR and testing upload avatar button works properly
