### PR TITLE
Center the logo and login fields

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -941,6 +941,34 @@ div.crumb:active {
 	margin: -13px;
 }
 
+/* Force constant vertical height for login box over all devices */
+#body-login .wrapper {
+    height: 100vh; /* fix IE11 */
+    display: -webkit-box !important;
+    -webkit-box-orient: horizontal !important;
+    -webkit-box-pack: center !important;
+    -webkit-box-align: center !important;
+    display: -webkit-flex !important;
+    -webkit-flex-direction: row !important;
+    -webkit-align-self: center !important;
+    -webkit-align-items: center !important;
+    display: -moz-box !important;
+    -moz-box-orient: horizontal !important;
+    -moz-box-pack: center !important;
+    -moz-box-align: center !important;
+    display: -ms-flexbox !important;
+    -ms-flex-direction: row !important;
+    -ms-flex-pack: center !important;
+    -ms-flex-align: center !important;
+    display: flex !important;
+    flex-direction: row !important;
+    align-self: center !important;
+    align-items: center !important;
+}
+
+#body-login .v-align {
+    margin-top: -120px;
+}
 
 /* LEGACY FIX only - do not use fieldsets for settings */
 fieldset.warning legend, fieldset.update legend {
@@ -963,4 +991,14 @@ fieldset.warning legend + p, fieldset.update legend + p {
    height: 0;
    opacity: 0;
    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+}
+
+@media only screen and (max-width: 1030px) {
+    #body-login .v-align {
+        margin-top: 30px;
+    }
+    #body-login p.info {
+        margin: 0 auto;
+        padding-top: 35px;
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Force constant vertical height for login box over all devices

## Motivation and Context
I incorporate this function into almost every theme I create. The logo and credential fields are centered on each device. That's why I thought it would be great to integrate this improvement into our Core Theme.

## How Has This Been Tested?
Tested on Chrome and Firefox browser with different resolutions
## Screenshots (if appropriate):

Before:
<img width="1478" alt="screenshot 2018-11-01 at 01 35 48" src="https://user-images.githubusercontent.com/33026403/47826648-56181400-dd79-11e8-88a6-88e666f92f36.png">

After (1440x900px):
<img width="799" alt="screenshot 2018-11-01 at 01 50 32" src="https://user-images.githubusercontent.com/33026403/47826659-629c6c80-dd79-11e8-9220-d1e848a955ff.png">

After (568x320px iPhone 5/5s/SE):
<img width="579" alt="screenshot 2018-11-01 at 01 50 48" src="https://user-images.githubusercontent.com/33026403/47826701-99728280-dd79-11e8-8da4-350ebd5780d9.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
