### PR TITLE
no need to add sharing scripts if the server is not ye…

### DIFF
--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -103,11 +103,11 @@ class OC_Template extends \OC\Template\Base {
 	 */
 	public static function initTemplateEngine($renderAs) {
 		if (self::$initTemplateEngineFirstRun) {
-
+			$isInstalled = \OC::$server->getSystemConfig()->getValue('installed', false);
 			//apps that started before the template initialization can load their own scripts/styles
 			//so to make sure this scripts/styles here are loaded first we use OC_Util::addScript() with $prepend=true
 			//meaning the last script/style in this list will be loaded first
-			if (\OC::$server->getSystemConfig()->getValue('installed', false) && $renderAs !== 'error' && !\OCP\Util::needUpgrade()) {
+			if ($isInstalled && $renderAs !== 'error' && !\OCP\Util::needUpgrade()) {
 				if (\OC::$server->getConfig()->getAppValue('core', 'backgroundjobs_mode', 'ajax') == 'ajax') {
 					OC_Util::addScript('backgroundjobs', null, true);
 				}
@@ -156,7 +156,7 @@ class OC_Template extends \OC\Template\Base {
 			OC_Util::addScript('files/fileinfo');
 			OC_Util::addScript('files/client');
 
-			if (\OCP\Share::isEnabled()) {
+			if ($isInstalled && \OCP\Share::isEnabled()) {
 				\OC_Util::addScript('core', 'shareconfigmodel');
 				\OC_Util::addScript('core', 'shareitemmodel');
 				\OC_Util::addScript('core', 'sharedialogresharerinfoview');


### PR DESCRIPTION
…t installed

## Description
Side effect of https://github.com/owncloud/core/pull/26608

In case owncloud is not yet installed we cannot call Share::isEnabled because this results in table not found exception

## Related Issue
- fixes #33408 

## How Has This Been Tested?
- try to install owncloud via the web ui
- ensure config.php as well as for sqlite the database file is deleted

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
