### PR TITLE
change share with settings function to be more readable

### DIFF
--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -11,7 +11,7 @@ Feature: sharing
     Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
-      | permissions | 4      |
+      | permissions | create |
     Then the public shared file "test.txt" should not be able to be downloaded
     And the HTTP status code should be "404"
 
@@ -40,7 +40,7 @@ Feature: sharing
     Given user "user1" has been created
     When user "user0" creates a share using the sharing API with settings
       | path      | PARENT |
-      | shareType | 0      |
+      | shareType | user   |
       | shareWith | user1  |
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
@@ -61,10 +61,10 @@ Feature: sharing
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission
     Given user "user1" has been created
     When user "user0" creates a share using the sharing API with settings
-      | path        | PARENT |
-      | shareType   | 0      |
-      | shareWith   | user1  |
-      | permissions | 15     |
+      | path        | PARENT    |
+      | shareType   | user      |
+      | shareWith   | user1     |
+      | permissions | change    |
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission
@@ -73,9 +73,9 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     When user "user0" creates a share using the sharing API with settings
       | path        | PARENT |
-      | shareType   | 1      |
+      | shareType   | group  |
       | shareWith   | grp1   |
-      | permissions | 15     |
+      | permissions | change |
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @public_link_share-feature-required
@@ -83,16 +83,16 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |
       | password    | %public% |
-      | permissions | 15       |
+      | permissions | change   |
     Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission
     Given user "user1" has been created
     When user "user0" creates a share using the sharing API with settings
       | path        | PARENT |
-      | shareType   | 0      |
+      | shareType   | user   |
       | shareWith   | user1  |
-      | permissions | 1      |
+      | permissions | read   |
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission
@@ -101,9 +101,9 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     When user "user0" creates a share using the sharing API with settings
       | path        | PARENT |
-      | shareType   | 1      |
+      | shareType   | group  |
       | shareWith   | grp1   |
-      | permissions | 1      |
+      | permissions | read   |
     Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @public_link_share-feature-required
@@ -111,5 +111,5 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |
       | password    | %public% |
-      | permissions | 1        |
+      | permissions | read     |
     Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -10,7 +10,7 @@ Feature: sharing
     Given as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER |
-      | permissions | 4      |
+      | permissions | create |
     When the public uploads file "test.txt" with content "test" using the public WebDAV API
     And the public uploads file "test.txt" with content "test2" with autorename mode using the public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
@@ -21,7 +21,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And user "user0" has created a public link share with settings
       | path        | FOLDER |
-      | permissions | 4      |
+      | permissions | create |
     When user "user0" deletes file "/FOLDER" using the WebDAV API
     Then publicly uploading a file should not work
     And the HTTP status code should be "404"
@@ -34,7 +34,7 @@ Feature: sharing
   Scenario: Uploading file to a public read-only share folder does not work
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
-      | permissions | 1      |
+      | permissions | read   |
     Then publicly uploading a file should not work
     And the HTTP status code should be "403"
 
@@ -42,8 +42,8 @@ Feature: sharing
     Given user "user1" has been created
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 0      |
-      | permissions | 1      |
+      | shareType   | user   |
+      | permissions | read   |
       | shareWith   | user1  |
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -55,8 +55,8 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 1      |
-      | permissions | 1      |
+      | shareType   | group  |
+      | permissions | read   |
       | shareWith   | grp1   |
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -70,7 +70,7 @@ Feature: sharing
     Given as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER |
-      | permissions | 4      |
+      | permissions | create |
     When the public uploads file "test.txt" with content "test" using the public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
@@ -80,7 +80,7 @@ Feature: sharing
     And the user has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
-      | permissions | 4        |
+      | permissions | create   |
     When the public uploads file "test.txt" with password "%public%" and content "test" using the public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
