### PR TITLE
Adjust expected permissions pattern in search.feature:151

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -164,7 +164,7 @@ Feature: Search
     And the folder "/upload folder" in the search result of "user0" should contain these properties:
       | name                                       | value                                                                                             |
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
-      | {http://owncloud.org/ns}permissions        | ^(RDNVCK\|RMDNVW)$                                                                                |
+      | {http://owncloud.org/ns}permissions        | ^(RDNVCK\|RMDNVCK)$                                                                                |
       | {DAV:}getlastmodified                      | ^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$ |
       | {DAV:}getetag                              | ^\"[a-f0-9]{1,32}\"$                                                                              |
       | {http://owncloud.org/ns}size               | 0                                                                                                 |


### PR DESCRIPTION
## Description
A new scenario ``search.feature:151`` was added recently https://github.com/owncloud/core/commit/00e4cb5ae9d0400288aa2b756cf8af210ba92357#diff-ae5bea7f7c2555ccea2cf0e53f0a7ab1R151

It expects certain permissions of a file/folder. It looks like the permissions were copied from an existing scenario, and one of the alternative values was modified to be correct for the "ordinary file system" case. But the other, which has the ``M`` in the permissions list, was not modified.

Fix the expected permissions string.

## Motivation and Context
Test fail in ``files_primary_s3`` https://drone.owncloud.com/owncloud/files_primary_s3/663/512
```
  Scenario Outline: report extra properties in search entries for a folder                           # /drone/server/tests/acceptance/features/apiWebdavOperations/search.feature:151
    Given using <dav_version> DAV path                                                               # FeatureContext::usingOldOrNewDavPath()
    When user "user0" searches for "upload" using the WebDAV API requesting these properties:        # SearchContext::userSearchesUsingWebDavAPI()
      | oc:fileid             |
      | oc:permissions        |
      | a:getlastmodified     |
      | a:getetag             |
      | a:getcontenttype      |
      | oc:size               |
      | oc:owner-id           |
      | oc:owner-display-name |
      | oc:size               |
    Then the HTTP status code should be "207"                                                        # FeatureContext::theHTTPStatusCodeShouldBe()
    And the folder "/upload folder" in the search result of "user0" should contain these properties: # SearchContext::fileOrFolderInTheSearchResultShouldContainProperties()
      | name                                       | value                                                                                             |
      | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
      | {http://owncloud.org/ns}permissions        | ^(RDNVCK|RMDNVW)$                                                                                 |
      | {DAV:}getlastmodified                      | ^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$ |
      | {DAV:}getetag                              | ^\"[a-f0-9]{1,32}\"$                                                                              |
      | {http://owncloud.org/ns}size               | 0                                                                                                 |
      | {http://owncloud.org/ns}owner-id           | user0                                                                                             |
      | {http://owncloud.org/ns}owner-display-name | User Zero                                                                                         |

    Examples:
      | dav_version |
      | old         |
        Failed asserting that 'RMDNVCK' matches PCRE pattern "/^(RDNVCK|RMDNVW)$/".
      | new         |
        Failed asserting that 'RMDNVCK' matches PCRE pattern "/^(RDNVCK|RMDNVW)$/".
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
