### PR TITLE
Bugfix/dav cors handling prio

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -109,7 +109,7 @@ class CorsPlugin extends ServerPlugin {
 		}
 
 		$this->server->on('beforeMethod:*', [$this, 'setCorsHeaders']);
-		$this->server->on('beforeMethod:OPTIONS', [$this, 'setOptionsRequestHeaders']);
+		$this->server->on('beforeMethod:OPTIONS', [$this, 'setOptionsRequestHeaders'], 5);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Sabre dav changed the event dispatch model slightly which caused that the handler for the OPTIONS request was triggered too late.

No backport - stable10 uses an older sabre dav version

By setting a prio higher the 10 (prio of the auth plugin) this works now as expected.

## Motivation and Context
- detected while working on phoenix

## How Has This Been Tested?
- connect phoenix to core master branch and see no files being loaded and cors errors in the browser console

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

