### PR TITLE
[stable10] Display error message in new password form

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -656,12 +656,23 @@ class UsersController extends Controller {
 		try {
 			$this->checkPasswordSetToken($token, $userId);
 
-			if (!$user->setPassword($password)) {
+			try {
+				if (!$user->setPassword($password)) {
+					$this->log->error('The password can not be set for user: '. $userId);
+					return new JSONResponse(
+						[
+							'status' => 'error',
+							'message' => $this->l10n->t('Failed to set password. Please contact your administrator.', [$userId]),
+							'type' => 'passwordsetfailed'
+						], Http::STATUS_FORBIDDEN
+					);
+				}
+			} catch (\Exception $e) {
 				$this->log->error('The password can not be set for user: '. $userId);
 				return new JSONResponse(
 					[
 						'status' => 'error',
-						'message' => $this->l10n->t('Failed to set password. Please contact your administrator.', [$userId]),
+						'message' => $e->getMessage(),
 						'type' => 'passwordsetfailed'
 					], Http::STATUS_FORBIDDEN
 				);

--- a/settings/js/setpassword.js
+++ b/settings/js/setpassword.js
@@ -27,11 +27,13 @@
 			var errorMessage;
 			errorMessage = responseObj.message;
 
-			if (errorMessage) {
-				errorObject.text(errorMessage);
-				errorObject.show();
-				$('#submit').prop('disabled', true);
+			if (!errorMessage) {
+				errorMessage = t('core', 'Failed to set password. Please contact your administrator.');
 			}
+
+			errorObject.text(errorMessage);
+			errorObject.show();
+			$('#submit').prop('disabled', false);
 		},
 
 		_resetDone : function(result){

--- a/settings/tests/js/setpasswordSpec.js
+++ b/settings/tests/js/setpasswordSpec.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+describe('OCA.UserManagement.SetPassword tests', function () {
+	var resultSpy, SetPassword, redirectURL;
+	beforeEach(function () {
+		$('#testArea').append(
+			'<label id="error-message" class="warning" style="display:none"></label>' +
+			'<form id="set-password" method="post">\n' +
+			'<fieldset>' +
+			'<p>' +
+			'<label for="password" class="infield">New password</label>' +
+			'<input type="password" name="password" id="password" value=""' +
+			'placeholder="New Password"' +
+			'autocomplete="off" autocapitalize="off" autocorrect="off"' +
+			'required autofocus />' +
+			'</p>' +
+			'<input type="submit" id="submit" value="Please set your password"' +
+			'</fieldset>' +
+			'</form>'
+		);
+	});
+
+	describe('set newpassword', function () {
+		beforeEach(function () {
+			SetPassword = OCA.UserManagement.SetPassword;
+			redirectURL = sinon.stub(OC, 'redirect');
+		});
+		afterEach(function () {
+			resultSpy.restore();
+			redirectURL.restore();
+		});
+
+		it('set password failed', function () {
+			resultSpy = sinon.spy(SetPassword, '_onSetPasswordFail');
+			var defr = $.Deferred();
+			defr.reject({'responseText' : '{"foo":"bar", "message": false}'});
+
+			spyOn($, 'post').and.returnValue(defr.promise());
+
+			SetPassword.init();
+			$('#password').val('foo');
+			$('#submit').click();
+
+			expect(resultSpy.calledOnce).toEqual(true);
+			expect($('#submit').prop('disabled')).toEqual(false);
+			expect($('#error-message').text()).toEqual('Failed to set password. Please contact your administrator.');
+		});
+
+		it('set password success', function () {
+			resultSpy = sinon.spy(SetPassword, '_resetDone');
+			var defr = $.Deferred();
+			defr.resolve({'status' : 'success'});
+
+			spyOn($, 'post').and.returnValue(defr.done());
+
+			SetPassword.init();
+			$('#password').val('foo');
+			$('#submit').click();
+
+			expect(resultSpy.calledOnce).toEqual(true);
+			expect(redirectURL.calledOnce).toEqual(true);
+			expect(redirectURL.getCall(0).args[0]).toContain('/owncloud');
+		});
+	});
+});

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -111,11 +111,13 @@ module.exports = function(config) {
 				name: 'settings',
 				srcFiles: [
 					'settings/js/users/deleteHandler.js',
-					'settings/js/admin-apps.js'
+					'settings/js/admin-apps.js',
+					'settings/js/setpassword.js'
 				],
 				testFiles: [
 					'settings/tests/js/users/deleteHandlerSpec.js',
-					'settings/tests/js/apps/appSettingsSpec.js'
+					'settings/tests/js/apps/appSettingsSpec.js',
+					'settings/tests/js/setpasswordSpec.js'
 				]
 			}
 		];


### PR DESCRIPTION
## Description
Display error message in new password form

## Related Issue
https://github.com/owncloud/enterprise/issues/2970

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Setup OC with this PR
1. Enable password policy 2.0.1
1. Set password more than 2 password rules like minimum chars, lowercase + uppcase chars, etc
1. Create a new user in the settings page using their email address
1. Open mail client and click the link
1. Enter a non-compliant password

Before the fix: nothing happened, JS errors, 500 error
After the fix: error appears and button becomes clickable again

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Forward port to master
