### PR TITLE
Add reset email tests for cli resetUserPassword test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -364,6 +364,7 @@ pipeline:
     pull: true
     environment:
       - TEST_SERVER_URL=https://server
+      - MAILHOG_HOST=email
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
@@ -860,6 +861,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      USE_EMAIL: true
 
   # CLI Main Acceptance tests
     - PHP_VERSION: 7.1

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -112,6 +112,7 @@ default:
         - %paths.base%/../features/cliProvisioning
       contexts:
         - FeatureContext: *common_feature_context_params
+        - EmailContext:
         - OccContext:
 
     cliMain:

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -573,6 +573,33 @@ trait CommandLine {
 	}
 
 	/**
+	 * Reset user password
+	 *
+	 * @param string $username
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function resetUserPassword($username, $password = null) {
+		$actualUsername = $this->getActualUsername($username);
+		if ($password === null) {
+			$this->invokingTheCommand(
+				"user:resetpassword $actualUsername --send-email"
+			);
+		} else {
+			$password = $this->getActualPassword($password);
+			$this->invokingTheCommandWithEnvVariable(
+				"user:resetpassword $actualUsername --password-from-env",
+				'OC_PASS',
+				$password
+			);
+			if ($username === "%admin%") {
+				$this->rememberNewAdminPassword($password);
+			}
+		}
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will setup anything needed by methods in this trait.
 	 *

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -96,6 +96,19 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has set the mail smtpmode to :smtpmode
+	 *
+	 * @param string $smtpmode
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasSetTheMailSmtpmodeTo($smtpmode) {
+		$this->featureContext->invokingTheCommand(
+			"config:system:set  --value $smtpmode mail_smtpmode"
+		);
+	}
+
+	/**
 	 * @When the administrator tries to create a user :username using the occ command
 	 *
 	 * @param string $username
@@ -136,19 +149,20 @@ class OccContext implements Context {
 	 * @param string $password
 	 *
 	 * @return void
-	 * @throws Exception
 	 */
 	public function resetUserPasswordUsingTheOccCommand($username, $password) {
-		$actualUsername = $this->featureContext->getActualUsername($username);
-		$password = $this->featureContext->getActualPassword($password);
-		$this->featureContext->invokingTheCommandWithEnvVariable(
-			"user:resetpassword $actualUsername  --password-from-env",
-			'OC_PASS',
-			$password
-		);
-		if ($username === "%admin%") {
-			$this->featureContext->rememberNewAdminPassword($password);
-		}
+		$this->featureContext->resetUserPassword($username, $password);
+	}
+
+	/**
+	 * @When the administrator invokes password reset for user :username using the occ command
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function theAdministratorInvokesPasswordResetForUserUsingTheOccCommand($username) {
+		$this->featureContext->resetUserPassword($username);
 	}
 
 	/**

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -1,6 +1,6 @@
 @cli @skipOnLDAP
 Feature: edit users
-  As an admin, subadmin or as myself
+  As an admin
   I want to be able to edit user information
   So that I can keep the user information up-to-date
 

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @mailhog
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password
@@ -13,6 +13,36 @@ Feature: reset user password
     And the command output should contain the text "Successfully reset password for brand-new-user"
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
+
+  Scenario: user should get email when admin resets their password and sends email
+    Given these users have been created:
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    When the administrator invokes password reset for user "brand-new-user" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text "The password reset link is:"
+    And the email address "brand.new.user@oc.com.np" should have received an email with the body containing
+      """
+      Use the following link to reset your password: <a href=
+      """
+
+  Scenario: administrator gets error message while trying to reset user password with send email when the email address of the user is not setup
+    Given these users have been created:
+      | username       | password  | displayname |
+      | brand-new-user | %regular% | New user    |
+    When the administrator invokes password reset for user "brand-new-user" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "Email address is not set for the user brand-new-user"
+
+  Scenario: user should not an get email when smtpmode is missing
+    Given these users have been created:
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    And the administrator has set the mail smtpmode to "sendmail"
+    When the administrator invokes password reset for user "brand-new-user" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "Can't send new user mail to brand.new.user@oc.com.np: Couldn't send reset email."
+    And the email address "brand.new.user@oc.com.np" should not have received an email
 
   Scenario: admin tries to reset the password of a user that does not exist
     Given user "not-a-user" has been deleted


### PR DESCRIPTION
## Description
Add tests to check if reset email is send to user when administrator invokes `--send-email` via occ command. And also check it a 
Related issue: #32564

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.