### PR TITLE
Tag more scenarios that require various apps

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @comments-app-required
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @comments-app-required
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/cliProvisioning/disableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/disableApp.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @comments-app-required
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/cliProvisioning/enableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/enableApp.feature
@@ -4,6 +4,7 @@ Feature: enable an app
   I want to be able to enable a disabled app
   So that I can use the app features again
 
+  @comments-app-required
   Scenario: Admin enables an app
     Given app "comments" has been disabled
     When the administrator enables app "comments" using the occ command
@@ -11,6 +12,7 @@ Feature: enable an app
     And the command output should contain the text 'comments enabled'
     And app "comments" should be enabled
 
+  @comments-app-required
   Scenario: Admin tries to enable an app which is already enabled
     Given app "comments" has been enabled
     When the administrator enables app "comments" using the occ command

--- a/tests/acceptance/features/cliProvisioning/getAppInfo.feature
+++ b/tests/acceptance/features/cliProvisioning/getAppInfo.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @comments-app-required
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/cliProvisioning/getApps.feature
+++ b/tests/acceptance/features/cliProvisioning/getApps.feature
@@ -4,7 +4,8 @@ Feature: get apps
   I want to be able to get the list of apps on my ownCloud
   So that I can manage apps
 
-Scenario: admin gets enabled apps
+  @comments-app-required @files_trashbin-app-required @files_versions-app-required @provisioning_api-app-required @systemtags-app-required
+  Scenario: admin gets enabled apps
     When the administrator gets the list of apps using the occ command
     Then the command should have been successful
     And the apps returned by the occ command should include
@@ -18,5 +19,17 @@ Scenario: admin gets enabled apps
       | files_versions       |
       | provisioning_api     |
       | systemtags           |
+      | updatenotification   |
+      | files_external       |
+
+  Scenario: admin gets enabled apps - check for the minimal list of apps
+    When the administrator gets the list of apps using the occ command
+    Then the command should have been successful
+    And the apps returned by the occ command should include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
       | updatenotification   |
       | files_external       |


### PR DESCRIPTION
## Description
Tag more scenarios that depend on the comments app, and other apps.

## Related Issue
#33161 

## Motivation and Context
Be safer skipping scenarios for people that try to run acceptance tests with comments, trashbin, versions... apps disabled.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
