### PR TITLE
[ UI-tests] move finding for 'New-file' button to function

### DIFF
--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -245,6 +245,23 @@ class FilesPageCRUD extends FilesPageBasic {
 	}
 
 	/**
+	 * finds the element of the button to create a new file/folder
+	 *
+	 * @return NodeElement
+	 */
+	public function findNewFileFolderButton() {
+		$newButtonElement = $this->find("xpath", $this->newFileFolderButtonXpath);
+		
+		$this->assertElementNotNull(
+			$newButtonElement,
+			__METHOD__ .
+			" xpath $this->newFileFolderButtonXpath " .
+			"could not find new file-folder button"
+		);
+		return $newButtonElement;
+	}
+
+	/**
 	 * create a folder with the given name.
 	 * If name is not given a random one is chosen
 	 *
@@ -262,16 +279,7 @@ class FilesPageCRUD extends FilesPageBasic {
 		if ($name === null) {
 			$name = \substr(\str_shuffle($this->strForNormalFileName), 0, 8);
 		}
-		
-		$newButtonElement = $this->find("xpath", $this->newFileFolderButtonXpath);
-		
-		$this->assertElementNotNull(
-			$newButtonElement,
-			__METHOD__ .
-			" xpath $this->newFileFolderButtonXpath " .
-			"could not find new file-folder button"
-		);
-		
+		$newButtonElement = $this->findNewFileFolderButton();
 		$newButtonElement->click();
 		
 		$newFolderButtonElement = $this->find("xpath", $this->newFolderButtonXpath);


### PR DESCRIPTION
## Description
move that to a function so it can be used from other places e.g. text editor page

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-  https://github.com/owncloud/files_texteditor/issues/260

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
