### PR TITLE
Add background job to clean up orphaned properties

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -20,6 +20,7 @@
 	</dependencies>
 	<background-jobs>
 		<job>OCA\DAV\CardDAV\SyncJob</job>
+		<job>OCA\DAV\BackgroundJob\CleanProperties</job>
 	</background-jobs>
 	<commands>
 		<command>OCA\DAV\Command\CreateAddressBook</command>

--- a/apps/dav/lib/BackgroundJob/CleanProperties.php
+++ b/apps/dav/lib/BackgroundJob/CleanProperties.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\BackgroundJob;
+
+use OC\BackgroundJob\TimedJob;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\ILogger;
+
+/**
+ * Class CleanProperties
+ *
+ * @package OCA\DAV\BackgroundJob
+ */
+class CleanProperties extends TimedJob {
+	const CHUNK_SIZE = 200;
+
+	/** @var IDBConnection  */
+	private $connection;
+	/** @var ILogger  */
+	private $logger;
+
+	/**
+	 * CleanProperties constructor.
+	 *
+	 * @param IDBConnection $connection
+	 * @param ILogger $logger
+	 */
+	public function __construct(IDBConnection $connection,
+								ILogger $logger) {
+		$this->connection = $connection;
+		$this->logger = $logger;
+
+		//Run once in a day
+		$this->setInterval(24*60*60);
+	}
+
+	/**
+	 * Delete the orphan fileid from oc_properties table
+	 *
+	 * @param array $fileids fileid of oc_properties table
+	 */
+	private function deleteOrphan($fileids) {
+		$qb = $this->connection->getQueryBuilder();
+
+		$qb->delete('properties')
+			->where($qb->expr()->in('fileid', $qb->createParameter('fileids')));
+		$qb->setParameter('fileids', $fileids, IQueryBuilder::PARAM_INT_ARRAY);
+		$qb->execute();
+	}
+
+	/**
+	 * Gathers the fileid which are orphan in the oc_properties table
+	 * and then deletes them
+	 */
+	private function processProperties() {
+		$orphanEntries = 0;
+		$qb = $this->connection->getQueryBuilder();
+
+		/**
+		 * select prop.fileid from oc_properties prop
+		 * left join oc_filecache fc on fc.fileid = prop.fileid
+		 * where fc.fileid is not null limit 200
+		 */
+		$qb->select('prop.fileid')
+			->from('properties', 'prop')
+			->where($qb->expr()->isNull('fc.fileid'))
+			->leftJoin('prop', 'filecache', 'fc', $qb->expr()->eq('prop.fileid', 'fc.fileid'))
+			->setMaxResults(self::CHUNK_SIZE);
+
+		while ($rows = $qb->execute()->fetchAll()) {
+			$fileIds = \array_map(function ($row) {
+				return (int) $row['fileid'];
+			}, $rows);
+
+			if (!empty($fileIds)) {
+				$this->deleteOrphan($fileIds);
+			}
+
+			$orphanEntries += \count($fileIds);
+		}
+
+		$this->logger->debug("{$orphanEntries} orphaned properties entries were deleted", ['app' => 'dav']);
+	}
+
+	protected function run($argument) {
+		$this->processProperties();
+	}
+}

