### PR TITLE
Remove more "the" in acceptance test steps 20181118

### DIFF
--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -9,7 +9,7 @@ Feature: favorite
   Scenario Outline: Favorite a folder
     Given using <dav_version> DAV path
     When the user favorites element "/FOLDER" using the WebDAV API
-    Then as the user the folder "/FOLDER" should be favorited
+    Then as the user folder "/FOLDER" should be favorited
     Examples:
       | dav_version |
       | old         |
@@ -19,7 +19,7 @@ Feature: favorite
     Given using <dav_version> DAV path
     When the user favorites element "/FOLDER" using the WebDAV API
     And the user unfavorites element "/FOLDER" using the WebDAV API
-    Then as the user the folder "/FOLDER" should not be favorited
+    Then as the user folder "/FOLDER" should not be favorited
     Examples:
       | dav_version |
       | old         |
@@ -29,7 +29,7 @@ Feature: favorite
   Scenario Outline: Favorite a file
     Given using <dav_version> DAV path
     When the user favorites element "/textfile0.txt" using the WebDAV API
-    Then as the user the file "/textfile0.txt" should be favorited
+    Then as the user file "/textfile0.txt" should be favorited
     Examples:
       | dav_version |
       | old         |
@@ -40,7 +40,7 @@ Feature: favorite
     Given using <dav_version> DAV path
     When the user favorites element "/textfile0.txt" using the WebDAV API
     And the user unfavorites element "/textfile0.txt" using the WebDAV API
-    Then as the user the file "/textfile0.txt" should not be favorited
+    Then as the user file "/textfile0.txt" should not be favorited
     Examples:
       | dav_version |
       | old         |
@@ -123,7 +123,7 @@ Feature: favorite
     And the user has moved file "/textfile0.txt" to "/favoriteFile.txt"
     And the user has shared file "/favoriteFile.txt" with user "user1"
     When the user favorites element "/favoriteFile.txt" using the WebDAV API
-    Then as user "user1" the file "/favoriteFile.txt" should not be favorited
+    Then as user "user1" file "/favoriteFile.txt" should not be favorited
     Examples:
       | dav_version |
       | old         |
@@ -135,7 +135,7 @@ Feature: favorite
     And the user has moved file "/textfile0.txt" to "/favoriteFile.txt"
     And the user has shared file "/favoriteFile.txt" with user "user1"
     When user "user1" favorites element "/favoriteFile.txt" using the WebDAV API
-    Then as the user the file "/favoriteFile.txt" should not be favorited
+    Then as the user file "/favoriteFile.txt" should not be favorited
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -28,7 +28,7 @@ Feature: checksums
   Scenario Outline: Uploading a file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" downloads the file "/myChecksumFile.txt" using the WebDAV API
+    When user "user0" downloads file "/myChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
       | dav_version |
@@ -49,7 +49,7 @@ Feature: checksums
     Given using old DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
-    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the WebDAV API
+    And user "user0" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   Scenario: Uploading a chunked file with checksum should return the checksum in the propfind
@@ -65,7 +65,7 @@ Feature: checksums
     And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
-    When user "user0" downloads the file "/myChecksumFile.txt" using the WebDAV API
+    When user "user0" downloads file "/myChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
 
   @local_storage
@@ -74,9 +74,9 @@ Feature: checksums
     # Create the file directly in local storage, bypassing ownCloud
     And file "prueba_cksum.txt" with text "Test file for checksums" has been created in local storage on the server
     # Do a first download, which will trigger ownCloud to calculate a checksum for the file
-    When user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
+    When user "user0" downloads file "/local_storage/prueba_cksum.txt" using the WebDAV API
     # Now do a download that is expected to have a checksum with it
-    And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
+    And user "user0" downloads file "/local_storage/prueba_cksum.txt" using the WebDAV API
     Then the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
     Examples:
       | dav_version |
@@ -87,7 +87,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
-    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the WebDAV API
+    And user "user0" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
       | dav_version |
@@ -104,7 +104,7 @@ Feature: checksums
     Given using new DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
-    And user "user0" downloads the file "/myChecksumFileCopy.txt" using the WebDAV API
+    And user "user0" downloads file "/myChecksumFileCopy.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
@@ -218,7 +218,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And file "/chksumtst.txt" has been deleted for user "user0"
     And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
-    When user "user0" downloads the file "/chksumtst.txt" using the WebDAV API
+    When user "user0" downloads file "/chksumtst.txt" using the WebDAV API
     Then the following headers should be set
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
@@ -231,7 +231,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And file "/local_storage/chksumtst.txt" has been deleted for user "user0"
     And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
-    When user "user0" downloads the file "/local_storage/chksumtst.txt" using the WebDAV API
+    When user "user0" downloads file "/local_storage/chksumtst.txt" using the WebDAV API
     Then the following headers should be set
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -27,8 +27,8 @@ Feature: external-storage
     And user "user1" has been created
     And user "user0" has created a folder "/local_storage/foo1"
     When user "user0" moves file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt" using the WebDAV API
-    Then as "user1" the file "/local_storage/foo1/textfile0.txt" should exist
-    And as "user0" the file "/local_storage/foo1/textfile0.txt" should exist
+    Then as "user1" file "/local_storage/foo1/textfile0.txt" should exist
+    And as "user0" file "/local_storage/foo1/textfile0.txt" should exist
 
   Scenario: Move a file out of storage
     Given user "user0" has been created
@@ -36,18 +36,18 @@ Feature: external-storage
     And user "user0" has created a folder "/local_storage/foo2"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
     When user "user1" moves file "/local_storage/foo2/textfile0.txt" to "/local.txt" using the WebDAV API
-    Then as "user1" the file "/local_storage/foo2/textfile0.txt" should not exist
-    And as "user0" the file "/local_storage/foo2/textfile0.txt" should not exist
-    And as "user1" the file "/local.txt" should exist
+    Then as "user1" file "/local_storage/foo2/textfile0.txt" should not exist
+    And as "user0" file "/local_storage/foo2/textfile0.txt" should not exist
+    And as "user1" file "/local.txt" should exist
 
   Scenario: Download a file that exists in filecache but not storage fails with 404
     Given user "user0" has been created
     And user "user0" has created a folder "/local_storage/foo3"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
     And file "foo3/textfile0.txt" has been deleted from local storage on the server
-    When user "user0" downloads the file "local_storage/foo3/textfile0.txt" using the WebDAV API
+    When user "user0" downloads file "local_storage/foo3/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
-    And as "user0" the file "local_storage/foo3/textfile0.txt" should not exist
+    And as "user0" file "local_storage/foo3/textfile0.txt" should not exist
 
   Scenario: Upload a file to external storage while quota is set on home storage
     Given user "user0" has been created

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -24,7 +24,7 @@ Feature: quota
     And the quota of user "user0" has been set to "20 B"
     When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
-    And as "user0" the file "/testquota.txt" should not exist
+    And as "user0" file "/testquota.txt" should not exist
     Examples:
       | dav_version |
       | old         |
@@ -49,7 +49,7 @@ Feature: quota
     And user "user0" has uploaded file with content "test" to "/testquota.txt"
     When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
-    And as "user0" the file "/testquota.txt" should not exist
+    And as "user0" file "/testquota.txt" should not exist
     Examples:
       | dav_version |
       | old         |
@@ -82,7 +82,7 @@ Feature: quota
     And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
     When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
-    And as "user0" the file "/testquota/testquota.txt" should not exist
+    And as "user0" file "/testquota/testquota.txt" should not exist
     Examples:
       | dav_version |
       | old         |
@@ -115,7 +115,7 @@ Feature: quota
     And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
     When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
-    And as "user0" the file "/testquota/testquota.txt" should not exist
+    And as "user0" file "/testquota/testquota.txt" should not exist
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -69,7 +69,7 @@ Feature: transfer-ownership
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
-    And as "user1" the folder "/test" should not exist
+    And as "user1" folder "/test" should not exist
     And using received transfer folder of "user1" as dav path
     And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
@@ -98,7 +98,7 @@ Feature: transfer-ownership
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
-    And as "user1" the folder "/test" should not exist
+    And as "user1" folder "/test" should not exist
 
   @local_storage @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not transfer external storage
@@ -107,7 +107,7 @@ Feature: transfer-ownership
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
-    And as "user1" the folder "/local_storage" should not exist
+    And as "user1" folder "/local_storage" should not exist
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not fail with shared trashed files
@@ -153,8 +153,8 @@ Feature: transfer-ownership
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
-    And as "user1" the folder "/test" should exist
-    And as "user1" the folder "/test/subfolder" should exist
+    And as "user1" folder "/test" should exist
+    And as "user1" folder "/test/subfolder" should exist
 
   Scenario: transferring ownership of an account containing only an empty folder
     Given user "user0" has been created
@@ -164,7 +164,7 @@ Feature: transfer-ownership
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
-    And as "user1" the folder "/test" should exist
+    And as "user1" folder "/test" should exist
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of file shares
@@ -213,7 +213,7 @@ Feature: transfer-ownership
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
     Then the command should have been successful
-    And as "user1" the folder "/test" should not exist
+    And as "user1" folder "/test" should not exist
     And using received transfer folder of "user1" as dav path
     And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
@@ -243,7 +243,7 @@ Feature: transfer-ownership
     When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
-    And as "user1" the folder "/sub/test" should not exist
+    And as "user1" folder "/sub/test" should not exist
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required
   Scenario: transferring ownership of folder shared with transfer recipient and public link created of received share works
@@ -259,7 +259,7 @@ Feature: transfer-ownership
       | path | /test |
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
-    And as "user0" the folder "/test" should not exist
+    And as "user0" folder "/test" should not exist
 
   @local_storage
   Scenario: transferring ownership does not transfer external storage
@@ -269,7 +269,7 @@ Feature: transfer-ownership
     When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
-    And as "user1" the folder "/local_storage" should not exist
+    And as "user1" folder "/local_storage" should not exist
 
   Scenario: transferring ownership fails with invalid source user
     Given user "user0" has been created

--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -315,7 +315,7 @@ Feature: sharing
     When user "user0" shares file "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And as "user1" the folder "/sub" should exist
+    And as "user1" folder "/sub" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -332,7 +332,7 @@ Feature: sharing
     When user "user0" shares file "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And as "user1" the folder "/sub" should exist
+    And as "user1" folder "/sub" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -387,7 +387,7 @@ Feature: sharing
     When user "user0" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And as "user1" the file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" should exist
+    And as "user1" file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -402,7 +402,7 @@ Feature: sharing
     When user "user0" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And as "user1" the file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" should exist
+    And as "user1" file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareManagement/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagement/deleteShare.feature
@@ -42,7 +42,7 @@ Feature: sharing
     And user "user0" has shared folder "/common/sub" with user "user1"
     When user "user0" deletes folder "/common" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "user1" the folder "/sub" should not exist
+    And as "user1" folder "/sub" should not exist
 
   Scenario Outline: sharing subfolder of already shared folder, GET result is correct
     Given using OCS API version "<ocs_api_version>"
@@ -81,10 +81,10 @@ Feature: sharing
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "user1" the file "/shared/shared_file.txt" should not exist
-    And as "user0" the file "/shared/shared_file.txt" should not exist
-    And as "user0" the file "/shared_file.txt" should exist in trash
-    And as "user1" the file "/shared_file.txt" should exist in trash
+    And as "user1" file "/shared/shared_file.txt" should not exist
+    And as "user0" file "/shared/shared_file.txt" should not exist
+    And as "user0" file "/shared_file.txt" should exist in trash
+    And as "user1" file "/shared_file.txt" should exist in trash
 
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
@@ -95,12 +95,12 @@ Feature: sharing
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" deletes folder "/shared/sub" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "user1" the folder "/shared/sub" should not exist
-    And as "user0" the folder "/shared/sub" should not exist
-    And as "user0" the folder "/sub" should exist in trash
-    And as "user0" the file "/sub/shared_file.txt" should exist in trash
-    And as "user1" the folder "/sub" should exist in trash
-    And as "user1" the file "/sub/shared_file.txt" should exist in trash
+    And as "user1" folder "/shared/sub" should not exist
+    And as "user0" folder "/shared/sub" should not exist
+    And as "user0" folder "/sub" should exist in trash
+    And as "user0" file "/sub/shared_file.txt" should exist in trash
+    And as "user1" folder "/sub" should exist in trash
+    And as "user1" file "/sub/shared_file.txt" should exist in trash
 
   @smokeTest
   Scenario Outline: unshare from self
@@ -133,7 +133,7 @@ Feature: sharing
       | permissions | 1      |
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
-    And as "user1" the file "/shared/shared_file.txt" should exist
+    And as "user1" file "/shared/shared_file.txt" should exist
 
   Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
     Given using OCS API version "1"
@@ -146,7 +146,7 @@ Feature: sharing
       | permissions | 4      |
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
-    And as "user0" the file "/shared/shared_file.txt" should exist
+    And as "user0" file "/shared/shared_file.txt" should exist
 
   Scenario: sharee of an upload-only shared folder tries to delete their file in the folder
     Given using OCS API version "1"
@@ -159,4 +159,4 @@ Feature: sharing
     When user "user1" uploads file "data/textfile.txt" to "shared/textfile.txt" using the WebDAV API
     And user "user1" deletes file "/shared/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
-    And as "user0" the file "/shared/textfile.txt" should exist
+    And as "user0" file "/shared/textfile.txt" should exist

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -14,15 +14,15 @@ Feature: sharing
     Given user "user0" has created a folder "/merge-test-outside"
     When user "user0" shares folder "/merge-test-outside" with group "grp1" using the sharing API
     And user "user0" shares folder "/merge-test-outside" with user "user1" using the sharing API
-    Then as "user1" the folder "/merge-test-outside" should exist
-    And as "user1" the folder "/merge-test-outside (2)" should not exist
+    Then as "user1" folder "/merge-test-outside" should exist
+    And as "user1" folder "/merge-test-outside (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
     Given user "user0" has created a folder "/merge-test-outside-perms"
     When user "user0" shares folder "/merge-test-outside-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the sharing API
-    Then as user "user1" the folder "/merge-test-outside-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "/merge-test-outside-perms (2)" should not exist
+    Then as user "user1" folder "/merge-test-outside-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" folder "/merge-test-outside-perms (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups
     Given group "grp4" has been created
@@ -30,8 +30,8 @@ Feature: sharing
     And user "user0" has created a folder "/merge-test-outside-twogroups"
     When user "user0" shares folder "/merge-test-outside-twogroups" with group "grp1" using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups" with group "grp4" using the sharing API
-    Then as "user1" the folder "/merge-test-outside-twogroups" should exist
-    And as "user1" the folder "/merge-test-outside-twogroups (2)" should not exist
+    Then as "user1" folder "/merge-test-outside-twogroups" should exist
+    And as "user1" folder "/merge-test-outside-twogroups (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
     Given group "grp4" has been created
@@ -39,8 +39,8 @@ Feature: sharing
     And user "user0" has created a folder "/merge-test-outside-twogroups-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp4" with permissions 31 using the sharing API
-    Then as user "user1" the folder "/merge-test-outside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" should not exist
+    Then as user "user1" folder "/merge-test-outside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" folder "/merge-test-outside-twogroups-perms (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups and member
     Given group "grp4" has been created
@@ -49,14 +49,14 @@ Feature: sharing
     When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp4" with permissions 31 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the sharing API
-    Then as user "user1" the folder "/merge-test-outside-twogroups-member-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
+    Then as user "user1" folder "/merge-test-outside-twogroups-member-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from inside with group
     Given user "user1" has created a folder "/merge-test-inside-group"
     When user "user1" shares folder "/merge-test-inside-group" with group "grp1" using the sharing API
-    Then as "user1" the folder "/merge-test-inside-group" should exist
-    And as "user1" the folder "/merge-test-inside-group (2)" should not exist
+    Then as "user1" folder "/merge-test-inside-group" should exist
+    And as "user1" folder "/merge-test-inside-group (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from inside with two groups
     Given group "grp4" has been created
@@ -64,9 +64,9 @@ Feature: sharing
     And user "user1" has created a folder "/merge-test-inside-twogroups"
     When user "user1" shares folder "/merge-test-inside-twogroups" with group "grp1" using the sharing API
     And user "user1" shares folder "/merge-test-inside-twogroups" with group "grp4" using the sharing API
-    Then as "user1" the folder "/merge-test-inside-twogroups" should exist
-    And as "user1" the folder "/merge-test-inside-twogroups (2)" should not exist
-    And as "user1" the folder "/merge-test-inside-twogroups (3)" should not exist
+    Then as "user1" folder "/merge-test-inside-twogroups" should exist
+    And as "user1" folder "/merge-test-inside-twogroups (2)" should not exist
+    And as "user1" folder "/merge-test-inside-twogroups (3)" should not exist
 
   Scenario: Merging shares for recipient when shared from inside with group with less permissions
     Given group "grp4" has been created
@@ -74,9 +74,9 @@ Feature: sharing
     And user "user1" has created a folder "/merge-test-inside-twogroups-perms"
     When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API
     And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp4" using the sharing API
-    Then as user "user1" the folder "/merge-test-inside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
-    And as "user1" the folder "/merge-test-inside-twogroups-perms (2)" should not exist
-    And as "user1" the folder "/merge-test-inside-twogroups-perms (3)" should not exist
+    Then as user "user1" folder "/merge-test-inside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
+    And as "user1" folder "/merge-test-inside-twogroups-perms (2)" should not exist
+    And as "user1" folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
   @skip @issue-29016 @skipOnLDAP
   Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
@@ -84,8 +84,8 @@ Feature: sharing
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
-    Then as user "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
+    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
 
   @skipOnLDAP @user_ldap-issue-274
   Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
@@ -93,5 +93,5 @@ Feature: sharing
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
-    Then as user "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-    And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
+    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -25,9 +25,9 @@ Feature: sharing
     And user "user0" has shared file "/sharefile.txt" with user "user1"
     And user "user0" has shared file "/sharefile.txt" with user "user2"
     When user "user2" moves file "/sharefile.txt" to "/renamedsharefile.txt" using the WebDAV API
-    Then as "user2" the file "/renamedsharefile.txt" should exist
-    And as "user0" the file "/sharefile.txt" should exist
-    And as "user1" the file "/sharefile.txt" should exist
+    Then as "user2" file "/renamedsharefile.txt" should exist
+    And as "user0" file "/sharefile.txt" should exist
+    And as "user1" file "/sharefile.txt" should exist
 
   Scenario: keep user shared file directory same in respect to respective user if one of the recipient has moved the file
     Given user "user0" has uploaded file with content "foo" to "/sharefile.txt"
@@ -35,6 +35,6 @@ Feature: sharing
     And user "user0" has shared file "/sharefile.txt" with user "user2"
     And user "user2" has created a folder "newfolder"
     When user "user2" moves file "/sharefile.txt" to "/newfolder/sharefile.txt" using the WebDAV API
-    Then as "user2" the file "/newfolder/sharefile.txt" should exist
-    And as "user0" the file "/sharefile.txt" should exist
-    And as "user1" the file "/sharefile.txt" should exist
+    Then as "user2" file "/newfolder/sharefile.txt" should exist
+    And as "user0" file "/sharefile.txt" should exist
+    And as "user1" file "/sharefile.txt" should exist

--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -127,7 +127,7 @@ Feature: sharing
       | permissions | 31                 |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And as "user2" the file "/textfile0 (2).txt" should not exist
+    And as "user2" file "/textfile0 (2).txt" should not exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -297,8 +297,8 @@ Feature: sharing
       | file_parent       | A_NUMBER             |
       | displayname_owner | User One             |
       | mimetype          | httpd/unix-directory |
-    And as "user0" the folder "/folder1/folder2" should not exist
-    And as "user2" the folder "/folder2" should exist
+    And as "user0" folder "/folder1/folder2" should not exist
+    And as "user2" folder "/folder2" should exist
 
   Scenario: Share ownership change after moving a shared file to another share
     Given user "user1" has been created
@@ -324,8 +324,8 @@ Feature: sharing
       | file_parent       | A_NUMBER             |
       | displayname_owner | User Two             |
       | mimetype          | httpd/unix-directory |
-    And as "user0" the folder "/user0-folder/folder2" should not exist
-    And as "user2" the folder "/user2-folder/folder2" should exist
+    And as "user0" folder "/user0-folder/folder2" should not exist
+    And as "user2" folder "/user2-folder/folder2" should exist
 
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -12,8 +12,8 @@ Feature: sharing
     Given user "user0" has created a folder "/shared"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the WebDAV API
-    Then as "user1" the file "/shared/shared_file.txt" should exist
-    And as "user0" the file "/shared/shared_file.txt" should exist
+    Then as "user1" file "/shared/shared_file.txt" should exist
+    And as "user0" file "/shared/shared_file.txt" should exist
 
   @smokeTest @files_trashbin-app-required
   Scenario: moving a file out of a share as recipient creates a backup for the owner
@@ -22,9 +22,9 @@ Feature: sharing
     And user "user0" has shared file "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/shared_renamed"
     When user "user1" moves file "/shared_renamed/shared_file.txt" to "/taken_out.txt" using the WebDAV API
-    Then as "user1" the file "/taken_out.txt" should exist
-    And as "user0" the file "/shared/shared_file.txt" should not exist
-    And as "user0" the file "/shared_file.txt" should exist in trash
+    Then as "user1" file "/taken_out.txt" should exist
+    And as "user0" file "/shared/shared_file.txt" should not exist
+    And as "user0" file "/shared_file.txt" should exist in trash
 
   @files_trashbin-app-required
   Scenario: moving a folder out of a share as recipient creates a backup for the owner
@@ -34,7 +34,7 @@ Feature: sharing
     And user "user0" has shared file "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/shared_renamed"
     When user "user1" moves folder "/shared_renamed/sub" to "/taken_out" using the WebDAV API
