### PR TITLE
Add smoke test for chunk upload case

### DIFF
--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -16,8 +16,7 @@ Feature: File Upload
     And the file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-  # disabled due to random fails
-  # @smokeTest
+  @smokeTest
   Scenario: chunking upload
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user uploads the file "big-video.mp4" using the webUI


### PR DESCRIPTION
Reverts owncloud/core#33466

We need to look into why it repeatedly fails this way in some drone envs:
```
  @smokeTest
  Scenario: chunking upload                                                                              # /drone/owncloud-smoketest/testsuite/tests/acceptance/features/webUIUpload/upload.feature:20
    Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally # WebUIGeneralContext::aFileWithSizeAndNameHasBeenCreatedLocally()
    When the user uploads the file "big-video.mp4" using the webUI                                       # WebUIFilesContext::theUserUploadsTheFileUsingTheWebUI()
    Then no notification should be displayed on the webUI                                                # WebUIGeneralContext::noNotificationShouldBeDisplayedOnTheWebUI()
      Expecting no notifications but got Chunks on server do not sum up to 30000000 but to 24576
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -''
      +'Chunks on server do not sum up to 30000000 but to 24576'
    And the file "big-video.mp4" should be listed on the webUI                                           # WebUIFilesContext::theFileFolderShouldBeListedOnTheWebUI()
And the content of "big-video.mp4" should be the same as the local "big-video.mp4" # WebUIFilesContext::theContentOfShouldBeTheSameAsTheLocal()
```

@tboerger @DeepDiver1975 @phil-davis 