### PR TITLE
File cache hole check only report storage id once

### DIFF
--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -243,9 +243,10 @@ class RepairMismatchFileCachePath implements IRepairStep {
 
 		$storageIds = [];
 		foreach ($rows as $row) {
-			$storageIds[] = $row['storage'];
+			$storageIds[$row['storage']] = true;
 		}
 
+		$storageIds = \array_keys($storageIds);
 		if (!empty($storageIds)) {
 			$out->warning('The file cache contains entries with invalid path values for the following storage numeric ids: ' . \implode(' ', $storageIds));
 			$out->warning('Please run `occ files:scan --all --repair` to repair'
@@ -271,9 +272,10 @@ class RepairMismatchFileCachePath implements IRepairStep {
 
 		$storageIds = [];
 		foreach ($rows as $row) {
-			$storageIds[] = $row['storage'];
+			$storageIds[$row['storage']] = true;
 		}
 
+		$storageIds = \array_keys($storageIds);
 		if (!empty($storageIds)) {
 			$out->warning('The file cache contains entries where the parent id does not point to any existing entry for the following storage numeric ids: ' . \implode(' ', $storageIds));
 			$out->warning('Please run `occ files:scan --all --repair` to repair all affected storages');

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -216,6 +216,15 @@ class RepairMismatchFileCachePathTest extends TestCase {
 			->method('getSystemValue')
 			->with('version', '0.0.0')
 			->willReturn('10.0.3');
+
+		// test report command first
+		$this->repair->setCountOnly(true);
+		$outputMock->expects($this->at(0))
+			->method('warning')
+			->with($this->logicalAnd($this->stringContains('with invalid path values'), $this->stringContains($sourceStorageId)));
+		$this->repair->run($outputMock);
+		$this->repair->setCountOnly(false);
+
 		if ($repairStoragesOrder === null) {
 			// no storage selected, full repair
 			$this->repair->setStorageNumericId(null);
@@ -552,6 +561,13 @@ class RepairMismatchFileCachePathTest extends TestCase {
 			->method('getSystemValue')
 			->with('version', '0.0.0')
 			->willReturn('10.0.3');
+
+		$this->repair->setCountOnly(true);
+		$outputMock->expects($this->at(0))
+			->method('warning')
+			->with($this->logicalAnd($this->stringContains('parent id does not point'), $this->stringContains($storageId)));
+		$this->repair->run($outputMock);
+		$this->repair->setCountOnly(false);
 		$this->repair->run($outputMock);
 
 		// wrong parent root reparented to actual root


### PR DESCRIPTION
## Description
Fix file cache repair check to only output the storage id once instead
of multiple times.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/31165

## Motivation and Context
Because having the same value multiple times is not readable.

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