-    Then as "user1" the file "/taken_out" should exist
-    And as "user0" the folder "/shared/sub" should not exist
-    And as "user0" the folder "/sub" should exist in trash
-    And as "user0" the file "/sub/shared_file.txt" should exist in trash
+    Then as "user1" file "/taken_out" should exist
+    And as "user0" folder "/shared/sub" should not exist
+    And as "user0" folder "/sub" should exist in trash
+    And as "user0" file "/sub/shared_file.txt" should exist in trash

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -42,14 +42,14 @@ Feature: sharing
       | path      | PARENT |
       | shareType | user   |
       | shareWith | user1  |
-    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
     Given user "user1" has been created
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     When user "user0" has shared folder "PARENT" with group "grp1"
-    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @smokeTest @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
@@ -65,7 +65,7 @@ Feature: sharing
       | shareType   | user      |
       | shareWith   | user1     |
       | permissions | change    |
-    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission
     Given user "user1" has been created
@@ -76,7 +76,7 @@ Feature: sharing
       | shareType   | group  |
       | shareWith   | grp1   |
       | permissions | change |
-    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission
@@ -93,7 +93,7 @@ Feature: sharing
       | shareType   | user   |
       | shareWith   | user1  |
       | permissions | read   |
-    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission
     Given user "user1" has been created
@@ -104,7 +104,7 @@ Feature: sharing
       | shareType   | group  |
       | shareWith   | grp1   |
       | permissions | read   |
-    Then user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
+    Then user "user1" should be able to download file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -54,7 +54,7 @@ Feature: sharing
     And user "user0" has shared file "tmp.txt" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 3 |
-    Then as user "user1" the file "/tmp.txt" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
+    Then as user "user1" file "/tmp.txt" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
     Examples:
       | dav-path |
       | old      |
@@ -84,7 +84,7 @@ Feature: sharing
     And user "user0" has shared file "tmp.txt" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 17 |
-    Then as user "user1" the file "/tmp.txt" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
+    Then as user "user1" file "/tmp.txt" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
     Examples:
       | dav-path |
       | old      |
@@ -154,7 +154,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 29 |
-    Then as user "user1" the folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
+    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
     Examples:
       | dav-path |
       | old      |
@@ -184,7 +184,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 27 |
-    Then as user "user1" the folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
+    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
     Examples:
       | dav-path |
       | old      |
@@ -214,7 +214,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 23 |
-    Then as user "user1" the folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
+    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
     Examples:
       | dav-path |
       | old      |
@@ -244,7 +244,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 15 |
-    Then as user "user1" the folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -15,8 +15,8 @@ Feature: files and folders can be deleted from the trashbin
     And a new browser session for "user0" has been started
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
-    And as "user0" the file "/textfile0.txt" should exist in trash
-    And as "user0" the file "/textfile1.txt" should exist in trash
+    And as "user0" file "/textfile0.txt" should exist in trash
+    And as "user0" file "/textfile1.txt" should exist in trash
     When user "user0" empties the trashbin using the trashbin API
     Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
     And as "user0" the file with original path "/textfile1.txt" should not exist in trash

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -13,8 +13,8 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "user0" has been created
     When user "user0" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "user0" the file "/textfile0.txt" should exist in trash
-    But as "user0" the file "/textfile0.txt" should not exist
+    Then as "user0" file "/textfile0.txt" should exist in trash
+    But as "user0" file "/textfile0.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -25,7 +25,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has been created
     And user "user0" has created a folder "/tmp"
     When user "user0" deletes folder "/tmp" using the WebDAV API
-    Then as "user0" the folder "/tmp" should exist in trash
+    Then as "user0" folder "/tmp" should exist in trash
     Examples:
       | dav-path |
       | old      |
@@ -38,8 +38,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
-    And as "user0" the file "/new-file.txt" should exist in trash
-    But as "user0" the file "/new-folder/new-file.txt" should not exist
+    And as "user0" file "/new-file.txt" should exist in trash
+    But as "user0" file "/new-folder/new-file.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -54,8 +54,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
-    And as "user0" the file "/shared_file.txt" should exist in trash
-    But as "user0" the file "/shared/shared_file.txt" should not exist
+    And as "user0" file "/shared_file.txt" should exist in trash
+    But as "user0" file "/shared/shared_file.txt" should not exist
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -33,7 +33,7 @@ Feature: Restore deleted files/folders
     Given using <dav-path> DAV path
     And user "user0" has been created
     And user "user0" has deleted file "/textfile0.txt"
-    And as "user0" the file "/textfile0.txt" should exist in trash
+    And as "user0" file "/textfile0.txt" should exist in trash
     And user "user0" has logged in to a web-style session
     When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
     Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
@@ -60,7 +60,7 @@ Feature: Restore deleted files/folders
     And user "user0" has logged in to a web-style session
     When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-    And as "user0" the file "/new-folder/new-file.txt" should exist
+    And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
       | old      |
@@ -76,7 +76,7 @@ Feature: Restore deleted files/folders
     And user "user0" has logged in to a web-style session
     When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-    And as "user0" the file "/new-file.txt" should exist
+    And as "user0" file "/new-file.txt" should exist
     Examples:
       | dav-path |
       | old      |
@@ -93,7 +93,7 @@ Feature: Restore deleted files/folders
     When user "user0" restores the folder with original path "/new-folder" using the trashbin API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-    And as "user0" the file "/new-folder/new-file.txt" should exist
+    And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
       | old      |
@@ -110,7 +110,7 @@ Feature: Restore deleted files/folders
     When user "user0" creates a folder "/new-folder" using the WebDAV API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-    And as "user0" the file "/new-folder/new-file.txt" should exist
+    And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
@@ -13,7 +13,7 @@ Feature: delete file
     Given using <dav_version> DAV path
     When user "user0" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "user0" the file "/textfile0.txt" should not exist
+    And as "user0" file "/textfile0.txt" should not exist
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -12,7 +12,7 @@ Feature: delete folder
     Given using <dav_version> DAV path
     When user "user0" deletes folder "/PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "user0" the folder "/PARENT" should not exist
+    And as "user0" folder "/PARENT" should not exist
     Examples:
       | dav_version |
       | old         |
@@ -22,9 +22,9 @@ Feature: delete folder
     Given using <dav_version> DAV path
     When user "user0" deletes folder "/PARENT/CHILD" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "user0" the folder "/PARENT/CHILD" should not exist
-    But as "user0" the folder "/PARENT" should exist
-    And as "user0" the file "/PARENT/parent.txt" should exist
+    And as "user0" folder "/PARENT/CHILD" should not exist
+    But as "user0" folder "/PARENT" should exist
+    And as "user0" file "/PARENT/parent.txt" should exist
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -11,7 +11,7 @@ Feature: download file
   @smokeTest
   Scenario Outline: download a file
     Given using <dav_version> DAV path
-    When user "user0" downloads the file "/textfile0.txt" using the WebDAV API
+    When user "user0" downloads file "/textfile0.txt" using the WebDAV API
     Then the downloaded content should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | dav_version |
@@ -44,7 +44,7 @@ Feature: download file
   @smokeTest
   Scenario Outline: Downloading a file should serve security headers
     Given using <dav_version> DAV path
-    When user "user0" downloads the file "/welcome.txt" using the WebDAV API
+    When user "user0" downloads file "/welcome.txt" using the WebDAV API
     Then the following headers should be set
       | Content-Disposition               | attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt" |
       | Content-Security-Policy           | default-src 'none';                                              |

--- a/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
@@ -24,7 +24,7 @@ Feature: refuse access
     Given using <dav_version> DAV path
     And user "user1" has been created
     And user "user1" has been disabled
-    When user "user1" downloads the file "/welcome.txt" using the WebDAV API
+    When user "user1" downloads file "/welcome.txt" using the WebDAV API
     Then the HTTP status code should be "401"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -133,7 +133,7 @@ Feature: Search
       | oc:owner-display-name |
       | oc:size               |
     Then the HTTP status code should be "207"
-    And the file "/upload.txt" in the search result of "user0" should contain these properties:
+    And file "/upload.txt" in the search result of "user0" should contain these properties:
       | name                                       | value                                                                                             |
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVW\|RMDNVW)$                                                                                 |
@@ -161,7 +161,7 @@ Feature: Search
       | oc:owner-display-name |
       | oc:size               |
     Then the HTTP status code should be "207"
-    And the folder "/upload folder" in the search result of "user0" should contain these properties:
+    And folder "/upload folder" in the search result of "user0" should contain these properties:
       | name                                       | value                                                                                             |
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVCK\|RMDNVCK)$                                                                                |

--- a/tests/acceptance/features/apiWebdavOperations/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileAsyncUsingNewChunking.feature
@@ -111,7 +111,7 @@ Feature: upload file using new chunking
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
       | fileId | /^[0-9a-z]{20,}$/ |
-    And as "user0" the file "/myChunkedFile.txt" should exist
+    And as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |
@@ -129,7 +129,7 @@ Feature: upload file using new chunking
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
       | fileId | /^[0-9a-z]{20,}$/ |
-    And as "user0" the file "/<file-name>" should exist
+    And as "user0" file "/<file-name>" should exist
     And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |
@@ -158,7 +158,7 @@ Feature: upload file using new chunking
     Then the HTTP status code should be "201"
     And the following headers should not be set
       | OC-JobStatus-Location |
-    And as "user0" the file "/myChunkedFile.txt" should exist
+    And as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |

--- a/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
@@ -16,7 +16,7 @@ Feature: upload file using new chunking
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
-    Then as "user0" the file "/myChunkedFile.txt" should exist
+    Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |
@@ -27,7 +27,7 @@ Feature: upload file using new chunking
       | 3 | CCCCC |
       | 2 | BBBBB |
       | 1 | AAAAA |
-    Then as "user0" the file "/myChunkedFile.txt" should exist
+    Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |
@@ -38,7 +38,7 @@ Feature: upload file using new chunking
       | 2 | BBBBB |
       | 3 | CCCCC |
       | 1 | AAAAA |
-    Then as "user0" the file "/myChunkedFile.txt" should exist
+    Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |
@@ -96,7 +96,7 @@ Feature: upload file using new chunking
     And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
     When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15 using the WebDAV API
     Then the HTTP status code should be "201"
-    And as "user0" the file "/myChunkedFile.txt" should exist
+    And as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |
@@ -109,7 +109,7 @@ Feature: upload file using new chunking
     And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>" using the WebDAV API
-    Then as "user0" the file "/<file-name>" should exist
+    Then as "user0" file "/<file-name>" should exist
     And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |
@@ -126,5 +126,5 @@ Feature: upload file using new chunking
     And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "user0" moves new chunk file with id "chunking-42" to "/0" using the WebDAV API
-    And as "user0" the file "/0" should exist
+    And as "user0" file "/0" should exist
     And the content of file "/0" for user "user0" should be "AAAAABBBBBCCCCC"

--- a/tests/acceptance/features/apiWebdavOperations/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileUsingOldChunking.feature
@@ -14,7 +14,7 @@ Feature: upload file using old chunking
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
-    Then as "user0" the file "/myChunkedFile.txt" should exist
+    Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
   Scenario: Upload chunked file desc
@@ -22,7 +22,7 @@ Feature: upload file using old chunking
       | 3 | CCCCC |
       | 2 | BBBBB |
       | 1 | AAAAA |
-    Then as "user0" the file "/myChunkedFile.txt" should exist
+    Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
   Scenario: Upload chunked file random
@@ -30,7 +30,7 @@ Feature: upload file using old chunking
       | 2 | BBBBB |
       | 3 | CCCCC |
       | 1 | AAAAA |
-    Then as "user0" the file "/myChunkedFile.txt" should exist
+    Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
   @smokeTest
@@ -39,7 +39,7 @@ Feature: upload file using old chunking
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
-    Then as "user0" the file "/<file-name>" should exist
+    Then as "user0" file "/<file-name>" should exist
     And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
     Examples:
       | file-name |

--- a/tests/acceptance/features/apiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/copyFile.feature
@@ -41,7 +41,7 @@ Feature: copy file
       | shareWith   | user0     |
     When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "403"
-    And user "user0" downloads the file "/testshare/textfile0.txt" using the WebDAV API
+    And user "user0" downloads file "/testshare/textfile0.txt" using the WebDAV API
     And the HTTP status code should be "404"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavProperties/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/createFolder.feature
@@ -11,7 +11,7 @@ Feature: create folder
   Scenario Outline: create a folder
     Given using <dav_version> DAV path
     When user "user0" creates a folder "<folder_name>" using the WebDAV API
-    Then as "user0" the folder "<folder_name>" should exist
+    Then as "user0" folder "<folder_name>" should exist
     Examples:
       | dav_version | folder_name     |
       | old         | /upload         |

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -11,7 +11,7 @@ Feature: get quota
   Scenario Outline: Retrieving folder quota when no quota is set
     Given using <dav_version> DAV path
     When the administrator gives unlimited quota to user "user0" using the provisioning API
-    Then as user "user0" the folder "/" should contain a property "{DAV:}quota-available-bytes" with value "-3"
+    Then as user "user0" folder "/" should contain a property "{DAV:}quota-available-bytes" with value "-3"
     Examples:
       | dav_version |
       | old         |
@@ -21,7 +21,7 @@ Feature: get quota
   Scenario Outline: Retrieving folder quota when quota is set
     Given using <dav_version> DAV path
     When the administrator sets the quota of user "user0" to "10 MB" using the provisioning API
-    Then as user "user0" the folder "/" should contain a property "{DAV:}quota-available-bytes" with value "10485406"
+    Then as user "user0" folder "/" should contain a property "{DAV:}quota-available-bytes" with value "10485406"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavProperties/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/moveFile.feature
@@ -34,7 +34,7 @@ Feature: move (rename) file
     Given using <dav_version> DAV path
     When user "user0" moves file "/textfile0.txt" to "/TextFile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And as "user0" the file "/textfile0.txt" should not exist
+    And as "user0" file "/textfile0.txt" should not exist
     And the content of file "/TextFile0.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | dav_version |
@@ -75,7 +75,7 @@ Feature: move (rename) file
       | shareWith   | user0     |
     When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "403"
-    When user "user0" downloads the file "/testshare/textfile0.txt" using the WebDAV API
+    When user "user0" downloads file "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     Examples:
       | dav_version |
@@ -150,12 +150,12 @@ Feature: move (rename) file
     And user "user1" has stored id of file "/folderA/ONE"
     And user "user1" has created a folder "/folderA/ONE/TWO"
     When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the WebDAV API
-    Then as "user1" the folder "/folderA" should exist
-    And as "user1" the folder "/folderA/ONE" should not exist
+    Then as "user1" folder "/folderA" should exist
+    And as "user1" folder "/folderA/ONE" should not exist
 		# yes, a weird bug used to make this one fail
-    And as "user1" the folder "/folderA/ONE/TWO" should not exist
-    And as "user1" the folder "/folderB/ONE" should exist
-    And as "user1" the folder "/folderB/ONE/TWO" should exist
+    And as "user1" folder "/folderA/ONE/TWO" should not exist
+    And as "user1" folder "/folderB/ONE" should exist
+    And as "user1" folder "/folderB/ONE/TWO" should exist
     And user "user1" file "/folderB/ONE" should have the previously stored id
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavProperties/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavProperties/moveFileAsync.feature
@@ -96,7 +96,7 @@ Feature: move (rename) file
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status    | /^error$/ |
       | errorCode | /^403$/   |
-    And user "user0" downloads the file "/testshare/textfile0.txt" using the WebDAV API
+    And user "user0" downloads file "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     And user "user0" should see the following elements
       | /textfile0.txt |
@@ -198,7 +198,7 @@ Feature: move (rename) file
       | shareWith   | user0     |
     When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "403"
-    When user "user0" downloads the file "/testshare/textfile0.txt" using the WebDAV API
+    When user "user0" downloads file "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -83,7 +83,7 @@ class SearchContext implements Context {
 	}
 
 	/**
-	 * @Then the file/folder :path in the search result of :user should contain these properties:
+	 * @Then file/folder :path in the search result of :user should contain these properties:
 	 *
 	 * @param string $path
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -422,7 +422,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userShouldBeAbleToDownloadTheFileUsingTheSharingApi($user, $path) {
+	public function userShouldBeAbleToDownloadFileUsingTheSharingApi($user, $path) {
 		$path = \ltrim($path, "/");
 		$fullUrl = $this->getBaseUrl() . "/remote.php/webdav/$path";
 		$this->checkUserDownload($fullUrl, $user, "text/plain");

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -415,7 +415,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be able to download the file "([^"]*)" using the sharing API$/
+	 * @Then /^user "([^"]*)" should be able to download file "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $path

--- a/tests/acceptance/features/bootstrap/Trashbin.php
+++ b/tests/acceptance/features/bootstrap/Trashbin.php
@@ -74,7 +74,7 @@ trait Trashbin {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (?:file|folder|entry) "([^"]*)" should exist in trash$/
+	 * @Then /^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should exist in trash$/
 	 *
 	 * @param string $user
 	 * @param string $path

--- a/tests/acceptance/features/bootstrap/Trashbin.php
+++ b/tests/acceptance/features/bootstrap/Trashbin.php
@@ -81,7 +81,7 @@ trait Trashbin {
 	 *
 	 * @return void
 	 */
-	public function asTheFileOrFolderExistsInTrash($user, $path) {
+	public function asFileOrFolderExistsInTrash($user, $path) {
 		$path = \trim($path, '/');
 		$sections = \explode('/', $path, 2);
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -909,7 +909,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the file :fileName using the WebDAV API
+	 * @When user :user downloads file :fileName using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $fileName
@@ -1163,7 +1163,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should not exist$/
+	 * @Then /^as "([^"]*)" (file|folder|entry) "([^"]*)" should not exist$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -1187,7 +1187,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should exist$/
+	 * @Then /^as "([^"]*)" (file|folder|entry) "([^"]*)" should exist$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -1288,7 +1288,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)" or with value "([^"]*)"$/
+	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)" or with value "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1310,7 +1310,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/
+	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1344,7 +1344,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the (?:file|folder|entry) "([^"]*)" should not be favorited$/
+	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should not be favorited$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1356,7 +1356,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as the user the (?:file|folder|entry) "([^"]*)" should be favorited$/
+	 * @Then /^as the user (?:file|folder|entry) "([^"]*)" should be favorited$/
 	 *
 	 * @param string $path
 	 * @param integer $expectedValue 0|1
