### PR TITLE
[UI test] improve details dialog

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -285,7 +285,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theThumbnailShouldBeVisibleInTheDetailsPanel() {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
-		$style = $detailsDialog->findThumbnail()->getAttribute("style");
+		$thumbnail = $detailsDialog->findThumbnail();
+		PHPUnit_Framework_Assert::assertTrue(
+			$thumbnail->isVisible(),
+			"thumbnail is not visible"
+		);
+		$style = $thumbnail->getAttribute("style");
 		PHPUnit_Framework_Assert::assertNotNull(
 			$style,
 			'style attribute of details thumbnail is null'

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -39,6 +39,7 @@ use TestHelpers\DownloadHelper;
 use Page\FilesPageBasic;
 use Page\FilesPageElement\FileActionsMenu;
 use Behat\Mink\Exception\ElementException;
+use Page\FilesPageElement\DetailsDialog;
 
 require_once 'bootstrap.php';
 
@@ -1933,6 +1934,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		switch ($action_label) {
 			case "details":
 				$this->openedFileActionMenu->openDetails();
+				$this->getCurrentPageObject()
+					->getDetailsDialog()
+					->waitTillPageIsLoaded($this->getSession());
 				break;
 			case "rename":
 				$this->openedFileActionMenu->rename();
@@ -2003,7 +2007,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theCommentShouldBeListedInTheCommentsTabInDetailsDialog($text, $shouldOrNot) {
 		$should = ($shouldOrNot !== "not");
 		$text = \trim($text, $text[0]);
+		/**
+		 *
+		 * @var DetailsDialog $detailsDialog
+		 */
 		$detailsDialog = $this->getCurrentPageObject()->getDetailsDialog();
+		$detailsDialog->waitTillPageIsLoaded($this->getSession());
 		if ($should) {
 			PHPUnit_Framework_Assert::assertTrue(
 				$detailsDialog->isCommentOnUI($text),

--- a/tests/acceptance/features/lib/FavoritesPage.php
+++ b/tests/acceptance/features/lib/FavoritesPage.php
@@ -82,16 +82,6 @@ class FavoritesPage extends FilesPageBasic {
 	}
 
 	/**
-	 * gets a details dialog object
-	 *
-	 * @throws ElementNotFoundException
-	 * @return DetailsDialog
-	 */
-	public function getDetailsDialog() {
-		return $this->getPage("FilesPageElement\\DetailsDialog");
-	}
-
-	/**
 	 * finds all rows that have the given name
 	 *
 	 * @param string|array $name

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -23,7 +23,6 @@
 namespace Page;
 
 use Behat\Mink\Session;
-use Page\FilesPageElement\DetailsDialog;
 use Page\FilesPageElement\SharingDialog;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
@@ -153,16 +152,6 @@ class FilesPage extends FilesPageBasic {
 	 */
 	public function uploadFile(Session $session, $name) {
 		$this->filesPageCRUDFunctions->uploadFile($session, $name);
-	}
-
-	/**
-	 * gets a details dialog object
-	 *
-	 * @throws ElementNotFoundException
-	 * @return DetailsDialog
-	 */
-	public function getDetailsDialog() {
-		return $this->getPage("FilesPageElement\\DetailsDialog");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -330,7 +330,11 @@ class FilesPage extends FilesPageBasic {
 			$detailsTab = "";
 		}
 
-		$detailsDialog = $this->getDetailsDialog();
+		/**
+		 *
+		 * @var DetailsDialog $dialog
+		 */
+		$detailsDialog = $this->getPage("FilesPageElement\\DetailsDialog");
 		$fullUrl = "$fullUrl&details=" . $detailsDialog->getDetailsTabId($detailsTab);
 
 		$this->getDriver()->visit($fullUrl);

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -24,6 +24,7 @@ namespace Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
+use Page\FilesPageElement\DetailsDialog;
 use Page\FilesPageElement\FileActionsMenu;
 use Page\FilesPageElement\FileRow;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
@@ -345,6 +346,16 @@ abstract class FilesPageBasic extends OwncloudPage {
 			$fileRow->clickFileActionButton();
 		} catch (\Exception $e) {
 		}
+	}
+
+	/**
+	 * gets a details dialog object
+	 *
+	 * @throws ElementNotFoundException
+	 * @return DetailsDialog
+	 */
+	public function getDetailsDialog() {
+		return $this->getPage("FilesPageElement\\DetailsDialog");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -50,6 +50,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	protected $selectAllFilesCheckboxXpath = "//label[@for='select_all_files']";
 	protected $appSettingsContentId = "app-settings-content";
 	protected $styleOfCheckboxWhenVisible = "display: block;";
+	protected $detailsDialogXpath = "//*[contains(@id, 'app-sidebar') and not(contains(@class, 'disappear'))]";
 
 	/**
 	 * @return string
@@ -355,7 +356,21 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 * @return DetailsDialog
 	 */
 	public function getDetailsDialog() {
-		return $this->getPage("FilesPageElement\\DetailsDialog");
+		$detailsDialogElement = $this->find("xpath", $this->detailsDialogXpath);
+		$this->assertElementNotNull(
+			$detailsDialogElement,
+			__METHOD__ .
+			" xpath: $this->detailsDialogXpath " .
+			" could not find Details Dialog"
+		);
+
+		/**
+		 *
+		 * @var DetailsDialog $dialog
+		 */
+		$dialog = $this->getPage("FilesPageElement\\DetailsDialog");
+		$dialog->setElement($detailsDialogElement);
+		return $dialog;
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -284,7 +284,7 @@ class DetailsDialog extends OwncloudPage {
 		$this->assertElementNotNull(
 			$commentList,
 			__METHOD__ .
-			" could not find comment with conteht $content"
+			" could not find comment with content $content"
 		);
 		$this->waitTillElementIsNotNull($this->commentListXpath);
 
@@ -316,7 +316,7 @@ class DetailsDialog extends OwncloudPage {
 			$commentDeleteButton,
 			__METHOD__ .
 			" xpath: $this->commentDeleteButtonXpath" .
-			"could not find comment delete button form"
+			"could not find comment delete button"
 		);
 		$commentDeleteButton->focus();
 		$commentDeleteButton->click();
@@ -470,7 +470,7 @@ class DetailsDialog extends OwncloudPage {
 					$deleteBtn,
 					__METHOD__ .
 					" xpath: $this->tagDeleteButtonInTagXpath" .
-					" could not find tag edit button"
+					" could not find tag delete button"
 				);
 				$deleteBtn->focus();
 				$deleteBtn->click();

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -475,6 +475,8 @@ class DetailsDialog extends OwncloudPage {
 				}
 			} catch (ElementNotFoundException $e) {
 				// Just loop and try again if the element was not found yet.
+			} catch (StaleElementReference $e) {
+				// Just loop and try again if the element is stale.
 			}
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
@@ -482,7 +484,7 @@ class DetailsDialog extends OwncloudPage {
 
 		if ($currentTime > $end) {
 			throw new \Exception(
-				__METHOD__ . " timeout waiting for page to load"
+				__METHOD__ . " timeout waiting for the files dialog to open"
 			);
 		}
 

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -27,6 +27,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use WebDriver\Exception\StaleElementReference;
 
 /**
  * The Details Dialog
@@ -38,8 +39,7 @@ class DetailsDialog extends OwncloudPage {
 	 * @var string $path
 	 */
 	protected $path = '/index.php/apps/files/';
-	private $detailsDialogXpath = "//*[contains(@id, 'app-sidebar') and not(contains(@class, 'disappear'))]";
-	private $detailsDialogCloseXpath = "//div[@id='app-sidebar']//*[@class='close icon-close']";
+	private $detailsDialogCloseXpath = "//*[@class='close icon-close']";
 	private $thumbnailContainerXpath = ".//*[contains(@class,'thumbnailContainer')]";
 	private $thumbnailFromContainerXpath = "/a";
 	private $detailsTabId = [
@@ -68,6 +68,29 @@ class DetailsDialog extends OwncloudPage {
 	private $lastVersionRevertButton = "//div[@id='versionsTabView']//ul[@class='versions']//li[1]/div/a";
 
 	/**
+	 *
+	 * @var NodeElement
+	 */
+	private $detailsDialogElement;
+
+	/**
+	 * sets the NodeElement for the current dialog
+	 * a little bit like __construct() but as we access this "sub-page-object"
+	 * from an other Page Object or a Context file by
+	 * $this->getPage("FilesPageElement\\SharingDialogElement\\EditPublicLinkPopup")
+	 * there is no real __construct() that can take arguments
+	 * In the rest of the class we can use $this->detailsDialogElement to find
+	 * other elements to make sure that we are searching in the right place
+	 *
+	 * @param NodeElement $detailsDialogElement
+	 *
+	 * @return void
+	 */
+	public function setElement(NodeElement $detailsDialogElement) {
+		$this->detailsDialogElement = $detailsDialogElement;
+	}
+
+	/**
 	 * Lookup the id for the requested details tab.
 	 * If the id is not known, then return the passed-in parameter as the id.
 	 *
@@ -94,7 +117,7 @@ class DetailsDialog extends OwncloudPage {
 	 * @return NodeElement
 	 */
 	private function findDetailsTab($tabName) {
-		$tab = $this->findById(
+		$tab = $this->detailsDialogElement->findById(
 			$this->getDetailsTabId($tabName)
 		);
 		$this->assertElementNotNull(
@@ -122,7 +145,9 @@ class DetailsDialog extends OwncloudPage {
 	 * @return string
 	 */
 	public function getVersionsList() {
-		$versionsList = $this->find("xpath", $this->versionsListXpath);
+		$versionsList = $this->detailsDialogElement->find(
+			"xpath", $this->versionsListXpath
+		);
 		$this->assertElementNotNull(
 			$versionsList,
 			__METHOD__ .
@@ -138,7 +163,9 @@ class DetailsDialog extends OwncloudPage {
 	 * @return void
 	 */
 	public function getLastVersionRevertButton() {
-		$btn = $this->find("xpath", $this->lastVersionRevertButton);
+		$btn = $this->detailsDialogElement->find(
+			"xpath", $this->lastVersionRevertButton
+		);
 		$this->assertElementNotNull(
 			$btn,
 			__METHOD__ .
@@ -159,7 +186,7 @@ class DetailsDialog extends OwncloudPage {
 	public function changeDetailsTab($tabName) {
 		$tabId = $this->getDetailsTabId($tabName);
 		$tabSwitchXpath = "//li[@data-tabid='" . $tabId . "']";
-		$tabSwitch = $this->find("xpath", $tabSwitchXpath);
+		$tabSwitch = $this->detailsDialogElement->find("xpath", $tabSwitchXpath);
 		$this->assertElementNotNull(
 			$tabSwitch,
 			__METHOD__ .
@@ -176,13 +203,7 @@ class DetailsDialog extends OwncloudPage {
 	 * @return bool
 	 */
 	public function isDialogVisible() {
-		try {
-			$dialog = $this->find("xpath", $this->detailsDialogXpath);
-			$visible = $dialog !== null;
-		} catch (ElementNotFoundException $e) {
-			$visible = false;
-		}
-		return $visible;
+		return $this->detailsDialogElement->isVisible();
 	}
 
 	/**
@@ -191,10 +212,9 @@ class DetailsDialog extends OwncloudPage {
 	 * @return NodeElement[]
 	 */
 	public function getCommentList() {
-		$this->waitTillElementIsNotNull($this->detailsDialogXpath);
-		$dialog = $this->find("xpath", $this->detailsDialogXpath);
-		$commentList = $dialog->findAll("xpath", $this->commentListXpath);
-		return  $commentList;
+		return $this->detailsDialogElement->findAll(
+			"xpath", $this->commentListXpath
+		);
 	}
 	/**
 	 * check if a comment with given text is listed in the webUI
@@ -225,9 +245,25 @@ class DetailsDialog extends OwncloudPage {
 	 * @return void
 	 */
 	public function addComment($content) {
-		$commentInput = $this->find("xpath", $this->commentInputXpath);
+		$commentInput = $this->detailsDialogElement->find(
+			"xpath", $this->commentInputXpath
+		);
+		$this->assertElementNotNull(
+			$commentInput,
+			__METHOD__ .
+			" xpath: $this->commentInputXpath" .
+			"could not find comment input field"
+		);
 		$commentInput->setValue($content);
-		$postButton = $this->find("xpath", $this->commentPostXpath);
+		$postButton = $this->detailsDialogElement->find(
+			"xpath", $this->commentPostXpath
+		);
+		$this->assertElementNotNull(
+			$commentInput,
+			__METHOD__ .
+			" xpath: $this->commentPostXpath" .
+			"could not find comment post button"
+		);
 		$postButton->focus();
 		$postButton->click();
 		$this->waitTillElementIsNotNull($this->getCommentXpath($content));
@@ -242,19 +278,46 @@ class DetailsDialog extends OwncloudPage {
 	 *
 	 */
 	public function deleteComment($content) {
-		$commentList = $this->find("xpath", $this->getCommentXpath($content));
+		$commentList = $this->detailsDialogElement->find(
+			"xpath", $this->getCommentXpath($content)
+		);
+		$this->assertElementNotNull(
+			$commentList,
+			__METHOD__ .
+			" could not find comment with conteht $content"
+		);
 		$this->waitTillElementIsNotNull($this->commentListXpath);
 
 		$this->waitTillElementIsNotNull($this->commentEditButtonXpath);
 		$commentEditButton = $commentList->getParent()->find("xpath", $this->commentEditButtonXpath);
+		$this->assertElementNotNull(
+			$commentEditButton,
+			__METHOD__ .
+			" xpath: $this->commentEditButtonXpath" .
+			"could not find comment edit button"
+		);
 		$commentEditButton->focus();
 		$commentEditButton->click();
 
 		$this->waitTillElementIsNotNull($this->commentEditFormXpath);
-		$commentEditForm = $this->find("xpath", $this->commentEditFormXpath);
+		$commentEditForm = $this->detailsDialogElement->find("xpath", $this->commentEditFormXpath);
+		$this->assertElementNotNull(
+			$commentEditForm,
+			__METHOD__ .
+			" xpath: $this->commentEditFormXpath" .
+			"could not find comment edit form"
+		);
 		$commentEditForm->focus();
 
-		$commentDeleteButton = $commentEditForm->find("xpath", $this->commentDeleteButtonXpath);
+		$commentDeleteButton = $commentEditForm->find(
+			"xpath", $this->commentDeleteButtonXpath
+		);
+		$this->assertElementNotNull(
+			$commentDeleteButton,
+			__METHOD__ .
+			" xpath: $this->commentDeleteButtonXpath" .
+			"could not find comment delete button form"
+		);
 		$commentDeleteButton->focus();
 		$commentDeleteButton->click();
 	}
@@ -281,7 +344,9 @@ class DetailsDialog extends OwncloudPage {
 	 * @return NodeElement of the whole container holding the thumbnail
 	 */
 	public function findThumbnailContainer() {
-		$thumbnailContainer = $this->find("xpath", $this->thumbnailContainerXpath);
+		$thumbnailContainer = $this->detailsDialogElement->find(
+			"xpath", $this->thumbnailContainerXpath
+		);
 		$this->assertElementNotNull(
 			$thumbnailContainer,
 			__METHOD__ .
@@ -319,7 +384,7 @@ class DetailsDialog extends OwncloudPage {
 	 * @throws ElementNotFoundException
 	 */
 	public function insertTagNameInTheTagsField($tagName) {
-		$inputField = $this->find(
+		$inputField = $this->detailsDialogElement->find(
 			"xpath",
 			$this->tagsContainer . $this->tagsInputXpath
 		);
@@ -389,10 +454,24 @@ class DetailsDialog extends OwncloudPage {
 			if ($tag->getText() === $tagName) {
 				$tagContainer = $tag->getParent();
 				$editBtn = $tagContainer->find("xpath", $this->tagEditButtonInTagXpath);
+				$this->assertElementNotNull(
+					$editBtn,
+					__METHOD__ .
+					" xpath: $this->tagEditButtonInTagXpath" .
+					"could not find tag edit button"
+				);
 				$editBtn->focus();
 				$editBtn->click();
 
-				$deleteBtn = $this->find("xpath", $this->tagDeleteButtonInTagXpath);
+				$deleteBtn = $this->find(
+					"xpath", $this->tagDeleteButtonInTagXpath
+				);
+				$this->assertElementNotNull(
+					$deleteBtn,
+					__METHOD__ .
+					" xpath: $this->tagDeleteButtonInTagXpath" .
+					" could not find tag edit button"
+				);
 				$deleteBtn->focus();
 				$deleteBtn->click();
 			}
@@ -425,7 +504,9 @@ class DetailsDialog extends OwncloudPage {
 	 * @return void
 	 */
 	public function closeDetailsDialog() {
-		$detailsDialogCloseButton = $this->find("xpath", $this->detailsDialogCloseXpath);
+		$detailsDialogCloseButton = $this->detailsDialogElement->find(
+			"xpath", $this->detailsDialogCloseXpath
+		);
 		$this->assertElementNotNull(
 			$detailsDialogCloseButton,
 			__METHOD__ .


### PR DESCRIPTION
## Description
improve the details dialog page

- move getDetailsDialog as every files page can show those: every type of a files page can have a details dialog, so move it to FilePageBasic
- wait till details dialog is loaded: wait in appropriate places till the dialog is loaded, and wait when receiving a `StaleElementReference`
- use always the details dialog element inside the dialog pageobject: set the NodeElement of the dialog in the pageobject and run `find()` from inside that element where-ever possible. This makes sure we don't accidentally find elements that are outside the dialog
- check visibility of thumbnail: actually check if the thumbnail is visible

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33330 at least I hope so

## Motivation and Context
make the UI tests more robust 

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
