### PR TITLE
Add new test step theResponseWhenUserGetsInfoOfLastShareShouldInclude

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1174,6 +1174,25 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then /^the response when user "([^"]*)" gets the info of the last share should include$/
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function theResponseWhenUserGetsInfoOfLastShareShouldInclude(
+		$user, $body
+	) {
+		$this->userGetsInfoOfLastShareUsingTheSharingApi($user);
+		$this->theHTTPStatusCodeShouldBe(
+			200,
+			"Error getting info of last share for user $user"
+		);
+		$this->checkFields($body);
+	}
+
+	/**
 	 * @Then /^the last share_id should be included in the response/
 	 *
 	 * @return void


### PR DESCRIPTION
## Description
Create a new combined acceptance test step ``theResponseWhenUserGetsInfoOfLastShareShouldInclude``

## Motivation and Context
In some app acceptance tests we have scenarios like:
```
    When user "user0" creates a public link share of file "confidential.docx" using the sharing API
    Then the HTTP status code should be "200"
    And the OCS status code should be "<ocs-status>"
    When user "user0" gets the info of the last share using the sharing API
    Then the fields of the last response should include
      | item_type   | file                                                                    |
      | share_type  | 3                                                                       |
...
```
It will be handy to have a combined ``Then`` step that gets the info and checks the response fields.

## How Has This Been Tested?
Make a "dummy" scenario locally in core that uses the new test.
Run the scenario and confirm it passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
