### PR TITLE
Improve acceptance test steps for user attributes

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -13,9 +13,7 @@ Feature: edit users
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
-    And user "brand-new-user" should exist
-    And the user attributes returned by the API should include
-      | email | brand-new-user@example.com |
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   @smokeTest
   Scenario: the administrator can edit a user display name
@@ -23,9 +21,7 @@ Feature: edit users
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
-    And user "brand-new-user" should exist
-    And the user attributes returned by the API should include
-      | displayname | A New User |
+    And the display name of user "brand-new-user" should be "A New User"
 
   @smokeTest
   Scenario: the administrator can edit a user quota
@@ -33,23 +29,17 @@ Feature: edit users
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
-    And user "brand-new-user" should exist
-    And the user attributes returned by the API should include
-      | quota definition | 12 MB |
+    And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: the administrator can override an existing user email
     Given user "brand-new-user" has been created
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
-    And the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
+    When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the user attributes returned by the API should include
-      | email | brand-new-user@example.com |
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
@@ -58,16 +48,12 @@ Feature: edit users
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "subadmin" has changed the quota of user "brand-new-user" to "12MB"
-    And user "subadmin" has changed the email of user "brand-new-user" to "brand-new-user@example.com"
-    And user "subadmin" has changed the display name of user "brand-new-user" to "Anne Brown"
-    When user "subadmin" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the user attributes returned by the API should include
-      | quota definition | 12 MB                      |
-      | email            | brand-new-user@example.com |
-      | displayname      | Anne Brown                 |
+    When user "subadmin" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
+    And user "subadmin" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    And user "subadmin" changes the display name of user "brand-new-user" to "Anne Brown" using the provisioning API
+    Then the display name of user "brand-new-user" should be "Anne Brown"
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
+    And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created
@@ -76,11 +62,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | email | brand-new-user@example.com |
-    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the attributes of user "brand-new-user" returned by the API should include
-      | email | brand-new-user@example.com |
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   Scenario: a normal user should be able to change their display name
     Given user "brand-new-user" has been created
@@ -89,11 +71,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | displayname | Alan Border |
-    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the attributes of user "brand-new-user" returned by the API should include
-      | displayname | Alan Border |
+    And the display name of user "brand-new-user" should be "Alan Border"
 
   Scenario: a normal user should not be able to change their quota
     Given user "brand-new-user" has been created
@@ -102,8 +80,4 @@ Feature: edit users
     And the HTTP status code should be "401"
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |
-    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the attributes of user "brand-new-user" returned by the API should include
-      | quota definition | default |
+    And the quota definition of user "brand-new-user" should be "default"

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -8,12 +8,13 @@ Feature: get user
     Given using OCS API version "1"
 
   @smokeTest
-  Scenario: admin gets existing user
+  Scenario: admin gets an existing user
     Given user "brand-new-user" has been created
     When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "brand-new-user"
+    And the quota definition returned by the API should be "default"
 
   Scenario: admin tries to get a not existing user
     When the administrator retrieves the information of user "not-a-user" using the provisioning API
@@ -32,6 +33,7 @@ Feature: get user
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
+    And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin tries to get information of a user not in their group
     Given user "subadmin" has been created
@@ -58,3 +60,4 @@ Feature: get user
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
+    And the quota definition returned by the API should be "default"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -13,9 +13,7 @@ Feature: edit users
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
-    And user "brand-new-user" should exist
-    And the user attributes returned by the API should include
-      | email | brand-new-user@example.com |
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   @smokeTest
   Scenario: the administrator can edit a user display name
@@ -23,9 +21,7 @@ Feature: edit users
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
-    And user "brand-new-user" should exist
-    And the user attributes returned by the API should include
-      | displayname | A New User |
+    And the display name of user "brand-new-user" should be "A New User"
 
   @smokeTest
   Scenario: the administrator can edit a user quota
@@ -33,23 +29,17 @@ Feature: edit users
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
-    And user "brand-new-user" should exist
-    And the user attributes returned by the API should include
-      | quota definition | 12 MB |
+    And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: the administrator can override existing user email
     Given user "brand-new-user" has been created
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
-    And the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
+    When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the user attributes returned by the API should include
-      | email | brand-new-user@example.com |
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
@@ -58,16 +48,12 @@ Feature: edit users
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "subadmin" has changed the quota of user "brand-new-user" to "12MB"
-    And user "subadmin" has changed the email of user "brand-new-user" to "brand-new-user@example.com"
-    And user "subadmin" has changed the display name of user "brand-new-user" to "Anne Brown"
-    When user "subadmin" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And the user attributes returned by the API should include
-      | quota definition | 12 MB                      |
-      | email            | brand-new-user@example.com |
-      | displayname      | Anne Brown                 |
+    When user "subadmin" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
+    And user "subadmin" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
+    And user "subadmin" changes the display name of user "brand-new-user" to "Anne Brown" using the provisioning API
+    Then the display name of user "brand-new-user" should be "Anne Brown"
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
+    And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created
@@ -76,11 +62,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | email | brand-new-user@example.com |
-    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And the attributes of user "brand-new-user" returned by the API should include
-      | email | brand-new-user@example.com |
+    And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   Scenario: a normal user should be able to change their display name
     Given user "brand-new-user" has been created
