### PR TITLE
remove composer_dev_deps from acceptance test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,15 +187,15 @@ test-js-debug: $(nodejs_deps)
 	NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js
 
 .PHONY: test-acceptance-api
-test-acceptance-api: $(composer_dev_deps)
+test-acceptance-api:
 	./tests/acceptance/run.sh --type api
 
 .PHONY: test-acceptance-cli
-test-acceptance-cli: $(composer_dev_deps)
+test-acceptance-cli:
 	./tests/acceptance/run.sh --type cli
 
 .PHONY: test-acceptance-webui
-test-acceptance-webui: $(composer_dev_deps)
+test-acceptance-webui:
 	./tests/acceptance/run.sh --type webUI
 
 .PHONY: test-php-lint


### PR DESCRIPTION
## Description
I don't think we need that for acceptance tests because the alias only refers to php_unit

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
