### PR TITLE
[stable10] Use PHPUnit dedicated assertions

### DIFF
--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -47,19 +47,19 @@ class DIContainerTest extends \Test\TestCase {
 	}
 
 	public function testProvidesRequest() {
-		$this->assertTrue(isset($this->container['Request']));
+		$this->assertArrayHasKey('Request', $this->container);
 	}
 
 	public function testProvidesSecurityMiddleware() {
-		$this->assertTrue(isset($this->container['SecurityMiddleware']));
+		$this->assertArrayHasKey('SecurityMiddleware', $this->container);
 	}
 
 	public function testProvidesMiddlewareDispatcher() {
-		$this->assertTrue(isset($this->container['MiddlewareDispatcher']));
+		$this->assertArrayHasKey('MiddlewareDispatcher', $this->container);
 	}
 
 	public function testProvidesAppName() {
-		$this->assertTrue(isset($this->container['AppName']));
+		$this->assertArrayHasKey('AppName', $this->container);
 	}
 
 	public function testAppNameIsSetCorrectly() {

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -448,8 +448,8 @@ class ManagerTest extends TestCase {
 
 		$saveSuccessful = $manager->save($comment);
 		$this->assertTrue($saveSuccessful);
-		$this->assertTrue($comment->getId() !== '');
-		$this->assertTrue($comment->getId() !== '0');
+		$this->assertNotSame('', $comment->getId());
+		$this->assertNotSame('0', $comment->getId());
 		$this->assertNotNull($comment->getCreationDateTime());
 		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreateEvent[1]);
 		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreateEvent[1]);

--- a/tests/lib/Files/External/Service/GlobalStoragesServiceDeleteUserTest.php
+++ b/tests/lib/Files/External/Service/GlobalStoragesServiceDeleteUserTest.php
@@ -159,11 +159,11 @@ class GlobalStoragesServiceDeleteUserTest extends TestCase {
 		$newStorageIds = [];
 		foreach ($storages as $storage) {
 			$users = $storage->getApplicableUsers();
-			$this->assertFalse(\in_array($userId, $users, true));
-			$this->assertTrue(\in_array($storage->getId(), $storageIds, true));
+			$this->assertNotContains($userId, $users);
+			$this->assertContains($storage->getId(), $storageIds);
 			$newStorageIds[] = $storage->getId();
 		}
 		$missingStorageId = \array_pop($storageIds);
-		$this->assertFalse(\in_array($missingStorageId, $newStorageIds, true));
+		$this->assertNotContains($missingStorageId, $newStorageIds);
 	}
 }

--- a/tests/lib/Files/External/Service/UserStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserStoragesServiceTest.php
@@ -267,8 +267,8 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 		$this->assertTrue($this->service->deleteAllMountsForUser($user1));
 		$storarge1Result1 = $userMountCache->getMountsForStorageId(10);
 		$storarge1Result2 = $userMountCache->getMountsForStorageId(12);
-		$this->assertEquals(0, \count($storarge1Result1));
-		$this->assertEquals(1, \count($storarge1Result2));
+		$this->assertCount(0, $storarge1Result1);
+		$this->assertCount(1, $storarge1Result2);
 		$this->assertEquals(12, $storarge1Result2[0]->getStorageId());
 		$this->assertEquals('/bar/', $storarge1Result2[0]->getMountPoint());
 		$this->assertNull($dbConfigService->getMountById($id));

