### PR TITLE
Change 'using the console' to 'using the occ command'

### DIFF
--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -7,11 +7,11 @@ Feature: AppManagement
   Scenario: Two app instances exist the first is more recent
     Given app "multidirtest" with version "1.0.1" has been put in dir "apps"
     And app "multidirtest" with version "1.0.0" has been put in dir "apps2"
-    When the administrator gets the path for app "multidirtest" using the console
+    When the administrator gets the path for app "multidirtest" using the occ command
     Then the path to "multidirtest" should be "apps"
 
   Scenario: Two app instances exist the second is more recent
     Given app "multidirtest" with version "1.0.0" has been put in dir "apps"
     And app "multidirtest" with version "1.0.5" has been put in dir "apps2"
-    When the administrator gets the path for app "multidirtest" using the console
+    When the administrator gets the path for app "multidirtest" using the occ command
     Then the path to "multidirtest" should be "apps2"

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -122,8 +122,8 @@ class AppManagementContext implements Context {
 	}
 
 	/**
-	 * @When the administrator gets the path for app :appId using the console
-	 * @Given the administrator has got the path for app :appId using the console
+	 * @When the administrator gets the path for app :appId using the occ command
+	 * @Given the administrator has got the path for app :appId using the occ command
 	 *
 	 * @param string $appId app id
 	 *


### PR DESCRIPTION
## Description
In accceptance tests, change ``using the console`` to ``using the occ command``

## Motivation and Context
Nowadays we say ``using the occ command``
There is 1 old step that says ``using the console``
Make stuff consistent


Noticed while preparing documentation for "how to write acceptance tests".

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
