### PR TITLE
Add webUI acceptance tests for checking the versions feature

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2051,4 +2051,26 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theUserDeletesTagWithNameUsingTheWebui($name) {
 		$this->filesPage->getDetailsDialog()->deleteTag($name);
 	}
+
+	/**
+	 * @Then the versions list should contain :num entries
+	 *
+	 * @param int $num
+	 *
+	 * @return void
+	 */
+	public function theVersionsListShouldContainEntries($num) {
+		$versionsList = $this->filesPage->getDetailsDialog()->getVersionsList();
+		$versionsCount = \count($versionsList->findAll("xpath", "//li"));
+		PHPUnit_Framework_Assert::assertEquals($num, $versionsCount);
+	}
+
+	/**
+	 * @When the user restores the file to last version using the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserRestoresTheFileToLastVersionUsingTheWebui() {
+		$this->filesPage->getDetailsDialog()->restoreCurrentFileToLastVersion();
+	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -119,10 +119,9 @@ class DetailsDialog extends OwncloudPage {
 	/**
 	 * find the xpath of version list
 	 *
-	 * @param string $content
-	 *
 	 * @return string
-	 */public function getVersionsList() {
+	 */
+	public function getVersionsList() {
 		$versionsList = $this->find("xpath", $this->versionsListXpath);
 		$this->assertElementNotNull(
 			$versionsList,
@@ -136,10 +135,9 @@ class DetailsDialog extends OwncloudPage {
 	/**
 	 * find the xpath of button to revert to last version
 	 *
-	 * @param string $content
-	 *
-	 * @return
-	 */public function getLastVersionRevertButton() {
+	 * @return void
+	 */
+	public function getLastVersionRevertButton() {
 		$btn = $this->find("xpath", $this->lastVersionRevertButton);
 		$this->assertElementNotNull(
 			$btn,
@@ -411,6 +409,9 @@ class DetailsDialog extends OwncloudPage {
 			"//span[@class='label']";
 	}
 
+	/**
+	 * @return void
+	 */
 	public function restoreCurrentFileToLastVersion() {
 		$revertBtn = $this->getLastVersionRevertButton();
 		$revertBtn->click();

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -64,6 +64,9 @@ class DetailsDialog extends OwncloudPage {
 	private $commentDeleteButtonXpath = "//a[@data-original-title='Delete comment']";
 	private $commentListXpath = "//ul[@class='comments']//div[@class='message']";
 
+	private $versionsListXpath = "//div[@id='versionsTabView']//ul[@class='versions']";
+	private $lastVersionRevertButton = "//div[@id='versionsTabView']//ul[@class='versions']//li[1]/div/a";
+
 	/**
 	 * Lookup the id for the requested details tab.
 	 * If the id is not known, then return the passed-in parameter as the id.
@@ -111,6 +114,40 @@ class DetailsDialog extends OwncloudPage {
 	 */
 	private function getCommentXpath($content) {
 		return "//ul[@class='comments']//div[@class='message' and contains(., '" . $content . "')]";
+	}
+
+	/**
+	 * find the xpath of comment with given content
+	 *
+	 * @param string $content
+	 *
+	 * @return string
+	 */public function getVersionsList() {
+		$versionsList = $this->find("xpath", $this->versionsListXpath);
+		$this->assertElementNotNull(
+			$versionsList,
+			__METHOD__ .
+			" could not find versions list for current file"
+		);
+		$this->waitTillElementIsNotNull($this->versionsListXpath);
+		return $versionsList;
+	}
+
+	/**
+	 * find the xpath of comment with given content
+	 *
+	 * @param string $content
+	 *
+	 * @return
+	 */public function getLastVersionRevertButton() {
+		$btn = $this->find("xpath", $this->lastVersionRevertButton);
+		$this->assertElementNotNull(
+			$btn,
+			__METHOD__ .
+			" could not find the button to revert the version"
+		);
+		$this->waitTillElementIsNotNull($this->lastVersionRevertButton);
+		return $btn;
 	}
 
 	/**
@@ -372,6 +409,12 @@ class DetailsDialog extends OwncloudPage {
 		return "//div[contains(@class, 'systemtags-select2-dropdown')]" .
 			"//ul[@class='select2-results']" .
 			"//span[@class='label']";
+	}
+
+	public function restoreCurrentFileToLastVersion() {
+		$revertBtn = $this->getLastVersionRevertButton();
+		$revertBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($this->getSession());
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -117,7 +117,7 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
-	 * find the xpath of comment with given content
+	 * find the xpath of version list
 	 *
 	 * @param string $content
 	 *
@@ -134,7 +134,7 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
-	 * find the xpath of comment with given content
+	 * find the xpath of button to revert to last version
 	 *
 	 * @param string $content
 	 *

--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -1,4 +1,4 @@
-@webUI @insulated  @files_versions-app-required @comments-app-required
+@webUI @insulated  @files_versions-app-required
 Feature: Versions of a file
 
   As a user
@@ -18,7 +18,7 @@ Feature: Versions of a file
     And user "user0" has uploaded file with content "new lorem content" to "/lorem.txt"
     When the user browses directly to display the "versions" details of file "lorem.txt" in folder "/"
     Then the content of file "lorem.txt" for user "user0" should be "new lorem content"
-    Then the versions list should contain 2 entries
+    And the versions list should contain 2 entries
 
   Scenario: restoring file to old version changes the content of the file
     Given user "user0" has logged in using the webUI
@@ -38,4 +38,4 @@ Feature: Versions of a file
     And the user has browsed to the files page
     When the user browses directly to display the "versions" details of file "lorem-file.txt" in folder "/"
     Then the content of file "lorem-file.txt" for user "user1" should be "new lorem content"
-    Then the versions list should contain 2 entries
+    And the versions list should contain 2 entries

--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -1,0 +1,41 @@
+@webUI @insulated  @files_versions-app-required @comments-app-required
+Feature: Versions of a file
+
+  As a user
+  I would like to see different versions of a file and delete and restore them
+  So that I can have more control over the files
+
+  Background:
+    Given these users have been created:
+      | username |
+      | user0    |
+      | user1    |
+
+  Scenario: upload new file with same name to see if different versions are shown
+    Given user "user0" has logged in using the webUI
+    And the user has browsed to the files page
+    And user "user0" has uploaded file with content "lorem content" to "/lorem.txt"
+    And user "user0" has uploaded file with content "new lorem content" to "/lorem.txt"
+    When the user browses directly to display the "versions" details of file "lorem.txt" in folder "/"
+    Then the content of file "lorem.txt" for user "user0" should be "new lorem content"
+    Then the versions list should contain 2 entries
+
+  Scenario: restoring file to old version changes the content of the file
+    Given user "user0" has logged in using the webUI
+    And the user has browsed to the files page
+    And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
+    And user "user0" has uploaded file with content "new lorem content" to "/lorem-file.txt"
+    When the user browses directly to display the "versions" details of file "lorem-file.txt" in folder "/"
+    And the user restores the file to last version using the webUI
+    Then the content of file "lorem-file.txt" for user "user0" should be "lorem content"
+
+  Scenario: sharee can see the versions of a file
+    Given user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
+    And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
+    And user "user0" has uploaded file with content "new lorem content" to "/lorem-file.txt"
+    And user "user0" has shared file "lorem-file.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user browses directly to display the "versions" details of file "lorem-file.txt" in folder "/"
+    Then the content of file "lorem-file.txt" for user "user1" should be "new lorem content"
+    Then the versions list should contain 2 entries


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add webUI Acceptance test to check
- Different versions of a file are shown in the webUI
- User can restore files to earlier versions
- Different versions are shown in shared files

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33382

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
