### PR TITLE
Make tests work with comments app disabled

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -7,7 +7,7 @@ Feature: get apps
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @comments-app-required @files_trashbin-app-required @files_versions-app-required @systemtags-app-required
   Scenario: admin gets enabled apps
     When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
     Then the OCS status code should be "100"
@@ -23,5 +23,18 @@ Feature: get apps
       | files_versions       |
       | provisioning_api     |
       | systemtags           |
+      | updatenotification   |
+      | files_external       |
+
+  Scenario: admin gets enabled apps - check for the minimal list of apps
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
       | updatenotification   |
       | files_external       |

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -7,7 +7,7 @@ Feature: get apps
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @comments-app-required @files_trashbin-app-required @files_versions-app-required @systemtags-app-required
   Scenario: admin gets enabled apps
     When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
     Then the OCS status code should be "200"
@@ -23,5 +23,18 @@ Feature: get apps
       | files_versions       |
       | provisioning_api     |
       | systemtags           |
+      | updatenotification   |
+      | files_external       |
+
+  Scenario: admin gets enabled apps - check for the minimal list of apps
+    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
       | updatenotification   |
       | files_external       |

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -151,6 +151,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		$username, $password
 	) {
 		$this->filesPage = $this->webUIGeneralContext->loginAs($username, $password);
+		$this->webUIGeneralContext->setCurrentPageObject($this->filesPage);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -19,6 +19,7 @@ Feature: browse directly to details tab
       | /             |
       | simple-folder |
 
+  @comments-app-required
   Scenario Outline: Browse directly to the comments details of a file
     When the user browses directly to display the "comments" details of file "lorem.txt" in folder "<folder>"
     Then the thumbnail should be visible in the details panel
@@ -28,6 +29,7 @@ Feature: browse directly to details tab
       | /             |
       | simple-folder |
 
+  @files_versions-app-required
   Scenario Outline: Browse directly to the versions details of a file
     When the user browses directly to display the "versions" details of file "lorem.txt" in folder "<folder>"
     Then the thumbnail should be visible in the details panel

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -12,7 +12,7 @@ Feature: User can open the details panel for any file or folder
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @files_versions-app-required
+  @comments-app-required @files_versions-app-required
   Scenario: View different areas of the details panel in files page
     When the user opens the file action menu of the file "lorem.txt" in the webUI
     And the user clicks the details file action in the webUI
@@ -25,7 +25,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "versions" tab in details panel using the webUI
     Then the "versions" details panel should be visible
 
-  @files_versions-app-required
+  @comments-app-required @files_versions-app-required
   Scenario: View different areas of the details panel in favorites page
     When the user marks the file "lorem.txt" as favorite using the webUI
     And the user browses to the favorites page
@@ -40,7 +40,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "versions" tab in details panel using the webUI
     Then the "versions" details panel should be visible
 
-  @public_link_share-feature-required
+  @comments-app-required @public_link_share-feature-required
   Scenario: user shares a file through public link and then the details dialog should work in a Shared by link page
     Given the user has created a new public link for the folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page
@@ -54,6 +54,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "comments" tab in details panel using the webUI
     Then the "comments" details panel should be visible
 
+  @comments-app-required
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
     Given the user has shared the folder "simple-folder" with the user "User Two" using the webUI
     When the user browses to the shared-with-others page
@@ -67,6 +68,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "comments" tab in details panel using the webUI
     Then the "comments" details panel should be visible
 
+  @comments-app-required
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
     Given the user has shared the folder "simple-folder" with the user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
@@ -81,6 +83,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to "comments" tab in details panel using the webUI
     Then the "comments" details panel should be visible
 
+  @comments-app-required
   Scenario: View different areas of details panel for the folder with given tag in Tags page
     Given user "user1" has created a "normal" tag with name "simple"
     And user "user1" has added the tag "simple" to "simple-folder"


### PR DESCRIPTION
## Description
1) Adjust getApps.feature to have test scenarios with an without the comments app included
2) Tag test scenarios that need the comments app
3) Fixup ``theUserLogsInWithUsernameAndPasswordUsingTheWebUI()`` so it remembers that it should end up on the files page. This makes potential later test steps understand the "current page object" correctly, and thus use the correct methods for that page object. In particular, they then use the correct ``waitTillPageIsLoaded`` method.

Without (1) and (2) then those test scenarios will fail when the comments app is disabled.

Without (3) then various test scenarios fail with "timeout waiting for page to load" when the comments app is disabled. (Disabling the comments app causes the "loading indicator" to not exist on the page, and the ``waitTillPageIsLoaded`` method in ``OwncloudPage`` was getting called and timing out)

## Related Issue
- Part of #33161 

## Motivation and Context

## How Has This Been Tested?
CI with comments app disabled - see PoC PR #32972 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
