### PR TITLE
HomeObjectStore is not returning the bucket id - introducing getBucket()

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -130,6 +130,10 @@ class ObjectStoreStorage extends Common {
 		return $this->id;
 	}
 
+	public function getBucket() {
+		return $this->objectStore->getStorageId();
+	}
+
 	/** {@inheritdoc} */
 	public function rmdir($path) {
 		$path = $this->normalizePath($path);
@@ -500,7 +504,7 @@ class ObjectStoreStorage extends Common {
 		}
 
 		// living on different buckets?
-		if ($this->getId() !== $sourceStorage->getId()) {
+		if ($this->getBucket() !== $sourceStorage->getBucket()) {
 			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
 


### PR DESCRIPTION
## Description
getId on HomeObjectStore is not returning the bucket id but the storage id which is unique for each user
getBucket is introduced therefore

## Related Issue
- fixes https://github.com/owncloud/files_primary_s3/issues/152

## How Has This Been Tested?
- manual testing as per ticket

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