@@ -89,11 +71,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
       | displayname | Alan Border |
-    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And the attributes of user "brand-new-user" returned by the API should include
-      | displayname | Alan Border |
+    And the display name of user "brand-new-user" should be "Alan Border"
 
   Scenario: a normal user should not be able to change their quota
     Given user "brand-new-user" has been created
@@ -102,8 +80,4 @@ Feature: edit users
     And the HTTP status code should be "401"
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |
-    When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And the attributes of user "brand-new-user" returned by the API should include
-      | quota definition | default |
+    And the quota definition of user "brand-new-user" should be "default"

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -14,6 +14,7 @@ Feature: get user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "brand-new-user"
+    And the quota definition returned by the API should be "default"
 
   Scenario: admin tries to get a not existing user
     When the administrator retrieves the information of user "not-a-user" using the provisioning API
@@ -32,6 +33,7 @@ Feature: get user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
+    And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin tries to get information of a user not in their group
     Given user "subadmin" has been created
@@ -52,9 +54,10 @@ Feature: get user
     And the API should not return any data
 
   @smokeTest
-  Scenario: normal user gets their own information
+  Scenario: a normal user gets their own information
     Given user "newuser" has been created
-    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
+    When user "newuser" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the display name returned by the API should be "newuser"
+    And the quota definition returned by the API should be "default"

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1766,13 +1766,85 @@ trait Provisioning {
 	/**
 	 * @Then /^the display name returned by the API should be "([^"]*)"$/
 	 *
+	 * @param string $expectedDisplayName
+	 *
+	 * @return void
+	 */
+	public function theDisplayNameReturnedByTheApiShouldBe($expectedDisplayName) {
+		$responseDisplayName = (string) $this->getResponseXml()->data[0]->displayname;
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedDisplayName,
+			$responseDisplayName
+		);
+	}
+
+	/**
+	 * @Then /^the display name of user "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string $user
 	 * @param string $displayname
 	 *
 	 * @return void
 	 */
-	public function theDisplayNameReturnedByTheApiShouldBe($displayname) {
-		$responseName = $this->getResponseXml()->data[0]->displayname;
-		PHPUnit_Framework_Assert::assertEquals($displayname, $responseName);
+	public function theDisplayNameOfUserShouldBe($user, $displayname) {
+		$this->adminRetrievesTheInformationOfUserUsingTheProvisioningApi($user);
+		$this->theDisplayNameReturnedByTheApiShouldBe($displayname);
+	}
+
+	/**
+	 * @Then /^the email address returned by the API should be "([^"]*)"$/
+	 *
+	 * @param string $expectedEmailAddress
+	 *
+	 * @return void
+	 */
+	public function theEmailAddressReturnedByTheApiShouldBe($expectedEmailAddress) {
+		$responseEmailAddress = (string) $this->getResponseXml()->data[0]->email;
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedEmailAddress,
+			$responseEmailAddress
+		);
+	}
+
+	/**
+	 * @Then /^the email address of user "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $expectedEmailAddress
+	 *
+	 * @return void
+	 */
+	public function theEmailAddressOfUserShouldBe($user, $expectedEmailAddress) {
+		$this->adminRetrievesTheInformationOfUserUsingTheProvisioningApi($user);
+		$this->theEmailAddressReturnedByTheApiShouldBe($expectedEmailAddress);
+	}
+
+	/**
+	 * @Then /^the quota definition returned by the API should be "([^"]*)"$/
+	 *
+	 * @param string $expectedQuotaDefinition a string that describes the quota
+	 *
+	 * @return void
+	 */
+	public function theQuotaDefinitionReturnedByTheApiShouldBe($expectedQuotaDefinition) {
+		$responseQuotaDefinition = (string) $this->getResponseXml()->data[0]->quota->definition;
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedQuotaDefinition,
+			$responseQuotaDefinition
+		);
+	}
+
+	/**
+	 * @Then /^the quota definition of user "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $expectedQuotaDefinition
+	 *
+	 * @return void
+	 */
+	public function theQuotaDefinitionOfUserShouldBe($user, $expectedQuotaDefinition) {
+		$this->adminRetrievesTheInformationOfUserUsingTheProvisioningApi($user);
+		$this->theQuotaDefinitionReturnedByTheApiShouldBe($expectedQuotaDefinition);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Make individual acceptance test step methods to check the display name, email address and quota definition of a user.

Tidy up some provisioning API tests that had mixed when-then steps.

## Related Issue
Part of issue #33374 

## Motivation and Context
1) tidy up existing provisioning API test scenarios
2) have handy step definitions available for checking user attribute settings from user management scenarios, independently of what the webUI says

## How Has This Been Tested?
Local acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