@@ -1368,7 +1368,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as the user the (?:file|folder|entry) "([^"]*)" should not be favorited$/
+	 * @Then /^as the user (?:file|folder|entry) "([^"]*)" should not be favorited$/
 	 *
 	 * @param string $path
 	 *

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -916,7 +916,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function userDownloadsTheFileUsingTheAPI(
+	public function userDownloadsFileUsingTheAPI(
 		$user, $fileName
 	) {
 		$this->downloadFileAsUserUsingPassword($user, $fileName);
@@ -1172,7 +1172,7 @@ trait WebDav {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function asTheFileOrFolderShouldNotExist($user, $entry, $path) {
+	public function asFileOrFolderShouldNotExist($user, $entry, $path) {
 		$client = $this->getSabreClient($user);
 		$response = $client->request(
 			'GET', $this->makeSabrePath($user, $path)
@@ -1196,7 +1196,7 @@ trait WebDav {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function asTheFileOrFolderShouldExist($user, $entry, $path) {
+	public function asFileOrFolderShouldExist($user, $entry, $path) {
 		$this->response = $this->listFolder($user, $path, 0);
 		try {
 			$this->thePropertiesResponseShouldContainAnEtag();
@@ -1298,7 +1298,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function asUserTheFolderShouldContainAPropertyWithValueOrWithValue(
+	public function asUserFolderShouldContainAPropertyWithValueOrWithValue(
 		$user, $path, $property, $expectedValue, $altExpectedValue
 	) {
 		$this->response = $this->listFolder(
@@ -1319,10 +1319,10 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function asUserTheFolderShouldContainAPropertyWithValue(
+	public function asUserFolderShouldContainAPropertyWithValue(
 		$user, $path, $property, $value
 	) {
-		$this->asUserTheFolderShouldContainAPropertyWithValueOrWithValue(
+		$this->asUserFolderShouldContainAPropertyWithValueOrWithValue(
 			$user, $path, $property, $value, $value
 		);
 	}
@@ -1338,7 +1338,7 @@ trait WebDav {
 	 */
 	public function asUserTheFileOrFolderShouldBeFavorited($user, $path, $expectedValue = 1) {
 		$property = "{http://owncloud.org/ns}favorite";
-		$this->asUserTheFolderShouldContainAPropertyWithValue(
+		$this->asUserFolderShouldContainAPropertyWithValue(
 			$user, $path, $property, $expectedValue
 		);
 	}
@@ -1351,7 +1351,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function asUserTheFileShouldNotBeFavorited($user, $path) {
+	public function asUserFileShouldNotBeFavorited($user, $path) {
 		$this->asUserTheFileOrFolderShouldBeFavorited($user, $path, 0);
 	}
 
@@ -1363,7 +1363,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function theFileOrFolderShouldBeFavorited($path, $expectedValue = 1) {
+	public function asTheUserFileOrFolderShouldBeFavorited($path, $expectedValue = 1) {
 		$this->asUserTheFileOrFolderShouldBeFavorited($this->getCurrentUser(), $path, $expectedValue);
 	}
 
@@ -1374,8 +1374,8 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function theFileOrFolderShouldNotBeFavorited($path) {
-		$this->theFileOrFolderShouldBeFavorited($path, 0);
+	public function asTheUserFileOrFolderShouldNotBeFavorited($path) {
+		$this->asTheUserFileOrFolderShouldBeFavorited($path, 0);
 	}
 
 	/**
@@ -1986,7 +1986,7 @@ trait WebDav {
 	 */
 	public function userShouldBeAbleToUploadFileTo($user, $source, $destination) {
 		$this->userUploadsAFileTo($user, $source, $destination);
-		$this->asTheFileOrFolderShouldExist($user, null, $destination);
+		$this->asFileOrFolderShouldExist($user, null, $destination);
 	}
 
 	/**
@@ -2000,7 +2000,7 @@ trait WebDav {
 	 */
 	public function theUserShouldNotBeAbleToUploadFileTo($user, $source, $destination) {
 		$this->userUploadsAFileTo($user, $source, $destination);
-		$this->asTheFileOrFolderShouldNotExist($user, null, $destination);
+		$this->asFileOrFolderShouldNotExist($user, null, $destination);
 	}
 
 	/**
@@ -2044,7 +2044,7 @@ trait WebDav {
 	) {
 		foreach (['old', 'new'] as $davVersion) {
 			foreach (["{$davVersion}dav-regular", "{$davVersion}dav-{$davVersion}chunking"] as $suffix) {
-				$this->asTheFileOrFolderShouldExist(
+				$this->asFileOrFolderShouldExist(
 					$user, 'file', "$destination-$suffix"
 				);
 			}

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -590,7 +590,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserRenamesTheFileFolderToUsingTheWebUI(
+	public function theUserRenamesFileFolderToUsingTheWebUI(
 		$fromName, $toName
 	) {
 		$pageObject = $this->getCurrentPageObject();
@@ -638,7 +638,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserRenamesTheFileToOneOfTheseNamesUsingTheWebUI(
+	public function theUserRenamesFileToOneOfTheseNamesUsingTheWebUI(
 		$fromName, TableNode $table
 	) {
 		$pageObject = $this->getCurrentPageObject();
@@ -686,7 +686,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserDeletesTheFileUsingTheWebUI($name) {
+	public function theUserDeletesFileUsingTheWebUI($name) {
 		$this->deleteTheFileUsingTheWebUI($name);
 	}
 
@@ -790,7 +790,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theUserMovesTheFileFolderToUsingTheWebUI($name, $destination) {
+	public function theUserMovesFileFolderIntoFolderUsingTheWebUI($name, $destination) {
 		$pageObject = $this->getCurrentPageObject();
 		$pageObject->moveFileTo($name, $destination, $this->getSession());
 	}
@@ -815,7 +815,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$itemToMoveNameParts[] = $namePartsRow['item-to-move-name-parts'];
 			$destinationNameParts[] = $namePartsRow['destination-name-parts'];
 		}
-		$this->theUserMovesTheFileFolderToUsingTheWebUI(
+		$this->theUserMovesFileFolderIntoFolderUsingTheWebUI(
 			$itemToMoveNameParts, $destinationNameParts
 		);
 	}
@@ -831,26 +831,28 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserBatchMovesTheseFilesIntoTheFolderUsingTheWebUI(
+	public function theUserBatchMovesTheseFilesIntoFolderUsingTheWebUI(
 		$folderName, TableNode $files
 	) {
 		$this->theUserMarksTheseFilesForBatchActionUsingTheWebUI($files);
 		$firstFileName = $files->getRow(1)[0];
-		$this->theUserMovesTheFileFolderToUsingTheWebUI($firstFileName, $folderName);
+		$this->theUserMovesFileFolderIntoFolderUsingTheWebUI(
+			$firstFileName, $folderName
+		);
 		$this->movedElementsTable = $files;
 	}
 
 	/**
-	 * @When the user uploads overwriting the file :name using the webUI
-	 * @Given the user has uploaded overwriting the file :name using the webUI
+	 * @When the user uploads overwriting file :name using the webUI
+	 * @Given the user has uploaded overwriting file :name using the webUI
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserUploadsOverwritingTheFileUsingTheWebUI($name) {
-		$this->theUserUploadsTheFileUsingTheWebUI($name);
+	public function theUserUploadsOverwritingFileUsingTheWebUI($name) {
+		$this->theUserUploadsFileUsingTheWebUI($name);
 		$this->choiceInUploadConflictDialogWebUI("new");
 		$this->theUserChoosesToInTheUploadDialog("Continue");
 	}
@@ -864,13 +866,13 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserUploadsOverwritingTheFileUsingTheWebUIRetry($name) {
+	public function theUserUploadsOverwritingFileUsingTheWebUIRetry($name) {
 		$previousNotificationsCount = 0;
 
 		for ($retryCounter = 0;
 			 $retryCounter < STANDARD_RETRY_COUNT;
 			 $retryCounter++) {
-			$this->theUserUploadsOverwritingTheFileUsingTheWebUI($name);
+			$this->theUserUploadsOverwritingFileUsingTheWebUI($name);
 
 			try {
 				$notifications = $this->getCurrentPageObject()->getNotifications();
@@ -912,8 +914,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserUploadsTheFileKeepingNewExistingUsingTheWebUI($name) {
-		$this->theUserUploadsTheFileUsingTheWebUI($name);
+	public function theUserUploadsFileKeepingNewExistingUsingTheWebUI($name) {
+		$this->theUserUploadsFileUsingTheWebUI($name);
 		$this->choiceInUploadConflictDialogWebUI("new");
 		$this->choiceInUploadConflictDialogWebUI("existing");
 		$this->theUserChoosesToInTheUploadDialog("Continue");
@@ -927,7 +929,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theUserUploadsTheFileUsingTheWebUI($name) {
+	public function theUserUploadsFileUsingTheWebUI($name) {
 		$this->getCurrentPageObject()->uploadFile($this->getSession(), $name);
 	}
 
@@ -1057,7 +1059,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFileFolderWithThePathShouldBeListedOnTheWebUI(
+	public function fileFolderWithPathShouldBeListedOnTheWebUI(
 		$name, $path, $shouldOrNot, $typeOfFilesPage = "", $folder = ""
 	) {
 		// The capturing groups of the regex include the quotes at each
@@ -1160,7 +1162,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserOpensTheFolderNamedUsingTheWebUI(
+	public function theUserOpensFolderNamedUsingTheWebUI(
 		$typeOfFilesPage, $fileOrFolder, $name
 	) {
 		// The capturing groups of the regex include the quotes at each
@@ -1246,7 +1248,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFileFolderShouldBeListedOnTheWebUI(
+	public function fileFolderShouldBeListedOnTheWebUI(
 		$name, $shouldOrNot, $typeOfFilesPage = "", $folder = ""
 	) {
 		// The capturing groups of the regex include the quotes at each
@@ -1398,7 +1400,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theMovedElementsShouldBeListedInTheFolderOnTheWebUI(
+	public function theMovedElementsShouldBeListedInFolderOnTheWebUI(
 		$shouldOrNot, $folderName
 	) {
 		$this->theUserOpensTheFolderUsingTheWebUI("", "folder", $folderName);
@@ -1486,7 +1488,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function nearTheFileATooltipWithTheTextShouldBeDisplayedOnTheWebUI(
+	public function nearFileATooltipWithTheTextShouldBeDisplayedOnTheWebUI(
 		$name,
 		$toolTipText
 	) {
@@ -1504,7 +1506,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function restoreFileFolderFromTrashbinUsingTheWebUI($fname) {
+	public function theUserRestoresFileFolderFromTheTrashbinUsingTheWebUI($fname) {
 		$session = $this->getSession();
 		$this->trashbinPage->restore($fname, $session);
 	}
@@ -1531,7 +1533,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function itShouldNotBePossibleToDeleteUsingTheWebUI($name) {
+	public function itShouldNotBePossibleToDeleteFileFolderUsingTheWebUI($name) {
 		try {
 			$this->deleteTheFileUsingTheWebUI($name, false);
 		} catch (ElementNotFoundException $e) {
@@ -1665,7 +1667,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserMarksTheFileAsFavoriteUsingTheWebUI($fileOrFolderName) {
+	public function theUserMarksFileAsFavoriteUsingTheWebUI($fileOrFolderName) {
 		$fileRow = $this->filesPage->findFileRowByName(
 			$fileOrFolderName, $this->getSession()
 		);
@@ -1681,7 +1683,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFileShouldBeMarkedAsFavoriteOnTheWebUI($fileOrFolderName) {
+	public function fileFolderShouldBeMarkedAsFavoriteOnTheWebUI($fileOrFolderName) {
 		$fileRow = $this->filesPage->findFileRowByName(
 			$fileOrFolderName, $this->getSession()
 		);
@@ -1717,7 +1719,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFolderShouldNotBeMarkedAsFavoriteOnTheWebUI(
+	public function fileFolderShouldNotBeMarkedAsFavoriteOnTheWebUI(
 		$fileOrFolderName
 	) {
 		$fileRow = $this->filesPage->findFileRowByName(
@@ -1906,7 +1908,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theUserOpensTheFileActionMenuOfTheFolderInTheWebui($name) {
+	public function theUserOpensTheFileActionMenuOfFileFolderInTheWebui($name) {
 		$session = $this->getSession();
 		$this->selectedFileRow = $this->getCurrentPageObject()->findFileRowByName($name, $session);
 		$this->openedFileActionMenu = $this->selectedFileRow->openFileActionsMenu($session);

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -581,8 +581,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user renames the file/folder :fromName to :toName using the webUI
-	 * @Given the user has renamed the file/folder :fromName to :toName using the webUI
+	 * @When the user renames file/folder :fromName to :toName using the webUI
+	 * @Given the user has renamed file/folder :fromName to :toName using the webUI
 	 *
 	 * @param string $fromName
 	 * @param string $toName
@@ -629,8 +629,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user renames the file/folder :fromName to one of these names using the webUI
-	 * @Given the user has renamed the file/folder :fromName to one of these names using the webUI
+	 * @When the user renames file/folder :fromName to one of these names using the webUI
+	 * @Given the user has renamed file/folder :fromName to one of these names using the webUI
 	 *
 	 * @param string $fromName
 	 * @param TableNode $table
@@ -678,8 +678,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * has an "Unshare" entry in the file actions menu. Clicking it works just
 	 * like delete.
 	 *
-	 * @When the user deletes/unshares the file/folder :name using the webUI
-	 * @Given the user has deleted/unshared the file/folder :name using the webUI
+	 * @When the user deletes/unshares file/folder :name using the webUI
+	 * @Given the user has deleted/unshared file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 *
@@ -782,8 +782,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user moves the file/folder :name into the folder :destination using the webUI
-	 * @Given the user has moved the file/folder :name into the folder :destination using the webUI
+	 * @When the user moves file/folder :name into folder :destination using the webUI
+	 * @Given the user has moved file/folder :name into folder :destination using the webUI
 	 *
 	 * @param string|array $name
 	 * @param string|array $destination
@@ -821,8 +821,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user batch moves these files/folders into the folder :folderName using the webUI
-	 * @Given the user has batch moved these files/folders into the folder :folderName using the webUI
+	 * @When the user batch moves these files/folders into folder :folderName using the webUI
+	 * @Given the user has batch moved these files/folders into folder :folderName using the webUI
 	 *
 	 * @param string $folderName
 	 * @param TableNode $files table of file names
@@ -856,8 +856,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user uploads overwriting the file :name using the webUI and retries if the file is locked
-	 * @Given the user has uploaded overwriting the file :name using the webUI and retries if the file is locked
+	 * @When the user uploads overwriting file :name using the webUI and retries if the file is locked
+	 * @Given the user has uploaded overwriting file :name using the webUI and retries if the file is locked
 	 *
 	 * @param string $name
 	 *
@@ -904,8 +904,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user uploads the file :name keeping both new and existing files using the webUI
-	 * @Given the user has uploaded the file :name keeping both new and existing files using the webUI
+	 * @When the user uploads file :name keeping both new and existing files using the webUI
+	 * @Given the user has uploaded file :name keeping both new and existing files using the webUI
 	 *
 	 * @param string $name
 	 *
@@ -920,8 +920,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user uploads the file :name using the webUI
-	 * @Given the user has uploaded the file :name using the webUI
+	 * @When the user uploads file :name using the webUI
+	 * @Given the user has uploaded file :name using the webUI
 	 *
 	 * @param string $name
 	 *
@@ -1046,7 +1046,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with the path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(files page|trashbin|favorites page|shared-with-you page|shared with others page|tags page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
+	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(files page|trashbin|favorites page|shared-with-you page|shared with others page|tags page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
 	 *
 	 * @param string $name enclosed in single or double quotes
 	 * @param string $path
@@ -1150,8 +1150,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the user opens the (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
-	 * @Given /^the user has opened the (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
+	 * @When /^the user opens (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
+	 * @Given /^the user has opened (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
 	 *
 	 * @param string $typeOfFilesPage
 	 * @param string $fileOrFolder
@@ -1236,7 +1236,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(files page|trashbin|favorites page|shared-with-you page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
+	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |in |)(files page|trashbin|favorites page|shared-with-you page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
 	 *
 	 * @param string $name enclosed in single or double quotes
 	 * @param string $shouldOrNot
@@ -1390,7 +1390,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the moved elements should (not|)\s?be listed in the folder ['"](.*)['"] on the webUI$/
+	 * @Then /^the moved elements should (not|)\s?be listed in folder ['"](.*)['"] on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 * @param string $folderName
@@ -1479,7 +1479,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then near the file/folder :name a tooltip with the text :toolTipText should be displayed on the webUI
+	 * @Then near file/folder :name a tooltip with the text :toolTipText should be displayed on the webUI
 	 *
 	 * @param string $name
 	 * @param string $toolTipText
@@ -1497,8 +1497,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @When the user restores the file/folder :fname from the trashbin using the webUI
-	 * @Given the user has restored the file/folder :fname from the trashbin using the webUI
+	 * @When the user restores file/folder :fname from the trashbin using the webUI
+	 * @Given the user has restored file/folder :fname from the trashbin using the webUI
 	 *
 	 * @param string $fname
 	 *
@@ -1524,7 +1524,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then it should not be possible to delete the file/folder :name using the webUI
+	 * @Then it should not be possible to delete file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 *
@@ -1657,8 +1657,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user marks the file/folder :fileOrFolderName as favorite using the webUI
-	 * @Given the user has marked the file/folder :fileOrFolderName as favorite using the webUI
+	 * @When the user marks file/folder :fileOrFolderName as favorite using the webUI
+	 * @Given the user has marked file/folder :fileOrFolderName as favorite using the webUI
 	 *
 	 * @param string $fileOrFolderName
 	 *
@@ -1674,7 +1674,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the file/folder :fileOrFolderName should be marked as favorite on the webUI
+	 * @Then file/folder :fileOrFolderName should be marked as favorite on the webUI
 	 *
 	 * @param string $fileOrFolderName
 	 *
@@ -1710,7 +1710,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the file/folder :fileOrFolderName should not be marked as favorite on the webUI
+	 * @Then file/folder :fileOrFolderName should not be marked as favorite on the webUI
 	 *
 	 * @param string $fileOrFolderName
 	 *
@@ -1900,7 +1900,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user opens the file action menu of the file/folder :name in the webUI
+	 * @When the user opens the file action menu of file/folder :name in the webUI
 	 *
 	 * @param string $name Name of the file/Folder
 	 *

--- a/tests/acceptance/features/bootstrap/WebUISearchContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISearchContext.php
@@ -83,7 +83,7 @@ class WebUISearchContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with the path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed in the search results in other folders section on the webUI$/
+	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed in the search results in the other folders section on the webUI$/
 	 *
 	 * @param string $fileName
 	 * @param string $path
@@ -101,7 +101,7 @@ class WebUISearchContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed in the search results in other folders section on the webUI$/
+	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed in the search results in the other folders section on the webUI$/
 	 *
 	 * @param string $fileName
 	 * @param string $shouldOrNot

--- a/tests/acceptance/features/bootstrap/WebUISearchContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISearchContext.php
@@ -91,7 +91,7 @@ class WebUISearchContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function fileShouldBeListedSearchResultOtherFolders($fileName, $path, $shouldOrNot) {
+	public function fileWithPathShouldBeListedInSearchResultOtherFolders($fileName, $path, $shouldOrNot) {
 		$fileName = \trim($fileName, $fileName[0]);
 		$path = \trim($path, $path[0]);
 		$this->webUIGeneralContext->setCurrentPageObject($this->searchResultInOtherFoldersPage);
@@ -109,7 +109,7 @@ class WebUISearchContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function fileShouldNotBeListedSearchResultOtherFolders($fileName, $shouldOrNot) {
+	public function fileShouldNotBeListedInSearchResultOtherFolders($fileName, $shouldOrNot) {
 		$fileName = \trim($fileName, $fileName[0]);
 		$this->webUIGeneralContext->setCurrentPageObject($this->searchResultInOtherFoldersPage);
 		$this->webUIFilesContext->checkIfFileFolderIsListedOnTheWebUI(

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -128,8 +128,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the user shares the (?:file|folder) "([^"]*)" with the (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
-	 * @Given /^the user has shared the (?:file|folder) "([^"]*)" with the (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
+	 * @When /^the user shares (?:file|folder) "([^"]*)" with (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
+	 * @Given /^the user has shared (?:file|folder) "([^"]*)" with (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
 	 *
 	 * @param string $folder
 	 * @param string $remote

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -140,7 +140,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserSharesTheFileFolderWithTheUserUsingTheWebUI(
+	public function theUserSharesFileFolderWithUserUsingTheWebUI(
 		$folder, $remote, $user, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
@@ -175,7 +175,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserSharesTheFileFolderWithGroupUsingTheWebUI(
+	public function theUserSharesFileFolderWithGroupUsingTheWebUI(
 		$folder, $group
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
@@ -200,7 +200,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserOpensTheShareDialogForTheFileFolder($name) {
+	public function theUserOpensTheShareDialogForFileFolder($name) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		$this->sharingDialog = $this->filesPage->openSharingDialog(
 			$name, $this->getSession()
@@ -333,8 +333,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserCreatesANewPublicLinkForUsingTheWebUI($name) {
-		$this->theUserCreatesANewPublicLinkForUsingTheWebUIWith($name);
+	public function theUserCreatesANewPublicLinkForFileFolderUsingTheWebUI($name) {
+		$this->theUserCreatesANewPublicLinkForFileFolderUsingTheWebUIWith($name);
 	}
 
 	/**
@@ -352,7 +352,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserCreatesANewPublicLinkForUsingTheWebUIWith(
+	public function theUserCreatesANewPublicLinkForFileFolderUsingTheWebUIWith(
 		$name, TableNode $settings = null
 	) {
 		$linkName = $this->createPublicShareLink($name, $settings);
@@ -374,7 +374,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theUserTriesToCreateANewPublicLinkForUsingTheWebUIWith(
+	public function theUserTriesToCreateANewPublicLinkForFileFolderUsingTheWebUIWith(
 		$name, TableNode $settings = null
 	) {
 		$this->linkName = $this->createPublicShareLink($name, $settings);
@@ -453,7 +453,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$userName, $fileName, TableNode $permissionsTable
 	) {
 		$userName = $this->featureContext->substituteInLineCodes($userName);
-		$this->theUserOpensTheShareDialogForTheFileFolder($fileName);
+		$this->theUserOpensTheShareDialogForFileFolder($fileName);
 		$this->sharingDialog->setSharingPermissions(
 			$userName, $permissionsTable->getRowsHash()
 		);
@@ -798,7 +798,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFileFolderShouldBeMarkedAsSharedBy(
+	public function fileFolderShouldBeMarkedAsSharedBy(
 		$fileOrFolder, $itemName, $sharedWithGroup, $sharerName
 	) {
 		//close any open sharing dialog
@@ -907,12 +907,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function itShouldNotBePossibleToShareUsingTheWebUI(
+	public function itShouldNotBePossibleToShareFileFolderUsingTheWebUI(
 		$fileName, $shareWith = null
 	) {
 		$sharingWasPossible = false;
 		try {
-			$this->theUserSharesTheFileFolderWithTheUserUsingTheWebUI(
+			$this->theUserSharesFileFolderWithUserUsingTheWebUI(
 				$fileName, null, $shareWith, 2, true
 			);
 			$sharingWasPossible = true;

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -166,8 +166,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user shares the file/folder :folder with group :group using the webUI
-	 * @Given the user has shared the file/folder :folder with group :group using the webUI
+	 * @When the user shares file/folder :folder with group :group using the webUI
+	 * @Given the user has shared file/folder :folder with group :group using the webUI
 	 *
 	 * @param string $folder
 	 * @param string $group
@@ -192,8 +192,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user opens the share dialog for the file/folder :name
-	 * @Given the user has opened the share dialog for the file/folder :name
+	 * @When the user opens the share dialog for file/folder :name
+	 * @Given the user has opened the share dialog for file/folder :name
 	 *
 	 * @param string $name
 	 *
@@ -325,8 +325,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user creates a new public link for the file/folder :name using the webUI
-	 * @Given the user has created a new public link for the file/folder :name using the webUI
+	 * @When the user creates a new public link for file/folder :name using the webUI
+	 * @Given the user has created a new public link for file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 *
@@ -338,8 +338,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user creates a new public link for the file/folder :name using the webUI with
-	 * @Given the user has created a new public link for the file/folder :name using the webUI with
+	 * @When the user creates a new public link for file/folder :name using the webUI with
+	 * @Given the user has created a new public link for file/folder :name using the webUI with
 	 *
 	 * @param string $name
 	 * @param TableNode $settings table with the settings and no header
@@ -361,8 +361,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user tries to create a new public link for the file/folder :name using the webUI with
-	 * @When the user tries to create a new public link for the file/folder :name using the webUI
+	 * @When the user tries to create a new public link for file/folder :name using the webUI with
+	 * @When the user tries to create a new public link for file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 * @param TableNode $settings table with the settings and no header
@@ -788,7 +788,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (file|folder) "([^"]*)" should be marked as shared(?: with "([^"]*)")? by "([^"]*)" on the webUI$/
+	 * @Then /^(file|folder) "([^"]*)" should be marked as shared(?: with "([^"]*)")? by "([^"]*)" on the webUI$/
 	 *
 	 * @param string $fileOrFolder
 	 * @param string $itemName
@@ -840,7 +840,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the file/folder :item should be in state :state in the shared-with-you page on the webUI
+	 * @Then file/folder :item should be in state :state in the shared-with-you page on the webUI
 	 *
 	 * @param string $item
 	 * @param string $state
@@ -856,7 +856,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the file/folder :item shared by :sharedBy should be in state :state in the shared-with-you page on the webUI
+	 * @Then file/folder :item shared by :sharedBy should be in state :state in the shared-with-you page on the webUI
 	 *
 	 * @param string $item
 	 * @param string $sharedBy
@@ -885,7 +885,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the file/folder :item should be in state :state in the shared-with-you page on the webUI after a page reload
+	 * @Then file/folder :item should be in state :state in the shared-with-you page on the webUI after a page reload
 	 *
 	 * @param string $item
 	 * @param string $state
@@ -899,7 +899,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @Then /^it should not be possible to share the (?:file|folder) "([^"]*)"(?: with "([^"]*)")? using the webUI$/
+	 * @Then /^it should not be possible to share (?:file|folder) "([^"]*)"(?: with "([^"]*)")? using the webUI$/
 	 *
 	 * @param string $fileName
 	 * @param string|null $shareWith

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -21,7 +21,7 @@ Feature: Add, delete and edit comments in files and folders
     Then the comment "lorem ipsum" should not be listed in the comments tab in details dialog
 
   Scenario: Add comment on a shared file and check it is shown in other user's UI
-    When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
+    When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
     And the user comments with content "lorem ipsum" using the webUI
     And the user shares file "new-lorem.txt" with user "User Two" using the webUI

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -24,7 +24,7 @@ Feature: Add, delete and edit comments in files and folders
     When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
     And the user comments with content "lorem ipsum" using the webUI
-    And the user shares the file "new-lorem.txt" with the user "User Two" using the webUI
+    And the user shares file "new-lorem.txt" with user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
     Then the comment "lorem ipsum" should be listed in the comments tab in details dialog

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -12,32 +12,32 @@ Feature: Mark file as favorite
 
   @smokeTest
   Scenario: mark a file as favorite and list it in favorites page
-    When the user marks the file "data.zip" as favorite using the webUI
-    Then the file "data.zip" should be marked as favorite on the webUI
+    When the user marks file "data.zip" as favorite using the webUI
+    Then file "data.zip" should be marked as favorite on the webUI
     When the user reloads the current page of the webUI
-    Then the file "data.zip" should be marked as favorite on the webUI
-    And the file "data.zip" should be listed in the favorites page on the webUI
-    And the file "lorem.txt" should not be listed in the favorites page on the webUI
+    Then file "data.zip" should be marked as favorite on the webUI
+    And file "data.zip" should be listed in the favorites page on the webUI
+    And file "lorem.txt" should not be listed in the favorites page on the webUI
 
   Scenario: mark a folder as favorite and list it in favorites page
-    When the user marks the folder "simple-folder" as favorite using the webUI
-    Then the folder "simple-folder" should be marked as favorite on the webUI
+    When the user marks folder "simple-folder" as favorite using the webUI
+    Then folder "simple-folder" should be marked as favorite on the webUI
     When the user reloads the current page of the webUI
-    Then the folder "simple-folder" should be marked as favorite on the webUI
-    And the folder "simple-folder" should be listed in the favorites page on the webUI
-    And the folder "simple-empty-folder" should not be listed in the favorites page on the webUI
+    Then folder "simple-folder" should be marked as favorite on the webUI
+    And folder "simple-folder" should be listed in the favorites page on the webUI
+    And folder "simple-empty-folder" should not be listed in the favorites page on the webUI
 
   Scenario: mark files with same name and different path as favorites and list them in favourites page
-    When the user marks the file "lorem.txt" as favorite using the webUI
-    And the user marks the folder "simple-empty-folder" as favorite using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    And the user marks the file "lorem.txt" as favorite using the webUI
-    And the user marks the folder "simple-empty-folder" as favorite using the webUI
+    When the user marks file "lorem.txt" as favorite using the webUI
+    And the user marks folder "simple-empty-folder" as favorite using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    And the user marks file "lorem.txt" as favorite using the webUI
+    And the user marks folder "simple-empty-folder" as favorite using the webUI
     And the user browses to the files page
-    And the user opens the folder "strängé नेपाली folder" using the webUI
-    And the user marks the file "lorem.txt" as favorite using the webUI
-    Then the file "lorem.txt" with the path "/" should be listed in the favorites page on the webUI
-    And the file "lorem.txt" with the path "/simple-folder" should be listed in the favorites page on the webUI
-    And the folder "simple-empty-folder" with the path "/" should be listed in the favorites page on the webUI
-    And the file "simple-empty-folder" with the path "/simple-folder" should be listed in the favorites page on the webUI
-    And the file "lorem.txt" with the path "/strängé नेपाली folder" should be listed in the favorites page on the webUI
+    And the user opens folder "strängé नेपाली folder" using the webUI
+    And the user marks file "lorem.txt" as favorite using the webUI
+    Then file "lorem.txt" with path "/" should be listed in the favorites page on the webUI
+    And file "lorem.txt" with path "/simple-folder" should be listed in the favorites page on the webUI
+    And folder "simple-empty-folder" with path "/" should be listed in the favorites page on the webUI
+    And file "simple-empty-folder" with path "/simple-folder" should be listed in the favorites page on the webUI
+    And file "lorem.txt" with path "/strängé नेपाली folder" should be listed in the favorites page on the webUI

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -12,34 +12,34 @@ Feature: Unmark file/folder as favorite
 
   @smokeTest
   Scenario: unmark a file as favorite from files page
-    Given the user has marked the file "data.zip" as favorite using the webUI
+    Given the user has marked file "data.zip" as favorite using the webUI
     When the user unmarks the favorited file "data.zip" using the webUI
-    Then the file "data.zip" should not be marked as favorite on the webUI
+    Then file "data.zip" should not be marked as favorite on the webUI
     When the user browses to the favorites page
-    Then the file "data.zip" should not be listed in the favorites page on the webUI
+    Then file "data.zip" should not be listed in the favorites page on the webUI
 
   Scenario: unmark a folder as favorite from files page
-    Given the user has marked the folder "simple-folder" as favorite using the webUI
+    Given the user has marked folder "simple-folder" as favorite using the webUI
     When the user unmarks the favorited folder "simple-folder" using the webUI
-    Then the folder "simple-folder" should not be marked as favorite on the webUI
+    Then folder "simple-folder" should not be marked as favorite on the webUI
     When the user browses to the favorites page
-    Then the folder "simple-folder" should not be listed in the favorites page on the webUI
+    Then folder "simple-folder" should not be listed in the favorites page on the webUI
 
   @smokeTest
   Scenario: unmark a file as favorite from favorite page
-    Given the user has marked the file "data.zip" as favorite using the webUI
+    Given the user has marked file "data.zip" as favorite using the webUI
     And the user has browsed to the favorites page
     When the user unmarks the favorited file "data.zip" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "data.zip" should not be listed in the favorites page on the webUI
+    Then file "data.zip" should not be listed in the favorites page on the webUI
     When the user browses to the files page
-    Then the file "data.zip" should not be marked as favorite on the webUI
+    Then file "data.zip" should not be marked as favorite on the webUI
 
   Scenario: unmark a folder as favorite from files page
-    Given the user has marked the folder "simple-folder" as favorite using the webUI
+    Given the user has marked folder "simple-folder" as favorite using the webUI
     And the user has browsed to the favorites page
     When the user unmarks the favorited folder "simple-folder" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "simple-folder" should not be listed in the favorites page on the webUI
+    Then folder "simple-folder" should not be listed in the favorites page on the webUI
     When the user browses to the files page
-    Then the folder "simple-folder" should not be marked as favorite on the webUI
+    Then folder "simple-folder" should not be marked as favorite on the webUI

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -12,25 +12,25 @@ Feature: create folders
   @smokeTest
   Scenario: Create a folder inside another folder
     When the user creates a folder with the name "top-folder" using the webUI
-    And the user opens the folder "top-folder" using the webUI
+    And the user opens folder "top-folder" using the webUI
     Then there should be no files/folders listed on the webUI
     When the user creates a folder with the name "sub-folder" using the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI
 
   Scenario: Create a folder with existing name
     When the user creates a folder with the invalid name "simple-folder" using the webUI
     Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed on the webUI
 
   Scenario: Create a folder in a public share
-    Given the user has created a new public link for the folder "simple-empty-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-empty-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     When the user creates a folder with the name "top-folder" using the webUI
-    And the user opens the folder "top-folder" using the webUI
+    And the user opens folder "top-folder" using the webUI
     Then there should be no files/folders listed on the webUI
     When the user creates a folder with the name "sub-folder" using the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
@@ -11,9 +11,9 @@ Feature: create folder
 
   Scenario Outline: Create a folder using special characters
     When the user creates a folder with the name <folder_name> using the webUI
-    Then the folder <folder_name> should be listed on the webUI
+    Then folder <folder_name> should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the folder <folder_name> should be listed on the webUI
+    Then folder <folder_name> should be listed on the webUI
     Examples:
       | folder_name              |
       | 'सिमप्ले फोल्देर $%#?&@' |
@@ -26,12 +26,12 @@ Feature: create folder
 	# First try and create a folder with problematic name
 	# Then try and create a sub-folder inside the folder with problematic name
     When the user creates a folder with the name <folder> using the webUI
-    And the user opens the folder <folder> using the webUI
+    And the user opens folder <folder> using the webUI
     Then there should be no files/folders listed on the webUI
     When the user creates a folder with the name "sub-folder" using the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI
     Examples:
       | folder    |
       | "?&%0"    |
@@ -41,11 +41,11 @@ Feature: create folder
   Scenario Outline: Create a sub-folder inside an existing folder with problematic name
 	# Use an existing folder with problematic name to create a sub-folder
 	# Uses the folder created by skeleton
-    When the user opens the folder <folder> using the webUI
+    When the user opens folder <folder> using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the folder "sub-folder" should be listed on the webUI
+    Then folder "sub-folder" should be listed on the webUI
     Examples:
       | folder                  |
       | "0"                     |

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -20,10 +20,10 @@ Feature: deleting files and folders
       | lorem.txt                             |
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
-    Then as "user1" the folder "simple-folder" should not exist
-    And as "user1" the file "lorem.txt" should not exist
-    And as "user1" the folder "strängé नेपाली folder" should not exist
-    And as "user1" the file "strängé filename (duplicate #2 &).txt" should not exist
+    Then as "user1" folder "simple-folder" should not exist
+    And as "user1" file "lorem.txt" should not exist
+    And as "user1" folder "strängé नेपाली folder" should not exist
+    And as "user1" file "strängé filename (duplicate #2 &).txt" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
@@ -68,9 +68,9 @@ Feature: deleting files and folders
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then as "user1" the file "data.zip" should not exist
-    And as "user1" the file "lorem.txt" should not exist
-    And as "user1" the folder "simple-folder" should not exist
+    Then as "user1" file "data.zip" should not exist
+    And as "user1" file "lorem.txt" should not exist
+    And as "user1" folder "simple-folder" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
@@ -78,9 +78,9 @@ Feature: deleting files and folders
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI
     # Check just some example files/folders that should not exist any more
-    Then as "user1" the file "data.zip" should not exist
-    And as "user1" the file "lorem.txt" should not exist
-    And as "user1" the folder "simple-folder" should not exist
+    Then as "user1" file "data.zip" should not exist
+    And as "user1" file "lorem.txt" should not exist
+    And as "user1" folder "simple-folder" should not exist
     And the folder should be empty on the webUI
     And the folder should be empty on the webUI after a page reload
 
@@ -91,52 +91,52 @@ Feature: deleting files and folders
       | lorem.txt     |
       | simple-folder |
     And the user batch deletes the marked files using the webUI
-    Then as "user1" the file "lorem.txt" should exist
-    And as "user1" the folder "simple-folder" should exist
-    And the folder "simple-folder" should be listed on the webUI
-    And the file "lorem.txt" should be listed on the webUI
+    Then as "user1" file "lorem.txt" should exist
+    And as "user1" folder "simple-folder" should exist
+    And folder "simple-folder" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
     # Check just an example of a file that should not exist any more
-    But as "user1" the file "data.zip" should not exist
-    And the file "data.zip" should not be listed on the webUI
+    But as "user1" file "data.zip" should not exist
+    And file "data.zip" should not be listed on the webUI
 
   Scenario: Delete an empty folder
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
-    And the user deletes the folder "my-empty-folder" using the webUI
-    Then as "user1" the folder "my-other-empty-folder" should exist
-    And the folder "my-other-empty-folder" should be listed on the webUI
-    But as "user1" the folder "my-empty-folder" should not exist
-    And the folder "my-empty-folder" should not be listed on the webUI
+    And the user deletes folder "my-empty-folder" using the webUI
+    Then as "user1" folder "my-other-empty-folder" should exist
+    And folder "my-other-empty-folder" should be listed on the webUI
+    But as "user1" folder "my-empty-folder" should not exist
+    And folder "my-empty-folder" should not be listed on the webUI
 
   Scenario: Delete the last file in a folder
-    When the user deletes the file "zzzz-must-be-last-file-in-folder.txt" using the webUI
-    Then as "user1" the file "zzzz-must-be-last-file-in-folder.txt" should not exist
-    And the file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
+    When the user deletes file "zzzz-must-be-last-file-in-folder.txt" using the webUI
+    Then as "user1" file "zzzz-must-be-last-file-in-folder.txt" should not exist
+    And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   Scenario: delete files from shared with others page
     Given the user has shared file "lorem.txt" with user "User Two" using the webUI
     And the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user has browsed to the shared-with-others page
-    When the user deletes the file "lorem.txt" using the webUI
-    And the user deletes the folder "simple-folder" using the webUI
-    Then as "user1" the file "lorem.txt" should not exist
-    And as "user1" the folder "simple-folder" should not exist
-    And the file "lorem.txt" should not be listed on the webUI
-    And the folder "simple-folder" should not be listed on the webUI
+    When the user deletes file "lorem.txt" using the webUI
+    And the user deletes folder "simple-folder" using the webUI
+    Then as "user1" file "lorem.txt" should not exist
+    And as "user1" folder "simple-folder" should not exist
+    And file "lorem.txt" should not be listed on the webUI
+    And folder "simple-folder" should not be listed on the webUI
     When the user browses to the files page
-    Then the file "lorem.txt" should not be listed on the webUI
-    And the folder "simple-folder" should not be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    And folder "simple-folder" should not be listed on the webUI
 
   @public_link_share-feature-required
   Scenario: delete files from shared by link page
-    Given the user has created a new public link for the file "lorem.txt" using the webUI
+    Given the user has created a new public link for file "lorem.txt" using the webUI
     And the user has browsed to the shared-by-link page
-    Then the file "lorem.txt" should be listed on the webUI
-    When the user deletes the file "lorem.txt" using the webUI
-    Then as "user1" the file "lorem.txt" should not exist
-    And the file "lorem.txt" should not be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When the user deletes file "lorem.txt" using the webUI
+    Then as "user1" file "lorem.txt" should not exist
+    And file "lorem.txt" should not be listed on the webUI
     When the user browses to the files page
-    Then the file "lorem.txt" should not be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
 
   @systemtags-app-required
   Scenario: delete files from tags page
@@ -144,15 +144,15 @@ Feature: deleting files and folders
     And user "user1" has added the tag "lorem" to "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    When the user deletes the file "lorem.txt" using the webUI
-    Then as "user1" the file "lorem.txt" should not exist
-    And the file "lorem.txt" should not be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When the user deletes file "lorem.txt" using the webUI
+    Then as "user1" file "lorem.txt" should not exist
+    And file "lorem.txt" should not be listed on the webUI
     When the user browses to the files page
-    Then the file "lorem.txt" should not be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
 
   Scenario: delete a file on a public share
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     When the user deletes the following elements using the webUI
@@ -160,14 +160,14 @@ Feature: deleting files and folders
       | simple-empty-folder                   |
       | lorem.txt                             |
       | strängé filename (duplicate #2 &).txt |
-    Then as "user1" the file "simple-folder/lorem.txt" should not exist
-    And as "user1" the folder "simple-folder/simple-empty-folder" should not exist
-    And as "user1" the file "simple-folder/strängé filename (duplicate #2 &).txt" should not exist
+    Then as "user1" file "simple-folder/lorem.txt" should not exist
+    And as "user1" folder "simple-folder/simple-empty-folder" should not exist
+    And as "user1" file "simple-folder/strängé filename (duplicate #2 &).txt" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
   Scenario: delete a file on a public share with problematic characters
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     When the user renames the following file using the webUI
@@ -197,7 +197,7 @@ Feature: deleting files and folders
       | &and#hash       |
 
   Scenario: Delete multiple files at once on a public share
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     When the user batch deletes these files using the webUI
@@ -205,8 +205,8 @@ Feature: deleting files and folders
       | data.zip            |
       | lorem.txt           |
       | simple-empty-folder |
-    Then as "user1" the file "simple-folder/data.zip" should not exist
-    And as "user1" the file "simple-folder/lorem.txt" should not exist
-    And as "user1" the folder "simple-folder/simple-empty-folder" should not exist
+    Then as "user1" file "simple-folder/data.zip" should not exist
+    And as "user1" file "simple-folder/lorem.txt" should not exist
+    And as "user1" folder "simple-folder/simple-empty-folder" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -114,8 +114,8 @@ Feature: deleting files and folders
     And the file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   Scenario: delete files from shared with others page
-    Given the user has shared the file "lorem.txt" with the user "User Two" using the webUI
-    And the user has shared the folder "simple-folder" with the user "User Two" using the webUI
+    Given the user has shared file "lorem.txt" with user "User Two" using the webUI
+    And the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user has browsed to the shared-with-others page
     When the user deletes the file "lorem.txt" using the webUI
     And the user deletes the folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -14,7 +14,7 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_versions-app-required
   Scenario: View different areas of the details panel in files page
-    When the user opens the file action menu of the file "lorem.txt" in the webUI
+    When the user opens the file action menu of file "lorem.txt" in the webUI
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel
@@ -27,9 +27,9 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_versions-app-required
   Scenario: View different areas of the details panel in favorites page
-    When the user marks the file "lorem.txt" as favorite using the webUI
+    When the user marks file "lorem.txt" as favorite using the webUI
     And the user browses to the favorites page
-    And the user opens the file action menu of the file "lorem.txt" in the webUI
+    And the user opens the file action menu of file "lorem.txt" in the webUI
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel
@@ -42,10 +42,10 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @public_link_share-feature-required
   Scenario: user shares a file through public link and then the details dialog should work in a Shared by link page
-    Given the user has created a new public link for the folder "simple-folder" using the webUI
+    Given the user has created a new public link for folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page
-    Then the folder "simple-folder" should be listed on the webUI
-    When the user opens the file action menu of the folder "simple-folder" in the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens the file action menu of folder "simple-folder" in the webUI
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel
@@ -58,8 +58,8 @@ Feature: User can open the details panel for any file or folder
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
     Given the user has shared folder "simple-folder" with user "User Two" using the webUI
     When the user browses to the shared-with-others page
-    Then the folder "simple-folder" should be listed on the webUI
-    When the user opens the file action menu of the folder "simple-folder" in the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens the file action menu of folder "simple-folder" in the webUI
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel
@@ -73,8 +73,8 @@ Feature: User can open the details panel for any file or folder
     Given the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
     When the user browses to the shared-with-you page
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    When the user opens the file action menu of the folder "simple-folder (2)" in the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    When the user opens the file action menu of folder "simple-folder (2)" in the webUI
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel
@@ -89,8 +89,8 @@ Feature: User can open the details panel for any file or folder
     And user "user1" has added the tag "simple" to "simple-folder"
     When the user browses to the tags page
     And the user searches for tag "simple" using the webUI
-    Then the folder "simple-folder" should be listed on the webUI
-    When the user opens the file action menu of the folder "simple-folder" in the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens the file action menu of folder "simple-folder" in the webUI
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -56,7 +56,7 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
-    Given the user has shared the folder "simple-folder" with the user "User Two" using the webUI
+    Given the user has shared folder "simple-folder" with user "User Two" using the webUI
     When the user browses to the shared-with-others page
     Then the folder "simple-folder" should be listed on the webUI
     When the user opens the file action menu of the folder "simple-folder" in the webUI
@@ -70,7 +70,7 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
-    Given the user has shared the folder "simple-folder" with the user "User Two" using the webUI
+    Given the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
     When the user browses to the shared-with-you page
     Then the folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -13,6 +13,6 @@ Feature: Hide file/folders
   @smokeTest
   Scenario: create a hidden folder
     When the user creates a folder with the name ".xyz" using the webUI
-    Then the folder ".xyz" should not be listed on the webUI
+    Then folder ".xyz" should not be listed on the webUI
     When the user enables the setting to view hidden folders on the webUI
-    Then the folder ".xyz" should be listed on the webUI
+    Then folder ".xyz" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -14,36 +14,36 @@ Feature: Search
   @smokeTest
   Scenario: Simple search
     When the user searches for "lorem" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    And the file "lorem-big.txt" should be listed on the webUI
-    And the file "lorem.txt" with the path "/simple-folder" should be listed in the search results in other folders section on the webUI
-    And the file "lorem-big.txt" with the path "/simple-folder" should be listed in the search results in other folders section on the webUI
-    And the file "lorem.txt" with the path "/0" should be listed in the search results in other folders section on the webUI
-    And the file "lorem.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
-    And the file "lorem-big.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem-big.txt" should be listed on the webUI
+    And file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI
+    And file "lorem-big.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI
+    And file "lorem.txt" with path "/0" should be listed in the search results in the other folders section on the webUI
+    And file "lorem.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
+    And file "lorem-big.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
 
   Scenario: search for folders
     When the user searches for "folder" using the webUI
-    Then the folder "simple-folder" should be listed on the webUI
-    And the folder "strängé नेपाली folder" should be listed on the webUI
-    And the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
-    And the folder "simple-empty-folder" with the path "/'single'quotes" should be listed in the search results in other folders section on the webUI
-    And the file "zzzz-must-be-last-file-in-folder.txt" with the path "/simple-folder" should be listed in the search results in other folders section on the webUI
-    And the file "zzzz-must-be-last-file-in-folder.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
-    But the file "lorem.txt" should not be listed on the webUI
-    And the file "lorem.txt" should not be listed in the search results in other folders section on the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    And folder "strängé नेपाली folder" should be listed on the webUI
+    And file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
+    And folder "simple-empty-folder" with path "/'single'quotes" should be listed in the search results in the other folders section on the webUI
+    And file "zzzz-must-be-last-file-in-folder.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI
+    And file "zzzz-must-be-last-file-in-folder.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
+    But file "lorem.txt" should not be listed on the webUI
+    And file "lorem.txt" should not be listed in the search results in the other folders section on the webUI
 
   Scenario: search in sub folder
-    When the user opens the folder "simple-folder" using the webUI
+    When the user opens folder "simple-folder" using the webUI
     And the user searches for "lorem" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    And the file "lorem-big.txt" should be listed on the webUI
-    And the file "lorem.txt" with the path "/" should be listed in the search results in other folders section on the webUI
-    And the file "lorem-big.txt" with the path "/" should be listed in the search results in other folders section on the webUI
-    And the file "lorem.txt" with the path "/0" should be listed in the search results in other folders section on the webUI
-    And the file "lorem.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
-    And the file "lorem-big.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
-    But the file "lorem.txt" with the path "/simple-folder" should not be listed in the search results in other folders section on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem-big.txt" should be listed on the webUI
+    And file "lorem.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+    And file "lorem-big.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+    And file "lorem.txt" with path "/0" should be listed in the search results in the other folders section on the webUI
+    And file "lorem.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
+    And file "lorem-big.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
+    But file "lorem.txt" with path "/simple-folder" should not be listed in the search results in the other folders section on the webUI
 
   @systemtags-app-required
   Scenario: search for a file using a tag
@@ -51,7 +51,7 @@ Feature: Search
     And user "user1" has added the tag "ipsum" to "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "ipsum" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
 
   @systemtags-app-required
   Scenario: search for a file with multiple tags
@@ -63,8 +63,8 @@ Feature: Search
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     And the user searches for tag "ipsum" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    And the file "testimage.jpg" should not be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "testimage.jpg" should not be listed on the webUI
 
   @systemtags-app-required
   Scenario: search for a file with tags
@@ -73,15 +73,15 @@ Feature: Search
     And user "user1" has added the tag "lorem" to "/simple-folder/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    And the file "lorem.txt" with the path "" should be listed in the tags page on the webUI
-    And the file "lorem.txt" with the path "/simple-folder" should be listed in the tags page on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem.txt" with path "" should be listed in the tags page on the webUI
+    And file "lorem.txt" with path "/simple-folder" should be listed in the tags page on the webUI
 
   Scenario: Search for a shared file
     When user "user0" shares file "/lorem.txt" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "lorem" using the webUI
-    Then the file "lorem (2).txt" should be listed on the webUI
+    Then file "lorem (2).txt" should be listed on the webUI
 
   Scenario: Search for a re-shared file
     Given user "user2" has been created
@@ -89,37 +89,37 @@ Feature: Search
     And user "user0" shares file "/lorem (2).txt" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "lorem" using the webUI
-    Then the file "lorem (2).txt" should be listed on the webUI
+    Then file "lorem (2).txt" should be listed on the webUI
 
   Scenario: Search for a shared folder
     When user "user0" shares folder "simple-folder" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "simple" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
 
   Scenario: Search for a file after name is changed
-    When the user renames the file "lorem.txt" to "torem.txt" using the webUI
+    When the user renames file "lorem.txt" to "torem.txt" using the webUI
     And the user searches for "torem" using the webUI
-    Then the file "lorem.txt" should not be listed on the webUI
-    And the file "torem.txt" should be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    And file "torem.txt" should be listed on the webUI
 
   Scenario: Search for a newly uploaded file
     Given user "user1" has uploaded file with content "does-not-matter" to "torem.txt"
     And user "user1" has uploaded file with content "does-not-matter" to "simple-folder/another-torem.txt"
     When the user searches for "torem" using the webUI
-    Then the file "torem.txt" with the path "/" should be listed in the search results in other folders section on the webUI
-    And the file "another-torem.txt" with the path "/simple-folder" should be listed in the search results in other folders section on the webUI
+    Then file "torem.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+    And file "another-torem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI
 
   Scenario: Search for files with difficult names
     Given user "user1" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
     And user "user1" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
     When the user searches for "lorem" using the webUI
-    Then the file "strängéनेपालीloremfile.txt" with the path "/" should be listed in the search results in other folders section on the webUI
-    And the file "strängéनेपालीloremfile.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
+    Then file "strängéनेपालीloremfile.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+    And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
 
   Scenario: Search for files with difficult names and difficult search phrase
     Given user "user1" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
     And user "user1" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
     When the user searches for "strängéनेपाली" using the webUI
-    Then the file "strängéनेपालीloremfile.txt" with the path "/" should be listed in the search results in other folders section on the webUI
-    And the file "strängéनेपालीloremfile.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
+    Then file "strängéनेपालीloremfile.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+    And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -10,51 +10,51 @@ Feature: move files
     And the user has browsed to the files page
 
   Scenario: An attempt to move a file into a sub-folder using rename is not allowed
-    When the user renames the file "data.zip" to "simple-folder/data.zip" using the webUI
-    Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
+    When the user renames file "data.zip" to "simple-folder/data.zip" using the webUI
+    Then near file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
   @skipOnFIREFOX
   @smokeTest
   Scenario: move a file into a folder
-    When the user moves the file "data.zip" into the folder "simple-empty-folder" using the webUI
-    Then the file "data.zip" should not be listed on the webUI
-    But the file "data.zip" should be listed in the folder "simple-empty-folder" on the webUI
+    When the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
+    Then file "data.zip" should not be listed on the webUI
+    But file "data.zip" should be listed in folder "simple-empty-folder" on the webUI
     When the user browses to the files page
-    And the user moves the file "data.tar.gz" into the folder "strängé नेपाली folder empty" using the webUI
-    Then the file "data.tar.gz" should not be listed on the webUI
-    But the file "data.tar.gz" should be listed in the folder "strängé नेपाली folder empty" on the webUI
+    And the user moves file "data.tar.gz" into folder "strängé नेपाली folder empty" using the webUI
+    Then file "data.tar.gz" should not be listed on the webUI
+    But file "data.tar.gz" should be listed in folder "strängé नेपाली folder empty" on the webUI
     When the user browses to the files page
-    And the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder empty" using the webUI
-    Then the file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
-    But the file "strängé filename (duplicate #2 &).txt" should be listed in the folder "strängé नेपाली folder empty" on the webUI
+    And the user moves file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder empty" using the webUI
+    Then file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
+    But file "strängé filename (duplicate #2 &).txt" should be listed in folder "strängé नेपाली folder empty" on the webUI
 
   @skipOnFIREFOX
   Scenario: move a file into a folder where a file with the same name already exists
-    When the user moves the file "data.zip" into the folder "simple-folder" using the webUI
-    And the user moves the file "data.zip" into the folder "strängé नेपाली folder" using the webUI
+    When the user moves file "data.zip" into folder "simple-folder" using the webUI
+    And the user moves file "data.zip" into folder "strängé नेपाली folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "data.zip", target exists |
       | Could not move "data.zip", target exists |
-    And the file "data.zip" should be listed on the webUI
+    And file "data.zip" should be listed on the webUI
 
   @skipOnFIREFOX
   Scenario: move a file into a folder where a file with the same name already exists
-    When the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder" using the webUI
+    When the user moves file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "strängé filename (duplicate #2 &).txt", target exists |
-    And the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    And file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 
   @skipOnFIREFOX
   @smokeTest
   Scenario: Move multiple files at once
-    When the user batch moves these files into the folder "simple-empty-folder" using the webUI
+    When the user batch moves these files into folder "simple-empty-folder" using the webUI
       | name        |
       | data.zip    |
       | lorem.txt   |
       | testapp.zip |
     Then the moved elements should not be listed on the webUI
     And the moved elements should not be listed on the webUI after a page reload
-    But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
+    But the moved elements should be listed in folder "simple-empty-folder" on the webUI
 
   @skipOnFIREFOX
   Scenario: move a file into a folder (problematic characters)
@@ -85,12 +85,12 @@ Feature: move files
 
   @skipOnFIREFOX
   Scenario: move files on a public share
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
-    And the user moves the file "data.zip" into the folder "simple-empty-folder" using the webUI
-    Then the file "data.zip" should not be listed on the webUI
+    And the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
+    Then file "data.zip" should not be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the file "data.zip" should not be listed on the webUI
-    And as "user1" the file "simple-folder/simple-empty-folder/data.zip" should exist
-    But as "user1" the file "simple-folder/data.zip" should not exist
+    Then file "data.zip" should not be listed on the webUI
+    And as "user1" file "simple-folder/simple-empty-folder/data.zip" should exist
+    But as "user1" file "simple-folder/data.zip" should not exist

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -10,35 +10,35 @@ Feature: move folders
     And the user has browsed to the files page
 
   Scenario: An attempt to move a folder into a sub-folder using rename is not allowed
-    When the user renames the folder "simple-empty-folder" to "simple-folder/simple-empty-folder" using the webUI
-    Then near the folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
+    When the user renames folder "simple-empty-folder" to "simple-folder/simple-empty-folder" using the webUI
+    Then near folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
   @skipOnFIREFOX
   Scenario: move a folder into another folder
-    When the user moves the folder "simple-folder" into the folder "simple-empty-folder" using the webUI
-    Then the folder "simple-folder" should not be listed on the webUI
-    But the folder "simple-folder" should be listed in the folder "simple-empty-folder" on the webUI
+    When the user moves folder "simple-folder" into folder "simple-empty-folder" using the webUI
+    Then folder "simple-folder" should not be listed on the webUI
+    But folder "simple-folder" should be listed in folder "simple-empty-folder" on the webUI
     When the user browses to the files page
-    And the user moves the folder "strängé नेपाली folder" into the folder "strängé नेपाली folder empty" using the webUI
-    Then the folder "strängé नेपाली folder" should not be listed on the webUI
-    But the folder "strängé नेपाली folder" should be listed in the folder "strängé नेपाली folder empty" on the webUI
+    And the user moves folder "strängé नेपाली folder" into folder "strängé नेपाली folder empty" using the webUI
+    Then folder "strängé नेपाली folder" should not be listed on the webUI
+    But folder "strängé नेपाली folder" should be listed in folder "strängé नेपाली folder empty" on the webUI
 
   @skipOnFIREFOX
   Scenario: move a folder into another folder where a folder with the same name already exists
-    When the user moves the folder "simple-empty-folder" into the folder "simple-folder" using the webUI
+    When the user moves folder "simple-empty-folder" into folder "simple-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "simple-empty-folder", target exists |
-    And the folder "simple-empty-folder" should be listed on the webUI
+    And folder "simple-empty-folder" should be listed on the webUI
 
   @skipOnFIREFOX
   Scenario: Move multiple folders at once
-    When the user batch moves these folders into the folder "simple-empty-folder" using the webUI
+    When the user batch moves these folders into folder "simple-empty-folder" using the webUI
       | name                  |
       | simple-folder         |
       | strängé नेपाली folder |
     Then the moved elements should not be listed on the webUI
     And the moved elements should not be listed on the webUI after a page reload
-    But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
+    But the moved elements should be listed in folder "simple-empty-folder" on the webUI
 
   @skipOnFIREFOX
   Scenario: move a folder into another folder (problematic characters)

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -17,21 +17,21 @@ Feature: personal general settings
   Scenario: change language and check that file actions menu have been translated
     When the user changes the language to "हिन्दी" using the webUI
     And the user browses to the files page
-    And the user opens the file action menu of the folder "simple-folder" in the webUI
+    And the user opens the file action menu of folder "simple-folder" in the webUI
     Then the user should see "Details" file action translated to "विवरण" in the webUI
     And the user should see "Delete" file action translated to "हटाना" in the webUI
 
   Scenario: change language using the occ command and check that file actions menu have been translated
     When the administrator changes the language of user "user1" to "fr" using the occ command
     And the user browses to the files page
-    And the user opens the file action menu of the folder "simple-folder" in the webUI
+    And the user opens the file action menu of folder "simple-folder" in the webUI
     Then the user should see "Details" file action translated to "Détails" in the webUI
     And the user should see "Delete" file action translated to "Supprimer" in the webUI
 
   Scenario: change language to invalid language using the occ command and check that the language defaults back to english
     When the administrator changes the language of user "user1" to "not-valid-lan" using the occ command
     And the user browses to the files page
-    And the user opens the file action menu of the folder "simple-folder" in the webUI
+    And the user opens the file action menu of folder "simple-folder" in the webUI
     Then the user should see "Details" file action translated to "Details" in the webUI
     And the user should see "Delete" file action translated to "Delete" in the webUI
 

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -11,10 +11,10 @@ Feature: rename files
 
   @smokeTest
   Scenario Outline: Rename a file using special characters
-    When the user renames the file "lorem.txt" to <to_file_name> using the webUI
-    Then the file <to_file_name> should be listed on the webUI
+    When the user renames file "lorem.txt" to <to_file_name> using the webUI
+    Then file <to_file_name> should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the file <to_file_name> should be listed on the webUI
+    Then file <to_file_name> should be listed on the webUI
     Examples:
       | to_file_name           |
       | 'लोरेम।तयक्स्त? $%#&@' |
@@ -22,10 +22,10 @@ Feature: rename files
       | "'quotes2'"            |
 
   Scenario Outline: Rename a file that has special characters in its name
-    When the user renames the file <from_name> to <to_name> using the webUI
-    Then the file <to_name> should be listed on the webUI
+    When the user renames file <from_name> to <to_name> using the webUI
+    Then file <to_name> should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the file <to_name> should be listed on the webUI
+    Then file <to_name> should be listed on the webUI
     Examples:
       | from_name                               | to_name                               |
       | "strängé filename (duplicate #2 &).txt" | "strängé filename (duplicate #3).txt" |
@@ -33,41 +33,41 @@ Feature: rename files
 
   @smokeTest
   Scenario: Rename a file using special characters and check its existence after page reload
-    When the user renames the file "lorem.txt" to "लोरेम।तयक्स्त $%&" using the webUI
+    When the user renames file "lorem.txt" to "लोरेम।तयक्स्त $%&" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "लोरेम।तयक्स्त $%&" should be listed on the webUI
-    When the user renames the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt' using the webUI
+    Then file "लोरेम।तयक्स्त $%&" should be listed on the webUI
+    When the user renames file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt' using the webUI
     And the user reloads the current page of the webUI
-    Then the file '"double"quotes.txt' should be listed on the webUI
-    When the user renames the file '"double"quotes.txt' to "no-double-quotes.txt" using the webUI
+    Then file '"double"quotes.txt' should be listed on the webUI
+    When the user renames file '"double"quotes.txt' to "no-double-quotes.txt" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "no-double-quotes.txt" should be listed on the webUI
-    When the user renames the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt" using the webUI
+    Then file "no-double-quotes.txt" should be listed on the webUI
+    When the user renames file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed on the webUI
-    When the user renames the file 'zzzz-must-be-last-file-in-folder.txt' to "aaaaaa.txt" using the webUI
+    Then file "hash#And&QuestionMark?At@Filename.txt" should be listed on the webUI
+    When the user renames file 'zzzz-must-be-last-file-in-folder.txt' to "aaaaaa.txt" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "aaaaaa.txt" should be listed on the webUI
+    Then file "aaaaaa.txt" should be listed on the webUI
 
   Scenario: Rename a file using spaces at front and/or back of file name and type
-    When the user renames the file "lorem.txt" to " space at start" using the webUI
+    When the user renames file "lorem.txt" to " space at start" using the webUI
     And the user reloads the current page of the webUI
-    Then the file " space at start" should be listed on the webUI
-    When the user renames the file " space at start" to "space at end " using the webUI
+    Then file " space at start" should be listed on the webUI
+    When the user renames file " space at start" to "space at end " using the webUI
     And the user reloads the current page of the webUI
-    Then the file "space at end " should be listed on the webUI
-    When the user renames the file "space at end " to "space at end .txt" using the webUI
+    Then file "space at end " should be listed on the webUI
+    When the user renames file "space at end " to "space at end .txt" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "space at end .txt" should be listed on the webUI
-    When the user renames the file "space at end .txt" to "space at end. lis" using the webUI
+    Then file "space at end .txt" should be listed on the webUI
+    When the user renames file "space at end .txt" to "space at end. lis" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "space at end. lis" should be listed on the webUI
-    When the user renames the file "space at end. lis" to "space at end.log " using the webUI
+    Then file "space at end. lis" should be listed on the webUI
+    When the user renames file "space at end. lis" to "space at end.log " using the webUI
     And the user reloads the current page of the webUI
-    Then the file "space at end.log " should be listed on the webUI
-    When the user renames the file "space at end.log " to "  multiple   space    all     over   .  dat  " using the webUI
+    Then file "space at end.log " should be listed on the webUI
+    When the user renames file "space at end.log " to "  multiple   space    all     over   .  dat  " using the webUI
     And the user reloads the current page of the webUI
-    Then the file "  multiple   space    all     over   .  dat  " should be listed on the webUI
+    Then file "  multiple   space    all     over   .  dat  " should be listed on the webUI
 
   Scenario: Rename a file using both double and single quotes
     When the user renames the following file using the webUI
@@ -84,10 +84,10 @@ Feature: rename files
       | First 'single' quotes | loremz.dat    |
       | -then "double".txt    |               |
     And the user reloads the current page of the webUI
-    Then the file "loremz.dat" should be listed on the webUI
+    Then file "loremz.dat" should be listed on the webUI
 
   Scenario: Rename a file using forbidden characters
-    When the user renames the file "data.zip" to one of these names using the webUI
+    When the user renames file "data.zip" to one of these names using the webUI
       | lorem\txt |
       | \\.txt    |
       | .htaccess |
@@ -95,43 +95,43 @@ Feature: rename files
       | Could not rename "data.zip" |
       | Could not rename "data.zip" |
       | Could not rename "data.zip" |
-    And the file "data.zip" should be listed on the webUI
+    And file "data.zip" should be listed on the webUI
 
   Scenario: Rename the last file in a folder
-    When the user renames the file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt" using the webUI
+    When the user renames file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "a-file.txt" should be listed on the webUI
+    Then file "a-file.txt" should be listed on the webUI
 
   Scenario: Rename a file to become the last file in a folder
-    When the user renames the file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt" using the webUI
+    When the user renames file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt" using the webUI
     And the user reloads the current page of the webUI
-    Then the file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
+    Then file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
 
   Scenario: Rename a file putting a name of a file which already exists
-    When the user renames the file "data.zip" to "lorem.txt" using the webUI
-    Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
+    When the user renames file "data.zip" to "lorem.txt" using the webUI
+    Then near file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
   Scenario: Rename a file to ..
-    When the user renames the file "data.zip" to ".." using the webUI
-    Then near the file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
+    When the user renames file "data.zip" to ".." using the webUI
+    Then near file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a file to .
-    When the user renames the file "data.zip" to "." using the webUI
-    Then near the file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
+    When the user renames file "data.zip" to "." using the webUI
+    Then near file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a file to .part
-    When the user renames the file "data.zip" to "data.part" using the webUI
-    Then near the file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI
+    When the user renames file "data.zip" to "data.part" using the webUI
+    Then near file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI
 
   Scenario: rename a file on a public share
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
-    And the user renames the file "lorem.txt" to "a-renamed-file.txt" using the webUI
-    Then the file "a-renamed-file.txt" should be listed on the webUI
-    But the file "lorem.txt" should not be listed on the webUI
+    And the user renames file "lorem.txt" to "a-renamed-file.txt" using the webUI
+    Then file "a-renamed-file.txt" should be listed on the webUI
+    But file "lorem.txt" should not be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the file "a-renamed-file.txt" should be listed on the webUI
-    But the file "lorem.txt" should not be listed on the webUI
-    And as "user1" the file "simple-folder/a-renamed-file.txt" should exist
-    And as "user1" the file "simple-folder/lorem.txt" should not exist
+    Then file "a-renamed-file.txt" should be listed on the webUI
+    But file "lorem.txt" should not be listed on the webUI
+    And as "user1" file "simple-folder/a-renamed-file.txt" should exist
+    And as "user1" file "simple-folder/lorem.txt" should not exist

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -9,11 +9,11 @@ Feature: Renaming files inside a folder with problematic name
     And user "user1" has logged in using the webUI
 
   Scenario Outline: Rename the existing file inside a problematic folder
-    When the user opens the folder <folder> using the webUI
-    And the user renames the file "lorem.txt" to "???.txt" using the webUI
-    Then the file "???.txt" should be listed on the webUI
+    When the user opens folder <folder> using the webUI
+    And the user renames file "lorem.txt" to "???.txt" using the webUI
+    Then file "???.txt" should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the file "???.txt" should be listed on the webUI
+    Then file "???.txt" should be listed on the webUI
     Examples:
       | folder                  |
       | "0"                     |

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -10,10 +10,10 @@ Feature: rename folders
     And the user has browsed to the files page
 
   Scenario Outline: Rename a folder using special characters
-    When the user renames the folder "simple-folder" to <to_folder_name> using the webUI
-    Then the folder <to_folder_name> should be listed on the webUI
+    When the user renames folder "simple-folder" to <to_folder_name> using the webUI
+    Then folder <to_folder_name> should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the folder <to_folder_name> should be listed on the webUI
+    Then folder <to_folder_name> should be listed on the webUI
     Examples:
       | to_folder_name          |
       | 'सिमप्ले फोल्देर$%#?&@' |
@@ -21,39 +21,39 @@ Feature: rename folders
       | "'quotes2'"             |
 
   Scenario Outline: Rename a folder that has special characters in its name
-    When the user renames the folder <from_name> to <to_name> using the webUI
-    Then the folder <to_name> should be listed on the webUI
+    When the user renames folder <from_name> to <to_name> using the webUI
+    Then folder <to_name> should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the folder <to_name> should be listed on the webUI
+    Then folder <to_name> should be listed on the webUI
     Examples:
       | from_name               | to_name                     |
       | "strängé नेपाली folder" | "strängé नेपाली folder-#?2" |
       | "'single'quotes"        | "single-quotes"             |
 
   Scenario: Rename a folder using special characters and check its existence after page reload
-    When the user renames the folder "simple-folder" to "लोरेम।तयक्स्त $%&" using the webUI
+    When the user renames folder "simple-folder" to "लोरेम।तयक्स्त $%&" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "लोरेम।तयक्स्त $%&" should be listed on the webUI
-    When the user renames the folder "लोरेम।तयक्स्त $%&" to '"double"quotes' using the webUI
+    Then folder "लोरेम।तयक्स्त $%&" should be listed on the webUI
+    When the user renames folder "लोरेम।तयक्स्त $%&" to '"double"quotes' using the webUI
     And the user reloads the current page of the webUI
-    Then the folder '"double"quotes' should be listed on the webUI
-    When the user renames the folder '"double"quotes' to "no-double-quotes" using the webUI
+    Then folder '"double"quotes' should be listed on the webUI
+    When the user renames folder '"double"quotes' to "no-double-quotes" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "no-double-quotes" should be listed on the webUI
-    When the user renames the folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName" using the webUI
+    Then folder "no-double-quotes" should be listed on the webUI
+    When the user renames folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
+    Then folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
 
   Scenario: Rename a folder using spaces at front and/or back of the name
-    When the user renames the folder "simple-folder" to " space at start" using the webUI
+    When the user renames folder "simple-folder" to " space at start" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder " space at start" should be listed on the webUI
-    When the user renames the folder " space at start" to "space at end " using the webUI
+    Then folder " space at start" should be listed on the webUI
+    When the user renames folder " space at start" to "space at end " using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "space at end " should be listed on the webUI
-    When the user renames the folder "space at end " to "  multiple   spaces    all     over   " using the webUI
+    Then folder "space at end " should be listed on the webUI
+    When the user renames folder "space at end " to "  multiple   spaces    all     over   " using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "  multiple   spaces    all     over   " should be listed on the webUI
+    Then folder "  multiple   spaces    all     over   " should be listed on the webUI
 
   Scenario: Rename a folder using both double and single quotes
     When the user renames the following folder using the webUI
@@ -70,10 +70,10 @@ Feature: rename folders
       | First 'single' quotes | a normal folder |
       | -then "double"        |                 |
     And the user reloads the current page of the webUI
-    Then the folder "a normal folder" should be listed on the webUI
+    Then folder "a normal folder" should be listed on the webUI
 
   Scenario: Rename a folder using forbidden characters
-    When the user renames the folder "simple-folder" to one of these names using the webUI
+    When the user renames folder "simple-folder" to one of these names using the webUI
       | simple\folder   |
       | \\simple-folder |
       | .htaccess       |
@@ -81,20 +81,20 @@ Feature: rename folders
       | Could not rename "simple-folder" |
       | Could not rename "simple-folder" |
       | Could not rename "simple-folder" |
-    And the folder "simple-folder" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI
 
   Scenario: Rename a folder putting a name of a file which already exists
-    When the user renames the folder "simple-folder" to "lorem.txt" using the webUI
-    Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
+    When the user renames folder "simple-folder" to "lorem.txt" using the webUI
+    Then near folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
   Scenario: Rename a folder to ..
-    When the user renames the folder "simple-folder" to ".." using the webUI
-    Then near the folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
+    When the user renames folder "simple-folder" to ".." using the webUI
+    Then near folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a folder to .
-    When the user renames the folder "simple-folder" to "." using the webUI
-    Then near the folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
+    When the user renames folder "simple-folder" to "." using the webUI
+    Then near folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a folder to .part
-    When the user renames the folder "simple-folder" to "simple.part" using the webUI
-    Then near the folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed on the webUI
+    When the user renames folder "simple-folder" to "simple.part" using the webUI
+    Then near folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed on the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -12,4 +12,4 @@ Feature: disable sharing
   Scenario: Users tries to share via WebUI when Sharing is disabled
     Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
     When user "user1" logs in using the webUI
-    Then it should not be possible to share the folder "simple-folder" using the webUI
+    Then it should not be possible to share folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -27,7 +27,7 @@ Feature: restrict resharing
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | share | no |
     And the user re-logs in as "user1" using the webUI
-    Then it should not be possible to share the folder "simple-folder (2)" using the webUI
+    Then it should not be possible to share folder "simple-folder (2)" using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
@@ -36,4 +36,4 @@ Feature: restrict resharing
     And the user has browsed to the files page
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then it should not be possible to share the folder "simple-folder (2)" using the webUI
+    Then it should not be possible to share folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -23,7 +23,7 @@ Feature: restrict resharing
   Scenario: share a folder with another internal user and prohibit resharing
     Given the setting "Allow resharing" in the section "Sharing" has been enabled
     And the user has browsed to the files page
-    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | share | no |
     And the user re-logs in as "user1" using the webUI
@@ -34,6 +34,6 @@ Feature: restrict resharing
   Scenario: forbid resharing globally
     Given the setting "Allow resharing" in the section "Sharing" has been disabled
     And the user has browsed to the files page
-    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then it should not be possible to share the folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -25,7 +25,7 @@ Feature: restrict Sharing
     Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
     When the user browses to the files page
     Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
-    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
@@ -54,6 +54,6 @@ Feature: restrict Sharing
     When the user browses to the files page
     Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
     And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
-    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -24,36 +24,36 @@ Feature: restrict Sharing
   Scenario: Restrict users to only share with users in their groups
     Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
     When the user browses to the files page
-    Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
+    Then it should not be possible to share folder "simple-folder" with "User Three" using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Restrict users to only share with groups they are member of
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
     When the user browses to the files page
-    Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
-    When the user shares the folder "simple-folder" with group "grp1" using the webUI
+    Then it should not be possible to share folder "simple-folder" with "grp2" using the webUI
+    When the user shares folder "simple-folder" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
   Scenario: Do not restrict users to only share with groups they are member of
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
     And the user browses to the files page
-    When the user shares the folder "simple-folder" with group "grp2" using the webUI
+    When the user shares folder "simple-folder" with group "grp2" using the webUI
     And the user re-logs in as "user3" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Forbid sharing with groups
     Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled
     When the user browses to the files page
-    Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
-    And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
+    Then it should not be possible to share folder "simple-folder" with "grp1" using the webUI
+    And it should not be possible to share folder "simple-folder" with "grp2" using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -33,9 +33,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user has reloaded the current page of the webUI
     Then dialogs should be displayed on the webUI
       | title        | content                                                                                              |
-      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%/?       |
-      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%/? |
-      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%/?           |
+      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%?        |
+      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%?  |
+      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%?            |
     When the user accepts the offered remote shares using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -12,8 +12,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" has logged in using the webUI
 
   Scenario: test the single steps of sharing a folder to a remote server
-    When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-    And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
+    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
+    And the user shares folder "simple-empty-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
@@ -33,9 +33,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user has reloaded the current page of the webUI
     Then dialogs should be displayed on the webUI
       | title        | content                                                                                              |
-      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%?        |
-      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%?  |
-      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%?            |
+      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%/?       |
+      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%/? |
+      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%/?           |
     When the user accepts the offered remote shares using the webUI
     Then the file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"
@@ -55,7 +55,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
-    When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
+    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
     And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
       | delete | no |
     And user "user1" re-logs in to "%remote_server%" using the webUI
@@ -66,7 +66,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
     When user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user shares the folder "simple-folder" with the remote user "user1@%local_server_without_scheme%" using the webUI
+    And the user shares folder "simple-folder" with remote user "user1@%local_server_without_scheme%" using the webUI
     And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
       | delete | no |
     And user "user1" re-logs in to "%local_server%" using the webUI
@@ -188,7 +188,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: test sharing long file names with federation share
     When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI
-    And the user shares the file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with the remote user "user1@%remote_server_without_scheme%" using the webUI
+    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "user1@%remote_server_without_scheme%" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -17,9 +17,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
-    Then as "user1" the folder "/simple-folder (2)" should exist
-    And as "user1" the file "/simple-folder (2)/lorem.txt" should exist
-    And as "user1" the folder "/simple-empty-folder (2)" should exist
+    Then as "user1" folder "/simple-folder (2)" should exist
+    And as "user1" file "/simple-folder (2)/lorem.txt" should exist
+    And as "user1" folder "/simple-empty-folder (2)" should exist
 
   Scenario: test the single steps of receiving a federation share
     Given using server "REMOTE"
@@ -37,21 +37,21 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%/? |
       | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%/?           |
     When the user accepts the offered remote shares using the webUI
-    Then the file "lorem (2).txt" should be listed on the webUI
+    Then file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"
-    And the folder "simple-folder (2)" should be listed on the webUI
-    And the file "lorem.txt" should be listed in the folder "simple-folder (2)" on the webUI
+    And folder "simple-folder (2)" should be listed on the webUI
+    And file "lorem.txt" should be listed in folder "simple-folder (2)" on the webUI
     And the content of "lorem.txt" on the local server should be the same as the original "simple-folder/lorem.txt"
-    And the file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
-    And the folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
+    And file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    And folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
 
   Scenario: declining a federation share on the webUI
     Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user declines the offered remote shares using the webUI
-    Then the file "lorem (2).txt" should not be listed on the webUI
-    And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
+    And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
@@ -60,8 +60,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | delete | no |
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    And the user opens the folder "simple-folder (2)" using the webUI
-    Then it should not be possible to delete the file "lorem.txt" using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
@@ -71,27 +71,27 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | delete | no |
     And user "user1" re-logs in to "%local_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    And the user opens the folder "simple-folder (2)" using the webUI
-    Then it should not be possible to delete the file "lorem.txt" using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: overwrite a file in a received share - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
     And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
 
   Scenario: overwrite a file in a received share - remote server shares - local server receives
     Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
-    And the user opens the folder "simple-folder (2)" using the webUI
-    And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    And the user opens folder "simple-folder (2)" using the webUI
+    And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
 
   Scenario: upload a new file in a received share - local server shares - remote server receives
@@ -99,19 +99,19 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
     And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "new-lorem.txt" should be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
 
   Scenario: upload a new file in a received share - remote server shares - local server receives
     Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
-    And the user opens the folder "simple-folder (2)" using the webUI
-    And the user uploads the file "new-lorem.txt" using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "new-lorem.txt" should be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
 
   Scenario: rename a file in a received share - local server shares - remote server receives
@@ -119,40 +119,40 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
     And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "renamed file.txt" should be listed on the webUI
-    But the file "lorem-big.txt" should not be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "renamed file.txt" should be listed on the webUI
+    But file "lorem-big.txt" should not be listed on the webUI
     And the content of "renamed file.txt" on the local server should be the same as the original "simple-folder/lorem-big.txt"
 
   Scenario: rename a file in a received share - remote server shares - local server receives
     Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
-    When the user opens the folder "simple-folder (2)" using the webUI
-    And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    And the user renames file "lorem-big.txt" to "renamed file.txt" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "renamed file.txt" should be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "renamed file.txt" should be listed on the webUI
     And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
-    But the file "lorem-big.txt" should not be listed on the webUI
+    But file "lorem-big.txt" should not be listed on the webUI
 
   Scenario: delete a file in a received share - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
     And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "data.zip" should not be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "data.zip" should not be listed on the webUI
 
   Scenario: delete a file in a received share - remote server shares - local server receives
     Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
-    And the user opens the folder "simple-folder (2)" using the webUI
-    And the user deletes the file "data.zip" using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    And the user deletes file "data.zip" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    Then the file "data.zip" should not be listed on the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then file "data.zip" should not be listed on the webUI
 
   Scenario: receive same name federation share from two users
     Given using server "REMOTE"
@@ -161,28 +161,28 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
-    Then the file "lorem (2).txt" should be listed on the webUI
-    And the file "lorem (3).txt" should be listed on the webUI
-    And the file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
-    And the file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
+    Then file "lorem (2).txt" should be listed on the webUI
+    And file "lorem (3).txt" should be listed on the webUI
+    And file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
+    And file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
 
   Scenario: unshare a federation share
     Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
-    When the user unshares the file "lorem (2).txt" using the webUI
-    Then the file "lorem (2).txt" should not be listed on the webUI
+    When the user unshares file "lorem (2).txt" using the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
     When the user has reloaded the current page of the webUI
-    Then the file "lorem (2).txt" should not be listed on the webUI
-    And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
+    And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
   Scenario: unshare a federation share from "share-with-you" page
     Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
-    When the user unshares the file "lorem (2).txt" using the webUI
-    Then the file "lorem (2).txt" should not be listed on the webUI
-    And the file "lorem (2).txt" should not be listed in the files page on the webUI
+    When the user unshares file "lorem (2).txt" using the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
+    And file "lorem (2).txt" should not be listed in the files page on the webUI
 
   @skip @issue-32732
   Scenario: test sharing long file names with federation share
@@ -192,4 +192,4 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
-    Then as "user1" the file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
+    Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -14,13 +14,13 @@ Feature: Share by public link
 
   @smokeTest
   Scenario: simple sharing by public link
-    When the user creates a new public link for the folder "simple-folder" using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI
     And the public accesses the last created public link using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
 
   @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     And the user deletes the following elements using the webUI
@@ -34,52 +34,52 @@ Feature: Share by public link
 
   @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read |
     And the public accesses the last created public link using the webUI
-    Then it should not be possible to delete the file "lorem.txt" using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link
     Given using server "REMOTE"
     And user "user2" has been created
-    When the user creates a new public link for the folder "simple-folder" using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
     And the public adds the public link to "%remote_server%" as user "user2" with the password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    When the user opens the folder "simple-folder (2)" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
-    And it should not be possible to delete the file "lorem.txt" using the webUI
+    And it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
     And user "user2" has been created
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
     And the public adds the public link to "%remote_server%" as user "user2" with the password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    When the user opens the folder "simple-folder (2)" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
-    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-    Then the file "lorem.txt" should be listed on the webUI
+    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
 
   Scenario: public should be able to access a public link with correct password
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     And the public accesses the last created public link with password "pass123" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
 
   Scenario: public should not be able to access a public link with wrong password
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     And the public tries to access the last created public link with wrong password "pass12" using the webUI
     Then the public should not get access to the publicly shared file
@@ -87,47 +87,47 @@ Feature: Share by public link
   Scenario: user tries to create a public link with name longer than 64 chars
     Given user "user1" has moved file "/lorem.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And the user has reloaded the current page of the webUI
-    When the user tries to create a new public link for the file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI
+    When the user tries to create a new public link for file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI
     Then the user should see an error message on the public link share dialog saying "Share name cannot be more than 64 characters"
     And the public link should not have been generated
 
   Scenario: user shares a public link with folder longer than 64 chars and shorter link name
     Given user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And the user has reloaded the current page of the webUI
-    When the user creates a new public link for the folder "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI with
+    When the user creates a new public link for folder "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI with
       | name | short_linkname |
     And the public accesses the last created public link using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user tries to create a public link with read only permission without entering share password while enforce password on read only public share is enforced
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-    When the user tries to create a new public link for the folder "simple-folder" using the webUI
+    When the user tries to create a new public link for folder "simple-folder" using the webUI
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And the public link should not have been generated
 
   Scenario: user tries to create a public link with read-write permission without entering share password while enforce password on read-write public share is enforced
     Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
-    When the user tries to create a new public link for the folder "simple-folder" using the webUI with
+    When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And the public link should not have been generated
 
   Scenario: user tries to create a public link with write only permission without entering share password while enforce password on write only public share is enforced
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
-    When the user tries to create a new public link for the folder "simple-folder" using the webUI with
+    When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | permission | upload |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And the public link should not have been generated
 
   Scenario: user creates a public link with read-write permission without entering share password while enforce password on read only public share is enforced
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
 
   Scenario: public should be able to access the shared file through public link
-    When the user creates a new public link for the file 'lorem.txt' using the webUI
+    When the user creates a new public link for file 'lorem.txt' using the webUI
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "Lorem ipsum dolor sit amet, consectetur"
     And the content of the file shared by last public link should be the same as "lorem.txt"
@@ -135,7 +135,7 @@ Feature: Share by public link
   Scenario: user shares a public link via email
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user has reloaded the current page of the webUI
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
@@ -146,7 +146,7 @@ Feature: Share by public link
   Scenario: user shares a public link via email and sends a copy to self
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user has reloaded the current page of the webUI
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | email       | foo@bar.co |
       | emailToSelf | true       |
     Then the email address "foo@bar.co" should have received an email with the body containing
@@ -163,7 +163,7 @@ Feature: Share by public link
   Scenario: user shares a public link via email with multiple addresses
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user has reloaded the current page of the webUI
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co, foo@barr.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
@@ -179,7 +179,7 @@ Feature: Share by public link
   Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user has reloaded the current page of the webUI
-    When the user opens the share dialog for the folder "simple-folder"
+    When the user opens the share dialog for folder "simple-folder"
     And the user opens the public link share tab
     And the user opens the create public link share popup
     And the user adds the following email addresses using the webUI:
@@ -209,7 +209,7 @@ Feature: Share by public link
   Scenario: user shares a public link via email with a personal message
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user has reloaded the current page of the webUI
-    When the user creates a new public link for the folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | email           | foo@bar.co  |
       | personalMessage | lorem ipsum |
     Then the email address "foo@bar.co" should have received an email with the body containing
@@ -223,43 +223,43 @@ Feature: Share by public link
     And the email address "foo@bar.co" should have received an email containing last shared public link
 
   Scenario: user edits a name of an already existing public link
-    Given the user has created a new public link for the folder "simple-folder" using the webUI
+    Given the user has created a new public link for folder "simple-folder" using the webUI
     And the user has opened the public link share tab
     When the user renames the public link name from "simple-folder link" to "simple-folder Share"
     And the public accesses the last created public link using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user shares a file through public link and then it appears in a Shared by link page
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user has reloaded the current page of the webUI
-    And the user has created a new public link for the folder "simple-folder" using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page
-    Then the folder "simple-folder" should be listed on the webUI
+    Then folder "simple-folder" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     When the user changes the password of the public link for "simple-folder link" to "pass1234"
     And the public accesses the last created public link with password "pass1234" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link and tries to access with old password
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     When the user changes the password of the public link for "simple-folder link" to "pass1234"
     And the public tries to access the last created public link with wrong password "pass123" using the webUI
     Then the public should not get access to the publicly shared file
 
   Scenario: user edits the permission of an already existing public link from read-write to read
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the user changes the permission of the public link for "simple-folder link" to "read"
     And the public accesses the last created public link using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    And it should not be possible to delete the file "lorem.txt" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user edits the permission of an already existing public link from read to read-write
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read |
     When the user changes the permission of the public link for "simple-folder link" to "read-write"
     And the public accesses the last created public link using the webUI
@@ -271,10 +271,10 @@ Feature: Share by public link
     And the deleted elements should not be listed on the webUI after a page reload
 
   Scenario: share two file with same name but different paths by public link
-    When the user creates a new public link for the file "lorem.txt" using the webUI
+    When the user creates a new public link for file "lorem.txt" using the webUI
     And the user closes the details dialog
-    And the user opens the folder "simple-folder" using the webUI
-    And the user creates a new public link for the file "lorem.txt" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    And the user creates a new public link for file "lorem.txt" using the webUI
     And the user browses to the shared-by-link page
-    Then the file "lorem.txt" with the path "" should be listed in the shared with others page on the webUI
-    And the file "lorem.txt" with the path "/simple-folder" should be listed in the shared with others page on the webUI
+    Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
+    And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -20,33 +20,33 @@ Feature: Sharing files and folders with internal groups
   @smokeTest
   Scenario: share a folder with an internal group
     Given user "user3" has logged in using the webUI
-    When the user shares the folder "simple-folder" with group "grp1" using the webUI
-    And the user shares the file "testimage.jpg" with group "grp1" using the webUI
+    When the user shares folder "simple-folder" with group "grp1" using the webUI
+    And the user shares file "testimage.jpg" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
-    And the file "testimage (2).jpg" should be listed on the webUI
-    And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    And folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
     When the user re-logs in as "user2" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
-    And the file "testimage (2).jpg" should be listed on the webUI
-    And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    And folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a file with an internal group a member overwrites and unshares the file
     Given user "user3" has logged in using the webUI
-    When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
-    And the user shares the file "new-lorem.txt" with group "grp1" using the webUI
+    When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
+    And the user shares file "new-lorem.txt" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-    When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
-    Then the file "new-lorem.txt" should be listed on the webUI
+    When the user uploads overwriting file "new-lorem.txt" using the webUI and retries if the file is locked
+    Then file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
-    When the user unshares the file "new-lorem.txt" using the webUI
-    Then the file "new-lorem.txt" should not be listed on the webUI
+    When the user unshares file "new-lorem.txt" using the webUI
+    Then file "new-lorem.txt" should not be listed on the webUI
 		# check that another group member can still see the file
     When the user re-logs in as "user2" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
@@ -57,55 +57,55 @@ Feature: Sharing files and folders with internal groups
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
     Given user "user3" has logged in using the webUI
-    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares the folder "new-simple-folder" with group "grp1" using the webUI
+    When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
+    And the user shares folder "new-simple-folder" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
-    And the user opens the folder "new-simple-folder" using the webUI
+    And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-    Then the file "lorem.txt" should be listed on the webUI
+    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share
-    When the user uploads the file "new-lorem.txt" using the webUI
+    When the user uploads file "new-lorem.txt" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# delete a file in the received share
-    When the user deletes the file "data.zip" using the webUI
-    Then the file "data.zip" should not be listed on the webUI
+    When the user deletes file "data.zip" using the webUI
+    Then file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible to another group member
     When the user re-logs in as "user2" using the webUI
-    And the user opens the folder "new-simple-folder" using the webUI
+    And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-    And the file "data.zip" should not be listed on the webUI
+    And file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
     When the user re-logs in as "user3" using the webUI
-    And the user opens the folder "new-simple-folder" using the webUI
+    And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-    And the file "data.zip" should not be listed on the webUI
+    And file "data.zip" should not be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a folder with an internal group and a member unshares the folder
     Given user "user3" has logged in using the webUI
-    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares the folder "new-simple-folder" with group "grp1" using the webUI
+    When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
+    And the user shares folder "new-simple-folder" with group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
     When the user re-logs in as "user1" using the webUI
-    And the user unshares the folder "new-simple-folder" using the webUI
-    Then the folder "new-simple-folder" should not be listed on the webUI
+    And the user unshares folder "new-simple-folder" using the webUI
+    Then folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible to another group member
     When the user re-logs in as "user2" using the webUI
-    Then the folder "new-simple-folder" should be listed on the webUI
-    When the user opens the folder "new-simple-folder" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then folder "new-simple-folder" should be listed on the webUI
+    When the user opens folder "new-simple-folder" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		# check that the folder is still visible for the share owner
     When the user re-logs in as "user3" using the webUI
-    Then the folder "new-simple-folder" should be listed on the webUI
-    When the user opens the folder "new-simple-folder" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then folder "new-simple-folder" should be listed on the webUI
+    When the user opens folder "new-simple-folder" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
   @skip @issue-33030

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -16,18 +16,18 @@ Feature: Sharing files and folders with internal groups
     And user "user1" has been added to group "<group>"
     And user "user2" has been added to group "<group>"
     And user "user3" has logged in using the webUI
-    When the user shares the folder "simple-folder" with group "<group>" using the webUI
-    And the user shares the file "testimage.jpg" with group "<group>" using the webUI
+    When the user shares folder "simple-folder" with group "<group>" using the webUI
+    And the user shares file "testimage.jpg" with group "<group>" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
-    And the file "testimage (2).jpg" should be listed on the webUI
-    And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    And folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
     When the user re-logs in as "user2" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
-    And the file "testimage (2).jpg" should be listed on the webUI
-    And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    And folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
     Examples:
       | group     |
       | ?\?@#%@,; |

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -22,20 +22,20 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     When user "user1" logs in using the webUI
-    Then the folder "simple-folder (2)" should not be listed on the webUI
-    And the file "testimage (2).jpg" should not be listed on the webUI
-    But the folder "simple-folder" should be listed in the shared-with-you page on the webUI
-    And the file "testimage.jpg" should be listed in the shared-with-you page on the webUI
-    And the folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
-    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    Then folder "simple-folder (2)" should not be listed on the webUI
+    And file "testimage (2).jpg" should not be listed on the webUI
+    But folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
 
   Scenario: receive shares with same name from different users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
     When user "user3" logs in using the webUI
-    Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
-    And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
+    Then folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
   Scenario: receive shares with same name from different users, accept one by one
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -46,8 +46,8 @@ Feature: accept/decline shares coming from internal users
     And user "user3" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User One" using the webUI
     And the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-    Then the folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
-    And the folder "simple-folder (3)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
+    And folder "simple-folder (3)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
     And user "user3" should see the following elements
       | /simple-folder%20(2)/from_user1/ |
       | /simple-folder%20(3)/from_user2/ |
@@ -57,8 +57,8 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
     When user "user3" logs in using the webUI
-    Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
-    And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
+    Then folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
   @smokeTest
   Scenario: accept an offered share
@@ -67,12 +67,12 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-    Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI after a page reload
-    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI after a page reload
-    And the folder "simple-folder (2)" should be listed in the files page on the webUI
-    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+    Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI after a page reload
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI after a page reload
+    And folder "simple-folder (2)" should be listed in the files page on the webUI
+    And file "testimage (2).jpg" should not be listed in the files page on the webUI
 
   @smokeTest
   Scenario: decline an offered (pending) share
@@ -81,10 +81,10 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
     When the user declines the share "simple-folder" offered by user "User Two" using the webUI
-    Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+    Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And file "testimage (2).jpg" should not be listed in the files page on the webUI
 
   @smokeTest
   Scenario: decline an accepted share (with page-reload in between)
@@ -95,10 +95,10 @@ Feature: accept/decline shares coming from internal users
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
-    Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+    Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And file "testimage (2).jpg" should not be listed in the files page on the webUI
 
   Scenario: decline an accepted share (without any page-reload in between)
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -107,10 +107,10 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
-    Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+    Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And file "testimage (2).jpg" should not be listed in the files page on the webUI
 
   Scenario: accept a previously declined share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -119,10 +119,10 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     And the user declines the share "simple-folder" offered by user "User Two" using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-    Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should be listed in the files page on the webUI
-    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
+    Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should be listed in the files page on the webUI
+    And file "testimage (2).jpg" should not be listed in the files page on the webUI
 
   Scenario: accept a share that you received as user and as group member
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -131,8 +131,8 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should be listed in the files page on the webUI
+    Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should be listed in the files page on the webUI
 
   Scenario: reject a share that you received as user and as group member
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -141,8 +141,8 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user declines the share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
+    Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should not be listed in the files page on the webUI
 
   Scenario: reshare a share that you received to a group that you are member of
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -150,11 +150,11 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
     And the user has browsed to the files page
-    And the user shares the folder "simple-folder (2)" with group "grp1" using the webUI
+    And the user shares folder "simple-folder (2)" with group "grp1" using the webUI
     And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
-    Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should not be listed in the files page on the webUI
+    Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should not be listed in the files page on the webUI
 
   @smokeTest
   Scenario: unshare an accepted share on the "All files" page
@@ -164,12 +164,12 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has accepted the share "/simple-folder" offered by user "user2"
     And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
     And user "user1" has logged in using the webUI
-    When the user unshares the folder "simple-folder (2)" using the webUI
-    And the user unshares the file "testimage (2).jpg" using the webUI
-    Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And the file "testimage (2).jpg" should not be listed in the files page on the webUI
-    And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+    When the user unshares folder "simple-folder (2)" using the webUI
+    And the user unshares file "testimage (2).jpg" using the webUI
+    Then folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And file "testimage (2).jpg" should not be listed in the files page on the webUI
+    And folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
   @smokeTest
   Scenario: Auto-accept shares
@@ -177,12 +177,12 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
     When user "user1" logs in using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    And the file "testimage (2).jpg" should be listed on the webUI
-    And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
-    And the file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
-    And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And the file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI
 
   Scenario: decline auto-accepted shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
@@ -192,48 +192,48 @@ Feature: accept/decline shares coming from internal users
     When the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
     And the user declines the share "testimage (2).jpg" offered by user "User Two" using the webUI
     And the user has browsed to the files page
-    Then the folder "simple-folder (2)" should not be listed on the webUI
-    And the file "testimage (2).jpg" should not be listed on the webUI
-    And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+    Then folder "simple-folder (2)" should not be listed on the webUI
+    And file "testimage (2).jpg" should not be listed on the webUI
+    And folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
   Scenario: unshare auto-accepted shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user unshares the folder "simple-folder (2)" using the webUI
-    And the user unshares the file "testimage (2).jpg" using the webUI
-    Then the folder "simple-folder (2)" should not be listed on the webUI
-    And the file "testimage (2).jpg" should not be listed on the webUI
-    And the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And the file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+    When the user unshares folder "simple-folder (2)" using the webUI
+    And the user unshares file "testimage (2).jpg" using the webUI
+    Then folder "simple-folder (2)" should not be listed on the webUI
+    And file "testimage (2).jpg" should not be listed on the webUI
+    And folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
   Scenario: unshare renamed shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
     And user "user1" has logged in using the webUI
-    When the user unshares the folder "simple-folder-renamed" using the webUI
-    Then the folder "simple-folder-renamed" should not be listed on the webUI
-    And the folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
+    When the user unshares folder "simple-folder-renamed" using the webUI
+    Then folder "simple-folder-renamed" should not be listed on the webUI
+    And folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
 
   Scenario: unshare moved shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder/shared"
     And user "user1" has logged in using the webUI
-    When the user opens the folder "simple-folder" using the webUI
-    And the user unshares the folder "shared" using the webUI
-    Then the folder "shared" should not be listed on the webUI
-    And the folder "shared" should be in state "Declined" in the shared-with-you page on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user unshares folder "shared" using the webUI
+    Then folder "shared" should not be listed on the webUI
+    And folder "shared" should be in state "Declined" in the shared-with-you page on the webUI
 
   Scenario: unshare renamed shares, accept it again
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
     And user "user1" has logged in using the webUI
-    When the user unshares the folder "simple-folder-renamed" using the webUI
+    When the user unshares folder "simple-folder-renamed" using the webUI
     And the user accepts the share "simple-folder-renamed" offered by user "User Two" using the webUI
-    Then the folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
-    And the folder "simple-folder-renamed" should be listed in the files page on the webUI
+    Then folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
+    And folder "simple-folder-renamed" should be listed in the files page on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -112,7 +112,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has shared the folder "simple-folder" with the user "User One" using the webUI
+    And the user has shared folder "simple-folder" with user "User One" using the webUI
     And the user has opened the share dialog for the folder "simple-folder"
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
@@ -122,7 +122,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has shared the file "data.zip" with the user "User Grp" using the webUI
+    And the user has shared file "data.zip" with user "User Grp" using the webUI
     And the user has opened the share dialog for the file "data.zip"
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -32,7 +32,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of regular existing users
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "us" in the share-with-field
     Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
@@ -42,7 +42,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of regular existing groups
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
@@ -50,7 +50,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion for a pattern that does not match any user or group
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "doesnotexist" in the share-with-field
     Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
@@ -63,7 +63,7 @@ Feature: Autocompletion of share-with names
     And these users have been created but not initialized:
       | username | password | displayname | email        |
       | use      | %alt1%   | Use         | uz@oc.com.np |
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "Use" in the share-with-field
     Then only "Use" should be listed in the autocomplete list on the webUI
 
@@ -75,7 +75,7 @@ Feature: Autocompletion of share-with names
       | fi        |
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
     Then only "fi (group)" should be listed in the autocomplete list on the webUI
 
@@ -83,7 +83,7 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "u" in the share-with-field
     Then a tooltip with the text "No users or groups found for u. Please enter at least 2 characters for suggestions" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
@@ -93,7 +93,7 @@ Feature: Autocompletion of share-with names
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "use" in the share-with-field
     Then a tooltip with the text "No users or groups found for use. Please enter at least 4 characters for suggestions" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
@@ -103,7 +103,7 @@ Feature: Autocompletion of share-with names
     Given the administrator has set the minimum characters for sharing autocomplete to "3"
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "use" in the share-with-field
     Then all users and groups that contain the string "use" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
@@ -113,7 +113,7 @@ Feature: Autocompletion of share-with names
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has shared folder "simple-folder" with user "User One" using the webUI
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
     And the users own name should not be listed in the autocomplete list on the webUI
@@ -123,7 +123,7 @@ Feature: Autocompletion of share-with names
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has shared file "data.zip" with user "User Grp" using the webUI
-    And the user has opened the share dialog for the file "data.zip"
+    And the user has opened the share dialog for file "data.zip"
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
     And the users own name should not be listed in the autocomplete list on the webUI
@@ -132,8 +132,8 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user shares the folder "simple-folder" with group "finance1" using the webUI
-    And the user has opened the share dialog for the folder "simple-folder"
+    And the user shares folder "simple-folder" with group "finance1" using the webUI
+    And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
     And the users own name should not be listed in the autocomplete list on the webUI
@@ -142,8 +142,8 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user shares the file "data.zip" with group "finance1" using the webUI
-    And the user has opened the share dialog for the file "data.zip"
+    And the user shares file "data.zip" with group "finance1" using the webUI
+    And the user has opened the share dialog for file "data.zip"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
     And the users own name should not be listed in the autocomplete list on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -14,8 +14,8 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a file & folder with another internal user
-    When the user shares the folder "simple-folder" with the user "User One" using the webUI
-    And the user shares the file "testimage.jpg" with the user "User One" using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
+    And the user shares file "testimage.jpg" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
@@ -28,7 +28,7 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend
   Scenario: share a file with another internal user who overwrites and unshares the file
     When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
-    And the user shares the file "new-lorem.txt" with the user "User One" using the webUI
+    And the user shares file "new-lorem.txt" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
@@ -45,7 +45,7 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
+    And the user shares folder "new-simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     And the user opens the folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
@@ -71,7 +71,7 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who unshares the folder
     When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
+    And the user shares folder "new-simple-folder" with user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
     And the user re-logs in as "user1" using the webUI
     And the user unshares the folder "new-simple-folder" using the webUI
@@ -85,7 +85,7 @@ Feature: Sharing files and folders with internal users
 
   @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user and prohibit deleting
-    When the user shares the folder "simple-folder" with the user "User One" using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | delete | no |
     And the user re-logs in as "user1" using the webUI
@@ -95,24 +95,24 @@ Feature: Sharing files and folders with internal users
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
     Given the user has renamed the folder "simple-folder" to "new-simple-folder" using the webUI
     And the user has renamed the file "lorem.txt" to "ipsum.txt" using the webUI
-    And the user has shared the file "ipsum.txt" with the user "User One" using the webUI
-    And the user has shared the folder "new-simple-folder" with the user "User One" using the webUI
+    And the user has shared file "ipsum.txt" with user "User One" using the webUI
+    And the user has shared folder "new-simple-folder" with user "User One" using the webUI
     When the user re-logs in as "user1" using the webUI
     And the user browses to the shared-with-you page
     Then the file "ipsum.txt" should be listed on the webUI
     And the folder "new-simple-folder" should be listed on the webUI
 
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
-    Given the user has shared the file "lorem.txt" with the user "User One" using the webUI
-    And the user has shared the folder "simple-folder" with the user "User One" using the webUI
+    Given the user has shared file "lorem.txt" with user "User One" using the webUI
+    And the user has shared folder "simple-folder" with user "User One" using the webUI
     When the user browses to the shared-with-others page
     Then the file "lorem.txt" should be listed on the webUI
     And the folder "simple-folder" should be listed on the webUI
 
   Scenario: share two file with same name but different paths
-    Given the user has shared the file "lorem.txt" with the user "User One" using the webUI
+    Given the user has shared file "lorem.txt" with user "User One" using the webUI
     When the user opens the folder "simple-folder" using the webUI
-    And the user shares the file "lorem.txt" with the user "User One" using the webUI
+    And the user shares file "lorem.txt" with user "User One" using the webUI
     And the user browses to the shared-with-others page
     Then the file "lorem.txt" with the path "" should be listed in the shared with others page on the webUI
     And the file "lorem.txt" with the path "/simple-folder" should be listed in the shared with others page on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -17,70 +17,70 @@ Feature: Sharing files and folders with internal users
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user shares file "testimage.jpg" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then the folder "simple-folder (2)" should be listed on the webUI
-    And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
-    And the file "testimage (2).jpg" should be listed on the webUI
-    And the file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
-    When the user opens the folder "simple-folder (2)" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    But the folder "simple-folder (2)" should not be listed on the webUI
+    Then folder "simple-folder (2)" should be listed on the webUI
+    And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    But folder "simple-folder (2)" should not be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a file with another internal user who overwrites and unshares the file
-    When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
+    When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares file "new-lorem.txt" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-    When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
-    Then the file "new-lorem.txt" should be listed on the webUI
+    When the user uploads overwriting file "new-lorem.txt" using the webUI and retries if the file is locked
+    Then file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
-    When the user unshares the file "new-lorem.txt" using the webUI
-    Then the file "new-lorem.txt" should not be listed on the webUI
+    When the user unshares file "new-lorem.txt" using the webUI
+    Then file "new-lorem.txt" should not be listed on the webUI
 		# check that the original file owner can still see the file
     When the user re-logs in as "user2" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
-    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+    When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
-    And the user opens the folder "new-simple-folder" using the webUI
+    And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-    Then the file "lorem.txt" should be listed on the webUI
+    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share
-    When the user uploads the file "new-lorem.txt" using the webUI
+    When the user uploads file "new-lorem.txt" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# delete a file in the received share
-    When the user deletes the file "data.zip" using the webUI
-    Then the file "data.zip" should not be listed on the webUI
+    When the user deletes file "data.zip" using the webUI
+    Then file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
     When the user re-logs in as "user2" using the webUI
-    And the user opens the folder "new-simple-folder" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    And the user opens folder "new-simple-folder" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
-    And the file "new-lorem.txt" should be listed on the webUI
+    And file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-    But the file "data.zip" should not be listed on the webUI
+    But file "data.zip" should not be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who unshares the folder
-    When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+    When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
     And the user re-logs in as "user1" using the webUI
-    And the user unshares the folder "new-simple-folder" using the webUI
-    Then the folder "new-simple-folder" should not be listed on the webUI
+    And the user unshares folder "new-simple-folder" using the webUI
+    Then folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible for the share owner
     When the user re-logs in as "user2" using the webUI
-    Then the folder "new-simple-folder" should be listed on the webUI
-    When the user opens the folder "new-simple-folder" using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
+    Then folder "new-simple-folder" should be listed on the webUI
+    When the user opens folder "new-simple-folder" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
   @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
@@ -89,30 +89,30 @@ Feature: Sharing files and folders with internal users
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | delete | no |
     And the user re-logs in as "user1" using the webUI
-    And the user opens the folder "simple-folder (2)" using the webUI
-    Then it should not be possible to delete the file "lorem.txt" using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
-    Given the user has renamed the folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user has renamed the file "lorem.txt" to "ipsum.txt" using the webUI
+    Given the user has renamed folder "simple-folder" to "new-simple-folder" using the webUI
+    And the user has renamed file "lorem.txt" to "ipsum.txt" using the webUI
     And the user has shared file "ipsum.txt" with user "User One" using the webUI
     And the user has shared folder "new-simple-folder" with user "User One" using the webUI
     When the user re-logs in as "user1" using the webUI
     And the user browses to the shared-with-you page
-    Then the file "ipsum.txt" should be listed on the webUI
-    And the folder "new-simple-folder" should be listed on the webUI
+    Then file "ipsum.txt" should be listed on the webUI
+    And folder "new-simple-folder" should be listed on the webUI
 
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
     Given the user has shared file "lorem.txt" with user "User One" using the webUI
     And the user has shared folder "simple-folder" with user "User One" using the webUI
     When the user browses to the shared-with-others page
-    Then the file "lorem.txt" should be listed on the webUI
-    And the folder "simple-folder" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI
 
   Scenario: share two file with same name but different paths
     Given the user has shared file "lorem.txt" with user "User One" using the webUI
-    When the user opens the folder "simple-folder" using the webUI
+    When the user opens folder "simple-folder" using the webUI
     And the user shares file "lorem.txt" with user "User One" using the webUI
     And the user browses to the shared-with-others page
-    Then the file "lorem.txt" with the path "" should be listed in the shared with others page on the webUI
-    And the file "lorem.txt" with the path "/simple-folder" should be listed in the shared with others page on the webUI
+    Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
+    And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -36,10 +36,10 @@ Feature: Sharing files and folders with internal users
     And user "user1" has shared folder "/simple-folder" with user "user2"
     And user "user1" has shared folder "/simple-empty-folder" with user "user2"
     When the user accepts all shares displayed in the notifications on the webUI
-    Then the folder "simple-folder (2)" should be listed in the files page on the webUI
-    And the folder "simple-empty-folder (2)" should be listed in the files page on the webUI
-    And the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And the folder "simple-empty-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder (2)" should be listed in the files page on the webUI
+    And folder "simple-empty-folder (2)" should be listed in the files page on the webUI
+    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And folder "simple-empty-folder (2)" should be in state "" in the shared-with-you page on the webUI
 
   @smokeTest
   Scenario: reject an offered share
@@ -47,8 +47,8 @@ Feature: Sharing files and folders with internal users
     And user "user1" has shared folder "/simple-folder" with user "user2"
     And user "user1" has shared folder "/simple-empty-folder" with user "user2"
     When the user declines all shares displayed in the notifications on the webUI
-    Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And the folder "simple-empty-folder (2)" should not be listed in the files page on the webUI
-    And the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-    And the folder "simple-empty-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    Then folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And folder "simple-empty-folder (2)" should not be listed in the files page on the webUI
+    And folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And folder "simple-empty-folder" should be in state "Declined" in the shared-with-you page on the webUI
 

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -46,7 +46,7 @@ Feature: Creation of tags for the files and folders
     Then file "simple-folder/lorem.txt" should have no tags for user "user1"
 
   Scenario: Create and add tag on a shared file
-    When the user renames the file "lorem.txt" to "coolnewfile.txt" using the webUI
+    When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI
     And the user shares file "coolnewfile.txt" with user "User Two" using the webUI
@@ -61,7 +61,7 @@ Feature: Creation of tags for the files and folders
       | tag2 | normal |
 
   Scenario: Delete a tag in a shared file
-    When the user renames the file "lorem.txt" to "coolnewfile.txt" using the webUI
+    When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI
     And the user shares file "coolnewfile.txt" with user "User Two" using the webUI

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -49,7 +49,7 @@ Feature: Creation of tags for the files and folders
     When the user renames the file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI
-    And the user shares the file "coolnewfile.txt" with the user "User Two" using the webUI
+    And the user shares file "coolnewfile.txt" with user "User Two" using the webUI
     And the user re-logs in with username "user2" and password "%alt2%" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag2" to the file using the webUI
@@ -64,7 +64,7 @@ Feature: Creation of tags for the files and folders
     When the user renames the file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI
-    And the user shares the file "coolnewfile.txt" with the user "User Two" using the webUI
+    And the user shares file "coolnewfile.txt" with user "User Two" using the webUI
     And the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then file "coolnewfile.txt" should have the following tags for user "user2"
       | tag1 | normal |

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -17,17 +17,17 @@ Feature: files and folders can be deleted from the trashbin
 
   @smokeTest
   Scenario: Delete files and check that they are gone
-    When the user deletes the file "lorem.txt" using the webUI
-    And the user opens the folder "simple-folder" using the webUI
-    And the user deletes the file "lorem-big.txt" using the webUI
-    Then the file "lorem.txt" should not be listed in the trashbin on the webUI
-    But the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
-    And the file "lorem-big.txt" should not be listed in the trashbin folder "simple-folder" on the webUI
-    But the file "lorem-big.txt" should be listed in the trashbin on the webUI
+    When the user deletes file "lorem.txt" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    And the user deletes file "lorem-big.txt" using the webUI
+    Then file "lorem.txt" should not be listed in the trashbin on the webUI
+    But file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
+    And file "lorem-big.txt" should not be listed in the trashbin folder "simple-folder" on the webUI
+    But file "lorem-big.txt" should be listed in the trashbin on the webUI
 
   Scenario: Delete folders and check that they are gone
-    When the user deletes the folder "simple-folder" using the webUI
-    Then the folder "simple-folder" should not be listed in the trashbin on the webUI
+    When the user deletes folder "simple-folder" using the webUI
+    Then folder "simple-folder" should not be listed in the trashbin on the webUI
 
   Scenario: Select some files and delete from trashbin in a batch
     When the user batch deletes these files using the webUI
@@ -36,11 +36,11 @@ Feature: files and folders can be deleted from the trashbin
       | lorem-big.txt |
     Then the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
-    But the file "data.zip" should be listed on the webUI
-    And the folder "simple-folder" should be listed on the webUI
+    But file "data.zip" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI
     # make sure the delete button is not accidentally doing restore
-    And the file "lorem.txt" should not be listed in the files page on the webUI
-    And the file "lorem-big.txt" should not be listed in the files page on the webUI
+    And file "lorem.txt" should not be listed in the files page on the webUI
+    And file "lorem-big.txt" should not be listed in the files page on the webUI
 
   Scenario: Select all except for some files and delete from trashbin in a batch
     When the user marks all files for batch action using the webUI
@@ -49,10 +49,10 @@ Feature: files and folders can be deleted from the trashbin
       | lorem.txt     |
       | lorem-big.txt |
     And the user batch deletes the marked files using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    And the file "lorem-big.txt" should be listed on the webUI
-    But the file "data.zip" should not be listed on the webUI
-    And the folder "simple-folder" should not be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem-big.txt" should be listed on the webUI
+    But file "data.zip" should not be listed on the webUI
+    And folder "simple-folder" should not be listed on the webUI
 
   Scenario: Select all files and delete from trashbin in a batch
     When the user marks all files for batch action using the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -17,12 +17,12 @@ Feature: files and folders exist in the trashbin after being deleted
       | lorem.txt                             |
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
-    Then as "user1" the folder "simple-folder" should exist in trash
-    And as "user1" the file "lorem.txt" should exist in trash
-    And as "user1" the folder "strängé नेपाली folder" should exist in trash
-    And as "user1" the file "strängé filename (duplicate #2 &).txt" should exist in trash
+    Then as "user1" folder "simple-folder" should exist in trash
+    And as "user1" file "lorem.txt" should exist in trash
+    And as "user1" folder "strängé नेपाली folder" should exist in trash
+    And as "user1" file "strängé filename (duplicate #2 &).txt" should exist in trash
     And the deleted elements should be listed in the trashbin on the webUI
-    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
+    And file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
   Scenario: Delete a file with problematic characters and check it is in the trashbin
     When the user renames the following file using the webUI
@@ -50,34 +50,34 @@ Feature: files and folders exist in the trashbin after being deleted
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then as "user1" the file "data.zip" should exist in trash
-    And as "user1" the file "lorem.txt" should exist in trash
-    And as "user1" the folder "simple-folder" should exist in trash
-    And as "user1" the file "simple-folder/lorem.txt" should exist in trash
+    Then as "user1" file "data.zip" should exist in trash
+    And as "user1" file "lorem.txt" should exist in trash
+    And as "user1" folder "simple-folder" should exist in trash
+    And as "user1" file "simple-folder/lorem.txt" should exist in trash
     And the deleted elements should be listed in the trashbin on the webUI
-    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
+    And file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
   Scenario: Delete an empty folder and check it is in the trashbin
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
-    And the user deletes the folder "my-empty-folder" using the webUI
-    Then as "user1" the folder "my-empty-folder" should exist in trash
+    And the user deletes folder "my-empty-folder" using the webUI
+    Then as "user1" folder "my-empty-folder" should exist in trash
     But as "user1" the folder with original path "my-other-empty-folder" should not exist in trash
-    And the folder "my-empty-folder" should be listed in the trashbin on the webUI
-    But the folder "my-other-empty-folder" should not be listed in the trashbin on the webUI
-    When the user opens the trashbin folder "my-empty-folder" using the webUI
+    And folder "my-empty-folder" should be listed in the trashbin on the webUI
+    But folder "my-other-empty-folder" should not be listed in the trashbin on the webUI
+    When the user opens trashbin folder "my-empty-folder" using the webUI
     Then there should be no files/folders listed on the webUI
 
   Scenario: Delete multiple file with same filename and check they are in the trashbin
     When the user deletes the following elements using the webUI
       | name      |
       | lorem.txt |
-    And the user opens the folder "simple-folder" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     And the user deletes the following elements using the webUI
       | name      |
       | lorem.txt |
     And the user browses to the files page
-    And the user opens the folder "strängé नेपाली folder" using the webUI
+    And the user opens folder "strängé नेपाली folder" using the webUI
     And the user deletes the following elements using the webUI
       | name      |
       | lorem.txt |
@@ -85,6 +85,6 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "user1" the file with original path "simple-folder/lorem.txt" should exist in trash
     And as "user1" the file with original path "strängé नेपाली folder/lorem.txt" should exist in trash
     Then the deleted elements should be listed in the trashbin on the webUI
-    And the file "lorem.txt" with the path "./lorem.txt" should be listed in the trashbin on the webUI
-    And the file "lorem.txt" with the path "simple-folder/lorem.txt" should be listed in the trashbin on the webUI
-    And the file "lorem.txt" with the path "strängé नेपाली folder/lorem.txt" should be listed in the trashbin on the webUI
+    And file "lorem.txt" with path "./lorem.txt" should be listed in the trashbin on the webUI
+    And file "lorem.txt" with path "simple-folder/lorem.txt" should be listed in the trashbin on the webUI
+    And file "lorem.txt" with path "strängé नेपाली folder/lorem.txt" should be listed in the trashbin on the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -11,20 +11,20 @@ Feature: Restore deleted files/folders
 
   @smokeTest
   Scenario: Restore files
-    When the user deletes the file "data.zip" using the webUI
-    Then the file "data.zip" should be listed in the trashbin on the webUI
-    When the user restores the file "data.zip" from the trashbin using the webUI
-    Then the file "data.zip" should not be listed on the webUI
+    When the user deletes file "data.zip" using the webUI
+    Then file "data.zip" should be listed in the trashbin on the webUI
+    When the user restores file "data.zip" from the trashbin using the webUI
+    Then file "data.zip" should not be listed on the webUI
     When the user browses to the files page
-    Then the file "data.zip" should be listed on the webUI
+    Then file "data.zip" should be listed on the webUI
 
   Scenario: Restore folder
-    When the user deletes the folder "folder with space" using the webUI
-    Then the folder "folder with space" should be listed in the trashbin on the webUI
-    When the user restores the folder "folder with space" from the trashbin using the webUI
-    Then the file "folder with space" should not be listed on the webUI
+    When the user deletes folder "folder with space" using the webUI
+    Then folder "folder with space" should be listed in the trashbin on the webUI
+    When the user restores folder "folder with space" from the trashbin using the webUI
+    Then file "folder with space" should not be listed on the webUI
     When the user browses to the files page
-    Then the folder "folder with space" should be listed on the webUI
+    Then folder "folder with space" should be listed on the webUI
 
   @smokeTest
   Scenario: Select some trashbin files and restore them in a batch
@@ -40,14 +40,14 @@ Feature: Restore deleted files/folders
       | lorem.txt     |
       | lorem-big.txt |
     And the user batch restores the marked files using the webUI
-    Then the file "data.zip" should be listed on the webUI
-    And the folder "simple-folder" should be listed on the webUI
-    But the file "lorem.txt" should not be listed on the webUI
-    And the file "lorem-big.txt" should not be listed on the webUI
-    And the file "lorem.txt" should be listed in the files page on the webUI
-    And the file "lorem-big.txt" should be listed in the files page on the webUI
-    But the file "data.zip" should not be listed in the files page on the webUI
-    And the folder "simple-folder" should not be listed in the files page on the webUI
+    Then file "data.zip" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI
+    But file "lorem.txt" should not be listed on the webUI
+    And file "lorem-big.txt" should not be listed on the webUI
+    And file "lorem.txt" should be listed in the files page on the webUI
+    And file "lorem-big.txt" should be listed in the files page on the webUI
+    But file "data.zip" should not be listed in the files page on the webUI
+    And folder "simple-folder" should not be listed in the files page on the webUI
 
   Scenario: Select all except for some trashbin files and restore them in a batch
     Given the following files have been deleted
@@ -63,14 +63,14 @@ Feature: Restore deleted files/folders
       | lorem.txt     |
       | lorem-big.txt |
     And the user batch restores the marked files using the webUI
-    Then the file "lorem.txt" should be listed on the webUI
-    And the file "lorem-big.txt" should be listed on the webUI
-    But the file "data.zip" should not be listed on the webUI
-    And the folder "simple-folder" should not be listed on the webUI
-    And the file "data.zip" should be listed in the files page on the webUI
-    And the folder "simple-folder" should be listed in the files page on the webUI
-    But the file "lorem.txt" should not be listed in the files page on the webUI
-    And the file "lorem-big.txt" should not be listed in the files page on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem-big.txt" should be listed on the webUI
+    But file "data.zip" should not be listed on the webUI
+    And folder "simple-folder" should not be listed on the webUI
+    And file "data.zip" should be listed in the files page on the webUI
+    And folder "simple-folder" should be listed in the files page on the webUI
+    But file "lorem.txt" should not be listed in the files page on the webUI
+    And file "lorem-big.txt" should not be listed in the files page on the webUI
 
   Scenario: Select all trashbin files and restore them in a batch
     Given the following files have been deleted
@@ -84,7 +84,7 @@ Feature: Restore deleted files/folders
     And the user batch restores the marked files using the webUI
     Then the folder should be empty on the webUI
     When the user browses to the files page
-    Then the file "lorem.txt" should be listed on the webUI
-    And the file "lorem-big.txt" should be listed on the webUI
-    And the file "data.zip" should be listed on the webUI
-    And the folder "simple-folder" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem-big.txt" should be listed on the webUI
+    And file "data.zip" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -11,94 +11,94 @@ Feature: File Upload
 
   @smokeTest
   Scenario: simple upload of a file that does not exist before
-    When the user uploads the file "new-lorem.txt" using the webUI
+    When the user uploads file "new-lorem.txt" using the webUI
     Then no notification should be displayed on the webUI
-    And the file "new-lorem.txt" should be listed on the webUI
+    And file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @smokeTest
   Scenario: chunking upload
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-    When the user uploads the file "big-video.mp4" using the webUI
+    When the user uploads file "big-video.mp4" using the webUI
     Then no notification should be displayed on the webUI
-    And the file "big-video.mp4" should be listed on the webUI
+    And file "big-video.mp4" should be listed on the webUI
     And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
   Scenario: conflict with a chunked file
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-    When the user renames the file "lorem.txt" to "big-video.mp4" using the webUI
-    And the user uploads overwriting the file "big-video.mp4" using the webUI and retries if the file is locked
-    Then the file "big-video.mp4" should be listed on the webUI
+    When the user renames file "lorem.txt" to "big-video.mp4" using the webUI
+    And the user uploads overwriting file "big-video.mp4" using the webUI and retries if the file is locked
+    Then file "big-video.mp4" should be listed on the webUI
     And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
   Scenario: upload a new file into a sub folder
-    When the user opens the folder "simple-folder" using the webUI
-    And the user uploads the file "new-lorem.txt" using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
     Then no notification should be displayed on the webUI
-    And the file "new-lorem.txt" should be listed on the webUI
+    And file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @smokeTest
   Scenario: overwrite an existing file
-    When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then no dialog should be displayed on the webUI
-    And the file "lorem.txt" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
-    But the file "lorem (2).txt" should not be listed on the webUI
+    But file "lorem (2).txt" should not be listed on the webUI
 
   @smokeTest
   Scenario: keep new and existing file
-    When the user uploads the file "lorem.txt" using the webUI
+    When the user uploads file "lorem.txt" using the webUI
     And the user chooses to keep the new files in the upload dialog
     And the user chooses to keep the existing files in the upload dialog
     And the user chooses "Continue" in the upload dialog
     Then no dialog should be displayed on the webUI
     And no notification should be displayed on the webUI
-    And the file "lorem.txt" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should not have changed
-    And the file "lorem (2).txt" should be listed on the webUI
+    And file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
 
   Scenario: cancel conflict dialog
-    When the user uploads the file "lorem.txt" using the webUI
+    When the user uploads file "lorem.txt" using the webUI
     And the user chooses "Cancel" in the upload dialog
     Then no dialog should be displayed on the webUI
     And no notification should be displayed on the webUI
-    And the file "lorem.txt" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should not have changed
-    And the file "lorem (2).txt" should not be listed on the webUI
+    And file "lorem (2).txt" should not be listed on the webUI
 
   Scenario: overwrite an existing file in a sub-folder
-    When the user opens the folder "simple-folder" using the webUI
-    And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-    Then the file "lorem.txt" should be listed on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
 
   Scenario: keep new and existing file in a sub-folder
-    When the user opens the folder "simple-folder" using the webUI
-    And the user uploads the file "lorem.txt" using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "lorem.txt" using the webUI
     And the user chooses to keep the new files in the upload dialog
     And the user chooses to keep the existing files in the upload dialog
     And the user chooses "Continue" in the upload dialog
     Then no dialog should be displayed on the webUI
     And no notification should be displayed on the webUI
-    And the file "lorem.txt" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should not have changed
-    And the file "lorem (2).txt" should be listed on the webUI
+    And file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
 
   Scenario: upload a file into a public share
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
-    And the user uploads the file "new-lorem.txt" using the webUI
-    Then the file "new-lorem.txt" should be listed on the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then file "new-lorem.txt" should be listed on the webUI
     And the content of "simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   Scenario: upload overwriting a file into a public share
-    Given the user has created a new public link for the folder "simple-folder" using the webUI with
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
-    And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-    Then the file "lorem.txt" should be listed on the webUI
+    And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    Then file "lorem.txt" should be listed on the webUI
     And the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -12,36 +12,36 @@ Feature: File Upload
     And user "user1" has logged in using the webUI
 
   Scenario: simple upload of a file that does not exist before
-    When the user uploads the file "new-'single'quotes.txt" using the webUI
-    Then the file "new-'single'quotes.txt" should be listed on the webUI
+    When the user uploads file "new-'single'quotes.txt" using the webUI
+    Then file "new-'single'quotes.txt" should be listed on the webUI
     And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
 
-    When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
-    Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    When the user uploads file "new-strängé filename (duplicate #2 &).txt" using the webUI
+    Then file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
     And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
 
-    When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
-    Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
+    When the user uploads file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
+    Then file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
     And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
 
   @smokeTest
   Scenario Outline: upload a new file into a sub folder
     Given a file with the size of "3000" bytes and the name "0" has been created locally
-    When the user opens the folder <folder-to-upload-to> using the webUI
-    And the user uploads the file "0" using the webUI
-    Then the file "0" should be listed on the webUI
+    When the user opens folder <folder-to-upload-to> using the webUI
+    And the user uploads file "0" using the webUI
+    Then file "0" should be listed on the webUI
     And the content of "0" should be the same as the local "0"
 
-    When the user uploads the file "new-'single'quotes.txt" using the webUI
-    Then the file "new-'single'quotes.txt" should be listed on the webUI
+    When the user uploads file "new-'single'quotes.txt" using the webUI
+    Then file "new-'single'quotes.txt" should be listed on the webUI
     And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
 
-    When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
-    Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    When the user uploads file "new-strängé filename (duplicate #2 &).txt" using the webUI
+    Then file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
     And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
 
-    When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
-    Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
+    When the user uploads file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
+    Then file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
     And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
     Examples:
       | folder-to-upload-to     |
@@ -50,41 +50,41 @@ Feature: File Upload
       | "strängé नेपाली folder" |
 
   Scenario: overwrite an existing file
-    When the user uploads overwriting the file "'single'quotes.txt" using the webUI and retries if the file is locked
-    Then the file "'single'quotes.txt" should be listed on the webUI
+    When the user uploads overwriting file "'single'quotes.txt" using the webUI and retries if the file is locked
+    Then file "'single'quotes.txt" should be listed on the webUI
     And the content of "'single'quotes.txt" should be the same as the local "'single'quotes.txt"
 
-    When the user uploads overwriting the file "strängé filename (duplicate #2 &).txt" using the webUI and retries if the file is locked
-    Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    When the user uploads overwriting file "strängé filename (duplicate #2 &).txt" using the webUI and retries if the file is locked
+    Then file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
     And the content of "strängé filename (duplicate #2 &).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
-    When the user uploads overwriting the file "zzzz-must-be-last-file-in-folder.txt" using the webUI and retries if the file is locked
-    Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
+    When the user uploads overwriting file "zzzz-must-be-last-file-in-folder.txt" using the webUI and retries if the file is locked
+    Then file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
     And the content of "zzzz-must-be-last-file-in-folder.txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
   Scenario: keep new and existing file
-    When the user uploads the file "'single'quotes.txt" keeping both new and existing files using the webUI
-    Then the file "'single'quotes.txt" should be listed on the webUI
+    When the user uploads file "'single'quotes.txt" keeping both new and existing files using the webUI
+    Then file "'single'quotes.txt" should be listed on the webUI
     And the content of "'single'quotes.txt" should not have changed
-    And the file "'single'quotes (2).txt" should be listed on the webUI
+    And file "'single'quotes (2).txt" should be listed on the webUI
     And the content of "'single'quotes (2).txt" should be the same as the local "'single'quotes.txt"
 
-    When the user uploads the file "strängé filename (duplicate #2 &).txt" keeping both new and existing files using the webUI
-    Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
+    When the user uploads file "strängé filename (duplicate #2 &).txt" keeping both new and existing files using the webUI
+    Then file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
     And the content of "strängé filename (duplicate #2 &).txt" should not have changed
-    And the file "strängé filename (duplicate #2 &) (2).txt" should be listed on the webUI
+    And file "strängé filename (duplicate #2 &) (2).txt" should be listed on the webUI
     And the content of "strängé filename (duplicate #2 &) (2).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
-    When the user uploads the file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files using the webUI
-    Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
+    When the user uploads file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files using the webUI
+    Then file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
     And the content of "zzzz-must-be-last-file-in-folder.txt" should not have changed
-    And the file "zzzz-must-be-last-file-in-folder (2).txt" should be listed on the webUI
+    And file "zzzz-must-be-last-file-in-folder (2).txt" should be listed on the webUI
     And the content of "zzzz-must-be-last-file-in-folder (2).txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
   Scenario Outline: chunking upload using difficult names
     Given a file with the size of "30000000" bytes and the name <file-name> has been created locally
-    When the user uploads the file <file-name> using the webUI
-    Then the file <file-name> should be listed on the webUI
+    When the user uploads file <file-name> using the webUI
+    Then file <file-name> should be listed on the webUI
     And the content of <file-name> should be the same as the local <file-name>
     Examples:
       | file-name |
@@ -94,7 +94,7 @@ Feature: File Upload
   # upload into "simple-folder" because there is already a folder called "0" in the root
   Scenario: Upload a file called "0" using chunking
     Given a file with the size of "30000000" bytes and the name "0" has been created locally
-    When the user opens the folder "simple-folder" using the webUI
-    And the user uploads the file "0" using the webUI
-    Then the file "0" should be listed on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "0" using the webUI
+    Then file "0" should be listed on the webUI
     And the content of "0" should be the same as the local "0"

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -14,7 +14,7 @@ Feature: Upload a file
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-    When the user uploads the file "big-video.mp4" using the webUI
-    Then the file "big-video.mp4" should not be listed on the webUI
+    When the user uploads file "big-video.mp4" using the webUI
+    Then file "big-video.mp4" should not be listed on the webUI
     And notifications should be displayed on the webUI with the text matching
       | /^Not enough free space, you are uploading (\d+(.\d+)?) MB but only (\d+(.\d+)?) MB is left$/ |


### PR DESCRIPTION
## Description
Make the acceptance test steps that refer to user, group, file and folder consistent.

## Motivation and Context
In acceptance tests, when naming a particular user, group, file or folder, we usually do not put ``the`` in front of it. e.g.
```
When user "user0" uploads file "abc.txt" using the webUI
```
We only put ``the`` in front when referring to the "current" user, e.g.:
```
When the user uploads file "abc.txt" using the webUI
```
But that convention has become inconsistent. There are some ``the user "user0"`` and a lot of ``the file "abc.txt"`` etc.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
