### PR TITLE
[stable10] Add methods to check setPasswordError message

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -410,6 +410,21 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then a set password error message with this text should be displayed on the webUI:
+	 *
+	 * @param PyStringNode $string
+	 *
+	 * @return void
+	 */
+	public function aSetPasswordErrorMessageWithTheTextShouldBeDisplayed(PyStringNode $string) {
+		$expectedString = $string->getRaw();
+		$setPasswordErrorMessage = $this->loginPage->getSetPasswordErrorMessage();
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedString, $setPasswordErrorMessage
+		);
+	}
+
+	/**
 	 * @Then the imprint url on the login page should link to :expectedImprintUrl
 	 *
 	 * @param string $expectedImprintUrl

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -39,6 +39,7 @@ class LoginPage extends OwncloudPage {
 	protected $passwordInputId = "password";
 	protected $submitLoginId = "submit";
 	protected $lostPasswordId = "lost-password";
+	protected $setPasswordErrorMessageId = "error-message";
 
 	protected $imprintUrlXpath = "//a[contains(text(),'Imprint')]";
 	protected $privacyPolicyXpath = "//a[contains(text(),'Privacy Policy')]";
@@ -119,6 +120,22 @@ class LoginPage extends OwncloudPage {
 	}
 
 	/**
+	 *
+	 * @throws ElementNotFoundException
+	 *
+	 * @return Page
+	 */
+	private function getSetPasswordErrorMessageField() {
+		$setPasswordErrorMessageField = $this->findById($this->setPasswordErrorMessageId);
+		$this->assertElementNotNull(
+			$setPasswordErrorMessageField,
+			__METHOD__ .
+			" id $this->setPasswordErrorMessageId could not find set password error message field"
+		);
+		return $setPasswordErrorMessageField;
+	}
+
+	/**
 	 * @param Session $session
 	 *
 	 * @return void
@@ -135,6 +152,15 @@ class LoginPage extends OwncloudPage {
 	public function getLostPasswordMessage() {
 		$passwordRecoveryMessage = $this->lostPasswordField()->getText();
 		return $passwordRecoveryMessage;
+	}
+
+	/**
+	 *
+	 * @return string
+	 */
+	public function getSetPasswordErrorMessage() {
+		$setPasswordErrorMessage = $this->getSetPasswordErrorMessageField()->getText();
+		return $setPasswordErrorMessage;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Add method to check set password error message which will be required for acceptance tests on `password_policy` app.

Related issue: https://github.com/owncloud/enterprise/issues/2970

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.