### PR TITLE
[stable10] Backport of Update the unique index for the systemtag table

### DIFF
--- a/core/Migrations/Version20181113071753.php
+++ b/core/Migrations/Version20181113071753.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Add assignable column to unique index in oc_systemtags table
+ */
+class Version20181113071753 implements ISchemaMigration {
+	/** @var string */
+	private $prefix;
+
+	public function changeSchema(Schema $schema, array $options) {
+		$this->prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$this->prefix}systemtag");
+		if ($schema->hasTable("{$this->prefix}systemtag")) {
+			$table->dropIndex('tag_ident');
+			$table->addUniqueIndex(['name', 'visibility', 'editable', 'assignable'], 'tag_ident');
+		}
+	}
+}


### PR DESCRIPTION
Update the unique index for the systemtag table.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Update the unique index for the systemtag table.

- Let us consider the dataprovider https://github.com/owncloud/core/blob/master/tests/lib/SystemTag/SystemTagManagerTest.php#L95-L102 for the test https://github.com/owncloud/core/blob/master/tests/lib/SystemTag/SystemTagManagerTest.php#L110
- The moment https://github.com/owncloud/core/blob/master/tests/lib/SystemTag/SystemTagManagerTest.php#L101 dataset is taken for execution, the database snapshot looks like, shown below:
```
sqlite> select * from oc_systemtag;
id          name        visibility  editable    assignable
----------  ----------  ----------  ----------  ----------
315         one         0           0           1         
316         one         1           0           1         
317         one         0           1           1         
318         one         1           1           1         
319         two         0           0           0         
sqlite>
```
- When the code tries to create a new tag for https://github.com/owncloud/core/blob/master/tests/lib/SystemTag/SystemTagManagerTest.php#L101, the new entry we expect will be like:
```
320         two         0           0           1
```
This conflicts with the unique index. For a moment just look at the column `name`, `visibility` and `editable` column only, then rows with id 319 and planned insertion (id 320) are duplicates!!! And causes the failure while executing the last dataprovider in the test. 
- The schema of the table is as shown below:
```
sqlite> .schema oc_systemtag
CREATE TABLE oc_systemtag (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, name VARCHAR(64) DEFAULT '' NOT NULL, visibility SMALLINT DEFAULT 1 NOT NULL, editable SMALLINT DEFAULT 1 NOT NULL, assignable INTEGER DEFAULT 0 NOT NULL);
CREATE UNIQUE INDEX tag_ident ON oc_systemtag (name, visibility, editable);
sqlite>
```
the column `assignable` is missing in the unique index.

### How this fix solves the problem ###
- When `assignable` column is added along with `name`, `visibility` and `editable` in the unique index, the issue caused by adding:
```
320         two         0           0           1
```
gets rectified because row id `319` and `320` are different. Only difference is in the assignable column ( 0 and 1).


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Update the unique index of the systemtag with `assignable` column. If `assignable` column is not added to the unique index, then there are chances that duplicate entry is found with `name`, `visibility` and `editable`. This patch fixes the issue cauesd.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
