### PR TITLE
Acceptance test wording 20181112

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -18,7 +18,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  Scenario: subadmin gets user of his group
+  Scenario: subadmin gets users in their group
     Given user "brand-new-user" has been created
     And user "another-new-user" has been created
     And group "new-group" has been created
@@ -33,7 +33,7 @@ Feature: access user provisioning API using app password
     And the HTTP status code should be "200"
 
   @smokeTest
-  Scenario: normal user gets his own information using the app password
+  Scenario: normal user gets their own information using the app password
     Given user "newuser" has been created
     And a new client token for "newuser" has been generated
     Given a new browser session for "newuser" has been started

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -15,7 +15,7 @@ Feature: create a subadmin
       | groupid | new-group |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the user "brand-new-user" should be the subadmin of the group "new-group"
+    And user "brand-new-user" should be a subadmin of group "new-group"
 
   Scenario: admin tries to create a subadmin using a user which does not exist
     Given user "not-user" has been deleted
@@ -24,7 +24,7 @@ Feature: create a subadmin
       | groupid | new-group |
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
-    And the user "not-user" should not be the subadmin of the group "new-group"
+    And user "not-user" should not be a subadmin of group "new-group"
 
   Scenario: admin tries to create a subadmin using a group which does not exist
     Given user "brand-new-user" has been created
@@ -46,4 +46,4 @@ Feature: create a subadmin
       | groupid | new-group |
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the user "brand-new-user" should not be the subadmin of the group "new-group"
+    And user "brand-new-user" should not be a subadmin of group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -16,7 +16,7 @@ Feature: delete users
     And user "brand-new-user" should not exist
 
   @smokeTest
-  Scenario: subadmin deletes a user in his group
+  Scenario: subadmin deletes a user in their group
     Given user "subadmin" has been created
     And user "brand-new-user" has been created
     And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -9,8 +9,8 @@ Feature: disable an app
 
   @smokeTest
   Scenario: Admin disables an app
-    Given the app "comments" has been enabled
-    When the administrator disables the app "comments"
+    Given app "comments" has been enabled
+    When the administrator disables app "comments"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And app "comments" should be disabled
@@ -19,16 +19,16 @@ Feature: disable an app
     Given user "subadmin" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    And the app "comments" has been enabled
-    When user "subadmin" disables the app "comments"
+    And app "comments" has been enabled
+    When user "subadmin" disables app "comments"
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And app "comments" should be enabled
 
   Scenario: normal user tries to disable an app
     Given user "newuser" has been created
-    And the app "comments" has been enabled
-    When user "newuser" disables the app "comments"
+    And app "comments" has been enabled
+    When user "newuser" disables app "comments"
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And app "comments" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -9,8 +9,8 @@ Feature: enable an app
 
   @smokeTest
   Scenario: Admin enables an app
-    Given the app "comments" has been disabled
-    When the administrator enables the app "comments"
+    Given app "comments" has been disabled
+    When the administrator enables app "comments"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And app "comments" should be enabled
@@ -20,16 +20,16 @@ Feature: enable an app
     Given user "subadmin" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    And the app "comments" has been disabled
-    When user "subadmin" enables the app "comments"
+    And app "comments" has been disabled
+    When user "subadmin" enables app "comments"
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And app "comments" should be disabled
 
   Scenario: normal user tries to enable an app
     Given user "newuser" has been created
-    And the app "comments" has been disabled
-    When user "newuser" enables the app "comments"
+    And app "comments" has been disabled
+    When user "newuser" enables app "comments"
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And app "comments" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
@@ -29,7 +29,7 @@ Feature: get group
     And the list of users returned by the API should be empty
 
   @smokeTest
-  Scenario: subadmin gets users in a group he is responsible for
+  Scenario: subadmin gets users in a group they are responsible for
     Given user "user1" has been created
     And user "user2" has been created
     And user "subadmin" has been created
@@ -44,7 +44,7 @@ Feature: get group
       | user1 |
       | user2 |
 
-  Scenario: subadmin tries to get users in a group he is not responsible for
+  Scenario: subadmin tries to get users in a group they are not responsible for
     Given user "subadmin" has been created
     And group "new-group" has been created
     And group "another-group" has been created
@@ -53,7 +53,7 @@ Feature: get group
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
-  Scenario: normal user tries to get users in his group
+  Scenario: normal user tries to get users in their group
     Given user "newuser" has been created
     And group "new-group" has been created
     When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -66,7 +66,7 @@ Feature: get user groups
     And the HTTP status code should be "200"
 
   @smokeTest
-  Scenario: subadmin tries to get other groups of the user in his group
+  Scenario: subadmin tries to get other groups of a user in their group
     Given user "newuser" has been created
     And user "subadmin" has been created
     And group "newgroup" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -18,7 +18,7 @@ Feature: get users
       | admin          |
 
   @smokeTest
-  Scenario: subadmin gets the users in his group
+  Scenario: subadmin gets the users in their group
     Given user "brand-new-user" has been created
     And user "another-new-user" has been created
     And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -103,7 +103,7 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And user "brand-new-user" should belong to group "new-group"
 
-  Scenario: normal user tries to remove the user in his group
+  Scenario: normal user tries to remove a user in their group
     Given user "newuser" has been created
     And user "anotheruser" has been created
     And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -16,7 +16,7 @@ Feature: remove subadmin
       | groupid | new-group |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the user "brand-new-user" should not be the subadmin of the group "new-group"
+    And user "brand-new-user" should not be a subadmin of group "new-group"
 
   Scenario: subadmin tries to remove other subadmin in the group
     Given user "subadmin" has been created
@@ -28,7 +28,7 @@ Feature: remove subadmin
       | groupid | new-group |
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the user "newsubadmin" should be the subadmin of the group "new-group"
+    And user "newsubadmin" should be a subadmin of group "new-group"
 
   Scenario: normal user tries to remove subadmin in the group
     Given user "subadmin" has been created
@@ -40,4 +40,4 @@ Feature: remove subadmin
       | groupid | new-group |
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the user "subadmin" should be the subadmin of the group "new-group"
+    And user "subadmin" should be a subadmin of group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -18,7 +18,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  Scenario: subadmin gets user of his group
+  Scenario: subadmin gets users in their group
     Given user "brand-new-user" has been created
     And user "another-new-user" has been created
     And group "new-group" has been created
@@ -33,7 +33,7 @@ Feature: access user provisioning API using app password
     And the HTTP status code should be "200"
 
   @smokeTest
-  Scenario: normal user gets his own information using the app password
+  Scenario: normal user gets their own information using the app password
     Given user "newuser" has been created
     And a new client token for "newuser" has been generated
     Given a new browser session for "newuser" has been started

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -15,7 +15,7 @@ Feature: create a subadmin
       | groupid | new-group |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the user "brand-new-user" should be the subadmin of the group "new-group"
+    And user "brand-new-user" should be a subadmin of group "new-group"
 
   Scenario: admin tries to create a subadmin using a user which does not exist
     Given user "not-user" has been deleted
@@ -24,7 +24,7 @@ Feature: create a subadmin
       | groupid | new-group |
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
-    And the user "not-user" should not be the subadmin of the group "new-group"
+    And user "not-user" should not be a subadmin of group "new-group"
 
   Scenario: admin tries to create a subadmin using a group which does not exist
     Given user "brand-new-user" has been created
@@ -47,5 +47,5 @@ Feature: create a subadmin
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
-    And the user "not-user" should not be the subadmin of the group "new-group"
+    And user "not-user" should not be a subadmin of group "new-group"
 	

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -16,7 +16,7 @@ Feature: delete users
     And user "brand-new-user" should not exist
 
   @smokeTest
-  Scenario: subadmin deletes a user in his group
+  Scenario: subadmin deletes a user in their group
     Given user "subadmin" has been created
     And user "brand-new-user" has been created
     And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -9,8 +9,8 @@ Feature: disable an app
 
   @smokeTest
   Scenario: Admin disables an app
