### PR TITLE
Add 'display' as well as 'displayname' editUser acceptance tests

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -16,6 +16,13 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   @smokeTest
+  Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")
+    Given user "brand-new-user" has been created
+    When the administrator changes the display of user "brand-new-user" to "A New User" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And the display name of user "brand-new-user" should be "A New User"
+
   Scenario: the administrator can edit a user display name
     Given user "brand-new-user" has been created
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
@@ -50,7 +57,7 @@ Feature: edit users
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     And user "subadmin" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
-    And user "subadmin" changes the display name of user "brand-new-user" to "Anne Brown" using the provisioning API
+    And user "subadmin" changes the display of user "brand-new-user" to "Anne Brown" using the provisioning API
     Then the display name of user "brand-new-user" should be "Anne Brown"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
     And the quota definition of user "brand-new-user" should be "12 MB"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -16,6 +16,13 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   @smokeTest
+  Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")
+    Given user "brand-new-user" has been created
+    When the administrator changes the display of user "brand-new-user" to "A New User" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the display name of user "brand-new-user" should be "A New User"
+
   Scenario: the administrator can edit a user display name
     Given user "brand-new-user" has been created
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
@@ -50,7 +57,7 @@ Feature: edit users
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     And user "subadmin" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
-    And user "subadmin" changes the display name of user "brand-new-user" to "Anne Brown" using the provisioning API
+    And user "subadmin" changes the display of user "brand-new-user" to "Anne Brown" using the provisioning API
     Then the display name of user "brand-new-user" should be "Anne Brown"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
     And the quota definition of user "brand-new-user" should be "12 MB"

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -571,6 +571,12 @@ trait Provisioning {
 	}
 
 	/**
+	 * Edit the "display name" of a user by sending the key "displayname" to the API end point.
+	 *
+	 * This is the newer and consistent key name.
+	 *
+	 * @see https://github.com/owncloud/core/pull/33040
+	 *
 	 * @When /^the administrator changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
 	 * @Given /^the administrator has changed the display name of user "([^"]*)" to "([^"]*)"$/
 	 *
@@ -578,14 +584,56 @@ trait Provisioning {
 	 * @param string $displayname
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	public function adminChangesTheDisplayNameOfTheUserUsingTheProvisioningApi(
+	public function adminChangesTheDisplayNameOfUserUsingTheProvisioningApi(
 		$user, $displayname
+	) {
+		$this->adminChangesTheDisplayNameOfUserUsingKey(
+			$user, 'displayname', $displayname
+		);
+	}
+
+	/**
+	 * As the administrator, edit the "display name" of a user by sending the key "display" to the API end point.
+	 *
+	 * This is the older and inconsistent key name, which remains for backward-compatibility.
+	 *
+	 * @see https://github.com/owncloud/core/pull/33040
+	 *
+	 * @When /^the administrator changes the display of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^the administrator has changed the display of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $displayname
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminChangesTheDisplayOfUserUsingTheProvisioningApi(
+		$user, $displayname
+	) {
+		$this->adminChangesTheDisplayNameOfUserUsingKey(
+			$user, 'display', $displayname
+		);
+	}
+
+	/**
+	 *
+	 * @param string $user
+	 * @param string $key
+	 * @param string $displayname
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminChangesTheDisplayNameOfUserUsingKey(
+		$user, $key, $displayname
 	) {
 		$result = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$this->getActualUsername($user),
-			'displayname',
+			$key,
 			$displayname,
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
@@ -594,13 +642,19 @@ trait Provisioning {
 		$this->response = $result;
 		if ($result->getStatusCode() !== 200) {
 			throw new \Exception(
-				"could not change display name of user. "
+				"could not change display name of user using key $key "
 				. $result->getStatusCode() . " " . $result->getBody()
 			);
 		}
 	}
 
 	/**
+	 * As a user, edit the "display name" of a user by sending the key "displayname" to the API end point.
+	 *
+	 * This is the newer and consistent key name.
+	 *
+	 * @see https://github.com/owncloud/core/pull/33040
+	 *
 	 * @When /^user "([^"]*)" changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
 	 * @Given /^user "([^"]*)" has changed the display name of user "([^"]*)" to "([^"]*)"$/
 	 *
@@ -613,10 +667,51 @@ trait Provisioning {
 	public function userChangesTheDisplayNameOfUserUsingTheProvisioningApi(
 		$requestingUser, $targetUser, $displayName
 	) {
+		$this->userChangesTheDisplayNameOfUserUsingKey(
+			$requestingUser, $targetUser, 'displayname', $displayName
+		);
+	}
+
+	/**
+	 * As a user, edit the "display name" of a user by sending the key "display" to the API end point.
+	 *
+	 * This is the older and inconsistent key name.
+	 *
+	 * @see https://github.com/owncloud/core/pull/33040
+	 *
+	 * @When /^user "([^"]*)" changes the display of user "([^"]*)" to "([^"]*)" using the provisioning API$/
+	 * @Given /^user "([^"]*)" has changed the display of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $displayName
+	 *
+	 * @return void
+	 */
+	public function userChangesTheDisplayOfUserUsingTheProvisioningApi(
+		$requestingUser, $targetUser, $displayName
+	) {
+		$this->userChangesTheDisplayNameOfUserUsingKey(
+			$requestingUser, $targetUser, 'display', $displayName
+		);
+	}
+
+	/**
+	 *
+	 * @param string $requestingUser
+	 * @param string $targetUser
+	 * @param string $key
+	 * @param string $displayName
+	 *
+	 * @return void
+	 */
+	public function userChangesTheDisplayNameOfUserUsingKey(
+		$requestingUser, $targetUser, $key, $displayName
+	) {
 		$result = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$this->getActualUsername($targetUser),
-			'displayname',
+			$key,
 			$displayName,
 			$this->getActualUsername($requestingUser),
 			$this->getPasswordForUser($requestingUser),


### PR DESCRIPTION
## Description
Add test scenarios to test editing a user "display name" using the key ``display``.
Adjust the ``Smoketest`` tagged scenarios so that they only use this "old" key ``display``.

## Related Issues
Issue #33039 
and PR #33040 
docker server issue https://github.com/owncloud-docker/server/pull/77

## Motivation and Context
1) The related issue/PR fixed up the provisioning API so that the "display name" of a user can be edited by specifying the key ``displayname`` (as well as the existing inconsistent key ```display``)
2) The acceptance tests were adjusted to use the new key ``displayname``

But we should also test that the old key ``display`` still works (for backward compatibility). And the scenarios that are tagged ``Smoketest`` should be ones that use the old key, so that they will/should pass when run against older ownCloud versions (e.g. 10.0.10 or 10.0.9)

## How Has This Been Tested?
Local acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
