### PR TITLE
move CRUD actions into separate pageobject

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -192,6 +192,7 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - WebUISharingContext:
 
     webUIPersonalSettings:
       paths:
@@ -215,6 +216,7 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - WebUISharingContext:
 
     webUIRenameFolders:
       paths:
@@ -307,6 +309,7 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - WebUISharingContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -486,8 +486,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function createAFolder($name) {
 		$session = $this->getSession();
-		$this->filesPage->createFolder($session, $name);
-		$this->filesPage->waitTillPageIsLoaded($session);
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->createFolder($session, $name);
+		$pageObject->waitTillPageIsLoaded($session);
 	}
 
 	/**
@@ -586,8 +587,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theUserRenamesTheFileFolderToUsingTheWebUI(
 		$fromName, $toName
 	) {
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->filesPage->renameFile($fromName, $toName, $this->getSession());
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->waitTillPageIsLoaded($this->getSession());
+		$pageObject->renameFile($fromName, $toName, $this->getSession());
 	}
 
 	/**
@@ -611,8 +613,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$fromNameParts[] = $namePartsRow['from-name-parts'];
 			$toNameParts[] = $namePartsRow['to-name-parts'];
 		}
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->filesPage->renameFile(
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->waitTillPageIsLoaded($this->getSession());
+		$pageObject->renameFile(
 			$fromNameParts,
 			$toNameParts,
 			$this->getSession()
@@ -632,9 +635,10 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theUserRenamesTheFileToOneOfTheseNamesUsingTheWebUI(
 		$fromName, TableNode $table
 	) {
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->waitTillPageIsLoaded($this->getSession());
 		foreach ($table->getRows() as $row) {
-			$this->filesPage->renameFile($fromName, $row[0], $this->getSession());
+			$pageObject->renameFile($fromName, $row[0], $this->getSession());
 		}
 	}
 
@@ -698,8 +702,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		foreach ($namePartsTable as $namePartsRow) {
 			$fileNameParts[] = $namePartsRow['name-parts'];
 		}
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->filesPage->deleteFile($fileNameParts, $this->getSession());
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->waitTillPageIsLoaded($this->getSession());
+		$pageObject->deleteFile($fileNameParts, $this->getSession());
 	}
 
 	/**
@@ -780,7 +785,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserMovesTheFileFolderToUsingTheWebUI($name, $destination) {
-		$this->filesPage->moveFileTo($name, $destination, $this->getSession());
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->moveFileTo($name, $destination, $this->getSession());
 	}
 
 	/**
@@ -861,7 +867,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$this->theUserUploadsOverwritingTheFileUsingTheWebUI($name);
 
 			try {
-				$notifications = $this->filesPage->getNotifications();
+				$notifications = $this->getCurrentPageObject()->getNotifications();
 			} catch (ElementNotFoundException $e) {
 				$notifications = [];
 			}
@@ -916,7 +922,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserUploadsTheFileUsingTheWebUI($name) {
-		$this->filesPage->uploadFile($this->getSession(), $name);
+		$this->getCurrentPageObject()->uploadFile($this->getSession(), $name);
 	}
 
 	/**
@@ -929,7 +935,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function choiceInUploadConflictDialogWebUI($choice) {
-		$dialogs = $this->filesPage->getOcDialogs();
+		$dialogs = $this->getCurrentPageObject()->getOcDialogs();
 		$isConflictDialog = false;
 		foreach ($dialogs as $dialog) {
 			$isConflictDialog = \strstr(
@@ -969,11 +975,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserChoosesToInTheUploadDialog($label) {
-		$dialogs = $this->filesPage->getOcDialogs();
+		$pageObject = $this->getCurrentPageObject();
+		$dialogs = $pageObject->getOcDialogs();
 		$dialog = \end($dialogs);
 		$this->conflictDialog->setElement($dialog->getOwnElement());
 		$this->conflictDialog->clickButton($this->getSession(), $label);
-		$this->filesPage->waitForUploadProgressbarToFinish();
+		$pageObject->waitForUploadProgressbarToFinish();
 	}
 
 	/**
@@ -1389,7 +1396,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$shouldOrNot, $folderName
 	) {
 		$this->theUserOpensTheFolderUsingTheWebUI("", "folder", $folderName);
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$this->getCurrentPageObject()->waitTillPageIsLoaded($this->getSession());
 		$this->theDeletedMovedElementsShouldBeListedOnTheWebUI($shouldOrNot);
 	}
 
@@ -1413,7 +1420,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$toBeListedTableArray[] = [$namePartsRow['item-name-parts']];
 		}
 		$this->theUserOpensTheFolderUsingTheWebUI("", "folder", $folderNameParts);
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$this->getCurrentPageObject()->waitTillPageIsLoaded($this->getSession());
 
 		$toBeListedTable = new TableNode($toBeListedTableArray);
 		$this->theFollowingFileFolderShouldBeListedOnTheWebUI(
@@ -1479,7 +1486,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	) {
 		PHPUnit_Framework_Assert::assertEquals(
 			$toolTipText,
-			$this->filesPage->getTooltipOfFile($name, $this->getSession())
+			$this->getCurrentPageObject()->getTooltipOfFile($name, $this->getSession())
 		);
 	}
 	
@@ -1506,7 +1513,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function folderInputFieldTooltipTextShouldBeDisplayedOnTheWebUI(
 		$tooltiptext
 	) {
-		$createFolderTooltip = $this->filesPage->getCreateFolderTooltip();
+		$createFolderTooltip = $this->getCurrentPageObject()->getCreateFolderTooltip();
 		PHPUnit_Framework_Assert::assertSame($tooltiptext, $createFolderTooltip);
 	}
 

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -27,9 +27,8 @@ use Page\FilesPageElement\DetailsDialog;
 use Page\FilesPageElement\SharingDialog;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
-use WebDriver\Exception\NoSuchElement;
-use WebDriver\Exception\StaleElementReference;
-use WebDriver\Key;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 
 /**
  * Files page.
@@ -42,12 +41,13 @@ class FilesPage extends FilesPageBasic {
 	//see https://github.com/owncloud/core/issues/27870
 	protected $fileListXpath = ".//div[@id='app-content-files']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-files']//div[@id='emptycontent']";
-	protected $newFileFolderButtonXpath = './/*[@id="controls"]//a[@class="button new"]';
-	protected $newFolderButtonXpath = './/div[contains(@class, "newFileMenu")]//a[@data-templatename="New folder"]';
-	protected $newFolderNameInputLabel = 'New folder';
 	protected $newFolderTooltipXpath = './/div[contains(@class, "newFileMenu")]//div[@class="tooltip-inner"]';
-	protected $fileUploadInputId = "file_upload_start";
-	protected $uploadProgressbarLabelXpath = "//div[@id='uploadprogressbar']/em";
+	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
+	/**
+	 *
+	 * @var FilesPageCRUD $filesPageCRUDFunctions
+	 */
+	protected $filesPageCRUDFunctions;
 	private $strForNormalFileName = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
 
 	/**
@@ -90,6 +90,25 @@ class FilesPage extends FilesPageBasic {
 	}
 
 	/**
+	 * @param Session $session
+	 * @param Factory $factory
+	 * @param array   $parameters
+	 */
+	public function __construct(
+		Session $session, Factory $factory, array $parameters = []
+	) {
+		parent::__construct($session, $factory, $parameters);
+		$this->filesPageCRUDFunctions = $this->getPage("FilesPageCRUD");
+		$this->filesPageCRUDFunctions->setXpath(
+			$this->emptyContentXpath,
+			$this->fileListXpath,
+			$this->fileNameMatchXpath,
+			$this->fileNamesXpath,
+			$this->deleteAllSelectedBtnXpath
+		);
+	}
+
+	/**
 	 * create a folder with the given name.
 	 * If name is not given a random one is chosen
 	 *
@@ -104,85 +123,9 @@ class FilesPage extends FilesPageBasic {
 		Session $session, $name = null,
 		$timeoutMsec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
-		if ($name === null) {
-			$name = \substr(\str_shuffle($this->strForNormalFileName), 0, 8);
-		}
-
-		$newButtonElement = $this->find("xpath", $this->newFileFolderButtonXpath);
-
-		$this->assertElementNotNull(
-			$newButtonElement,
-			__METHOD__ .
-			" xpath $this->newFileFolderButtonXpath " .
-			"could not find new file-folder button"
+		return $this->filesPageCRUDFunctions->createFolder(
+			$session, $name, $timeoutMsec
 		);
-
-		$newButtonElement->click();
-
-		$newFolderButtonElement = $this->find("xpath", $this->newFolderButtonXpath);
-
-		$this->assertElementNotNull(
-			$newFolderButtonElement,
-			__METHOD__ .
-			" xpath $this->newFolderButtonXpath " .
-			"could not find new folder button"
-		);
-
-		try {
-			$newFolderButtonElement->click();
-		} catch (NoSuchElement $e) {
-			// Edge sometimes reports NoSuchElement even though we just found it.
-			// Log the event and continue, because maybe the button was clicked.
-			// TODO: Edge - if it keeps happening then find out why.
-			\error_log(
-				__METHOD__
-				. " NoSuchElement while doing newFolderButtonElement->click()"
-				. "\n-------------------------\n"
-				. $e->getMessage()
-				. "\n-------------------------\n"
-			);
-		}
-
-		try {
-			$this->fillField($this->newFolderNameInputLabel, $name . Key::ENTER);
-		} catch (NoSuchElement $e) {
-			// this seems to be a bug in MinkSelenium2Driver.
-			// Used to work fine in 1.3.1 but now throws this exception
-			// Actually all that we need does happen, so we just don't do anything
-		} catch (StaleElementReference $e) {
-			// At the end of processing setValue, MinkSelenium2Driver tries to blur
-			// away from the element. But we pressed enter which has already
-			// made the element go away. So we do not care about this exception.
-			// This issue started happening due to:
-			// https://github.com/minkphp/MinkSelenium2Driver/pull/286
-		}
-		$timeoutMsec = (int) $timeoutMsec;
-		$currentTime = \microtime(true);
-		$end = $currentTime + ($timeoutMsec / 1000);
-
-		while ($currentTime <= $end) {
-			$newFolderButton = $this->find("xpath", $this->newFolderButtonXpath);
-			if ($newFolderButton === null || !$newFolderButton->isVisible()) {
-				break;
-			}
-			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
-			$currentTime = \microtime(true);
-		}
-		while ($currentTime <= $end) {
-			try {
-				$this->findFileRowByName($name, $session);
-				break;
-			} catch (ElementNotFoundException $e) {
-				//loop around
-			}
-			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
-			$currentTime = \microtime(true);
-		}
-
-		if ($currentTime > $end) {
-			throw new \Exception("could not create folder");
-		}
-		return $name;
 	}
 
 	/**
@@ -209,16 +152,7 @@ class FilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function uploadFile(Session $session, $name) {
-		$uploadField = $this->findById($this->fileUploadInputId);
-		$this->assertElementNotNull(
-			$uploadField,
-			__METHOD__ .
-			" id $this->fileUploadInputId " .
-			"could not find file upload input field"
-		);
-		$uploadField->attachFile(\getenv("FILES_FOR_UPLOAD") . $name);
-		$this->waitForAjaxCallsToStartAndFinish($session, 20000);
-		$this->waitForUploadProgressbarToFinish();
+		$this->filesPageCRUDFunctions->uploadFile($session, $name);
 	}
 
 	/**
@@ -283,32 +217,39 @@ class FilesPage extends FilesPageBasic {
 		Session $session,
 		$maxRetries = STANDARD_RETRY_COUNT
 	) {
-		if (\is_array($toFileName)) {
-			$toFileName = \implode($toFileName);
-		}
+		$this->filesPageCRUDFunctions->renameFile(
+			$fromFileName, $toFileName, $session, $maxRetries
+		);
+	}
 
-		for ($counter = 0; $counter < $maxRetries; $counter++) {
-			try {
-				$fileRow = $this->findFileRowByName($fromFileName, $session);
-				$fileRow->rename($toFileName, $session);
-				break;
-			} catch (\Exception $e) {
-				$this->closeFileActionsMenu();
-				\error_log(
-					"Error while renaming file"
-					. "\n-------------------------\n"
-					. $e->getMessage()
-					. "\n-------------------------\n"
-				);
-			}
-		}
-		if ($counter > 0) {
-			$message = "INFORMATION: retried to rename file $counter times";
-			echo $message;
-			\error_log($message);
-		}
+	/**
+	 *
+	 * @param string|array $name
+	 * @param Session $session
+	 * @param bool $expectToDeleteFile
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$this->filesPageCRUDFunctions->deleteFile(
+			$name, $session, $expectToDeleteFile, $maxRetries
+		);
+	}
 
-		$this->waitTillFileRowsAreReady($session);
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteAllSelectedFiles(Session $session) {
+		$this->filesPageCRUDFunctions->deleteAllSelectedFiles($session);
 	}
 
 	/**
@@ -324,30 +265,9 @@ class FilesPage extends FilesPageBasic {
 	public function moveFileTo(
 		$name, $destination, Session $session, $maxRetries = STANDARD_RETRY_COUNT
 	) {
-		$toMoveFileRow = $this->findFileRowByName($name, $session);
-		$destinationFileRow = $this->findFileRowByName($destination, $session);
-
-		$this->initAjaxCounters($session);
-		$this->resetSumStartedAjaxRequests($session);
-		
-		for ($retryCounter = 0; $retryCounter < $maxRetries; $retryCounter++) {
-			$toMoveFileRow->findFileLink()->dragTo(
-				$destinationFileRow->findFileLink()
-			);
-			$this->waitForAjaxCallsToStartAndFinish($session);
-			$countXHRRequests = $this->getSumStartedAjaxRequests($session);
-			if ($countXHRRequests === 0) {
-				\error_log("Error while moving file");
-			} else {
-				break;
-			}
-		}
-		if ($retryCounter > 0) {
-			$message
-				= "INFORMATION: retried to move file $retryCounter times";
-			echo $message;
-			\error_log($message);
-		}
+		$this->filesPageCRUDFunctions->moveFileTo(
+			$name, $destination, $session, $maxRetries
+		);
 	}
 
 	/**
@@ -436,23 +356,6 @@ class FilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function waitForUploadProgressbarToFinish() {
-		$uploadProgressbar = $this->find(
-			"xpath", $this->uploadProgressbarLabelXpath
-		);
-		$this->assertElementNotNull(
-			$uploadProgressbar,
-			__METHOD__ .
-			" xpath $this->uploadProgressbarLabelXpath " .
-			"could not find upload progressbar"
-		);
-		$currentTime = \microtime(true);
-		$end = $currentTime + (STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000);
-		while ($uploadProgressbar->isVisible()) {
-			if ($currentTime > $end) {
-				break;
-			}
-			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
-			$currentTime = \microtime(true);
-		}
+		$this->filesPageCRUDFunctions->waitForUploadProgressbarToFinish();
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -1,0 +1,475 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Session;
+use Behat\Mink\Element\NodeElement;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use WebDriver\Key;
+use WebDriver\Exception\NoSuchElement;
+use WebDriver\Exception\StaleElementReference;
+
+/**
+ * PageObject with CRUD actions that are shared among some file pages, but not all
+ *
+ */
+class FilesPageCRUD extends FilesPageBasic {
+	protected $fileNamesXpath = null;
+	protected $fileNameMatchXpath = null;
+	protected $fileListXpath = null;
+	protected $emptyContentXpath = null;
+	protected $newFileFolderButtonXpath = './/*[@id="controls"]//a[@class="button new"]';
+	protected $newFolderButtonXpath = './/div[contains(@class, "newFileMenu")]//a[@data-templatename="New folder"]';
+	protected $newFolderNameInputLabel = 'New folder';
+	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
+	protected $fileUploadInputId = "file_upload_start";
+	protected $uploadProgressbarLabelXpath = "//div[@id='uploadprogressbar']/em";
+
+	/**
+	 * @param string $fileNamesXpath
+	 *
+	 * @return void
+	 */
+	public function setFileNamesXpath($fileNamesXpath) {
+		$this->fileNamesXpath = $fileNamesXpath;
+	}
+
+	/**
+	 * @param string $fileNameMatchXpath
+	 *
+	 * @return void
+	 */
+	public function setFileNameMatchXpath($fileNameMatchXpath) {
+		$this->fileNameMatchXpath = $fileNameMatchXpath;
+	}
+
+	/**
+	 * @param string $fileListXpath
+	 *
+	 * @return void
+	 */
+	public function setFileListXpath($fileListXpath) {
+		$this->fileListXpath = $fileListXpath;
+	}
+
+	/**
+	 * @param string $emptyContentXpath
+	 *
+	 * @return void
+	 */
+	public function setEmptyContentXpath($emptyContentXpath) {
+		$this->emptyContentXpath = $emptyContentXpath;
+	}
+
+	/**
+	 * @param string $deleteAllSelectedBtnXpath
+	 *
+	 * @return void
+	 */
+	public function setDeleteAllSelectedBtnXpath($deleteAllSelectedBtnXpath) {
+		$this->deleteAllSelectedBtnXpath = $deleteAllSelectedBtnXpath;
+	}
+
+	/**
+	 * set all needed xpath
+	 *
+	 * @param string $emptyContentXpath
+	 * @param string $fileListXpath
+	 * @param string $fileNameMatchXpath
+	 * @param string $fileNamesXpath
+	 * @param string $deleteAllSelectedBtnXpath
+	 *
+	 * @return void
+	 */
+	public function setXpath(
+		$emptyContentXpath,
+		$fileListXpath,
+		$fileNameMatchXpath,
+		$fileNamesXpath,
+		$deleteAllSelectedBtnXpath
+	) {
+		$this->setEmptyContentXpath($emptyContentXpath);
+		$this->setFileListXpath($fileListXpath);
+		$this->setFileNameMatchXpath($fileNameMatchXpath);
+		$this->setFileNamesXpath($fileNamesXpath);
+		$this->setDeleteAllSelectedBtnXpath($deleteAllSelectedBtnXpath);
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getFileListXpath() {
+		return $this->fileListXpath;
+	}
+	
+	/**
+	 * @return string
+	 */
+	protected function getFileNamesXpath() {
+		return $this->fileNamesXpath;
+	}
+	
+	/**
+	 * @return string
+	 */
+	protected function getFileNameMatchXpath() {
+		return $this->fileNameMatchXpath;
+	}
+	
+	/**
+	 * @return string
+	 */
+	protected function getEmptyContentXpath() {
+		return $this->emptyContentXpath;
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getDeleteAllSelectedBtnXpath() {
+		return $this->deleteAllSelectedBtnXpath;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
+	 *
+	 * @return void
+	 */
+	protected function getFilePathInRowXpath() {
+		throw new \Exception("not implemented");
+	}
+
+	/**
+	 * renames a file
+	 *
+	 * @param string|array $fromFileName
+	 * @param string|array $toFileName
+	 * @param Session $session
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function renameFile(
+		$fromFileName,
+		$toFileName,
+		Session $session,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		if (\is_array($toFileName)) {
+			$toFileName = \implode($toFileName);
+		}
+		
+		for ($counter = 0; $counter < $maxRetries; $counter++) {
+			try {
+				$fileRow = $this->findFileRowByName($fromFileName, $session);
+				$fileRow->rename($toFileName, $session);
+				break;
+			} catch (\Exception $e) {
+				$this->closeFileActionsMenu();
+				\error_log(
+					"Error while renaming file"
+					. "\n-------------------------\n"
+					. $e->getMessage()
+					. "\n-------------------------\n"
+				);
+			}
+		}
+		if ($counter > 0) {
+			$message = "INFORMATION: retried to rename file $counter times";
+			echo $message;
+			\error_log($message);
+		}
+		
+		$this->waitTillFileRowsAreReady($session);
+	}
+
+	/**
+	 * moves a file or folder into an other folder by drag and drop
+	 *
+	 * @param string|array $name
+	 * @param string|array $destination
+	 * @param Session $session
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function moveFileTo(
+		$name, $destination, Session $session, $maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$toMoveFileRow = $this->findFileRowByName($name, $session);
+		$destinationFileRow = $this->findFileRowByName($destination, $session);
+		
+		$this->initAjaxCounters($session);
+		$this->resetSumStartedAjaxRequests($session);
+		
+		for ($retryCounter = 0; $retryCounter < $maxRetries; $retryCounter++) {
+			$toMoveFileRow->findFileLink()->dragTo(
+				$destinationFileRow->findFileLink()
+			);
+			$this->waitForAjaxCallsToStartAndFinish($session);
+			$countXHRRequests = $this->getSumStartedAjaxRequests($session);
+			if ($countXHRRequests === 0) {
+				\error_log("Error while moving file");
+			} else {
+				break;
+			}
+		}
+		if ($retryCounter > 0) {
+			$message
+				= "INFORMATION: retried to move file $retryCounter times";
+			echo $message;
+			\error_log($message);
+		}
+	}
+
+	/**
+	 * create a folder with the given name.
+	 * If name is not given a random one is chosen
+	 *
+	 * @param Session $session
+	 * @param string $name
+	 * @param int $timeoutMsec
+	 *
+	 * @throws ElementNotFoundException|\Exception
+	 * @return string name of the created file
+	 */
+	public function createFolder(
+		Session $session, $name = null,
+		$timeoutMsec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	) {
+		if ($name === null) {
+			$name = \substr(\str_shuffle($this->strForNormalFileName), 0, 8);
+		}
+		
+		$newButtonElement = $this->find("xpath", $this->newFileFolderButtonXpath);
+		
+		$this->assertElementNotNull(
+			$newButtonElement,
+			__METHOD__ .
+			" xpath $this->newFileFolderButtonXpath " .
+			"could not find new file-folder button"
+		);
+		
+		$newButtonElement->click();
+		
+		$newFolderButtonElement = $this->find("xpath", $this->newFolderButtonXpath);
+		
+		$this->assertElementNotNull(
+			$newFolderButtonElement,
+			__METHOD__ .
+			" xpath $this->newFolderButtonXpath " .
+			"could not find new folder button"
+		);
+		
+		try {
+			$newFolderButtonElement->click();
+		} catch (NoSuchElement $e) {
+			// Edge sometimes reports NoSuchElement even though we just found it.
+			// Log the event and continue, because maybe the button was clicked.
+			// TODO: Edge - if it keeps happening then find out why.
+			\error_log(
+				__METHOD__
+				. " NoSuchElement while doing newFolderButtonElement->click()"
+				. "\n-------------------------\n"
+				. $e->getMessage()
+				. "\n-------------------------\n"
+			);
+		}
+		
+		try {
+			$this->fillField($this->newFolderNameInputLabel, $name . Key::ENTER);
+		} catch (NoSuchElement $e) {
+			// this seems to be a bug in MinkSelenium2Driver.
+			// Used to work fine in 1.3.1 but now throws this exception
+			// Actually all that we need does happen, so we just don't do anything
+		} catch (StaleElementReference $e) {
+			// At the end of processing setValue, MinkSelenium2Driver tries to blur
+			// away from the element. But we pressed enter which has already
+			// made the element go away. So we do not care about this exception.
+			// This issue started happening due to:
+			// https://github.com/minkphp/MinkSelenium2Driver/pull/286
+		}
+		$timeoutMsec = (int) $timeoutMsec;
+		$currentTime = \microtime(true);
+		$end = $currentTime + ($timeoutMsec / 1000);
+		
+		while ($currentTime <= $end) {
+			$newFolderButton = $this->find("xpath", $this->newFolderButtonXpath);
+			if ($newFolderButton === null || !$newFolderButton->isVisible()) {
+				break;
+			}
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+			$currentTime = \microtime(true);
+		}
+		while ($currentTime <= $end) {
+			try {
+				$this->findFileRowByName($name, $session);
+				break;
+			} catch (ElementNotFoundException $e) {
+				//loop around
+			}
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+			$currentTime = \microtime(true);
+		}
+		
+		if ($currentTime > $end) {
+			throw new \Exception("could not create folder");
+		}
+		return $name;
+	}
+
+	/**
+	 *
+	 * @param string|array $name
+	 * @param Session $session
+	 * @param bool $expectToDeleteFile
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$this->initAjaxCounters($session);
+		$this->resetSumStartedAjaxRequests($session);
+		
+		for ($counter = 0; $counter < $maxRetries; $counter++) {
+			$row = $this->findFileRowByName($name, $session);
+			try {
+				$row->delete($session);
+				$this->waitForAjaxCallsToStartAndFinish($session);
+				$countXHRRequests = $this->getSumStartedAjaxRequests($session);
+				//if no XHR Request were fired we assume the delete action
+				//did not work and we retry
+				if ($countXHRRequests === 0) {
+					if ($expectToDeleteFile) {
+						\error_log("Error while deleting file");
+					}
+				} else {
+					break;
+				}
+			} catch (\Exception $e) {
+				$this->closeFileActionsMenu();
+				if ($expectToDeleteFile) {
+					\error_log(
+						"Error while deleting file"
+						. "\n-------------------------\n"
+						. $e->getMessage()
+						. "\n-------------------------\n"
+					);
+				}
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+			}
+		}
+		if ($expectToDeleteFile && ($counter > 0)) {
+			if (\is_array($name)) {
+				$name = \implode($name);
+			}
+			$message = "INFORMATION: retried to delete file '$name' $counter times";
+			echo $message;
+			\error_log($message);
+		}
+	}
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return NodeElement
+	 */
+	public function findDeleteAllSelectedFilesBtn() {
+		$deleteAllSelectedBtn = $this->find(
+			"xpath", $this->deleteAllSelectedBtnXpath
+		);
+		$this->assertElementNotNull(
+			$deleteAllSelectedBtn,
+			__METHOD__ .
+			" xpath $this->deleteAllSelectedBtnXpath " .
+			"could not find button to delete all selected files"
+		);
+		return $deleteAllSelectedBtn;
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteAllSelectedFiles(Session $session) {
+		$this->findDeleteAllSelectedFilesBtn()->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+		$this->waitTillFileRowsAreReady($session);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param string $name
+	 *
+	 * @return void
+	 */
+	public function uploadFile(Session $session, $name) {
+		$uploadField = $this->findById($this->fileUploadInputId);
+		$this->assertElementNotNull(
+			$uploadField,
+			__METHOD__ .
+			" id $this->fileUploadInputId " .
+			"could not find file upload input field"
+		);
+		$uploadField->attachFile(\getenv("FILES_FOR_UPLOAD") . $name);
+		$this->waitForAjaxCallsToStartAndFinish($session, 20000);
+		$this->waitForUploadProgressbarToFinish();
+	}
+
+	/**
+	 * waits till the upload progressbar is not visible anymore
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function waitForUploadProgressbarToFinish() {
+		$uploadProgressbar = $this->find(
+			"xpath", $this->uploadProgressbarLabelXpath
+		);
+		$this->assertElementNotNull(
+			$uploadProgressbar,
+			__METHOD__ .
+			" xpath $this->uploadProgressbarLabelXpath " .
+			"could not find upload progressbar"
+		);
+		$currentTime = \microtime(true);
+		$end = $currentTime + (STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000);
+		while ($uploadProgressbar->isVisible()) {
+			if ($currentTime > $end) {
+				break;
+			}
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+			$currentTime = \microtime(true);
+		}
+	}
+}

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -23,6 +23,7 @@
 namespace Page;
 
 use Behat\Mink\Session;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use WebDriver\Exception\NoSuchElement;
 use WebDriver\Exception\StaleElementReference;
@@ -44,6 +45,12 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	protected $passwordFieldId = 'password';
 	protected $passwordSubmitButtonId = 'password-submit';
 	protected $warningMessageCss = '.warning';
+	protected $deleteAllSelectedBtnXpath = "//a[@class='delete-selected']";
+	/**
+	 *
+	 * @var FilesPageCRUD $filesPageCRUDFunctions
+	 */
+	protected $filesPageCRUDFunctions;
 
 	/**
 	 * @return string
@@ -86,6 +93,25 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	}
 
 	/**
+	 * @param Session $session
+	 * @param Factory $factory
+	 * @param array   $parameters
+	 */
+	public function __construct(
+		Session $session, Factory $factory, array $parameters = []
+	) {
+		parent::__construct($session, $factory, $parameters);
+		$this->filesPageCRUDFunctions = $this->getPage("FilesPageCRUD");
+		$this->filesPageCRUDFunctions->setXpath(
+			$this->emptyContentXpath,
+			$this->fileListXpath,
+			$this->fileNameMatchXpath,
+			$this->fileNamesXpath,
+			$this->deleteAllSelectedBtnXpath
+		);
+	}
+
+	/**
 	 * adding public link share to particular server
 	 *
 	 * @param string $server
@@ -121,13 +147,20 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * create a folder with the given name.
 	 * If name is not given a random one is chosen
 	 *
+	 * @param Session $session
 	 * @param string $name
+	 * @param int $timeoutMsec
 	 *
-	 * @throws ElementNotFoundException
+	 * @throws ElementNotFoundException|\Exception
 	 * @return string name of the created file
 	 */
-	public function createFolder($name = null) {
-		throw new \Exception("not implemented");
+	public function createFolder(
+		Session $session, $name = null,
+		$timeoutMsec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	) {
+		return $this->filesPageCRUDFunctions->createFolder(
+			$session, $name, $timeoutMsec
+		);
 	}
 
 	/**
@@ -146,7 +179,9 @@ class PublicLinkFilesPage extends FilesPageBasic {
 		Session $session,
 		$maxRetries = STANDARD_RETRY_COUNT
 	) {
-		throw new \Exception("not implemented");
+		$this->filesPageCRUDFunctions->renameFile(
+			$fromFileName, $toFileName, $session, $maxRetries
+		);
 	}
 
 	/**
@@ -162,7 +197,9 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	public function moveFileTo(
 		$name, $destination, Session $session, $maxRetries = STANDARD_RETRY_COUNT
 	) {
-		throw new \Exception("not implemented");
+		$this->filesPageCRUDFunctions->moveFileTo(
+			$name, $destination, $session, $maxRetries
+		);
 	}
 
 	/**
@@ -358,5 +395,56 @@ class PublicLinkFilesPage extends FilesPageBasic {
 		}
 
 		$this->waitForOutstandingAjaxCalls($session);
+	}
+
+	/**
+	 *
+	 * @param string|array $name
+	 * @param Session $session
+	 * @param bool $expectToDeleteFile
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$this->filesPageCRUDFunctions->deleteFile(
+			$name, $session, $expectToDeleteFile, $maxRetries
+		);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteAllSelectedFiles(Session $session) {
+		$this->filesPageCRUDFunctions->deleteAllSelectedFiles($session);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param string $name
+	 *
+	 * @return void
+	 */
+	public function uploadFile(Session $session, $name) {
+		$this->filesPageCRUDFunctions->uploadFile($session, $name);
+	}
+
+	/**
+	 * waits till the upload progressbar is not visible anymore
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function waitForUploadProgressbarToFinish() {
+		$this->filesPageCRUDFunctions->waitForUploadProgressbarToFinish();
 	}
 }

--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -23,6 +23,7 @@
 namespace Page;
 
 use Behat\Mink\Session;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
 
 /**
  * Shared By Link page.
@@ -38,6 +39,12 @@ class SharedByLinkPage extends FilesPageBasic {
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext')) and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-sharinglinks']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-sharinglinks']//div[@id='emptycontent']";
+	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
+	/**
+	 *
+	 * @var FilesPageCRUD $filesPageCRUDFunctions
+	 */
+	protected $filesPageCRUDFunctions;
 
 	/**
 	 * @return string
@@ -76,5 +83,54 @@ class SharedByLinkPage extends FilesPageBasic {
 	 */
 	protected function getFilePathInRowXpath() {
 		throw new \Exception("not implemented in SharedByLinkPage");
+	}
+
+	/**
+	 * @param Session $session
+	 * @param Factory $factory
+	 * @param array   $parameters
+	 */
+	public function __construct(
+		Session $session, Factory $factory, array $parameters = []
+	) {
+		parent::__construct($session, $factory, $parameters);
+		$this->filesPageCRUDFunctions = $this->getPage("FilesPageCRUD");
+		$this->filesPageCRUDFunctions->setXpath(
+			$this->emptyContentXpath,
+			$this->fileListXpath,
+			$this->fileNameMatchXpath,
+			$this->fileNamesXpath,
+			$this->deleteAllSelectedBtnXpath
+		);
+	}
+
+	/**
+	 *
+	 * @param string|array $name
+	 * @param Session $session
+	 * @param bool $expectToDeleteFile
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$this->filesPageCRUDFunctions->deleteFile(
+			$name, $session, $expectToDeleteFile, $maxRetries
+		);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteAllSelectedFiles(Session $session) {
+		$this->filesPageCRUDFunctions->deleteAllSelectedFiles($session);
 	}
 }

--- a/tests/acceptance/features/lib/SharedWithOthersPage.php
+++ b/tests/acceptance/features/lib/SharedWithOthersPage.php
@@ -23,6 +23,9 @@
 namespace Page;
 
 use Behat\Mink\Session;
+use Page\FilesPageElement\FileRow;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
  * Shared With Others page.
@@ -39,7 +42,12 @@ class SharedWithOthersPage extends FilesPageBasic {
 	protected $fileListXpath = ".//div[@id='app-content-sharingout']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-sharingout']//div[@id='emptycontent']";
 	protected $filePathInRowXpath = ".//div[@id='app-content-sharingout']//tbody[@id='fileList']//tr";
-
+	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
+	/**
+	 *
+	 * @var FilesPageCRUD $filesPageCRUDFunctions
+	 */
+	protected $filesPageCRUDFunctions;
 	/**
 	 * @return string
 	 */
@@ -80,6 +88,25 @@ class SharedWithOthersPage extends FilesPageBasic {
 	}
 
 	/**
+	 * @param Session $session
+	 * @param Factory $factory
+	 * @param array   $parameters
+	 */
+	public function __construct(
+		Session $session, Factory $factory, array $parameters = []
+	) {
+		parent::__construct($session, $factory, $parameters);
+		$this->filesPageCRUDFunctions = $this->getPage("FilesPageCRUD");
+		$this->filesPageCRUDFunctions->setXpath(
+			$this->emptyContentXpath,
+			$this->fileListXpath,
+			$this->fileNameMatchXpath,
+			$this->fileNamesXpath,
+			$this->deleteAllSelectedBtnXpath
+		);
+	}
+
+	/**
 	 * finds all rows that have the given name
 	 *
 	 * @param string|array $name
@@ -97,5 +124,35 @@ class SharedWithOthersPage extends FilesPageBasic {
 			$fileRows[] = $fileRow;
 		}
 		return $fileRows;
+	}
+
+	/**
+	 *
+	 * @param string|array $name
+	 * @param Session $session
+	 * @param bool $expectToDeleteFile
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$this->filesPageCRUDFunctions->deleteFile(
+			$name, $session, $expectToDeleteFile, $maxRetries
+		);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteAllSelectedFiles(Session $session) {
+		$this->filesPageCRUDFunctions->deleteAllSelectedFiles($session);
 	}
 }

--- a/tests/acceptance/features/lib/TagsPage.php
+++ b/tests/acceptance/features/lib/TagsPage.php
@@ -23,6 +23,8 @@
 namespace Page;
 
 use Behat\Mink\Session;
+use Page\FilesPageElement\FileRow;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
@@ -35,6 +37,12 @@ class TagsPage extends FilesPageBasic {
 	protected $fileListXpath = ".//div[@id='app-content-systemtagsfilter']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-systemtagsfilter']//div[@id='emptycontent']";
 	protected $filePathInRowXpath = ".//div[@id='app-content-systemtagsfilter']//tbody[@id='fileList']//tr";
+	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
+	/**
+	 *
+	 * @var FilesPageCRUD $filesPageCRUDFunctions
+	 */
+	protected $filesPageCRUDFunctions;
 
 	private $tagsInputXpath = "//div[@id='app-content-systemtagsfilter']//li[@class='select2-search-field']//input";
 	private $tagsSuggestDropDown = "//div[contains(@class, 'select2-drop-active') and contains(@id, 'select2-drop')]";
@@ -73,6 +81,25 @@ class TagsPage extends FilesPageBasic {
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;
+	}
+
+	/**
+	 * @param Session $session
+	 * @param Factory $factory
+	 * @param array   $parameters
+	 */
+	public function __construct(
+		Session $session, Factory $factory, array $parameters = []
+	) {
+		parent::__construct($session, $factory, $parameters);
+		$this->filesPageCRUDFunctions = $this->getPage("FilesPageCRUD");
+		$this->filesPageCRUDFunctions->setXpath(
+			$this->emptyContentXpath,
+			$this->fileListXpath,
+			$this->fileNameMatchXpath,
+			$this->fileNamesXpath,
+			$this->deleteAllSelectedBtnXpath
+		);
 	}
 
 	/**
@@ -137,5 +164,35 @@ class TagsPage extends FilesPageBasic {
 			$fileRows[] = $fileRow;
 		}
 		return $fileRows;
+	}
+
+	/**
+	 *
+	 * @param string|array $name
+	 * @param Session $session
+	 * @param bool $expectToDeleteFile
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$this->filesPageCRUDFunctions->deleteFile(
+			$name, $session, $expectToDeleteFile, $maxRetries
+		);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteAllSelectedFiles(Session $session) {
+		$this->filesPageCRUDFunctions->deleteAllSelectedFiles($session);
 	}
 }

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -24,6 +24,8 @@ namespace Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
+use Page\FilesPageElement\FileRow;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
@@ -44,7 +46,11 @@ class TrashbinPage extends FilesPageBasic {
 	protected $restoreAllSelectedBtnXpath = ".//*[@id='app-content-trashbin']//*[@class='undelete']";
 	protected $selectAllFilesCheckboxXpath = "//label[@for='select_all_trash']";
 	protected $filePathInRowXpath = "//span[@class='nametext extra-data']";
-
+	/**
+	 *
+	 * @var FilesPageCRUD $filesPageCRUDFunctions
+	 */
+	protected $filesPageCRUDFunctions;
 	/**
 	 * @return string
 	 */
@@ -82,6 +88,25 @@ class TrashbinPage extends FilesPageBasic {
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;
+	}
+
+	/**
+	 * @param Session $session
+	 * @param Factory $factory
+	 * @param array   $parameters
+	 */
+	public function __construct(
+		Session $session, Factory $factory, array $parameters = []
+	) {
+		parent::__construct($session, $factory, $parameters);
+		$this->filesPageCRUDFunctions = $this->getPage("FilesPageCRUD");
+		$this->filesPageCRUDFunctions->setXpath(
+			$this->emptyContentXpath,
+			$this->fileListXpath,
+			$this->fileNameMatchXpath,
+			$this->fileNamesXpath,
+			$this->deleteAllSelectedBtnXpath
+		);
 	}
 
 	/**
@@ -143,5 +168,35 @@ class TrashbinPage extends FilesPageBasic {
 			$fileRows[] = $fileRow;
 		}
 		return $fileRows;
+	}
+
+	/**
+	 *
+	 * @param string|array $name
+	 * @param Session $session
+	 * @param bool $expectToDeleteFile
+	 * @param int $maxRetries
+	 *
+	 * @return void
+	 */
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARD_RETRY_COUNT
+	) {
+		$this->filesPageCRUDFunctions->deleteFile(
+			$name, $session, $expectToDeleteFile, $maxRetries
+		);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteAllSelectedFiles(Session $session) {
+		$this->filesPageCRUDFunctions->deleteAllSelectedFiles($session);
 	}
 }

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -22,4 +22,15 @@ Feature: create folders
   Scenario: Create a folder with existing name
     When the user creates a folder with the invalid name "simple-folder" using the webUI
     Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed on the webUI
-	
+
+  Scenario: Create a folder in a public share
+    Given the user has created a new public link for the folder "simple-empty-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    When the user creates a folder with the name "top-folder" using the webUI
+    And the user opens the folder "top-folder" using the webUI
+    Then there should be no files/folders listed on the webUI
+    When the user creates a folder with the name "sub-folder" using the webUI
+    Then the folder "sub-folder" should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the folder "sub-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -150,3 +150,63 @@ Feature: deleting files and folders
     And the file "lorem.txt" should not be listed on the webUI
     When the user browses to the files page
     Then the file "lorem.txt" should not be listed on the webUI
+
+  Scenario: delete a file on a public share
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    When the user deletes the following elements using the webUI
+      | name                                  |
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | strängé filename (duplicate #2 &).txt |
+    Then as "user1" the file "simple-folder/lorem.txt" should not exist
+    And as "user1" the folder "simple-folder/simple-empty-folder" should not exist
+    And as "user1" the file "simple-folder/strängé filename (duplicate #2 &).txt" should not exist
+    And the deleted elements should not be listed on the webUI
+    And the deleted elements should not be listed on the webUI after a page reload
+
+  Scenario: delete a file on a public share with problematic characters
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    When the user renames the following file using the webUI
+      | from-name-parts | to-name-parts   |
+      | lorem.txt       | 'single'        |
+      |                 | "double" quotes |
+      |                 | question?       |
+      |                 | &and#hash       |
+    And the user deletes the following file using the webUI
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+    Then the following file should not be listed on the webUI
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+    When the user reloads the current page of the webUI
+    Then the following file should not be listed on the webUI
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+
+  Scenario: Delete multiple files at once on a public share
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    When the user batch deletes these files using the webUI
+      | name                |
+      | data.zip            |
+      | lorem.txt           |
+      | simple-empty-folder |
+    Then as "user1" the file "simple-folder/data.zip" should not exist
+    And as "user1" the file "simple-folder/lorem.txt" should not exist
+    And as "user1" the folder "simple-folder/simple-empty-folder" should not exist
+    And the deleted elements should not be listed on the webUI
+    And the deleted elements should not be listed on the webUI after a page reload

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -82,3 +82,15 @@ Feature: move files
       | "double" quotes | "double" quotes     |
       | question?       | question?           |
       | &and#hash       | &and#hash           |
+
+  @skipOnFIREFOX
+  Scenario: move files on a public share
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    And the user moves the file "data.zip" into the folder "simple-empty-folder" using the webUI
+    Then the file "data.zip" should not be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the file "data.zip" should not be listed on the webUI
+    And as "user1" the file "simple-folder/simple-empty-folder/data.zip" should exist
+    But as "user1" the file "simple-folder/data.zip" should not exist

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -122,3 +122,16 @@ Feature: rename files
   Scenario: Rename a file to .part
     When the user renames the file "data.zip" to "data.part" using the webUI
     Then near the file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI
+
+  Scenario: rename a file on a public share
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    When the public accesses the last created public link using the webUI
+    And the user renames the file "lorem.txt" to "a-renamed-file.txt" using the webUI
+    Then the file "a-renamed-file.txt" should be listed on the webUI
+    But the file "lorem.txt" should not be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then the file "a-renamed-file.txt" should be listed on the webUI
+    But the file "lorem.txt" should not be listed on the webUI
+    And as "user1" the file "simple-folder/a-renamed-file.txt" should exist
+    And as "user1" the file "simple-folder/lorem.txt" should not exist

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -86,3 +86,19 @@ Feature: File Upload
     And the content of "lorem.txt" should not have changed
     And the file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
+
+  Scenario: upload a file into a public share
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    And the user uploads the file "new-lorem.txt" using the webUI
+    Then the file "new-lorem.txt" should be listed on the webUI
+    And the content of "simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
+
+  Scenario: upload overwriting a file into a public share
+    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    Then the file "lorem.txt" should be listed on the webUI
+    And the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"


### PR DESCRIPTION
## Description
moving webUI CRUD functions into separate page object and tests that use this page object from the public share page

## Related Issue
needed for #33359

## Motivation and Context
This functions are similar but not exactly the same on the normal files page and on the public link page. This refactoring helps to use the functions on both places without duplicating code

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