--- a/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\BackgroundJob;
+
+use OCA\DAV\BackgroundJob\CleanProperties;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * Class CleanPropertiesTest
+ *
+ * @group DB
+ * @package OCA\DAV\Tests\Unit\BackgroundJob
+ */
+class CleanPropertiesTest extends TestCase {
+	use UserTrait;
+	/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject */
+	private $connection;
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+	/** @var CleanProperties */
+	private $cleanProperties;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->logger = \OC::$server->getLogger();
+		$this->cleanProperties = new CleanProperties($this->connection, $this->logger);
+		$this->createUser('user1');
+		$this->loginAsUser('user1');
+	}
+
+	public function testDeleteOrphanEntries() {
+		$userFolder = \OC::$server->getUserFolder('user1');
+		$userFolder->newFile('a.txt');
+		$userFolder->newFile('b.txt');
+		$userFolder->newFile('c.txt');
+
+		$fileIds[] = $userFolder->get('a.txt')->getId();
+		$fileIds[] = $userFolder->get('b.txt')->getId();
+		$fileIds[] = $userFolder->get('c.txt')->getId();
+
+		foreach ($fileIds as $fileId) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->insert('properties')
+				->values([
+					'propertyname' => $qb->createNamedParameter('foo'),
+					'propertyvalue' => $qb->createNamedParameter('bar'),
+					'fileid' => $qb->createNamedParameter($fileId)
+				]);
+			$qb->execute();
+		}
+
+		$userFolder->get('a.txt')->delete();
+		$userFolder->get('c.txt')->delete();
+
+		$this->invokePrivate($this->cleanProperties, 'run', ['']);
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('fileid')
+			->from('properties');
+		$result = $qb->execute()->fetchAll();
+
+		/**
+		 * Only one result should be there.
+		 * And the fileid should match with the file which is not deleted.
+		 */
+		$this->assertCount(1, $result);
+		$this->assertEquals($fileIds[1], $result[0]['fileid']);
+	}
+
+	public function providesDeleteLargeOrphans() {
+		return [
+			[450, 100, 350],
+			[650, 220, 430],
+			[890, 300, 590],
+		];
+	}
+	/**
+	 * Delete large orphans lets say 300 entries out of 310 entries
+	 *
+	 * @dataProvider providesDeleteLargeOrphans
+	 */
+	public function testDeleteLargeOrphans($totalFiles, $deletedFiles, $expectedResult) {
+		$userFolder = \OC::$server->getUserFolder('user1');
+
+		for ($i = 1; $i <= $totalFiles; $i++) {
+			$fileName = 'a' . (string) $i . '.txt';
+			$userFolder->newFile($fileName);
+			$fileIds[] = (string) $userFolder->get($fileName)->getId();
+		}
+
+		foreach ($fileIds as $fileId) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->insert('properties')
+				->values([
+					'propertyname' => $qb->createNamedParameter('foo'),
+					'propertyvalue' => $qb->createNamedParameter('bar'),
+					'fileid' => $qb->createNamedParameter($fileId)
+				]);
+			$qb->execute();
+		}
+
+		for ($i = 1; $i <= $deletedFiles; $i++) {
+			$fileName = 'a' . (string) $i . '.txt';
+			$userFolder->get($fileName)->delete();
+			unset($fileIds[$i-1]);
+		}
+
+		$this->invokePrivate($this->cleanProperties, 'run', ['']);
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('fileid')
+			->from('properties');
+		$results = $qb->execute()->fetchAll();
+
+		/**
+		 * 10 result should be there.
+		 * And the fileid should match with the file which is not deleted.
+		 */
+		$this->assertCount($expectedResult, $results);
+
+		foreach ($results as $result) {
+			$this->assertEquals(true, \in_array((string)$result['fileid'], $fileIds, true));
+		}
+	}
+}


### PR DESCRIPTION
Add a background job to clean up orphaned properties
in the table.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Clean up orphan properties in the table.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/33413

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Clean up orphan properties.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create files a.txt, b.txt, c.txt and d.txt
- Add properties to all the files created above, by using proppatch.xml file `<?xml version="1.0" encoding="utf-8" ?><propertyupdate xmlns='DAV:'><set><prop><t:valnspace xmlns:t='http://example.com/neon/litmus/'><foo xmlns='http://bar'/></t:valnspace></prop></set></propertyupdate>`
- Verify that oc_properties table has been updated
- Now delete the file `a.txt` and `c.txt` using a small script 
```<?php
require_once __DIR__ . '/lib/base.php';
/*$a = new \OC\Files\View('/admin/files/');
$a->unlink('a.txt');*/
//$name = \OC::$server->getRootFolder()->getName('/admin/files/a.txt');
$adminUser = \OC::$server->getUserFolder('admin');
$a = $adminUser->get('a.txt');
$a->delete();
```
- Verify there are 4 entries in the oc_properties.
- Made small modification to the code by adding method in CleanProperties.php
```
	public function execute($jobList, ILogger $logger = null) {
		$this->processProperties();
	}

```
- Now run the background job as ```./occ system:cron```.
- Verify that there should be only 2 entries. And the fileid's of oc_properties should belong to fileid's of `b.txt` and `d.txt.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