--- a/tests/lib/Files/MetaFilesTest.php
+++ b/tests/lib/Files/MetaFilesTest.php
@@ -109,7 +109,7 @@ class MetaFilesTest extends TestCase {
 		$this->assertEquals($file, $metaNodeOfFile->getContentDispositionFileName());
 		$this->assertEquals('text/plain', $metaNodeOfFile->getMimetype());
 		$this->assertInternalType('string', $metaNodeOfFile->getEtag());
-		$this->assertTrue(\strlen($metaNodeOfFile->getEtag()) > 0);
+		$this->assertGreaterThan(0, \strlen($metaNodeOfFile->getEtag()));
 		$this->assertInstanceOf(IMountPoint::class, $metaNodeOfFile->getMountPoint());
 		$thumbnail = $metaNodeOfFile->getThumbnail([]);
 		$this->assertInstanceOf(IImage::class, $thumbnail);

--- a/tests/lib/Files/Stream/StaticStreamTest.php
+++ b/tests/lib/Files/Stream/StaticStreamTest.php
@@ -48,9 +48,9 @@ class StaticStreamTest extends \Test\TestCase {
 	}
 
 	public function testIsDir() {
-		$this->assertFalse(\is_dir('static://foo'));
+		$this->assertDirectoryNotExists('static://foo');
 		\file_put_contents('static://foo', $this->sourceText);
-		$this->assertFalse(\is_dir('static://foo'));
+		$this->assertDirectoryNotExists('static://foo');
 	}
 
 	public function testFileType() {

--- a/tests/lib/Group/Backend.php
+++ b/tests/lib/Group/Backend.php
@@ -70,19 +70,19 @@ abstract class Backend extends \Test\TestCase {
 		$this->backend->createGroup($name1);
 		$count = \count($this->backend->getGroups()) - $startCount;
 		$this->assertEquals(1, $count);
-		$this->assertTrue((\array_search($name1, $this->backend->getGroups()) !== false));
-		$this->assertFalse((\array_search($name2, $this->backend->getGroups()) !== false));
+		$this->assertContains($name1, $this->backend->getGroups());
+		$this->assertNotContains($name2, $this->backend->getGroups());
 		$this->backend->createGroup($name2);
 		$count = \count($this->backend->getGroups()) - $startCount;
 		$this->assertEquals(2, $count);
-		$this->assertTrue((\array_search($name1, $this->backend->getGroups()) !== false));
-		$this->assertTrue((\array_search($name2, $this->backend->getGroups()) !== false));
+		$this->assertContains($name1, $this->backend->getGroups());
+		$this->assertContains($name2, $this->backend->getGroups());
 
 		$this->backend->deleteGroup($name2);
 		$count = \count($this->backend->getGroups()) - $startCount;
 		$this->assertEquals(1, $count);
-		$this->assertTrue((\array_search($name1, $this->backend->getGroups()) !== false));
-		$this->assertFalse((\array_search($name2, $this->backend->getGroups()) !== false));
+		$this->assertContains($name1, $this->backend->getGroups());
+		$this->assertNotContains($name2, $this->backend->getGroups());
 	}
 
 	public function testUser() {

--- a/tests/lib/Memcache/Cache.php
+++ b/tests/lib/Memcache/Cache.php
@@ -55,9 +55,9 @@ abstract class Cache extends \Test\Cache\TestCache {
 	}
 
 	public function testArrayAccessExists() {
-		$this->assertFalse(isset($this->instance['foo']));
+		$this->assertArrayNotHasKey('foo', $this->instance);
 		$this->instance->set('foo', 'bar');
-		$this->assertTrue(isset($this->instance['foo']));
+		$this->assertArrayHasKey('foo', $this->instance);
 	}
 
 	public function testArrayAccessUnset() {

--- a/tests/lib/Repair/RepairOrphanedSubshareTest.php
+++ b/tests/lib/Repair/RepairOrphanedSubshareTest.php
@@ -385,7 +385,7 @@ class RepairOrphanedSubshareTest extends TestCase {
 				$row = $checkQuery->select('parent')
 					->from('share')->where($checkQuery->expr()->eq('id', $checkQuery->createNamedParameter($getAllIdsPerUser['admin'][$adminIndex])))
 					->execute()->fetchAll();
-				$this->assertEquals(0, \count($row));
+				$this->assertCount(0, $row);
 			}
 		}
 
@@ -397,7 +397,7 @@ class RepairOrphanedSubshareTest extends TestCase {
 				$row = $checkQuery->select('parent')
 					->from('share')->where($checkQuery->expr()->eq('id', $checkQuery->createNamedParameter($getAllIdsPerUser['admin'][$adminIndex])))
 					->execute()->fetchAll();
-				$this->assertEquals(1, \count($row));
+				$this->assertCount(1, $row);
 			}
 		}
 	}

--- a/tests/lib/Repair/RepairSubSharesTest.php
+++ b/tests/lib/Repair/RepairSubSharesTest.php
@@ -146,7 +146,7 @@ class RepairSubSharesTest extends TestCase {
 		$this->assertCount(3, $results);
 
 		foreach ($results as $id) {
-			$this->assertTrue(\in_array($id, $getAllIdsPerUser[$id['share_with']]));
+			$this->assertContains($id, $getAllIdsPerUser[$id['share_with']]);
 		}
 	}
 
@@ -228,12 +228,12 @@ class RepairSubSharesTest extends TestCase {
 		$this->assertCount(7, $results);
 
 		foreach ($results as $id) {
-			$this->assertTrue(\in_array($id, $getAllIdsPerUser['ids']));
+			$this->assertContains($id, $getAllIdsPerUser['ids']);
 		}
 
 		//Verify that these ids are not there
 		foreach ($results as $id) {
-			$this->assertFalse(\in_array($id['id'], $idsNotPresent, true));
+			$this->assertNotContains($id['id'], $idsNotPresent);
 		}
 	}
 
@@ -295,15 +295,15 @@ class RepairSubSharesTest extends TestCase {
 		$this->assertCount(6, $results);
 
 		foreach ($results as $id) {
-			$this->assertTrue(\in_array($id, $getAllIdsPerUser['ids']));
+			$this->assertContains($id, $getAllIdsPerUser['ids']);
 			if (\array_search($id, $results, true) === 5) {
 				for ($i = $id['id'] + 1; $i < $id['id'] + 486; $i++) {
-					$this->assertFalse(\in_array(['id' => $i], $results));
+					$this->assertNotContains(['id' => $i], $results);
 				}
 			} else {
 				//The next 1000 ids will not be there.
 				for ($i = $id['id'] + 1; $i < $id['id'] + 999; $i++) {
-					$this->assertFalse(\in_array(['id' => $i], $results));
+					$this->assertNotContains(['id' => $i], $results);
 				}
 			}
 		}

--- a/tests/lib/Session/Session.php
+++ b/tests/lib/Session/Session.php
@@ -57,11 +57,11 @@ abstract class Session extends \Test\TestCase {
 	}
 
 	public function testArrayInterface() {
-		$this->assertFalse(isset($this->instance['foo']));
+		$this->assertArrayNotHasKey('foo', $this->instance);
 		$this->instance['foo'] = 'bar';
-		$this->assertTrue(isset($this->instance['foo']));
+		$this->assertArrayHasKey('foo', $this->instance);
 		$this->assertEquals('bar', $this->instance['foo']);
 		unset($this->instance['foo']);
-		$this->assertFalse(isset($this->instance['foo']));
+		$this->assertArrayNotHasKey('foo', $this->instance);
 	}
 }


### PR DESCRIPTION
Backport #33475 

Note: the unit tests in ``tests/lib/User/SyncServiceTest.php`` are not in ``stable10``, thus the changes to those do not backport.