### PR TITLE
[UI-tests] message for ajax call start timeout

### DIFF
--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -499,6 +499,11 @@ class OwncloudPage extends Page {
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
+		if ($currentTime > $end) {
+			$message = "INFORMATION: timed out waiting for ajax calls to start";
+			echo $message;
+			\error_log($message);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
show a message when waiting for the ajax calls to start times out

## Motivation and Context
hope to get a bit of a clue why encryption tests fail

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
