### PR TITLE
Given when step separation 201811

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -38,7 +38,8 @@ trait AppConfiguration {
 	private $webUIGeneralContext;
 
 	/**
-	 * @var string the original capabilities in XML format
+	 * @var array with keys for each baseURL (e.g. of local and remote server)
+	 *            that contain the original capabilities in XML format
 	 */
 	private $savedCapabilitiesXml;
 	
@@ -158,8 +159,19 @@ trait AppConfiguration {
 	 *
 	 * @return void
 	 */
-	public function userGetsCapabilitiesCheckResponse($username) {
+	public function userGetsCapabilities($username) {
 		$this->userSendsToOcsApiEndpoint($username, 'GET', '/cloud/capabilities');
+	}
+
+	/**
+	 * @Given user :username has retrieved the capabilities
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function userGetsCapabilitiesCheckResponse($username) {
+		$this->userGetsCapabilities($username);
 		PHPUnit_Framework_Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
@@ -170,12 +182,30 @@ trait AppConfiguration {
 	 *
 	 * @return void
 	 */
-	public function getCapabilitiesCheckResponse() {
+	public function theUserGetsCapabilities() {
+		$this->userGetsCapabilities($this->getCurrentUser());
+	}
+
+	/**
+	 * @Given the user has retrieved the capabilities
+	 *
+	 * @return void
+	 */
+	public function theUserGetsCapabilitiesCheckResponse() {
 		$this->userGetsCapabilitiesCheckResponse($this->getCurrentUser());
 	}
 
 	/**
 	 * @When the administrator retrieves the capabilities using the capabilities API
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsCapabilities() {
+		$this->userGetsCapabilities($this->getAdminUsername());
+	}
+
+	/**
+	 * @Given the administrator has retrieved the capabilities
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -36,7 +36,7 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	protected function resetAppConfigs() {
 		// Remember the current capabilities
-		$this->getCapabilitiesCheckResponse();
+		$this->theAdministratorGetsCapabilitiesCheckResponse();
 		$this->savedCapabilitiesXml[$this->getBaseUrl()] = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
 		$this->setCapabilities($this->getCommonSharingConfigs());

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -218,12 +218,9 @@ trait Provisioning {
 	 * @throws \Exception
 	 */
 	public function adminCreatesUserUsingTheProvisioningApi($user) {
-		if (!$this->userExists($user)) {
-			$this->createUser(
-				$user, null, null, null, true, 'api'
-			);
-		}
-		$this->userShouldExist($user);
+		$this->createUser(
+			$user, null, null, null, true, 'api'
+		);
 	}
 
 	/**
@@ -296,10 +293,10 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function adminResetsUserPasswordUsingTheProvisioningApi(
+	public function adminChangesPasswordOfUserToUsingTheProvisioningApi(
 		$user, $password
 	) {
-		$result = UserHelper::editUser(
+		$this->response = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$user,
 			'password',
@@ -307,13 +304,29 @@ trait Provisioning {
 			$this->getAdminUsername(),
 			$this->getAdminPassword()
 		);
-		if ($result->getStatusCode() !== 200) {
-			throw new \Exception(
-				"could not change password of user. "
-				. $result->getStatusCode() . " " . $result->getBody()
-			);
-		}
 	}
+
+	/**
+	 * @Given the administrator has changed the password of user :user to :password
+	 *
+	 * @param string $user
+	 * @param string $password
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function adminHasChangedPasswordOfUserTo(
+		$user, $password
+	) {
+		$this->adminChangesPasswordOfUserToUsingTheProvisioningApi(
+			$user, $password
+		);
+		$this->theHTTPStatusCodeShouldBe(
+			200,
+			"could not change password of user $user"
+		);
+	}
+
 	/**
 	 * @When /^user "([^"]*)" (enables|disables) app "([^"]*)"$/
 	 *
@@ -402,6 +415,7 @@ trait Provisioning {
 	public function theAdministratorCreatesUserPasswordGroupUsingTheProvisioningApi(
 		$user, $password, $group
 	) {
+		$password = $this->getActualPassword($password);
 		$bodyTable = new TableNode(
 			[['userid', $user], ['password', $password], ['groups[]', $group]]
 		);
@@ -505,17 +519,16 @@ trait Provisioning {
 
 	/**
 	 * @When /^the administrator changes the email of user "([^"]*)" to "([^"]*)" using the provisioning API$/
-	 * @Given /^the administrator has changed the email of user "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $email
 	 *
 	 * @return void
 	 */
-	public function adminChangesTheEmailOfTheUserUsingTheProvisioningApi(
+	public function adminChangesTheEmailOfUserToUsingTheProvisioningApi(
 		$user, $email
 	) {
-		$result = UserHelper::editUser(
+		$this->response = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$this->getActualUsername($user),
 			'email',
@@ -524,13 +537,24 @@ trait Provisioning {
 			$this->getAdminPassword(),
 			$this->ocsApiVersion
 		);
-		$this->response = $result;
-		if ($result->getStatusCode() !== 200) {
-			throw new \Exception(
-				"could not change email of user. "
-				. $result->getStatusCode() . " " . $result->getBody()
-			);
-		}
+	}
+
+	/**
+	 * @Given /^the administrator has changed the email of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $email
+	 *
+	 * @return void
+	 */
+	public function adminHasChangedTheEmailOfUserTo($user, $email) {
+		$this->adminChangesTheEmailOfUserToUsingTheProvisioningApi(
+			$user, $email
+		);
+		$this->theHTTPStatusCodeShouldBe(
+			200,
+			"could not change email of user $user"
+		);
 	}
 
 	/**
@@ -542,7 +566,7 @@ trait Provisioning {
 	 */
 	public function theAdministratorHasChangedTheirOwnEmailAddressTo($email) {
 		$admin = $this->getAdminUsername();
-		$this->adminChangesTheEmailOfTheUserUsingTheProvisioningApi($admin, $email);
+		$this->adminHasChangedTheEmailOfUserTo($admin, $email);
 	}
 
 	/**
@@ -558,7 +582,7 @@ trait Provisioning {
 	public function userChangesTheEmailOfUserUsingTheProvisioningApi(
 		$requestingUser, $targetUser, $email
 	) {
-		$result = UserHelper::editUser(
+		$this->response = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$this->getActualUsername($targetUser),
 			'email',
@@ -567,7 +591,6 @@ trait Provisioning {
 			$this->getPasswordForUser($requestingUser),
 			$this->ocsApiVersion
 		);
-		$this->response = $result;
 	}
 
 	/**
@@ -722,14 +745,13 @@ trait Provisioning {
 
 	/**
 	 * @When /^the administrator changes the quota of user "([^"]*)" to "([^"]*)" using the provisioning API$/
-	 * @Given /^the administrator has changed the quota of user "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $quota
 	 *
 	 * @return void
 	 */
-	public function adminChangesTheQuotaOfTheUserUsingTheProvisioningApi(
+	public function adminChangesTheQuotaOfUserUsingTheProvisioningApi(
 		$user, $quota
 	) {
 		$result = UserHelper::editUser(
@@ -742,12 +764,26 @@ trait Provisioning {
 			$this->ocsApiVersion
 		);
 		$this->response = $result;
-		if ($result->getStatusCode() !== 200) {
-			throw new \Exception(
-				"could not change quota of user. "
-				. $result->getStatusCode() . " " . $result->getBody()
-			);
-		}
+	}
+
+	/**
+	 * @Given /^the administrator has changed the quota of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $quota
+	 *
+	 * @return void
+	 */
+	public function adminHasChangedTheQuotaOfUserTo(
+		$user, $quota
+	) {
+		$this->adminChangesTheQuotaOfUserUsingTheProvisioningApi(
+			$user, $quota
+		);
+		$this->theHTTPStatusCodeShouldBe(
+			200,
+			"could not change quota of user $user"
+		);
 	}
 
 	/**
@@ -901,7 +937,6 @@ trait Provisioning {
 
 	/**
 	 * @When /^the administrator deletes user "([^"]*)" using the provisioning API$/
-	 * @Given /^user "([^"]*)" has been deleted$/
 	 *
 	 * @param string $user
 	 *
@@ -909,6 +944,18 @@ trait Provisioning {
 	 * @throws \Exception
 	 */
 	public function adminDeletesUserUsingTheProvisioningApi($user) {
+		$this->deleteTheUserUsingTheProvisioningApi($user);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has been deleted$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userHasBeenDeleted($user) {
 		if ($this->userExists($user)) {
 			$this->deleteTheUserUsingTheProvisioningApi($user);
 		}
@@ -1248,11 +1295,7 @@ trait Provisioning {
 	 * @throws \Exception
 	 */
 	public function adminAddsUserToGroupUsingTheProvisioningApi($user, $group) {
-		if (!$this->userBelongsToGroup($user, $group)) {
-			$this->userHasBeenAddedToGroup($user, $group);
-		}
-
-		$this->userShouldBelongToGroup($user, $group);
+		$this->addUserToGroup($user, $group);
 	}
 
 	/**
@@ -1260,12 +1303,24 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $group
-	 * @param string $method how to add the user to the group api|occ
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function userHasBeenAddedToGroup($user, $group, $method = null) {
+	public function userHasBeenAddedToGroup($user, $group) {
+		$this->addUserToGroup($user, $group, null, true);
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $group
+	 * @param string $method how to add the user to the group api|occ
+	 * @param bool $checkResult if true, then check the status of the operation. default false.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function addUserToGroup($user, $group, $method = null, $checkResult = false) {
 		$user = $this->getActualUsername($user);
 		if ($method === null && \getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
 			//guess yourself
@@ -1282,7 +1337,7 @@ trait Provisioning {
 					$this->getAdminUsername(),
 					$this->getAdminPassword()
 				);
-				if ($result->getStatusCode() !== 200) {
+				if ($checkResult && ($result->getStatusCode() !== 200)) {
 					throw new Exception(
 						"could not add user to group. "
 						. $result->getStatusCode() . " " . $result->getBody()
@@ -1291,7 +1346,7 @@ trait Provisioning {
 				break;
 			case "occ":
 				$result = SetupHelper::addUserToGroup($group, $user);
-				if ($result["code"] != 0) {
+				if ($checkResult && ($result["code"] != 0)) {
 					throw new Exception(
 						"could not add user to group. {$result['stdOut']} {$result['stdErr']}"
 					);
@@ -1314,10 +1369,11 @@ trait Provisioning {
 	 * @param string $group
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function theAdministratorHasBeenAddedToGroup($group) {
 		$admin = $this->getAdminUsername();
-		$this->userHasBeenAddedToGroup($admin, $group);
+		$this->addUserToGroup($admin, $group, null, true);
 	}
 
 	/**
@@ -1429,7 +1485,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function adminTriesToSendGroupCreationRequestUsingTheAPI($group) {
-		$this->adminSendsGroupCreationRequestUsingTheAPI($group);
+		$this->adminSendsGroupCreationRequestUsingTheProvisioningApi($group);
 		$this->rememberThatGroupIsNotExpectedToExist($group);
 	}
 
@@ -1629,7 +1685,6 @@ trait Provisioning {
 
 	/**
 	 * @When /^the administrator makes user "([^"]*)" a subadmin of group "([^"]*)" using the provisioning API$/
-	 * @Given /^user "([^"]*)" has been made a subadmin of group "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1645,6 +1700,22 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::post(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword(), null,
 			$body
+		);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has been made a subadmin of group "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function userHasBeenMadeSubadminOfGroup(
+		$user, $group
+	) {
+		$this->adminMakesUserSubadminOfGroupUsingTheProvisioningApi(
+			$user, $group
 		);
 		PHPUnit_Framework_Assert::assertEquals(
 			200, $this->response->getStatusCode()
@@ -2097,7 +2168,6 @@ trait Provisioning {
 
 	/**
 	 * @When the administrator sets the quota of user :user to :quota using the provisioning API
-	 * @Given the quota of user :user has been set to :quota
 	 *
 	 * @param string $user
 	 * @param string $quota
@@ -2120,15 +2190,23 @@ trait Provisioning {
 			$body,
 			2
 		);
+	}
 
-		PHPUnit_Framework_Assert::assertEquals(
-			200, $this->response->getStatusCode()
-		);
+	/**
+	 * @Given the quota of user :user has been set to :quota
+	 *
+	 * @param string $user
+	 * @param string $quota
+	 *
+	 * @return void
+	 */
+	public function theQuotaOfUserHasBeenSetTo($user, $quota) {
+		$this->adminSetsUserQuotaToUsingTheProvisioningApi($user, $quota);
+		$this->theHTTPStatusCodeShouldBe(200);
 	}
 
 	/**
 	 * @When the administrator gives unlimited quota to user :user using the provisioning API
-	 * @Given user :user has been given unlimited quota
 	 *
 	 * @param string $user
 	 *
@@ -2136,6 +2214,17 @@ trait Provisioning {
 	 */
 	public function adminGivesUnlimitedQuotaToUserUsingTheProvisioningApi($user) {
 		$this->adminSetsUserQuotaToUsingTheProvisioningApi($user, 'none');
+	}
+
+	/**
+	 * @Given user :user has been given unlimited quota
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userHasBeeenGivenUnlimitedQuota($user) {
+		$this->theQuotaOfUserHasBeenSetTo($user, 'none');
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -644,7 +644,6 @@ trait Sharing {
 
 	/**
 	 * @When /^the user adds an expiration date to the last share using the sharing API$/
-	 * @Given /^the user has added an expiration date to the last share$/
 	 *
 	 * @return void
 	 */
@@ -658,6 +657,15 @@ trait Sharing {
 			$fullUrl, $this->currentUser,
 			$this->getPasswordForUser($this->currentUser), null, $body
 		);
+	}
+
+	/**
+	 * @Given /^the user has added an expiration date to the last share$/
+	 *
+	 * @return void
+	 */
+	public function theUserHasAddedExpirationDateToLastShare() {
+		$this->theUserAddsExpirationDateToLastShare();
 		PHPUnit_Framework_Assert::assertEquals(
 			200,
 			$this->response->getStatusCode()
@@ -914,7 +922,6 @@ trait Sharing {
 
 	/**
 	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
-	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))?$/
 	 *
 	 * @param string $user1
 	 * @param string $filepath
@@ -952,6 +959,24 @@ trait Sharing {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $user1, $this->getPasswordForUser($user1)
 		);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))?$/
+	 *
+	 * @param string $user1
+	 * @param string $filepath
+	 * @param string $user2
+	 * @param int $permissions
+	 *
+	 * @return void
+	 */
+	public function userHasSharedFileWithUserUsingTheSharingApi(
+		$user1, $filepath, $user2, $permissions = null
+	) {
+		$this->userSharesFileWithUserUsingTheSharingApi(
+			$user1, $filepath, $user2, $permissions
+		);
 		PHPUnit_Framework_Assert::assertTrue(
 			$this->isUserOrGroupInSharedData($user2, $permissions),
 			"User $user1 failed to share $filepath with user $user2"
@@ -971,14 +996,13 @@ trait Sharing {
 		$sharer, $filepath, $permissions = null
 	) {
 		$admin = $this->getAdminUsername();
-		$this->userSharesFileWithUserUsingTheSharingApi(
+		$this->userHasSharedFileWithUserUsingTheSharingApi(
 			$sharer, $filepath, $admin, $permissions = null
 		);
 	}
 
 	/**
 	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
-	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))?$/
 	 *
 	 * @param string $filepath
 	 * @param string $user2
@@ -995,8 +1019,24 @@ trait Sharing {
 	}
 
 	/**
+	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))?$/
+	 *
+	 * @param string $filepath
+	 * @param string $user2
+	 * @param int $permissions
+	 *
+	 * @return void
+	 */
+	public function theUserHasSharedFileWithUserUsingTheSharingApi(
+		$filepath, $user2, $permissions = null
+	) {
+		$this->userHasSharedFileWithUserUsingTheSharingApi(
+			$this->getCurrentUser(), $filepath, $user2, $permissions
+		);
+	}
+
+	/**
 	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
-	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
 	 *
 	 * @param string $filepath
 	 * @param string $group
@@ -1013,8 +1053,24 @@ trait Sharing {
 	}
 
 	/**
+	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
+	 *
+	 * @param string $filepath
+	 * @param string $group
+	 * @param int $permissions
+	 *
+	 * @return void
+	 */
+	public function theUserHasSharedFileWithGroupUsingTheSharingApi(
+		$filepath, $group, $permissions = null
+	) {
+		$this->userHasSharedFileWithGroupUsingTheSharingApi(
+			$this->currentUser, $filepath, $group, $permissions
+		);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
-	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
 	 *
 	 * @param string $user
 	 * @param string $filepath
@@ -1040,6 +1096,24 @@ trait Sharing {
 		}
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $user, $this->getPasswordForUser($user)
+		);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
+	 *
+	 * @param string $user
+	 * @param string $filepath
+	 * @param string $group
+	 * @param int $permissions
+	 *
+	 * @return void
+	 */
+	public function userHasSharedFileWithGroupUsingTheSharingApi(
+		$user, $filepath, $group, $permissions = null
+	) {
+		$this->userSharesFileWithGroupUsingTheSharingApi(
+			$user, $filepath, $group, $permissions
 		);
 
 		PHPUnit_Framework_Assert::assertEquals(
@@ -1454,7 +1528,6 @@ trait Sharing {
 
 	/**
 	 * @When /^user "([^"]*)" (declines|accepts) the share "([^"]*)" offered by user "([^"]*)" using the sharing API$/
-	 * @Given /^user "([^"]*)" has (declined|accepted) the share "([^"]*)" offered by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -1462,6 +1535,7 @@ trait Sharing {
 	 * @param string $offeredBy
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function userReactsToShareOfferedBy($user, $action, $share, $offeredBy) {
 		$dataResponded = $this->getAllSharesSharedWithUser($user);
@@ -1491,11 +1565,25 @@ trait Sharing {
 		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, $httpRequestMethod, $url, null
 		);
-		if ($this->response->getStatusCode() !== 200) {
-			throw new Exception(
-				__METHOD__ . " could not $action share"
-			);
-		}
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has (declined|accepted) the share "([^"]*)" offered by user "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $action
+	 * @param string $share
+	 * @param string $offeredBy
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userHasReactedToShareOfferedBy($user, $action, $share, $offeredBy) {
+		$this->userReactsToShareOfferedBy($user, $action, $share, $offeredBy);
+		$this->theHTTPStatusCodeShouldBe(
+			200,
+			__METHOD__ . " could not $action share to $user by $offeredBy"
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -32,8 +32,6 @@ use TestHelpers\SetupHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use Sabre\DAV\Xml\Property\Complex;
-use PhpParser\Node\Stmt\TryCatch;
-use Behat\Behat\Definition\Call\Given;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -1108,10 +1106,9 @@ trait WebDav {
 		$properties = [
 			   $propertyName
 		];
-		$response = $client->propfind(
+		$this->response = $client->propfind(
 			$this->makeSabrePath($user, $path), $properties
 		);
-		$this->response = $response;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Separate various steps that had both ``When`` and ``Given`` forms combined in a single step, and had tests included (e.g. various assert, or status code checks). The ``When`` form now does the action without the checks.

## Motivation and Context
``When`` steps should do actions, remember responses, but not actually check if the action succeeds. It is the job of ``Then`` steps to say what the expected result is (HTTP status, file exists...)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
