### PR TITLE
Bugfix/multibucket share copy

### DIFF
--- a/lib/private/Files/Mount/ObjectHomeMountProvider.php
+++ b/lib/private/Files/Mount/ObjectHomeMountProvider.php
@@ -118,7 +118,12 @@ class ObjectHomeMountProvider implements IHomeMountProvider {
 			if (!isset($config['arguments']['bucket'])) {
 				$config['arguments']['bucket'] = '';
 			}
-			$mapper = new \OC\Files\ObjectStore\Mapper($user);
+			if (isset($config['arguments']['mapper-class'])) {
+				$mapperClass = $config['arguments']['mapper-class'];
+				$mapper = new $mapperClass($user);
+			} else {
+				$mapper = new \OC\Files\ObjectStore\Mapper($user);
+			}
 			$config['arguments']['bucket'] .= $mapper->getBucket();
 
 			$this->config->setUserValue($user->getUID(), 'homeobjectstore', 'bucket', $config['arguments']['bucket']);

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -499,6 +499,11 @@ class ObjectStoreStorage extends Common {
 			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
 
+		// living on different buckets?
+		if ($this->getId() !== $sourceStorage->getId()) {
+			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+
 		// source and target live on the same object store and we can simply rename
 		// which updates the cache properly
 		$this->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -88,14 +88,14 @@ class FileCacheTest extends TestCache {
 			$this->instance->remove('hack', 'hack');
 		}
 
+		parent::tearDown();
+
 		\OC_User::setUserId($this->user);
 		\OC::$server->getConfig()->setSystemValue('cachedirectory', $this->datadir);
 
 		// Restore the original mount point
 		\OC\Files\Filesystem::clearMounts();
 		\OC\Files\Filesystem::mount($this->storage, [], '/');
-
-		parent::tearDown();
 	}
 
 	private function setupMockStorage() {

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -553,7 +553,8 @@ abstract class TestCase extends BaseTestCase {
 	}
 
 	public function runsWithPrimaryObjectstorage() {
-		$objectstoreConfiguration = \OC::$server->getConfig()->getSystemValue('objectstore', null);
+		$objectstoreConfiguration = \OC::$server->getConfig()->getSystemValue('objectstore_multibucket', null);
+		$objectstoreConfiguration = \OC::$server->getConfig()->getSystemValue('objectstore', $objectstoreConfiguration);
 		if ($objectstoreConfiguration !== null) {
 			return true;
 		}


### PR DESCRIPTION
## Description
In a multibucket objectstore scenario the move operation needs to respect that source and target live on different buckets -> objectst have to be moved physically ...

## How Has This Been Tested?
- manually
- automation in progress

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