-    Given the app "comments" has been enabled
-    When the administrator disables the app "comments"
+    Given app "comments" has been enabled
+    When the administrator disables app "comments"
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And app "comments" should be disabled
@@ -20,8 +20,8 @@ Feature: disable an app
     Given user "subadmin" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    And the app "comments" has been enabled
-    When user "subadmin" disables the app "comments"
+    And app "comments" has been enabled
+    When user "subadmin" disables app "comments"
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -30,8 +30,8 @@ Feature: disable an app
   @issue-31276
   Scenario: normal user tries to disable an app
     Given user "newuser" has been created
-    And the app "comments" has been enabled
-    When user "newuser" disables the app "comments"
+    And app "comments" has been enabled
+    When user "newuser" disables app "comments"
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -9,8 +9,8 @@ Feature: enable an app
 
   @smokeTest
   Scenario: Admin enables an app
-    Given the app "comments" has been disabled
-    When the administrator enables the app "comments"
+    Given app "comments" has been disabled
+    When the administrator enables app "comments"
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And app "comments" should be enabled
@@ -20,8 +20,8 @@ Feature: enable an app
     Given user "subadmin" has been created
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
-    And the app "comments" has been disabled
-    When user "subadmin" enables the app "comments"
+    And app "comments" has been disabled
+    When user "subadmin" enables app "comments"
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -30,8 +30,8 @@ Feature: enable an app
   @issue-31276
   Scenario: normal user tries to enable an app
     Given user "newuser" has been created
-    And the app "comments" has been disabled
-    When user "newuser" enables the app "comments"
+    And app "comments" has been disabled
+    When user "newuser" enables app "comments"
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
@@ -29,7 +29,7 @@ Feature: get group
     And the list of users returned by the API should be empty
 
   @smokeTest
-  Scenario: subadmin gets users in a group he is responsible for
+  Scenario: subadmin gets users in a group they are responsible for
     Given user "user1" has been created
     And user "user2" has been created
     And user "subadmin" has been created
@@ -45,7 +45,7 @@ Feature: get group
       | user2 |
 
   @issue-31276
-  Scenario: subadmin tries to get users in a group he is not responsible for
+  Scenario: subadmin tries to get users in a group they are not responsible for
     Given user "subadmin" has been created
     And group "new-group" has been created
     And group "another-group" has been created
@@ -56,7 +56,7 @@ Feature: get group
     And the HTTP status code should be "401"
 
   @issue-31276
-  Scenario: normal user tries to get users in his group
+  Scenario: normal user tries to get users in their group
     Given user "newuser" has been created
     And group "new-group" has been created
     When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -52,7 +52,7 @@ Feature: get user
     And the API should not return any data
 
   @smokeTest
-  Scenario: normal user gets his own information
+  Scenario: normal user gets their own information
     Given user "newuser" has been created
     When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
     Then the OCS status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -66,7 +66,7 @@ Feature: get user groups
     And the HTTP status code should be "200"
 
   @smokeTest
-  Scenario: subadmin tries to get other groups of the user in his group
+  Scenario: subadmin tries to get other groups of a user in their group
     Given user "newuser" has been created
     And user "subadmin" has been created
     And group "newgroup" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -18,7 +18,7 @@ Feature: get users
       | admin          |
 
   @smokeTest
-  Scenario: subadmin gets the users in his group
+  Scenario: subadmin gets the users in their group
     Given user "brand-new-user" has been created
     And user "another-new-user" has been created
     And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -104,7 +104,7 @@ Feature: remove a user from a group
     And user "brand-new-user" should belong to group "new-group"
 
   @issue-31276
-  Scenario: normal user tries to remove the user in his group
+  Scenario: normal user tries to remove a user in their group
     Given user "newuser" has been created
     And user "anotheruser" has been created
     And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -16,7 +16,7 @@ Feature: remove subadmin
       | groupid | new-group |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the user "brand-new-user" should not be the subadmin of the group "new-group"
+    And user "brand-new-user" should not be a subadmin of group "new-group"
 
   @issue-31276
   Scenario: subadmin tries to remove other subadmin in the group
@@ -30,7 +30,7 @@ Feature: remove subadmin
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
-    And the user "newsubadmin" should be the subadmin of the group "new-group"
+    And user "newsubadmin" should be a subadmin of group "new-group"
 
   @issue-31276
   Scenario: normal user tries to remove subadmin in the group
@@ -44,4 +44,4 @@ Feature: remove subadmin
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
-    And the user "subadmin" should be the subadmin of the group "new-group"
+    And user "subadmin" should be a subadmin of group "new-group"

--- a/tests/acceptance/features/apiShareManagement/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagement/deleteShare.feature
@@ -149,7 +149,7 @@ Feature: sharing
     Then the HTTP status code should be "403"
     And as "user0" the file "/shared/shared_file.txt" should exist
 
-  Scenario: sharee of a upload-only share folder tries to delete his file in the folder
+  Scenario: sharee of an upload-only shared folder tries to delete their file in the folder
     Given using OCS API version "1"
     And user "user0" has created a folder "/shared"
     And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -82,7 +82,7 @@ Feature: sharing
       | 2               | 404              |
 
   @smokeTest
-  Scenario Outline: user tries to share a file with user who is not in his group when sharing outside the group has been restricted
+  Scenario Outline: user tries to share a file with user who is not in their group when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
@@ -95,7 +95,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 403              |
 
-  Scenario Outline: user shares a file with user who is in his group when sharing outside the group has been restricted
+  Scenario Outline: user shares a file with user who is in their group when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user2" has been created
@@ -110,7 +110,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: user shares a file with the group he is not member of when sharing outside the group has been restricted
+  Scenario Outline: user shares a file with the group they are not member of when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp2" has been created
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -42,14 +42,14 @@ Feature: sharing
       | path      | PARENT |
       | shareType | user   |
       | shareWith | user1  |
-    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
     Given user "user1" has been created
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     When user "user0" has shared folder "PARENT" with group "grp1"
-    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @smokeTest @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
@@ -65,7 +65,7 @@ Feature: sharing
       | shareType   | user      |
       | shareWith   | user1     |
       | permissions | change    |
-    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission
     Given user "user1" has been created
@@ -76,7 +76,7 @@ Feature: sharing
       | shareType   | group  |
       | shareWith   | grp1   |
       | permissions | change |
-    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission
@@ -93,7 +93,7 @@ Feature: sharing
       | shareType   | user   |
       | shareWith   | user1  |
       | permissions | read   |
-    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission
     Given user "user1" has been created
@@ -104,7 +104,7 @@ Feature: sharing
       | shareType   | group  |
       | shareWith   | grp1   |
       | permissions | read   |
-    Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -5,7 +5,7 @@ Feature: Display notifications when receiving a share
   So that I can easily decide what I want to do with new received shares
 
   Background:
-    Given the app "notifications" has been enabled
+    Given app "notifications" has been enabled
     And using OCS API version "1"
     And using new DAV path
     And these users have been created:
@@ -57,7 +57,7 @@ Feature: Display notifications when receiving a share
   Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
     Given user "user0" has shared folder "/PARENT" with group "grp1"
     When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
-    And the administrator creates the user "user3" using the provisioning API
+    And the administrator creates user "user3" using the provisioning API
     And the administrator adds user "user3" to group "grp1" using the provisioning API
     Then user "user1" should have 0 notifications
     And user "user2" should have 0 notifications
@@ -69,7 +69,7 @@ Feature: Display notifications when receiving a share
   Scenario: share to group sends notifications to existing members, but not to new members, for a share created after auto-accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-    And the administrator creates the user "user3" using the provisioning API
+    And the administrator creates user "user3" using the provisioning API
     And the administrator adds user "user3" to group "grp1" using the provisioning API
     Then user "user1" should have 1 notification
     And the last notification of user "user1" should match these regular expressions
@@ -95,7 +95,7 @@ Feature: Display notifications when receiving a share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "user0" has shared folder "/PARENT" with group "grp1"
     When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "yes"
