### PR TITLE
change 'must have' to 'should have' in acceptance test

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1964,7 +1964,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Then the config key :key of app :appID must have value :value
+	 * @Then the config key :key of app :appID should have value :value
 	 *
 	 * @param string $key
 	 * @param string $appID
@@ -1972,7 +1972,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function theConfigKeyOfAppMustHaveValue($key, $appID, $value) {
+	public function theConfigKeyOfAppShouldHaveValue($key, $appID, $value) {
 		$response = OcsApiHelper::sendRequest(
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
@@ -2078,7 +2078,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function followingConfigKeysMustExist($shouldOrNot, TableNode $table) {
+	public function followingConfigKeysShouldExist($shouldOrNot, TableNode $table) {
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
 			foreach ($table as $item) {


### PR DESCRIPTION
## Description
Use ``should`` rather than ``must`` in acceptance tests

## Related Issue
- Fixes #33403 

## Motivation and Context
See issue

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
