### PR TITLE
[stable10] skip encryption UI tests on S3

### DIFF
--- a/tests/acceptance/features/webUIEncryptionUserKeysType/userKeys.feature
+++ b/tests/acceptance/features/webUIEncryptionUserKeysType/userKeys.feature
@@ -1,4 +1,4 @@
-@webUI @skipOnEncryptionType:masterkey
+@webUI @skipOnEncryptionType:masterkey @skipOnStorage:ceph
 Feature: encrypt files using user specific keys
   As an admin
   I want to be able to encrypt user files using user specific keys


### PR DESCRIPTION
## Description
skip the encryption tests on S3 because we do not set the encryption app up in drone there
Note this is not needed in master because the encryption app for master is in a separate repo and when S3 runs all the core tests it does not get the encryption tests

## Motivation and Context
make the S3 CI pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
