### PR TITLE
Add acceptance tests for federated resharing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,7 @@ pipeline:
       - php occ config:list
       - echo "export TEST_SERVER_FED_URL=https://federated" > /drone/saved-settings.sh
       - php occ security:certificates:import /drone/server.crt
+      - php occ security:certificates:import /drone/federated.crt
       - php occ security:certificates
     when:
       matrix:
@@ -145,6 +146,7 @@ pipeline:
       - php occ config:system:set trusted_domains 2 --value=federated
       - php occ log:manage --level 0
       - php occ config:list
+      - php occ security:certificates:import /drone/server.crt
       - php occ security:certificates:import /drone/federated.crt
       - php occ security:certificates
     when:

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -184,6 +184,64 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the files page on the webUI
 
+  Scenario: test sharing folder to a remote server and resharing it back to the local
+    Given using server "LOCAL"
+    And these users have been created:
+      | username |
+      | user2 |
+    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
+    And using server "REMOTE"
+    And user "user1" re-logs in to "%remote_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    And user "user1" from server "REMOTE" has shared "/simple-folder (2)" with user "user2" from server "LOCAL"
+    And using server "LOCAL"
+    And user "user2" re-logs in to "%local_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then as "user2" folder "/simple-folder (2)" should exist
+    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
+
+  Scenario: test resharing folder as readonly and set it as readonly by resharer
+    Given using server "LOCAL"
+    And these users have been created:
+      | username |
+      | user2 |
+    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
+    And using server "REMOTE"
+    And user "user1" re-logs in to "%remote_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    And user "user1" from server "REMOTE" has shared "/simple-folder (2)" with user "user2" from server "LOCAL"
+    And the user sets the sharing permissions of "user2@%local_server%/ (federated)" for "simple-folder (2)" using the webUI to
+      | edit | no |
+    And using server "LOCAL"
+    And user "user2" re-logs in to "%local_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then as "user2" folder "/simple-folder (2)" should exist
+    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
+    And the user opens folder "simple-folder (2)" using the webUI
+    And it should not be possible to delete file "lorem.txt" using the webUI
+    
+  Scenario: test resharing folder and set it as readonly by owner
+    Given using server "LOCAL"
+    And these users have been created:
+      | username |
+      | user2 |
+    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
+    And using server "REMOTE"
+    And user "user1" re-logs in to "%remote_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    And user "user1" from server "REMOTE" has shared "/simple-folder (2)" with user "user2" from server "LOCAL"
+    And using server "LOCAL"
+    And user "user1" re-logs in to "%local_server%" using the webUI
+    And the user opens the share dialog for folder "simple-folder"
+    And the user sets the sharing permissions of "user2@%local_server% (federated)" for "simple-folder" using the webUI to
+      | edit | no |
+    And user "user2" re-logs in to "%local_server%" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then as "user2" folder "/simple-folder (2)" should exist
+    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
+    And the user opens folder "simple-folder (2)" using the webUI
+    And it should not be possible to delete file "lorem.txt" using the webUI
+
   @skip @issue-32732
   Scenario: test sharing long file names with federation share
     When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -190,11 +190,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | username |
       | user2 |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And using server "REMOTE"
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    And user "user1" from server "REMOTE" has shared "/simple-folder (2)" with user "user2" from server "LOCAL"
-    And using server "LOCAL"
+    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
     And user "user2" re-logs in to "%local_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then as "user2" folder "/simple-folder (2)" should exist
@@ -206,19 +204,17 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | username |
       | user2 |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And using server "REMOTE"
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    And user "user1" from server "REMOTE" has shared "/simple-folder (2)" with user "user2" from server "LOCAL"
+    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
     And the user sets the sharing permissions of "user2@%local_server%/ (federated)" for "simple-folder (2)" using the webUI to
       | edit | no |
-    And using server "LOCAL"
     And user "user2" re-logs in to "%local_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then as "user2" folder "/simple-folder (2)" should exist
     And as "user2" file "/simple-folder (2)/lorem.txt" should exist
-    And the user opens folder "simple-folder (2)" using the webUI
-    And it should not be possible to delete file "lorem.txt" using the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
     
   Scenario: test resharing folder and set it as readonly by owner
     Given using server "LOCAL"
@@ -226,11 +222,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | username |
       | user2 |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And using server "REMOTE"
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    And user "user1" from server "REMOTE" has shared "/simple-folder (2)" with user "user2" from server "LOCAL"
-    And using server "LOCAL"
+    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
     And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens the share dialog for folder "simple-folder"
     And the user sets the sharing permissions of "user2@%local_server% (federated)" for "simple-folder" using the webUI to
@@ -239,8 +233,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user accepts the offered remote shares using the webUI
     Then as "user2" folder "/simple-folder (2)" should exist
     And as "user2" file "/simple-folder (2)/lorem.txt" should exist
-    And the user opens folder "simple-folder (2)" using the webUI
-    And it should not be possible to delete file "lorem.txt" using the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @skip @issue-32732
   Scenario: test sharing long file names with federation share


### PR DESCRIPTION
## Description
More acceptance tests for federation

## Related Issue
https://github.com/owncloud/core/issues/33422

## Motivation and Context
Tests

## How Has This Been Tested?
By CI


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