-    And the administrator creates the user "user3" using the provisioning API
+    And the administrator creates user "user3" using the provisioning API
     And the administrator adds user "user3" to group "grp1" using the provisioning API
     Then user "user1" should have 1 notification
     And the last notification of user "user1" should match these regular expressions
@@ -117,7 +117,7 @@ Feature: Display notifications when receiving a share
   Scenario: share to group does not send notifications to existing and new members for a share created after auto-accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-    And the administrator creates the user "user3" using the provisioning API
+    And the administrator creates user "user3" using the provisioning API
     And the administrator adds user "user3" to group "grp1" using the provisioning API
     Then user "user1" should have 0 notifications
     And user "user2" should have 0 notifications

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -2091,7 +2091,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Then /^the app ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?have config key ((?:'[^']*')|(?:"[^"]*"))$/
+	 * @Then /^app ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?have config key ((?:'[^']*')|(?:"[^"]*"))$/
 	 *
 	 * @param string $appID
 	 * @param string $shouldOrNot
@@ -2099,7 +2099,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function theAppShouldHaveConfigKey($appID, $shouldOrNot, $key) {
+	public function appShouldHaveConfigKey($appID, $shouldOrNot, $key) {
 		$appID = \trim($appID, $appID[0]);
 		$key = \trim($key, $key[0]);
 

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -124,7 +124,7 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator sends a user creation request for user :username password :password group :group using the occ command
+	 * @When the administrator creates user :username password :password group :group using the occ command
 	 *
 	 * @param string $username
 	 * @param string $password
@@ -132,7 +132,7 @@ class OccContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theAdministratorSendsAUserCreationRequestForUserPasswordGroupUsingTheOccCommand($username, $password, $group) {
+	public function theAdministratorCreatesUserPasswordGroupUsingTheOccCommand($username, $password, $group) {
 		$cmd = "user:add $username  --password-from-env --group=$group";
 		$this->featureContext->invokingTheCommandWithEnvVariable(
 			$cmd,
@@ -155,13 +155,13 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator resets his own password to :newPassword using the occ command
+	 * @When the administrator resets their own password to :newPassword using the occ command
 	 *
 	 * @param string $newPassword
 	 *
 	 * @return void
 	 */
-	public function theAdministratorResetsHisOwnPasswordToUsingTheOccCommand($newPassword) {
+	public function theAdministratorResetsTheirOwnPasswordToUsingTheOccCommand($newPassword) {
 		$password = $this->featureContext->getActualPassword($newPassword);
 		$admin = $this->featureContext->getAdminUsername();
 		$this->featureContext->invokingTheCommandWithEnvVariable(
@@ -226,13 +226,13 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator sends a user deletion request for user :username using the occ command
+	 * @When the administrator deletes user :username using the occ command
 	 *
 	 * @param string $username
 	 *
 	 * @return void
 	 */
-	public function theAdministratorSendsAUserDeletionRequestForUserUsingTheOccCommand($username) {
+	public function theAdministratorDeletesUserUsingTheOccCommand($username) {
 		$this->featureContext->invokingTheCommand(
 			"user:delete $username"
 		);
@@ -314,13 +314,13 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator sends a group creation request for group :group using the occ command
+	 * @When the administrator creates group :group using the occ command
 	 *
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function theAdministratorSendsAGroupCreationRequestForGroupUsingTheOccCommand($group) {
+	public function theAdministratorCreatesGroupUsingTheOccCommand($group) {
 		$this->featureContext->invokingTheCommand(
 			"group:add $group"
 		);
@@ -328,14 +328,14 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator adds the user :username to the group :group using the occ command
+	 * @When the administrator adds user :username to group :group using the occ command
 	 *
 	 * @param string $username
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function theAdministratorAddsTheUserToTheGroupUsingTheOccCommand($username, $group) {
+	public function theAdministratorAddsUserToGroupUsingTheOccCommand($username, $group) {
 		$this->featureContext->invokingTheCommand(
 			"group:add-member -m $username $group"
 		);
@@ -355,13 +355,13 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator gets the users in the group :groupName in JSON format using the occ command
+	 * @When the administrator gets the users in group :groupName in JSON format using the occ command
 	 *
 	 * @param string $groupName
 	 *
 	 * @return void
 	 */
-	public function theAdministratorGetsTheUsersInTheGroupInJsonUsingTheOccCommand($groupName) {
+	public function theAdministratorGetsTheUsersInGroupInJsonUsingTheOccCommand($groupName) {
 		$this->featureContext->invokingTheCommand(
 			"group:list-members $groupName --output=json"
 		);
@@ -393,39 +393,39 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator disables the app :appName using the occ command
+	 * @When the administrator disables app :appName using the occ command
 	 *
 	 * @param string $appName
 	 *
 	 * @return void
 	 */
-	public function theAdministratorDisablesTheAppUsingTheOccCommand($appName) {
+	public function theAdministratorDisablesAppUsingTheOccCommand($appName) {
 		$this->featureContext->invokingTheCommand(
 			"app:disable $appName"
 		);
 	}
 
 	/**
-	 * @When the administrator enables the app :appName using the occ command
+	 * @When the administrator enables app :appName using the occ command
 	 *
 	 * @param string $appName
 	 *
 	 * @return void
 	 */
-	public function theAdministratorEnablesTheAppUsingTheOccCommand($appName) {
+	public function theAdministratorEnablesAppUsingTheOccCommand($appName) {
 		$this->featureContext->invokingTheCommand(
 			"app:enable $appName"
 		);
 	}
 
 	/**
-	 * @When the administrator gets the app info of the app :appName
+	 * @When the administrator gets the app info of app :appName
 	 *
 	 * @param string $appName
 	 *
 	 * @return void
 	 */
-	public function administratorGetsTheAppInfoOfTheApp($appName) {
+	public function administratorGetsTheAppInfoOfApp($appName) {
 		$this->featureContext->invokingTheCommand(
 			"config:list $appName"
 		);
@@ -443,40 +443,40 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator disables the user :username using the occ command
+	 * @When the administrator disables user :username using the occ command
 	 *
 	 * @param string $username
 	 *
 	 * @return void
 	 */
-	public function theAdministratorDisablesTheUserUsingTheOccCommand($username) {
+	public function theAdministratorDisablesUserUsingTheOccCommand($username) {
 		$this->featureContext->invokingTheCommand(
 			"user:disable $username"
 		);
 	}
 
 	/**
-	 * @When administrator enables the user :username using the occ command
+	 * @When administrator enables user :username using the occ command
 	 *
 	 * @param string $username
 	 *
 	 * @return void
 	 */
-	public function administratorEnablesTheUserUsingTheOccCommand($username) {
+	public function administratorEnablesUserUsingTheOccCommand($username) {
 		$this->featureContext->invokingTheCommand(
 			"user:enable $username"
 		);
 	}
 
 	/**
-	 * @Then the language of the user :username returned by the occ command should be :language
+	 * @Then the language of user :username returned by the occ command should be :language
 	 *
 	 * @param string $username
 	 * @param string $language
 	 *
 	 * @return void
 	 */
-	public function theLanguageOfTheUserReturnedByTheOccCommandShouldBe($username, $language) {
+	public function theLanguageOfUserReturnedByTheOccCommandShouldBe($username, $language) {
 		$this->featureContext->invokingTheCommand(
 			"user:setting $username core lang"
 		);
@@ -548,13 +548,13 @@ class OccContext implements Context {
 	}
 	
 	/**
-	 * @When the administrator sets the file size to :size for using the occ command
+	 * @When the administrator sets the log rotate file size to :size using the occ command
 	 *
 	 * @param string $size
 	 *
 	 * @return void
 	 */
-	public function theAdministratorSetsLogFileSizeUsingTheOccCommand($size) {
+	public function theAdministratorSetsLogRotateFileSizeUsingTheOccCommand($size) {
 		$this->featureContext->invokingTheCommand(
 			"log:owncloud --rotate-size $size"
 		);
@@ -734,7 +734,7 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator adds a config key :key with value :value in app :app using the occ command
+	 * @When the administrator adds config key :key with value :value in app :app using the occ command
 	 *
 	 * @param string $key
 	 * @param string $value
@@ -742,74 +742,74 @@ class OccContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theAdministratorAddsAConfigKeyWithValueInAppUsingTheOccCommand($key, $value, $app) {
+	public function theAdministratorAddsConfigKeyWithValueInAppUsingTheOccCommand($key, $value, $app) {
 		$this->featureContext->invokingTheCommand(
 			"config:app:set --value ${value} ${app} ${key}"
 		);
 	}
 
 	/**
-	 * @When the administrator deletes the config key :key of app :app using the occ command
+	 * @When the administrator deletes config key :key of app :app using the occ command
 	 *
 	 * @param string $key
 	 * @param string $app
 	 *
 	 * @return void
 	 */
-	public function theAdministratorDeletesTheConfigKeyOfAppUsingTheOccCommand($key, $app) {
+	public function theAdministratorDeletesConfigKeyOfAppUsingTheOccCommand($key, $app) {
 		$this->featureContext->invokingTheCommand(
 			"config:app:delete ${app} ${key}"
 		);
 	}
 
 	/**
-	 * @When the administrator adds a system config key :key with value :value using the occ command
+	 * @When the administrator adds system config key :key with value :value using the occ command
 	 *
 	 * @param string $key
 	 * @param string $value
 	 *
 	 * @return void
 	 */
-	public function theAdministratorAddsASystemConfigKeyWithValueUsingTheOccCommand($key, $value) {
+	public function theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand($key, $value) {
 		$this->featureContext->invokingTheCommand(
 			"config:system:set --value ${value} ${key}"
 		);
 	}
 
 	/**
-	 * @When the administrator deletes a system config key :key using the occ command
+	 * @When the administrator deletes system config key :key using the occ command
 	 *
 	 * @param string $key
 	 *
 	 * @return void
 	 */
-	public function theAdministratorDeletesASystemConfigKeyUsingTheOccCommand($key) {
+	public function theAdministratorDeletesSystemConfigKeyUsingTheOccCommand($key) {
 		$this->featureContext->invokingTheCommand(
 			"config:system:delete ${key}"
 		);
 	}
 
 	/**
-	 * @Then the system config key :key with value :value should exist
+	 * @Then system config key :key should have value :value
 	 *
 	 * @param string $key
 	 * @param string $value
 	 *
 	 * @return void
 	 */
-	public function theSystemConfigKeyWithValueShouldExist($key, $value) {
+	public function systemConfigKeyShouldHaveValue($key, $value) {
 		$config = \trim($this->featureContext->getSystemConfigValue($key));
 		PHPUnit_Framework_Assert::assertSame($value, $config);
 	}
 
 	/**
-	 * @Then the system config key :key should not exist
+	 * @Then system config key :key should not exist
 	 *
 	 * @param string $key
 	 *
 	 * @return void
 	 */
-	public function theSystemConfigKeyShouldNotExist($key) {
+	public function systemConfigKeyShouldNotExist($key) {
 		PHPUnit_Framework_Assert::assertEmpty($this->featureContext->getSystemConfig($key)['stdOut']);
 	}
 
@@ -834,11 +834,11 @@ class OccContext implements Context {
 		PHPUnit_Framework_Assert::assertArrayHasKey(
 			'apps',
 			$config_list,
-			"The occ output doesnot contain apps configs"
+			"The occ output does not contain apps configs"
 		);
 		PHPUnit_Framework_Assert::assertNotEmpty(
 			$config_list['apps'],
-			"The occ output doesnot contain apps configs"
+			"The occ output does not contain apps configs"
 		);
 	}
 
@@ -852,11 +852,11 @@ class OccContext implements Context {
 		PHPUnit_Framework_Assert::assertArrayHasKey(
 			'system',
 			$config_list,
-			"The occ output doesnot contain system configs"
+			"The occ output does not contain system configs"
 		);
 		PHPUnit_Framework_Assert::assertNotEmpty(
 			$config_list['system'],
-			"The occ output doesnot contain system configs"
+			"The occ output does not contain system configs"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -210,7 +210,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator creates the user "([^"]*)" using the provisioning API$/
+	 * @When /^the administrator creates user "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 *
@@ -315,7 +315,7 @@ trait Provisioning {
 		}
 	}
 	/**
-	 * @When /^user "([^"]*)" (enables|disables) the app "([^"]*)"$/
+	 * @When /^user "([^"]*)" (enables|disables) app "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $action enables or disables
@@ -338,7 +338,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator (enables|disables) the app "([^"]*)"$/
+	 * @When /^the administrator (enables|disables) app "([^"]*)"$/
 	 *
 	 * @param string $action enables or disables
 	 * @param string $app
@@ -352,14 +352,14 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^the app "([^"]*)" has been (enabled|disabled)$/
+	 * @Given /^app "([^"]*)" has been (enabled|disabled)$/
 	 *
 	 * @param string $app
 	 * @param string $action enabled or disabled
 	 *
 	 * @return void
 	 */
-	public function theAppHasBeenDisabled($app, $action) {
+	public function appHasBeenDisabled($app, $action) {
 		if ($action === 'enabled') {
 			$action = 'enables';
 		} else {
@@ -1726,13 +1726,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^the app "([^"]*)" should not be on the apps list$/
+	 * @Then /^app "([^"]*)" should not be in the apps list$/
 	 *
 	 * @param string $appName
 	 *
 	 * @return void
 	 */
-	public function theAppShouldNotBeOnTheAppsList($appName) {
+	public function appShouldNotBeInTheAppsList($appName) {
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/apps";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
@@ -1742,14 +1742,14 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should be the subadmin of the group "([^"]*)"$/
+	 * @Then /^user "([^"]*)" should be a subadmin of group "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function theUserIsTheSubadminOfTheGroup($user, $group) {
+	public function userShouldBeASubadminOfGroup($user, $group) {
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
@@ -1762,14 +1762,14 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should not be the subadmin of the group "([^"]*)"$/
+	 * @Then /^user "([^"]*)" should not be a subadmin of group "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function theUserIsNotTheSubadminOfTheGroup($user, $group) {
+	public function userShouldNotBeASubadminOfGroup($user, $group) {
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1533,27 +1533,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be a subadmin of group "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $group
-	 *
-	 * @return void
-	 */
-	public function userShouldBeSubadminOfGroup($user, $group) {
-		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
-		$this->response = HttpRequestHelper::get(
-			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
-		);
-		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
-		\sort($respondedArray);
-		PHPUnit_Framework_Assert::assertContains($user, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(
-			200, $this->response->getStatusCode()
-		);
-	}
-
-	/**
 	 * @When /^the administrator makes user "([^"]*)" a subadmin of group "([^"]*)" using the provisioning API$/
 	 * @Given /^user "([^"]*)" has been made a subadmin of group "([^"]*)"$/
 	 *
@@ -1753,6 +1732,9 @@ trait Provisioning {
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
 		);
 		$listOfSubadmins = $this->getArrayOfSubadminsResponded($this->response);
 		PHPUnit_Framework_Assert::assertContains(

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -534,13 +534,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given the administrator has changed his own email address to :email
+	 * @Given the administrator has changed their own email address to :email
 	 *
 	 * @param string $email
 	 *
 	 * @return void
 	 */
-	public function theAdministratorHasChangedHisOwnEmailAddressTo($email) {
+	public function theAdministratorHasChangedTheirOwnEmailAddressTo($email) {
 		$admin = $this->getAdminUsername();
 		$this->adminChangesTheEmailOfTheUserUsingTheProvisioningApi($admin, $email);
 	}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -415,14 +415,14 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should be able to download the file "([^"]*)" using the sharing API$/
+	 * @Then /^user "([^"]*)" should be able to download the file "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
-	public function theUserShouldBeAbleToDownloadTheFileUsingTheSharingApi($user, $path) {
+	public function userShouldBeAbleToDownloadTheFileUsingTheSharingApi($user, $path) {
 		$path = \ltrim($path, "/");
 		$fullUrl = $this->getBaseUrl() . "/remote.php/webdav/$path";
 		$this->checkUserDownload($fullUrl, $user, "text/plain");

--- a/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
@@ -78,13 +78,13 @@ class WebUIAdminAppsSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the administrator disables the app :app using the webUI
+	 * @When the administrator disables app :app using the webUI
 	 *
 	 * @param string $appName
 	 *
 	 * @return void
 	 */
-	public function theAdminDisablesTheAppUsingTheWebUI($appName) {
+	public function theAdminDisablesAppUsingTheWebUI($appName) {
 		$this->adminAppsSettingsPage->disableApp($appName);
 		$this->adminAppsSettingsPage->waitForAjaxCallsToStartAndFinish(
 			$this->getSession()
@@ -92,13 +92,13 @@ class WebUIAdminAppsSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the administrator enables the app :app using the webUI
+	 * @When the administrator enables app :app using the webUI
 	 *
 	 * @param string $appName
 	 *
 	 * @return void
 	 */
-	public function theAdminEnablesTheAppUsingTheWebui($appName) {
+	public function theAdminEnablesAppUsingTheWebui($appName) {
 		$this->adminAppsSettingsPage->enableApp($appName);
 		$this->adminAppsSettingsPage->waitForAjaxCallsToStartAndFinish(
 			$this->getSession()

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -219,13 +219,13 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When the administrator adds the group :group to the group sharing blacklist using the webUI
+	 * @When the administrator adds group :group to the group sharing blacklist using the webUI
 	 *
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function theAdministratorAddsTheGroupToTheGroupSharingBlacklistUsingTheWebui($group) {
+	public function theAdministratorAddsGroupToTheGroupSharingBlacklistUsingTheWebui($group) {
 		$this->adminSharingSettingsPage->addGroupToGroupSharingBlacklist($group);
 		$this->adminSharingSettingsPage->waitForAjaxCallsToStartAndFinish(
 			$this->getSession()

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -192,13 +192,13 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @Then the group :groupName should be displayed on the personal general settings page in the webUI
+	 * @Then group :groupName should be displayed on the personal general settings page in the webUI
 	 *
 	 * @param string $groupName
 	 *
 	 * @return void
 	 */
-	public function theGroupShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($groupName) {
+	public function groupShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($groupName) {
 		PHPUnit_Framework_Assert::assertTrue($this->personalGeneralSettingsPage->isGroupNameDisplayed($groupName));
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -166,8 +166,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user shares the file/folder :folder with the group :group using the webUI
-	 * @Given the user has shared the file/folder :folder with the group :group using the webUI
+	 * @When the user shares the file/folder :folder with group :group using the webUI
+	 * @Given the user has shared the file/folder :folder with group :group using the webUI
 	 *
 	 * @param string $folder
 	 * @param string $group
@@ -175,7 +175,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserSharesTheFileFolderWithTheGroupUsingTheWebUI(
+	public function theUserSharesTheFileFolderWithGroupUsingTheWebUI(
 		$folder, $group
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());

--- a/tests/acceptance/features/bootstrap/WebUIUserContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUserContext.php
@@ -28,7 +28,7 @@ require_once 'bootstrap.php';
 
 /**
  * WebUIUser context.
- * Context for steps associated with the User logged in to the WebUI
+ * Context for steps associated with the user logged in to the WebUI
  */
 class WebUIUserContext extends RawMinkContext implements Context {
 	

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -3,33 +3,34 @@ Feature: add and delete app configs using occ command
 
   As an administrator
   I want to be able to add and delete app configs via the command line
+  So that I can configure apps via the command line, rather than having to use the webUI
 
   Scenario: admin adds and deletes a config for an app using the occ command
-    When the administrator adds a config key "con" with value "conkey" in app "core" using the occ command
+    When the administrator adds config key "con" with value "conkey" in app "core" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Config value con for app core set to conkey'
     And the config key "con" of app "core" should have value "conkey"
-    When the administrator deletes the config key "con" of app "core" using the occ command
+    When the administrator deletes config key "con" of app "core" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Config value con of app core deleted'
     And the app "core" should not have config key "con"
 
   Scenario: admin adds and deletes a system config
-    When the administrator adds a system config key "con" with value "conkey" using the occ command
+    When the administrator adds system config key "con" with value "conkey" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'System config value con set to string conkey'
-    And the system config key "con" with value "conkey" should exist
-    When the administrator deletes a system config key "con" using the occ command
+    And system config key "con" should have value "conkey"
+    When the administrator deletes system config key "con" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'System config value con deleted'
-    And the system config key "con" should not exist
+    And system config key "con" should not exist
 
-  Scenario: admin can list system config
+  Scenario: admin can list system config keys
     When the administrator lists the config keys
     Then the command should have been successful
     And the command output should contain the system configs
 
-  Scenario: admin can list app config
+  Scenario: admin can list app config keys
     When the administrator lists the config keys
     Then the command should have been successful
     And the command output should contain the apps configs

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -13,7 +13,7 @@ Feature: add and delete app configs using occ command
     When the administrator deletes config key "con" of app "core" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Config value con of app core deleted'
-    And the app "core" should not have config key "con"
+    And app "core" should not have config key "con"
 
   Scenario: admin adds and deletes a system config
     When the administrator adds system config key "con" with value "conkey" using the occ command

--- a/tests/acceptance/features/cliMain/logManage.feature
+++ b/tests/acceptance/features/cliMain/logManage.feature
@@ -10,18 +10,18 @@ Feature: manage logging configuration
     And the command output should contain the text 'Log level: <loglevel>'
     Examples:
       | loglevel |
-      | Debug |
-      | Info |
-      | Warning |
-      | Error |
-      | Fatal |
+      | Debug    |
+      | Info     |
+      | Warning  |
+      | Error    |
+      | Fatal    |
 
   Scenario Outline: Admin sets a non-valid log level
     Given the administrator sets the log level to <loglevel> using the occ command
     Then the command should have failed with exit code 1
     Examples:
-        | loglevel |
-        | nonvalid |
+      | loglevel |
+      | nonvalid |
 
   Scenario Outline: Admin sets a valid timezone
     Given the administrator sets the timezone to <timezone> using the occ command
@@ -29,29 +29,29 @@ Feature: manage logging configuration
     And the command output should contain the text 'Log timezone: <timezone>'
     Examples:
       | timezone |
-      | GMT |
-      | UTC |
+      | GMT      |
+      | UTC      |
 
   Scenario Outline: Admin sets a non-valid timezone
     Given the administrator sets the timezone to <timezone> using the occ command
     Then the command should have failed with exit code 1
     Examples:
-        | timezone |
-        | nonvalid |
+      | timezone |
+      | nonvalid |
 
   Scenario Outline: Admin sets the backend to a valid backend
     Given the administrator sets the backend to <backend> using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Enabled logging backend: <backend>'
     Examples:
-      | backend |
+      | backend  |
       | owncloud |
-      | syslog |
+      | syslog   |
       | errorlog |
 
   Scenario Outline: Admin sets the backend to a non-valid backend
     Given the administrator sets the backend to <backend> using the occ command
     Then the command should have failed with exit code 1
     Examples:
-        | backend |
-        | nonvalid |
+      | backend  |
+      | nonvalid |

--- a/tests/acceptance/features/cliMain/logOwnCloud.feature
+++ b/tests/acceptance/features/cliMain/logOwnCloud.feature
@@ -1,10 +1,10 @@
 @cli @skipOnLDAP
-Feature: manipulate ownCloud logging backend
+Feature: manipulate the ownCloud logging backend
   As an admin
-  I want to be able to manipulate ownCloud logging backend
-  So that I set the loggging backend configuration suitable for each situation
+  I want to be able to manipulate the ownCloud logging backend
+  So that I set the logging backend configuration suitable for each situation
 
-  Scenario: Admin enables ownCloud logging backend
+  Scenario: Admin enables the ownCloud logging backend
     When the administrator enables the ownCloud backend using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Log backend ownCloud: enabled'
@@ -13,16 +13,16 @@ Feature: manipulate ownCloud logging backend
     When the administrator sets the log file path to "<path>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Log file: <path>'
-      Examples:
-      | path |
+    Examples:
+      | path                         |
       | /mnt/data/files/owncloud.log |
-      | file.log |
+      | file.log                     |
 
   Scenario Outline: Admin sets the file size for log rotation
-    When the administrator sets the file size to <size> for using the occ command
+    When the administrator sets the log rotate file size to <size> using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Rotate at: <output>'
     Examples:
-      | size | output |
-      | 100 | 100 B |
+      | size  | output |
+      | 100   | 100 B  |
       | 100MB | 100 MB |

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -5,7 +5,7 @@ Feature: add group
   So that I can more easily manage access to resources by groups rather than individual users
 
   Scenario Outline: admin creates a group
-    When the administrator sends a group creation request for group "<group_id>" using the occ command
+    When the administrator creates group "<group_id>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Created group "<group_id>"'
     And group "<group_id>" should exist
@@ -13,10 +13,10 @@ Feature: add group
       | group_id    | comment                     |
       | simplegroup | nothing special here        |
       | España      | special European characters |
-             | नेपाली      | Unicode group name          |
+      | नेपाली      | Unicode group name          |
 
   Scenario: admin tries to create a group that already exists
     Given group "new-group" has been created
-    When the administrator sends a group creation request for group "new-group" using the occ command
+    When the administrator creates group "new-group" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The group "new-group" already exists'

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -8,7 +8,7 @@ Feature: add users to group
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created
     And group "<group_id>" has been created
-    When the administrator adds the user "brand-new-user" to the group "<group_id>" using the occ command
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'User "brand-new-user" added to group "<group_id>"'
     And user "brand-new-user" should belong to group "<group_id>"
@@ -16,12 +16,12 @@ Feature: add users to group
       | group_id    | comment                     |
       | simplegroup | nothing special here        |
       | España      | special European characters |
-            | नेपाली      | Unicode group name          |
+      | नेपाली      | Unicode group name          |
 
   Scenario: admin tries to add user to a group which does not exist
     Given user "brand-new-user" has been created
     And group "not-group" has been deleted
-    When the administrator adds the user "brand-new-user" to the group "not-group" using the occ command
+    When the administrator adds user "brand-new-user" to group "not-group" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group "not-group" does not exist'
     And user "brand-new-user" should not belong to group "not-group"
@@ -29,7 +29,7 @@ Feature: add users to group
   Scenario: admin tries to add a user which does not exist to a group
     Given user "not-user" has been deleted
     And group "new-group" has been created
-    When the administrator adds the user "not-user" to the group "new-group" using the occ command
+    When the administrator adds user "not-user" to group "new-group" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'User "not-user" could not be found - not added to group "new-group"'
     And group "new-group" should not contain user "not-user"

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -15,7 +15,7 @@ Feature: add a user using the using the occ command
     And user "justauser" should exist
     And user "justauser" should be able to access a skeleton file
 
-  Scenario: admin creates an ordinary user sspecifying attributes using the occ command
+  Scenario: admin creates an ordinary user specifying attributes using the occ command
     When the administrator creates this user using the occ command:
       | username  | displayname | email                 |
       | justauser | Just A User | justauser@example.com |
@@ -27,8 +27,8 @@ Feature: add a user using the using the occ command
     And user "justauser" should be able to access a skeleton file
     When the administrator retrieves the information of user "justauser" using the provisioning API
     Then the user attributes returned by the API should include
-      | displayname      | Just A User           |
-      | email            | justauser@example.com |
+      | displayname | Just A User           |
+      | email       | justauser@example.com |
 
   Scenario: admin tries to create an existing user
     Given user "brand-new-user" has been created
@@ -43,9 +43,9 @@ Feature: add a user using the using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The user "brand-new-user" already exists.'
 
-Scenario: Admin creates a new user and adds him directly to a group
+  Scenario: Admin creates a new user and adds them directly to a group
     Given group "newgroup" has been created
-    When the administrator sends a user creation request for user "justauser" password "%alt1%" group "newgroup" using the occ command
+    When the administrator creates user "justauser" password "%alt1%" group "newgroup" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The user "justauser" was created successfully'
     And user "justauser" should belong to group "newgroup"

--- a/tests/acceptance/features/cliProvisioning/deleteGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteGroup.feature
@@ -4,7 +4,7 @@ Feature: delete groups
   I want to be able to delete groups
   So that I can remove unnecessary groups
 
-Scenario Outline: admin deletes a group
+  Scenario Outline: admin deletes a group
     Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/deleteUser.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteUser.feature
@@ -2,18 +2,18 @@
 Feature: delete users
   As an admin
   I want to be able to delete users
-  So that I can remove user from ownCloud
+  So that I can remove users from ownCloud
 
   Scenario: admin deletes a user
     Given user "brand-new-user" has been created
-    When the administrator sends a user deletion request for user "brand-new-user" using the occ command
+    When the administrator deletes user "brand-new-user" using the occ command
     Then the command should have been successful
     And the command output should contain the text "User with uid 'brand-new-user', display name 'brand-new-user', email '' was deleted"
     And user "brand-new-user" should not exist
 
   Scenario: admin tries to delete a non-existing user
     Given user "brand-new-user" has been deleted
-    When the administrator sends a user deletion request for user "brand-new-user" using the occ command
+    When the administrator deletes user "brand-new-user" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text "User with uid 'brand-new-user' does not exist"
     And user "brand-new-user" should not exist

--- a/tests/acceptance/features/cliProvisioning/disableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/disableApp.feature
@@ -5,14 +5,14 @@ Feature: disable an app
   So that I can stop the app features being used
 
   Scenario: Admin disables an app
-    Given the app "comments" has been enabled
+    Given app "comments" has been enabled
     When the administrator disables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'comments disabled'
     And app "comments" should be disabled
 
   Scenario: Admin tries to disable an app which is not enabled
-    Given the app "comments" has been disabled
+    Given app "comments" has been disabled
     When the administrator disables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text "No such app enabled: comments"

--- a/tests/acceptance/features/cliProvisioning/disableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/disableApp.feature
@@ -6,14 +6,14 @@ Feature: disable an app
 
   Scenario: Admin disables an app
     Given the app "comments" has been enabled
-    When the administrator disables the app "comments" using the occ command
+    When the administrator disables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'comments disabled'
     And app "comments" should be disabled
 
   Scenario: Admin tries to disable an app which is not enabled
     Given the app "comments" has been disabled
-    When the administrator disables the app "comments" using the occ command
+    When the administrator disables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text "No such app enabled: comments"
     And app "comments" should be disabled

--- a/tests/acceptance/features/cliProvisioning/disableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/disableUser.feature
@@ -6,7 +6,7 @@ Feature: disable user
 
   Scenario: admin disables an user
     Given user "user1" has been created
-    When the administrator disables the user "user1" using the occ command
+    When the administrator disables user "user1" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is disabled'
     And user "user1" should be disabled
@@ -14,7 +14,7 @@ Feature: disable user
   Scenario: Admin can disable another admin user
     Given user "another-admin" has been created
     And user "another-admin" has been added to group "admin"
-    When the administrator disables the user "another-admin" using the occ command
+    When the administrator disables user "another-admin" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is disabled'
     And user "another-admin" should be disabled
@@ -25,7 +25,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When the administrator disables the user "subadmin" using the occ command
+    When the administrator disables user "subadmin" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is disabled'
     And user "subadmin" should be disabled

--- a/tests/acceptance/features/cliProvisioning/enableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/enableApp.feature
@@ -6,20 +6,20 @@ Feature: enable an app
 
   Scenario: Admin enables an app
     Given the app "comments" has been disabled
-    When the administrator enables the app "comments" using the occ command
+    When the administrator enables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'comments enabled'
     And app "comments" should be enabled
 
   Scenario: Admin tries to enable an app which is already enabled
     Given the app "comments" has been enabled
-    When the administrator enables the app "comments" using the occ command
+    When the administrator enables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'comments enabled'
     And app "comments" should be enabled
 
-  Scenario: Admin tries to enable an app which is not installed in ownCloud server
-    When the administrator enables the app "not-installed-app" using the occ command
+  Scenario: Admin tries to enable an app which is not installed in the ownCloud server
+    When the administrator enables app "not-installed-app" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'not-installed-app not found'
     And the app "not-installed-app" should not be on the apps list

--- a/tests/acceptance/features/cliProvisioning/enableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/enableApp.feature
@@ -5,14 +5,14 @@ Feature: enable an app
   So that I can use the app features again
 
   Scenario: Admin enables an app
-    Given the app "comments" has been disabled
+    Given app "comments" has been disabled
     When the administrator enables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'comments enabled'
     And app "comments" should be enabled
 
   Scenario: Admin tries to enable an app which is already enabled
-    Given the app "comments" has been enabled
+    Given app "comments" has been enabled
     When the administrator enables app "comments" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'comments enabled'
@@ -22,4 +22,4 @@ Feature: enable an app
     When the administrator enables app "not-installed-app" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'not-installed-app not found'
-    And the app "not-installed-app" should not be on the apps list
+    And app "not-installed-app" should not be in the apps list

--- a/tests/acceptance/features/cliProvisioning/enableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/enableUser.feature
@@ -7,7 +7,7 @@ Feature: enable user
   Scenario: admin enables an user
     Given user "user1" has been created
     And user "user1" has been disabled
-    When administrator enables the user "user1" using the occ command
+    When administrator enables user "user1" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is enabled'
     And user "user1" should be enabled
@@ -16,7 +16,7 @@ Feature: enable user
     Given user "another-admin" has been created
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
-    When administrator enables the user "another-admin" using the occ command
+    When administrator enables user "another-admin" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is enabled'
     And user "another-admin" should be enabled
@@ -28,7 +28,7 @@ Feature: enable user
     And the administrator has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "subadmin" has been disabled
-    When administrator enables the user "subadmin" using the occ command
+    When administrator enables user "subadmin" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is enabled'
     And user "subadmin" should be enabled

--- a/tests/acceptance/features/cliProvisioning/getAppInfo.feature
+++ b/tests/acceptance/features/cliProvisioning/getAppInfo.feature
@@ -6,14 +6,14 @@ Feature: get app info
 
   Scenario: admin gets app info of an enabled app
     Given the app "comments" has been enabled
-    When the administrator gets the app info of the app "comments"
+    When the administrator gets the app info of app "comments"
     Then the command should have been successful
     And the app name returned by the occ command should be "comments"
     And the app enabled status of app "comments" should be "yes"
 
   Scenario: admin gets app info of a disabled app
     Given the app "comments" has been disabled
-    When the administrator gets the app info of the app "comments"
+    When the administrator gets the app info of app "comments"
     Then the command should have been successful
     And the app name returned by the occ command should be "comments"
     And the app enabled status of app "comments" should be "no"

--- a/tests/acceptance/features/cliProvisioning/getAppInfo.feature
+++ b/tests/acceptance/features/cliProvisioning/getAppInfo.feature
@@ -5,14 +5,14 @@ Feature: get app info
   So that I can get the information of a specific application
 
   Scenario: admin gets app info of an enabled app
-    Given the app "comments" has been enabled
+    Given app "comments" has been enabled
     When the administrator gets the app info of app "comments"
     Then the command should have been successful
     And the app name returned by the occ command should be "comments"
     And the app enabled status of app "comments" should be "yes"
 
   Scenario: admin gets app info of a disabled app
-    Given the app "comments" has been disabled
+    Given app "comments" has been disabled
     When the administrator gets the app info of app "comments"
     Then the command should have been successful
     And the app name returned by the occ command should be "comments"

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -11,7 +11,7 @@ Feature: get group
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "123" has been added to group "new-group"
-    When the administrator gets the users in the group "new-group" in JSON format using the occ command
+    When the administrator gets the users in group "new-group" in JSON format using the occ command
     Then the command should have been successful
     And the users returned by the occ command should be
       | uid            | display name |
@@ -24,7 +24,7 @@ Feature: get group
     And user "brand-new-user" has been disabled
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
-    When the administrator gets the users in the group "new-group" in JSON format using the occ command
+    When the administrator gets the users in group "new-group" in JSON format using the occ command
     Then the command should have been successful
     And the users returned by the occ command should be
       | uid            | display name |

--- a/tests/acceptance/features/cliProvisioning/getGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroups.feature
@@ -1,7 +1,7 @@
 @cli @skipOnLDAP
 Feature: get groups
   As an admin
-  I want to be able to get groups
+  I want to be able to get a list of groups
   So that I can see all the groups in my ownCloud
 
   Scenario: admin gets all the groups

--- a/tests/acceptance/features/cliProvisioning/getUser.feature
+++ b/tests/acceptance/features/cliProvisioning/getUser.feature
@@ -1,6 +1,6 @@
 @cli @skipOnLDAP
 Feature: get user
-  As an admin, subadmin or as myself
+  As an admin
   I want to be able to retrieve user information
   So that I can see the information
 
@@ -12,7 +12,7 @@ Feature: get user
     And the display name returned by the occ command should be "Anne Brown"
 
   Scenario: admin tries to get a not existing user
-    Given user "not-a-user" has been deleted 
+    Given user "not-a-user" has been deleted
     When the administrator retrieves the information of user "not-a-user" in JSON format using the occ command
     Then the command should have been successful
     And the occ command JSON output should be empty

--- a/tests/acceptance/features/cliProvisioning/getUserGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getUserGroups.feature
@@ -1,7 +1,7 @@
 @cli @skipOnLDAP
 Feature: get user groups
   As an admin
-  I want to be able to get groups
+  I want to be able to get group membership information
   So that I can manage group membership
 
   Scenario: admin gets groups of an user
@@ -25,9 +25,9 @@ Feature: get user groups
       | 0                    |
       | Admin & Finance (NP) |
       | admin:Pokhara@Nepal  |
-    | नेपाली               |
+      | नेपाली               |
 
-Scenario: admin gets groups of an user who is not in any groups
+  Scenario: admin gets groups of an user who is not in any groups
     Given user "brand-new-user" has been created
     And group "unused-group" has been created
     When the administrator gets the groups of user "brand-new-user" in JSON format using the occ command

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -25,14 +25,14 @@ Feature: remove a user from a group
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group "not-group" does not exist'
 
-  Scenario: admin tries to remove a user from a group which he is not member of
+  Scenario: admin tries to remove a user from a group which he is not a member of
     Given user "brand-new-user" has been created
     And group "new-group" has been created
     When the administrator removes user "brand-new-user" from group "new-group" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Member "brand-new-user" could not be found in group "new-group"'
 
-  Scenario: admin tries to remove a user who does not exists from an existing group
+  Scenario: admin tries to remove a user who does not exist from an existing group
     Given user "not-a-user" has been deleted
     And group "new-group" has been created
     When the administrator removes user "not-a-user" from group "new-group" using the occ command

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -25,7 +25,7 @@ Feature: remove a user from a group
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group "not-group" does not exist'
 
-  Scenario: admin tries to remove a user from a group which he is not a member of
+  Scenario: admin tries to remove a user from a group which the user is not a member of
     Given user "brand-new-user" has been created
     And group "new-group" has been created
     When the administrator removes user "brand-new-user" from group "new-group" using the occ command

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -34,7 +34,7 @@ Feature: reset user password
     Then the command should have failed with exit code 1
     And the command output should contain the text "Email address is not set for the user brand-new-user"
 
-  Scenario: user should not an get email when smtpmode is missing
+  Scenario: user should not get an email when the smtpmode value points to an invalid or missing mail program
     Given these users have been created:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
@@ -52,7 +52,7 @@ Feature: reset user password
 
   Scenario: admin should be able to reset their own password
     Given user "brand-new-user" has been created
-    When the administrator resets his own password to "%alt1%" using the occ command
+    When the administrator resets their own password to "%alt1%" using the occ command
     Then the command should have been successful
     And the command output should contain the text "Successfully reset password for admin"
     When the administrator retrieves the information of user "brand-new-user" using the provisioning API

--- a/tests/acceptance/features/cliProvisioning/userReport.feature
+++ b/tests/acceptance/features/cliProvisioning/userReport.feature
@@ -23,7 +23,7 @@ Feature: get user report
     Then the command should have been successful
     And the total users returned by the command should be 3
 
-  Scenario: admin gets the user report when the user created and deleted
+  Scenario: admin gets the user report when a user has been created and deleted
     Given these users have been created but not initialized:
       | username         |
       | brand-new-user-1 |

--- a/tests/acceptance/features/cliProvisioning/userSettings.feature
+++ b/tests/acceptance/features/cliProvisioning/userSettings.feature
@@ -4,8 +4,8 @@ Feature: user settings
   I want to be able set user settings
   So that I can set specific settings for a specific user
 
-  Scenario: admin changes user language 
-  Given user "brand-new-user" has been created
-  When the administrator changes the language of user "brand-new-user" to "fr" using the occ command
-  Then the command should have been successful
-  And the language of the user "brand-new-user" returned by the occ command should be "fr"
+  Scenario: admin changes user language
+    Given user "brand-new-user" has been created
+    When the administrator changes the language of user "brand-new-user" to "fr" using the occ command
+    Then the command should have been successful
+    And the language of user "brand-new-user" returned by the occ command should be "fr"

--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -9,13 +9,13 @@ Feature: admin apps settings
 
   @smokeTest
   Scenario: admin disables an app
-    Given the app "comments" has been enabled
-    When the administrator disables the app "comments" using the webUI
+    Given app "comments" has been enabled
+    When the administrator disables app "comments" using the webUI
     Then app "comments" should be disabled
 
   @smokeTest
   Scenario: admin enables an app
-    Given the app "comments" has been disabled
+    Given app "comments" has been disabled
     And the administrator has browsed to the disabled apps page
-    When the administrator enables the app "comments" using the webUI
+    When the administrator enables app "comments" using the webUI
     Then app "comments" should be enabled

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -5,7 +5,7 @@ Feature: admin general settings
   So that I can configure general settings on the ownCloud server
 
   Background:
-    Given the administrator has changed his own email address to "admin@owncloud.com"
+    Given the administrator has changed their own email address to "admin@owncloud.com"
     And the administrator has browsed to the admin general settings page
 
   @smokeTest

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -43,5 +43,5 @@ Feature: personal general settings
     And the user has reloaded the current page of the webUI
     Then the owncloud version should be displayed on the personal general settings page in the webUI
     And the federated cloud id for user "user1" should be displayed on the personal general settings page in the webUI
-    And the group "new-group" should be displayed on the personal general settings page in the webUI
-    And the group "another-group" should be displayed on the personal general settings page in the webUI
+    And group "new-group" should be displayed on the personal general settings page in the webUI
+    And group "another-group" should be displayed on the personal general settings page in the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -35,7 +35,7 @@ Feature: restrict Sharing
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
     When the user browses to the files page
     Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
@@ -43,7 +43,7 @@ Feature: restrict Sharing
   Scenario: Do not restrict users to only share with groups they are member of
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
     And the user browses to the files page
-    When the user shares the folder "simple-folder" with the group "grp2" using the webUI
+    When the user shares the folder "simple-folder" with group "grp2" using the webUI
     And the user re-logs in as "user3" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -20,8 +20,8 @@ Feature: Sharing files and folders with internal groups
   @smokeTest
   Scenario: share a folder with an internal group
     Given user "user3" has logged in using the webUI
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
-    And the user shares the file "testimage.jpg" with the group "grp1" using the webUI
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
+    And the user shares the file "testimage.jpg" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
@@ -37,7 +37,7 @@ Feature: Sharing files and folders with internal groups
   Scenario: share a file with an internal group a member overwrites and unshares the file
     Given user "user3" has logged in using the webUI
     When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
-    And the user shares the file "new-lorem.txt" with the group "grp1" using the webUI
+    And the user shares the file "new-lorem.txt" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
@@ -58,7 +58,7 @@ Feature: Sharing files and folders with internal groups
   Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
     Given user "user3" has logged in using the webUI
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
+    And the user shares the folder "new-simple-folder" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
@@ -90,7 +90,7 @@ Feature: Sharing files and folders with internal groups
   Scenario: share a folder with an internal group and a member unshares the folder
     Given user "user3" has logged in using the webUI
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
+    And the user shares the folder "new-simple-folder" with group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
     When the user re-logs in as "user1" using the webUI
     And the user unshares the folder "new-simple-folder" using the webUI
@@ -111,11 +111,11 @@ Feature: Sharing files and folders with internal groups
   @skip @issue-33030
   Scenario: user tries to share a file in a group which is blacklisted from sharing
     Given the administrator has browsed to the admin sharing settings page
-    When the administrator adds the group "grp1" to the group sharing blacklist using the webUI
+    When the administrator adds group "grp1" to the group sharing blacklist using the webUI
     Then user "user3" should not be able to share folder "lorem.txt" with group "grp1" using the sharing API
 
   @skip @issue-33030
   Scenario: user tries to share a folder in a group which is blacklisted from sharing
     Given the administrator has browsed to the admin sharing settings page
-    When the administrator adds the group "grp1" to the group sharing blacklist using the webUI
+    When the administrator adds group "grp1" to the group sharing blacklist using the webUI
     Then user "user3" should not be able to share folder "simple-folder" with group "grp1" using the sharing API

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -16,8 +16,8 @@ Feature: Sharing files and folders with internal groups
     And user "user1" has been added to group "<group>"
     And user "user2" has been added to group "<group>"
     And user "user3" has logged in using the webUI
-    When the user shares the folder "simple-folder" with the group "<group>" using the webUI
-    And the user shares the file "testimage.jpg" with the group "<group>" using the webUI
+    When the user shares the folder "simple-folder" with group "<group>" using the webUI
+    And the user shares the file "testimage.jpg" with group "<group>" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -150,7 +150,7 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user has browsed to the files page
-    And the user shares the folder "simple-folder (2)" with the group "grp1" using the webUI
+    And the user shares the folder "simple-folder (2)" with group "grp1" using the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -132,7 +132,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user shares the folder "simple-folder" with the group "finance1" using the webUI
+    And the user shares the folder "simple-folder" with group "finance1" using the webUI
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
@@ -142,7 +142,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user shares the file "data.zip" with the group "finance1" using the webUI
+    And the user shares the file "data.zip" with group "finance1" using the webUI
     And the user has opened the share dialog for the file "data.zip"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -5,7 +5,7 @@ Feature: Display notifications when receiving a share and follow embedded links
   So that I will be redirected to the most appropriate screen
 
   Background:
-    Given the app "notifications" has been enabled
+    Given app "notifications" has been enabled
     And these users have been created:
       | username |
       | user1    |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal groups
   So that those groups can access the files and folders
 
   Background:
-    Given the app "notifications" has been enabled
+    Given app "notifications" has been enabled
     And these users have been created:
       | username |
       | user1    |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal users
   So that those users can access the files and folders
 
   Background:
-    Given the app "notifications" has been enabled
+    Given app "notifications" has been enabled
     And these users have been created:
       | username |
       | user1    |


### PR DESCRIPTION
## Description
1) Adjust wording of various cli acceptance test steps
2) remove "his" and "he" from acceptance test step code - ownCloud users and admins are not all male!
3) In most places we have not been putting "the" in front of places where we say ``When user "user0"`` or ``group "new-group"`` or ``app "comments"`` - but there were still some inconsistent places that had step text like ``When the user "user0"``. Make these consistent with the other existing steps, to reduce confusion for other developers when they try to write acceptance tests.

## Related Issue
#33174 

## Motivation and Context
See issue

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
