### PR TITLE
Update the unique index for the systemtag table

### DIFF
--- a/core/Migrations/Version20181113071753.php
+++ b/core/Migrations/Version20181113071753.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Add assignable column to unique index in oc_systemtags table
+ */
+class Version20181113071753 implements ISchemaMigration {
+	/** @var string */
+	private $prefix;
+
+	public function changeSchema(Schema $schema, array $options) {
+		$this->prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$this->prefix}systemtag");
+		if ($schema->hasTable("{$this->prefix}systemtag")) {
+			$table->dropIndex('tag_ident');
+			$table->addUniqueIndex(['name', 'visibility', 'editable', 'assignable'], 'tag_ident');
+		}
+	}
+}


### PR DESCRIPTION
Update the unique index for the systemtag table.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Update the unique index for the systemtag table.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the unique index is not updated with `assignable`, then inserts to the table were causing problems.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Download owncloud http://download.owncloud.org/community/owncloud-8.2.11.tar.bz2 and install it.
- Download owncloud http://download.owncloud.org/community/owncloud-daily-stable10-qa.tar.bz2 for the upgrade
- When upgraded from 8.2.11 to 10 below are the upgrade log captured from the console:
```
➜  owncloud4 ./occ upgrade                                                 
Cannot load Xdebug - it was already loaded
ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
2018-11-09T11:00:26+00:00 Set log level to debug
2018-11-09T11:00:26+00:00 Repair step: Repair MySQL database engine
2018-11-09T11:00:26+00:00 Repair info: Not a mysql database -> nothing to do
2018-11-09T11:00:26+00:00 Repair step: Repair MySQL collation
2018-11-09T11:00:26+00:00 Repair info: Not a mysql database -> nothing to do
2018-11-09T11:00:26+00:00 Repair step: Repair SQLite autoincrement
2018-11-09T11:00:26+00:00 Repair step: Repair orphaned reshare
2018-11-09T11:00:26+00:00 Repair step: Repair duplicate entries in oc_lucene_status
2018-11-09T11:00:26+00:00 Repair info: lucene_status table does not exist -> nothing to do
2018-11-09T11:00:26+00:00 Repair step: Upgrade app code from the marketplace
2018-11-09T11:00:26+00:00 Repair info: Enabling market app to assist with update
2018-11-09T11:00:26+00:00 Repair info: Using market to update existing apps
2018-11-09T11:00:26+00:00 Repair info: Attempting to update the following missing apps from market: activity, files_pdfviewer, files_texteditor, gallery, templateeditor
2018-11-09T11:00:26+00:00 Repair info: Fetching app from market: activity
2018-11-09T11:00:45+00:00 Repair info: Fetching app from market: files_pdfviewer
2018-11-09T11:01:10+00:00 Repair info: Fetching app from market: files_texteditor
2018-11-09T11:01:28+00:00 Repair info: Fetching app from market: gallery
2018-11-09T11:01:40+00:00 Repair info: Fetching app from market: templateeditor
2018-11-09T11:01:51+00:00 Repair info: Attempting to update the following existing compatible apps from market: activity, files_pdfviewer, files_texteditor, gallery, templateeditor
2018-11-09T11:01:51+00:00 Repair info: Fetching app from market: dav
2018-11-09T11:01:51+00:00 Repair info: App (dav) is not installed
2018-11-09T11:01:51+00:00 Repair info: Fetching app from market: federatedfilesharing
2018-11-09T11:01:51+00:00 Repair info: App (federatedfilesharing) is not installed
2018-11-09T11:01:51+00:00 Repair info: Fetching app from market: files
2018-11-09T11:01:54+00:00 Repair info: App (files) is not known at the marketplace.
2018-11-09T11:01:54+00:00 Repair info: Fetching app from market: files_external
2018-11-09T11:01:54+00:00 Repair info: App (files_external) is not installed
2018-11-09T11:01:54+00:00 Repair info: Fetching app from market: files_sharing
2018-11-09T11:01:57+00:00 Repair info: App (files_sharing) is not known at the marketplace.
2018-11-09T11:01:57+00:00 Repair info: Fetching app from market: files_trashbin
2018-11-09T11:02:01+00:00 Repair info: App (files_trashbin) is not known at the marketplace.
2018-11-09T11:02:01+00:00 Repair info: Fetching app from market: files_versions
2018-11-09T11:02:04+00:00 Repair info: App (files_versions) is not known at the marketplace.
2018-11-09T11:02:04+00:00 Repair info: Fetching app from market: firstrunwizard
2018-11-09T11:02:07+00:00 Repair info: App (firstrunwizard) is not known at the marketplace.
2018-11-09T11:02:07+00:00 Repair info: Fetching app from market: notifications
2018-11-09T11:02:10+00:00 Repair info: App (notifications) is not known at the marketplace.
2018-11-09T11:02:10+00:00 Repair info: Fetching app from market: provisioning_api
2018-11-09T11:02:13+00:00 Repair info: App (provisioning_api) is not known at the marketplace.
2018-11-09T11:02:13+00:00 Repair info: App was not updated: dav
2018-11-09T11:02:13+00:00 Repair info: App was not updated: federatedfilesharing
2018-11-09T11:02:13+00:00 Repair info: App was not updated: files
2018-11-09T11:02:13+00:00 Repair info: App was not updated: files_external
2018-11-09T11:02:13+00:00 Repair info: App was not updated: files_sharing
2018-11-09T11:02:13+00:00 Repair info: App was not updated: files_trashbin
2018-11-09T11:02:13+00:00 Repair info: App was not updated: files_versions
2018-11-09T11:02:13+00:00 Repair info: App was not updated: firstrunwizard
2018-11-09T11:02:13+00:00 Repair info: App was not updated: notifications
2018-11-09T11:02:13+00:00 Repair info: App was not updated: provisioning_api
2018-11-09T11:02:13+00:00 Updating database schema
2018-11-09T11:02:15+00:00 Updated database
2018-11-09T11:02:15+00:00 Updating <files_pdfviewer> ...
2018-11-09T11:02:15+00:00 Updated <files_pdfviewer> to 0.9.0
2018-11-09T11:02:15+00:00 Updating <files_texteditor> ...
2018-11-09T11:02:15+00:00 Updated <files_texteditor> to 2.2.1
2018-11-09T11:02:15+00:00 Updating <gallery> ...
2018-11-09T11:02:15+00:00 Updated <gallery> to 16.1.0
2018-11-09T11:02:15+00:00 Updating <templateeditor> ...
2018-11-09T11:02:15+00:00 Updated <templateeditor> to 0.3.1
2018-11-09T11:02:15+00:00 Updating <files> ...
2018-11-09T11:02:15+00:00 Updated <files> to 1.5.1
2018-11-09T11:02:15+00:00 Updating <activity> ...
2018-11-09T11:02:15+00:00 Updated <activity> to 2.3.8
2018-11-09T11:02:15+00:00 Updating <files_sharing> ...
2018-11-09T11:02:16+00:00 Updated <files_sharing> to 0.11.0
2018-11-09T11:02:16+00:00 Updating <files_trashbin> ...
2018-11-09T11:02:16+00:00 Updated <files_trashbin> to 0.9.1
2018-11-09T11:02:16+00:00 Updating <files_versions> ...
2018-11-09T11:02:16+00:00 Updated <files_versions> to 1.3.0
2018-11-09T11:02:16+00:00 Updating <notifications> ...
2018-11-09T11:02:17+00:00 Updated <notifications> to 0.4.0
2018-11-09T11:02:17+00:00 Updating <provisioning_api> ...
2018-11-09T11:02:17+00:00 Updated <provisioning_api> to 0.5.0
2018-11-09T11:02:19+00:00 Repair step: Repair mime types
2018-11-09T11:02:19+00:00 Repair step: Detect file cache entries with path that does not match parent-child relationships
2018-11-09T11:02:19+00:00 Repair step: Generate ETags for file where no ETag is present.
2018-11-09T11:02:19+00:00 Repair info: ETags have been fixed for 0 files/folders.
2018-11-09T11:02:19+00:00 Repair step: Clean tags and favorites
2018-11-09T11:02:19+00:00 Repair info: 0 tags of deleted users have been removed.
2018-11-09T11:02:19+00:00 Repair info: 0 tags for delete files have been removed.
2018-11-09T11:02:19+00:00 Repair info: 0 tag entries for deleted tags have been removed.
2018-11-09T11:02:19+00:00 Repair info: 0 tags with no entries have been removed.
2018-11-09T11:02:19+00:00 Repair step: Drop old database tables
2018-11-09T11:02:19+00:00 Drop old database tables
2018-11-09T11:02:19+00:00 
                                                    2018-11-09T11:02:19+00:00  Done
 28/28 [============================] 100%2018-11-09T11:02:19+00:00 
2018-11-09T11:02:19+00:00 Repair step: Drop old background jobs
2018-11-09T11:02:19+00:00 Repair step: Remove getetag entries in properties table
2018-11-09T11:02:19+00:00 Repair info: Removed 0 unneeded "{DAV:}getetag" entries from properties table.
2018-11-09T11:02:19+00:00 Repair step: Repair outdated OCS IDs
2018-11-09T11:02:19+00:00 Repair step: Repair invalid shares
2018-11-09T11:02:19+00:00 Repair step: Remove old share propagation app entries
2018-11-09T11:02:19+00:00 Repair step: Move user avatars outside the homes to the new location
2018-11-09T11:02:19+00:00 Move user avatars outside the homes to the new location
                                                    2018-11-09T11:02:19+00:00  Done
 1/1 [============================] 100%2018-11-09T11:02:19+00:00 
2018-11-09T11:02:19+00:00 Repair step: Remove shares of a users root folder
2018-11-09T11:02:19+00:00 Repair step: Repair unmerged shares
2018-11-09T11:02:19+00:00 Repair step: Disable extra themes
2018-11-09T11:02:19+00:00 Repair step: Repair sub shares
2018-11-09T11:02:19+00:00 Starting code integrity check...
2018-11-09T11:02:40+00:00 Finished code integrity check
2018-11-09T11:02:40+00:00 Update successful
2018-11-09T11:02:40+00:00 Maintenance mode is kept active
2018-11-09T11:02:40+00:00 Reset log level
➜  owncloud4
```
- Now try to run the test for `SystemTagManagerTest.php`
```
➜  tests ../lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml lib/SystemTag/SystemTagManagerTest.php 
Cannot load Xdebug - it was already loaded
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.11-4+ubuntu18.04.1+deb.sury.org+1 with Xdebug 2.6.1
Configuration: /home/sujith/test/owncloud4/tests/phpunit-autotest.xml

.............................................................     61 / 61 (100%)

Time: 34.15 seconds, Memory: 14.00MB

OK (61 tests, 170 assertions)
➜  tests
```
- Failure is not observed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
