### PR TITLE
use --remote switch when running acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,15 +188,15 @@ test-js-debug: $(nodejs_deps)
 
 .PHONY: test-acceptance-api
 test-acceptance-api: $(composer_dev_deps)
-	./tests/acceptance/run.sh --type api
+	./tests/acceptance/run.sh --remote --type api
 
 .PHONY: test-acceptance-cli
 test-acceptance-cli: $(composer_dev_deps)
-	./tests/acceptance/run.sh --type cli
+	./tests/acceptance/run.sh --remote --type cli
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui: $(composer_dev_deps)
-	./tests/acceptance/run.sh --type webUI
+	./tests/acceptance/run.sh --remote --type webUI
 
 .PHONY: test-php-lint
 test-php-lint: $(composer_dev_deps)


### PR DESCRIPTION
## Description
assume the SUT is remote

## Motivation and Context
do not use any local occ calls when running acceptance tests from the make command

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
