### PR TITLE
Set max-version of shipped apps to 11

### DIFF
--- a/apps/comments/appinfo/info.xml
+++ b/apps/comments/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<default_enable/>
 	<version>0.3.0</version>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<types>
 		<logging/>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -16,7 +16,7 @@
 		<webdav>appinfo/v1/publicwebdav.php</webdav>
 	</public>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\DAV\CardDAV\SyncJob</job>

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -13,7 +13,7 @@
         <filesystem/>
     </types>
     <dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
     </dependencies>
     <settings>
         <admin>OCA\FederatedFileSharing\AdminPanel</admin>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<namespace>Federation</namespace>
 	<category>other</category>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<default_enable/>
 	<types>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -11,7 +11,7 @@
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<documentation>
 		<user>user-files</user>

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -22,7 +22,7 @@
 	<namespace>Files_External</namespace>
 
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 
 	<commands>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -16,7 +16,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	</types>
 	<use-migrations>true</use-migrations>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<public>
 		<files>public.php</files>

--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -17,7 +17,7 @@ To prevent a user from running out of disk space, the ownCloud Deleted files app
 	<use-migrations>true</use-migrations>
 	<namespace>Files_Trashbin</namespace>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<documentation>
 		<user>user-trashbin</user>

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -15,7 +15,7 @@ In addition to the expiry of versions, ownCloud’s versions app makes certain n
 	</types>
 	<namespace>Files_Versions</namespace>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<documentation>
 		<user>user-versions</user>

--- a/apps/provisioning_api/appinfo/info.xml
+++ b/apps/provisioning_api/appinfo/info.xml
@@ -23,6 +23,6 @@
 		<prevent_group_restriction/>
 	</types>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 </info>

--- a/apps/systemtags/appinfo/info.xml
+++ b/apps/systemtags/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<default_enable/>
 	<version>0.3.0</version>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 	<namespace>SystemTags</namespace>
 	<types>

--- a/apps/updatenotification/appinfo/info.xml
+++ b/apps/updatenotification/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<namespace>UpdateNotification</namespace>
 	<default_enable/>
 	<dependencies>
-		<owncloud min-version="11.0" max-version="11.0" />
+		<owncloud min-version="11" max-version="11" />
 	</dependencies>
 
 	<background-jobs>


### PR DESCRIPTION
Same as https://github.com/owncloud/core/pull/33496 but with max-version=11