@@ -89,8 +89,8 @@ Feature: sharing
     And user "user1" has been created
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 0      |
-      | permissions | 4      |
+      | shareType   | user   |
+      | permissions | create |
       | shareWith   | user1  |
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -106,8 +106,8 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 1      |
-      | permissions | 4      |
+      | shareType   | group  |
+      | permissions | create |
       | shareWith   | grp1   |
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -122,7 +122,7 @@ Feature: sharing
     And the user has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
-      | permissions | 15       |
+      | permissions | change   |
     When the public uploads file "test.txt" with password "%public%" and content "test" using the public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
@@ -132,8 +132,8 @@ Feature: sharing
     And user "user1" has been created
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 0      |
-      | permissions | 15     |
+      | shareType   | user   |
+      | permissions | change |
       | shareWith   | user1  |
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -149,8 +149,8 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 1      |
-      | permissions | 15     |
+      | shareType   | group  |
+      | permissions | change |
       | shareWith   | grp1   |
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -179,7 +179,7 @@ Feature: sharing
     And the user has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
-      | permissions | 15       |
+      | permissions | change   |
     When the public uploads file "test.txt" with password "%public%" and content "test" using the public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
@@ -188,8 +188,8 @@ Feature: sharing
     And user "user1" has been created
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 0      |
-      | permissions | 15     |
+      | shareType   | user   |
+      | permissions | change |
       | shareWith   | user1  |
     And the quota of user "user0" has been set to "0"
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
@@ -206,8 +206,8 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 1      |
-      | permissions | 15     |
+      | shareType   | group  |
+      | permissions | change |
       | shareWith   | grp1   |
     And the quota of user "user0" has been set to "0"
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
@@ -221,7 +221,7 @@ Feature: sharing
   Scenario: Uploading file to a public shared folder with read/write permission when the sharer has unsufficient quota does not work
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
-      | permissions | 15     |
+      | permissions | change |
     When the quota of user "user0" has been set to "0"
     Then publicly uploading a file should not work
     And the HTTP status code should be "507"
@@ -231,8 +231,8 @@ Feature: sharing
     And user "user1" has been created
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 0      |
-      | permissions | 4      |
+      | shareType   | user   |
+      | permissions | create |
       | shareWith   | user1  |
     And the quota of user "user0" has been set to "0"
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
@@ -249,8 +249,8 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
       | path        | FOLDER |
-      | shareType   | 1      |
-      | permissions | 4      |
+      | shareType   | group  |
+      | permissions | create |
       | shareWith   | grp1   |
     And the quota of user "user0" has been set to "0"
     When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
@@ -264,7 +264,7 @@ Feature: sharing
   Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has unsufficient quota does not work
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
-      | permissions | 4      |
+      | permissions | create |
     When the quota of user "user0" has been set to "0"
     Then publicly uploading a file should not work
     And the HTTP status code should be "507"
@@ -273,7 +273,7 @@ Feature: sharing
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
     Given user "user0" has created a public link share with settings
       | path        | FOLDER |
-      | permissions | 4      |
+      | permissions | create |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
     Then publicly uploading a file should not work
     And the HTTP status code should be "403"
@@ -283,7 +283,7 @@ Feature: sharing
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "user0" has created a public link share with settings
       | path        | FOLDER |
-      | permissions | 31     |
+      | permissions | all    |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
     Then publicly uploading a file should not work
     And the HTTP status code should be "403"
@@ -292,7 +292,7 @@ Feature: sharing
   Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
     Given user "user0" has created a public link share with settings
       | path        | FOLDER |
-      | permissions | 4      |
+      | permissions | create |
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
     When the public uploads file "test.txt" with content "test" using the public WebDAV API


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
 in ``Sharing.php`` we have ``userCreatesAShareWithSettings($user, $body)``
That lets you specify a table of settings.
Now that settings like permissions can be added in readable form like ``share, update, read``
Also shareType can be specified in readable form like `user` and `public`

update ApiShareOperations accpetance tests to comply with this change

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #32700
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
