### PR TITLE
[stable10] Backport of Add uid to the symfony login events for consis…

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -573,7 +573,7 @@ class Session implements IUserSession, Emitter {
 		}
 
 		$this->manager->emit('\OC\User', 'preLogin', [$uid, $password]);
-		$beforeEvent = new GenericEvent(null, ['loginType' => 'token', 'login' => $uid, 'password' => $password]);
+		$beforeEvent = new GenericEvent(null, ['loginType' => 'token', 'login' => $uid, 'uid' => $uid, 'password' => $password]);
 		$this->eventDispatcher->dispatch('user.beforelogin', $beforeEvent);
 
 		$user = $this->manager->get($uid);
@@ -593,7 +593,7 @@ class Session implements IUserSession, Emitter {
 		$this->setUser($user);
 		$this->setLoginName($dbToken->getLoginName());
 		$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
-		$afterEvent = new GenericEvent(null, ['loginType' => 'token', 'user' => $user, 'login' => $user->getUID(), 'password' => $password]);
+		$afterEvent = new GenericEvent(null, ['loginType' => 'token', 'user' => $user, 'login' => $user->getUID(), 'uid' => $user->getUID(), 'password' => $password]);
 		$this->eventDispatcher->dispatch('user.afterlogin', $afterEvent);
 
 		if ($this->isLoggedIn()) {
@@ -655,7 +655,7 @@ class Session implements IUserSession, Emitter {
 		$this->session->regenerateId();
 
 		$this->manager->emit('\OC\User', 'preLogin', [$uid, '']);
-		$beforeEvent = new GenericEvent(null, ['loginType' => 'apache', 'login' => $uid, 'password' => '']);
+		$beforeEvent = new GenericEvent(null, ['loginType' => 'apache', 'login' => $uid, 'uid' => $uid, 'password' => '']);
 		$this->eventDispatcher->dispatch('user.beforelogin', $beforeEvent);
 
 		// Die here if not valid
@@ -688,7 +688,7 @@ class Session implements IUserSession, Emitter {
 
 			$firstTimeLogin = $user->updateLastLoginTimestamp();
 			$this->manager->emit('\OC\User', 'postLogin', [$user, '']);
-			$afterEvent = new GenericEvent(null, ['loginType' => 'apache', 'user' => $user, 'login' => $user->getUID(), 'password' => '']);
+			$afterEvent = new GenericEvent(null, ['loginType' => 'apache', 'user' => $user, 'login' => $user->getUID(), 'uid' => $user->getUID(), 'password' => '']);
 			$this->eventDispatcher->dispatch('user.afterlogin', $afterEvent);
 			if ($this->isLoggedIn()) {
 				$this->prepareUserLogin($firstTimeLogin);
@@ -1008,8 +1008,8 @@ class Session implements IUserSession, Emitter {
 			}
 
 			return true;
-		}, ['before' => ['user' => $user, 'uid' => $uid, 'password' => $password],
-			'after' => ['user' => $user, 'uid' => $uid, 'password' => $password]],
+		}, ['before' => ['user' => $user, 'login' => $uid, 'uid' => $uid, 'password' => $password],
+			'after' => ['user' => $user, 'login' => $uid, 'uid' => $uid, 'password' => $password]],
 			'user', 'login');
 	}
 

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1169,7 +1169,7 @@ class SessionTest extends TestCase {
 		$apacheBackend->expects($this->once())->method('isSessionActive')->willReturn(true);
 
 		$failedEvent = new GenericEvent(null, ['user' => 'foo']);
-		$beforeLoginEvent = new GenericEvent(null, ['login' => 'foo', 'password' => '', 'loginType' => 'apache']);
+		$beforeLoginEvent = new GenericEvent(null, ['login' => 'foo', 'uid' => 'foo', 'password' => '', 'loginType' => 'apache']);
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
@@ -1204,7 +1204,7 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->exactly(2))
 			->method('isEnabled')
 			->willReturn(true);
-		$iUser->expects($this->exactly(3))
+		$iUser->expects($this->exactly(4))
 			->method('getUID')
 			->willReturn('foo');
 
@@ -1212,8 +1212,8 @@ class SessionTest extends TestCase {
 			->method('get')
 			->willReturn($iUser);
 
-		$beforeLoginEvent = new GenericEvent(null, ['login' => 'foo', 'password' => '', 'loginType' => 'apache']);
-		$afterLoginEvent = new GenericEvent(null, ['user' => $iUser, 'login' => 'foo', 'password' => '', 'loginType' => 'apache']);
+		$beforeLoginEvent = new GenericEvent(null, ['login' => 'foo', 'uid' => 'foo', 'password' => '', 'loginType' => 'apache']);
+		$afterLoginEvent = new GenericEvent(null, ['user' => $iUser, 'login' => 'foo', 'uid' => 'foo', 'password' => '', 'loginType' => 'apache']);
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
@@ -1327,7 +1327,7 @@ class SessionTest extends TestCase {
 			->method('get')
 			->willReturn(null);
 
-		$event = new GenericEvent(null, ['login' => 'foo', 'password' => 'foobar', 'loginType' => 'token']);
+		$event = new GenericEvent(null, ['login' => 'foo', 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token']);
 		$failedEvent = new GenericEvent(null, ['user' => 'foo']);
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
@@ -1378,11 +1378,11 @@ class SessionTest extends TestCase {
 
 		$beforeEvent = new GenericEvent(null,
 			[
-				'login' => 'foo', 'password' => 'foobar', 'loginType' => 'token'
+				'login' => 'foo', 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token'
 			]);
 		$afterEvent = new GenericEvent(null,
 			[
-				'user' => $iUser, 'login' => 'foo', 'password' => 'foobar', 'loginType' => 'token'
+				'user' => $iUser, 'login' => 'foo', 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token'
 			]);
 
 		$eventDispatcher->expects($this->exactly(2))


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This change adds uid to the symfony login events, which brings consistency to the listeners of the event.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/33060

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change adds uid to the symfony login events, which brings consistency to the listeners of the event.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
