### PR TITLE
Adjust tags acceptance test steps

### DIFF
--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -15,7 +15,7 @@ Feature: Assign tags to file/folder
     Given the administrator has created a "normal" tag with name "JustARegularTagName"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" using the WebDAV API
+    When user "user1" adds tag "JustARegularTagName" to file "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by the user should have the following tags
       | JustARegularTagName | normal |
@@ -24,8 +24,8 @@ Feature: Assign tags to file/folder
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    When the user adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
+    When the user adds tag "MyFirstTag" to file "/myFileToTag.txt" using the WebDAV API
+    And user "user1" adds tag "MySecondTag" to file "/myFileToTag.txt" owned by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" owned by the user should have the following tags
       | MyFirstTag | normal |
@@ -35,8 +35,8 @@ Feature: Assign tags to file/folder
     And the administrator has created a "not user-assignable" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When the user adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
+    When the user adds tag "MyFirstTag" to file "/myFileToTag.txt" using the WebDAV API
+    And user "user1" adds tag "MySecondTag" to file "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" shared by the user should have the following tags
       | MyFirstTag | normal |
@@ -47,7 +47,7 @@ Feature: Assign tags to file/folder
     And the administrator has created a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" using the WebDAV API
+    When user "user1" adds tag "JustARegularTagName" to file "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by the user should have the following tags
       | JustARegularTagName | not user-assignable |
@@ -57,8 +57,8 @@ Feature: Assign tags to file/folder
     And the administrator has created a "not user-visible" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When the user adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
+    When the user adds tag "MyFirstTag" to file "/myFileToTag.txt" using the WebDAV API
+    And user "user1" adds tag "MySecondTag" to file "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "412"
     And file "/myFileToTag.txt" shared by the user should have the following tags
       | MyFirstTag | normal |
@@ -68,8 +68,8 @@ Feature: Assign tags to file/folder
     And the administrator has created a "not user-visible" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    When the user adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
-    And the administrator adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
+    When the user adds tag "MyFirstTag" to file "/myFileToTag.txt" using the WebDAV API
+    And the administrator adds tag "MySecondTag" to file "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" should have the following tags for the administrator
       | MyFirstTag  | normal           |
@@ -82,8 +82,8 @@ Feature: Assign tags to file/folder
     And the administrator has created a "not user-assignable" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    When the user adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
-    And the administrator adds the tag "MySecondTag" to "/myFileToTag.txt" using the WebDAV API
+    When the user adds tag "MyFirstTag" to file "/myFileToTag.txt" using the WebDAV API
+    And the administrator adds tag "MySecondTag" to file "/myFileToTag.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" should have the following tags for the administrator
       | MyFirstTag  | normal              |

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -17,7 +17,7 @@ Feature: Deletion of tags
   Scenario: Deleting a normal tag that has already been assigned to a file should work
     Given the user has created a "normal" tag with name "JustARegularTagName"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    And the user has added the tag "MyFirstTag" to "/myFileToTag.txt"
+    And the user has added tag "MyFirstTag" to file "/myFileToTag.txt"
     When the user deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for the administrator

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -11,7 +11,7 @@ Feature: tags
   Scenario: Getting tags only works with access to the file
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    When the user adds the tag "MyFirstTag" to "/myFileToTag.txt" using the WebDAV API
+    When the user adds tag "MyFirstTag" to file "/myFileToTag.txt" using the WebDAV API
     Then file "/myFileToTag.txt" should have the following tags for the user
       | MyFirstTag | normal |
     And the HTTP status when user "user1" requests tags for file "/myFileToTag.txt" owned by "user0" should be "404"

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -16,9 +16,9 @@ Feature: Unassigning tags from file/folder
     And the administrator has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    And the user has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    And the user has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When user "user1" removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for the user
       | MySecondTag | normal |
@@ -27,9 +27,9 @@ Feature: Unassigning tags from file/folder
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    And the user has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    And the user has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When user "user1" removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" should have the following tags for the user
       | MyFirstTag  | normal |
@@ -41,9 +41,9 @@ Feature: Unassigning tags from file/folder
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    And the administrator has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    And the administrator has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When user "user1" removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" should have the following tags for the user
       | MySecondTag | normal |
@@ -57,9 +57,9 @@ Feature: Unassigning tags from file/folder
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    And the administrator has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
-    When the administrator removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    And the administrator has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When the administrator removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for the user
       | MySecondTag | normal |
@@ -72,10 +72,10 @@ Feature: Unassigning tags from file/folder
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    And the administrator has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
+    And the administrator has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
     And user "user0" has removed all shares from the file named "/myFileToTag.txt"
-    When the administrator removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When the administrator removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as regular user should fail
@@ -84,9 +84,9 @@ Feature: Unassigning tags from file/folder
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    And the administrator has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    And the administrator has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When user "user1" removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" should have the following tags for the user
       | MyFirstTag  | not user-assignable |
@@ -101,9 +101,9 @@ Feature: Unassigning tags from file/folder
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    And the administrator has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
-    When the administrator removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    And the administrator has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When the administrator removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for the user
       | MySecondTag | normal |
@@ -116,8 +116,8 @@ Feature: Unassigning tags from file/folder
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has shared file "/myFileToTag.txt" with the administrator
-    And the administrator has added the tag "MyFirstTag" to "/myFileToTag.txt"
-    And the user has added the tag "MySecondTag" to "/myFileToTag.txt"
+    And the administrator has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
     And user "user0" has removed all shares from the file named "/myFileToTag.txt"
-    When the administrator removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When the administrator removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -258,7 +258,7 @@ trait Tags {
 	 * @throws \Exception
 	 */
 	public function theFollowingTagsShouldExistForTheAdministrator(TableNode $table) {
-		$this->theFollowingTagsShouldExistFor($this->getAdminUsername(), $table);
+		$this->theFollowingTagsShouldExistForUser($this->getAdminUsername(), $table);
 	}
 
 	/**
@@ -270,11 +270,11 @@ trait Tags {
 	 * @throws \Exception
 	 */
 	public function theFollowingTagsShouldExistForTheUser(TableNode $table) {
-		$this->theFollowingTagsShouldExistFor($this->getCurrentUser(), $table);
+		$this->theFollowingTagsShouldExistForUser($this->getCurrentUser(), $table);
 	}
 
 	/**
-	 * @Then the following tags should exist for :user
+	 * @Then the following tags should exist for user :user
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -282,7 +282,7 @@ trait Tags {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theFollowingTagsShouldExistFor($user, TableNode $table) {
+	public function theFollowingTagsShouldExistForUser($user, TableNode $table) {
 		$user = $this->getActualUsername($user);
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
 			$tagData = $this->requestTagByDisplayName($user, $rowDisplayName);
@@ -297,7 +297,7 @@ trait Tags {
 	}
 
 	/**
-	 * @Then tag :tagDisplayName should not exist for :user
+	 * @Then tag :tagDisplayName should not exist for user :user
 	 *
 	 * @param string $tagDisplayName
 	 * @param string $user
@@ -407,7 +407,7 @@ trait Tags {
 	}
 
 	/**
-	 * @Then :count tags should exist for :user
+	 * @Then :count tags should exist for user :user
 	 *
 	 * @param int $count
 	 * @param string $user
@@ -415,7 +415,7 @@ trait Tags {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function tagsShouldExistFor($count, $user) {
+	public function tagsShouldExistForUser($count, $user) {
 		if ((int)$count !== \count($this->requestTagsForUser($user))) {
 			throw new \Exception(
 				"Expected $count tags, got "
@@ -662,8 +662,8 @@ trait Tags {
 	}
 
 	/**
-	 * @When /^the (administrator|user) adds the tag "([^"]*)" to "([^"]*)" using the WebDAV API$/
-	 * @Given /^the (administrator|user) has added the tag "([^"]*)" to "([^"]*)"$/
+	 * @When /^the (administrator|user) adds tag "([^"]*)" to (?:file|folder) "([^"]*)" using the WebDAV API$/
+	 * @Given /^the (administrator|user) has added tag "([^"]*)" to (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $adminOrUser
 	 * @param string $tagName
@@ -671,7 +671,7 @@ trait Tags {
 	 *
 	 * @return void
 	 */
-	public function theUserOrAdministratorAddsTheTagTo(
+	public function theUserOrAdministratorAddsTagToFileFolder(
 		$adminOrUser, $tagName, $fileName
 	) {
 		if ($adminOrUser === 'administrator') {
@@ -679,12 +679,12 @@ trait Tags {
 		} else {
 			$taggingUser = $this->getCurrentUser();
 		}
-		$this->addsTheTagTo($taggingUser, $tagName, $fileName);
+		$this->addsTagToFileFolder($taggingUser, $tagName, $fileName);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" adds the tag "([^"]*)" to "([^"]*)" using the WebDAV API$/
-	 * @Given /^user "([^"]*)" has added the tag "([^"]*)" to "([^"]*)"$/
+	 * @When /^user "([^"]*)" adds tag "([^"]*)" to (?:file|folder) "([^"]*)" using the WebDAV API$/
+	 * @Given /^user "([^"]*)" has added tag "([^"]*)" to (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $taggingUser
 	 * @param string $tagName
@@ -692,15 +692,15 @@ trait Tags {
 	 *
 	 * @return void
 	 */
-	public function addsTheTagTo(
+	public function addsTagToFileFolder(
 		$taggingUser, $tagName, $fileName
 	) {
 		$this->tag($taggingUser, $tagName, $fileName);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" adds the tag "([^"]*)" to "([^"]*)" (?:shared|owned) by "([^"]*)" using the WebDAV API$/
-	 * @Given /^user "([^"]*)" has added the tag "([^"]*)" to "([^"]*)" (?:shared|owned) by "([^"]*)"$/
+	 * @When /^user "([^"]*)" adds tag "([^"]*)" to (?:file|folder) "([^"]*)" (?:shared|owned) by "([^"]*)" using the WebDAV API$/
+	 * @Given /^user "([^"]*)" has added tag "([^"]*)" to (?:file|folder) "([^"]*)" (?:shared|owned) by "([^"]*)"$/
 	 *
 	 * @param string $taggingUser
 	 * @param string $tagName
@@ -709,7 +709,7 @@ trait Tags {
 	 *
 	 * @return void
 	 */
-	public function addsTheTagToSharedBy(
+	public function addsTagToSharedBy(
 		$taggingUser, $tagName, $fileName, $sharingUser
 	) {
 		$this->tag($taggingUser, $tagName, $fileName, $sharingUser);
@@ -897,8 +897,8 @@ trait Tags {
 	}
 
 	/**
-	 * @When user :user removes the tag :tagName from :fileName shared by :shareUser using the WebDAV API
-	 * @Given user :user has removed the tag :tagName from :fileName shared by :shareUser
+	 * @When user :user removes tag :tagName from file :fileName shared by :shareUser using the WebDAV API
+	 * @Given user :user has removed tag :tagName from file :fileName shared by :shareUser
 	 *
 	 * @param string $user
 	 * @param string $tagName
@@ -907,15 +907,15 @@ trait Tags {
 	 *
 	 * @return void
 	 */
-	public function removesTheTagFromSharedBy(
+	public function removesTagFromFileSharedBy(
 		$user, $tagName, $fileName, $shareUser
 	) {
 		$this->untag($user, $tagName, $fileName, $shareUser);
 	}
 
 	/**
-	 * @When the administrator removes the tag :tagName from :fileName shared by :shareUser using the WebDAV API
-	 * Given the administrator has removed the tag :tagName from :fileName shared by :shareUser
+	 * @When the administrator removes tag :tagName from file :fileName shared by :shareUser using the WebDAV API
+	 * Given the administrator has removed tag :tagName from file :fileName shared by :shareUser
 	 *
 	 * @param string $tagName
 	 * @param string $fileName
@@ -923,11 +923,11 @@ trait Tags {
 	 *
 	 * @return void
 	 */
-	public function theAdministratorRemovesTheTagFromSharedByUsingTheWebdavApi(
+	public function theAdministratorRemovesTheTagFromFileSharedByUsingTheWebdavApi(
 		$tagName, $fileName, $shareUser
 	) {
 		$admin = $this->getAdminUsername();
-		$this->removesTheTagFromSharedBy($admin, $tagName, $fileName, $shareUser);
+		$this->removesTagFromFileSharedBy($admin, $tagName, $fileName, $shareUser);
 	}
 	
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1813,14 +1813,14 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the tag :tagName should not be listed in the dropdown list on the webUI
+	 * @Then tag :tagName should not be listed in the dropdown list on the webUI
 	 *
 	 * @param string $tagName
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theTagShouldNotBeListedInTheDropdownListOnTheWebui($tagName) {
+	public function tagShouldNotBeListedInTheDropdownListOnTheWebui($tagName) {
 		try {
 			$this->theTagShouldBeListedInTheDropdownListOnTheWebUI($tagName);
 		} catch (\Exception $e) {

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -238,8 +238,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the user has changed the password of the public link for :name to :newPassword
-	 * @When the user changes the password of the public link for :name to :newPassword
+	 * @Given the user has changed the password of the public link named :name to :newPassword
+	 * @When the user changes the password of the public link named :name to :newPassword
 	 *
 	 * @param string $name
 	 * @param string $newPassword
@@ -247,7 +247,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws ElementNotFoundException
 	 */
-	public function theUserChangesThePasswordOfThePublicLinkForTo($name, $newPassword) {
+	public function theUserChangesThePasswordOfThePublicLinkNamedTo($name, $newPassword) {
 		$this->publicShareTab->editLink($name, null, null, $newPassword);
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($this->getSession());
 
@@ -256,8 +256,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the user has changed the permission of the public link for :name to :newPermission
-	 * @When the user changes the permission of the public link for :name to :newPermission
+	 * @Given the user has changed the permission of the public link named :name to :newPermission
+	 * @When the user changes the permission of the public link named :name to :newPermission
 	 *
 	 * @param string $name
 	 * @param string $newPermission
@@ -265,7 +265,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws ElementNotFoundException
 	 */
-	public function theUserChangesThePermissionOfThePublicLinkForTo($name, $newPermission) {
+	public function theUserChangesThePermissionOfThePublicLinkNamedTo($name, $newPermission) {
 		$this->publicShareTab->editLink($name, null, $newPermission);
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($this->getSession());
 
@@ -550,8 +550,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the public adds the public link to :server as user :username with the password :password using the webUI
-	 * @Given the public has added the public link to :server as user :username with the password :password using the webUI
+	 * @When the public adds the public link to :server as user :username with password :password using the webUI
+	 * @Given the public has added the public link to :server as user :username with password :password using the webUI
 	 *
 	 * @param string $server
 	 * @param string $username
@@ -574,8 +574,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the user (declines|accepts) the share "([^"]*)" offered by user "([^"]*)" using the webUI$/
-	 * @Given /^the user has (declined|accepted) the share "([^"]*)" offered by user "([^"]*)" using the webUI$/
+	 * @When /^the user (declines|accepts) share "([^"]*)" offered by user "([^"]*)" using the webUI$/
+	 * @Given /^the user has (declined|accepted) share "([^"]*)" offered by user "([^"]*)" using the webUI$/
 	 *
 	 * @param string $action
 	 * @param string $share
@@ -1030,7 +1030,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the content of the file shared by last public link should be the same as :originalFile
+	 * @Then the content of the file shared by the last public link should be the same as :originalFile
 	 *
 	 * @param string $originalFile
 	 *
@@ -1052,7 +1052,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the email address :address should have received an email containing last shared public link
+	 * @Then the email address :address should have received an email containing the last shared public link
 	 *
 	 * @param string $address
 	 *

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -141,7 +141,7 @@ Feature: deleting files and folders
   @systemtags-app-required
   Scenario: delete files from tags page
     Given user "user1" has created a "normal" tag with name "lorem"
-    And user "user1" has added the tag "lorem" to "/lorem.txt"
+    And user "user1" has added tag "lorem" to file "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -86,7 +86,7 @@ Feature: User can open the details panel for any file or folder
   @comments-app-required
   Scenario: View different areas of details panel for the folder with given tag in Tags page
     Given user "user1" has created a "normal" tag with name "simple"
-    And user "user1" has added the tag "simple" to "simple-folder"
+    And user "user1" has added tag "simple" to folder "simple-folder"
     When the user browses to the tags page
     And the user searches for tag "simple" using the webUI
     Then folder "simple-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -48,7 +48,7 @@ Feature: Search
   @systemtags-app-required
   Scenario: search for a file using a tag
     Given user "user1" has created a "normal" tag with name "ipsum"
-    And user "user1" has added the tag "ipsum" to "/lorem.txt"
+    And user "user1" has added tag "ipsum" to file "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "ipsum" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -57,9 +57,9 @@ Feature: Search
   Scenario: search for a file with multiple tags
     Given user "user1" has created a "normal" tag with name "lorem"
     And user "user1" has created a "normal" tag with name "ipsum"
-    And user "user1" has added the tag "lorem" to "/lorem.txt"
-    And user "user1" has added the tag "lorem" to "/testimage.jpg"
-    And user "user1" has added the tag "ipsum" to "/lorem.txt"
+    And user "user1" has added tag "lorem" to file "/lorem.txt"
+    And user "user1" has added tag "lorem" to file "/testimage.jpg"
+    And user "user1" has added tag "ipsum" to file "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     And the user searches for tag "ipsum" using the webUI
@@ -69,8 +69,8 @@ Feature: Search
   @systemtags-app-required
   Scenario: search for a file with tags
     Given user "user1" has created a "normal" tag with name "lorem"
-    And user "user1" has added the tag "lorem" to "/lorem.txt"
-    And user "user1" has added the tag "lorem" to "/simple-folder/lorem.txt"
+    And user "user1" has added tag "lorem" to file "/lorem.txt"
+    And user "user1" has added tag "lorem" to file "/simple-folder/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -46,7 +46,7 @@ Feature: Share by public link
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
-    And the public adds the public link to "%remote_server%" as user "user2" with the password "%alt2%" using the webUI
+    And the public adds the public link to "%remote_server%" as user "user2" with password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
     When the user opens folder "simple-folder (2)" using the webUI
@@ -62,7 +62,7 @@ Feature: Share by public link
       | permission | read-write |
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
-    And the public adds the public link to "%remote_server%" as user "user2" with the password "%alt2%" using the webUI
+    And the public adds the public link to "%remote_server%" as user "user2" with password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
     When the user opens folder "simple-folder (2)" using the webUI
@@ -130,7 +130,7 @@ Feature: Share by public link
     When the user creates a new public link for file 'lorem.txt' using the webUI
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "Lorem ipsum dolor sit amet, consectetur"
-    And the content of the file shared by last public link should be the same as "lorem.txt"
+    And the content of the file shared by the last public link should be the same as "lorem.txt"
 
   Scenario: user shares a public link via email
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
@@ -141,7 +141,7 @@ Feature: Share by public link
 			"""
 			User One shared simple-folder with you
 			"""
-    And the email address "foo@bar.co" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email and sends a copy to self
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
@@ -157,8 +157,8 @@ Feature: Share by public link
 			"""
 			User One shared simple-folder with you
 			"""
-    And the email address "foo@bar.co" should have received an email containing last shared public link
-    And the email address "user1@example.org" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
+    And the email address "user1@example.org" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email with multiple addresses
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
@@ -173,8 +173,8 @@ Feature: Share by public link
 			"""
 			User One shared simple-folder with you
 			"""
-    And the email address "foo@bar.co" should have received an email containing last shared public link
-    And the email address "foo@barr.co" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
+    And the email address "foo@barr.co" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
@@ -201,8 +201,8 @@ Feature: Share by public link
 			"""
 			User One shared simple-folder with you
 			"""
-    And the email address "foo5678@bar.co" should have received an email containing last shared public link
-    And the email address "foo1234@barr.co" should have received an email containing last shared public link
+    And the email address "foo5678@bar.co" should have received an email containing the last shared public link
+    And the email address "foo1234@barr.co" should have received an email containing the last shared public link
     But the email address "foo1234@bar.co" should not have received an email
     And the email address "foo5678@barr.co" should not have received an email
 
@@ -220,7 +220,7 @@ Feature: Share by public link
 			"""
 			lorem ipsum
 			"""
-    And the email address "foo@bar.co" should have received an email containing last shared public link
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   Scenario: user edits a name of an already existing public link
     Given the user has created a new public link for folder "simple-folder" using the webUI
@@ -239,21 +239,21 @@ Feature: Share by public link
   Scenario: user edits the password of an already existing public link
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
-    When the user changes the password of the public link for "simple-folder link" to "pass1234"
+    When the user changes the password of the public link named "simple-folder link" to "pass1234"
     And the public accesses the last created public link with password "pass1234" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link and tries to access with old password
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
-    When the user changes the password of the public link for "simple-folder link" to "pass1234"
+    When the user changes the password of the public link named "simple-folder link" to "pass1234"
     And the public tries to access the last created public link with wrong password "pass123" using the webUI
     Then the public should not get access to the publicly shared file
 
   Scenario: user edits the permission of an already existing public link from read-write to read
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
-    When the user changes the permission of the public link for "simple-folder link" to "read"
+    When the user changes the permission of the public link named "simple-folder link" to "read"
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And it should not be possible to delete file "lorem.txt" using the webUI
@@ -261,7 +261,7 @@ Feature: Share by public link
   Scenario: user edits the permission of an already existing public link from read to read-write
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read |
-    When the user changes the permission of the public link for "simple-folder link" to "read-write"
+    When the user changes the permission of the public link named "simple-folder link" to "read-write"
     And the public accesses the last created public link using the webUI
     And the user deletes the following elements using the webUI
       | name                                  |

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -44,8 +44,8 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has created a folder "/simple-folder/from_user1"
     And user "user1" has shared folder "/simple-folder" with user "user3"
     And user "user3" has logged in using the webUI
-    When the user accepts the share "simple-folder" offered by user "User One" using the webUI
-    And the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
+    And the user accepts share "simple-folder" offered by user "User Two" using the webUI
     Then folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
     And folder "simple-folder (3)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
     And user "user3" should see the following elements
@@ -66,7 +66,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI after a page reload
@@ -80,7 +80,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user declines the share "simple-folder" offered by user "User Two" using the webUI
+    When the user declines share "simple-folder" offered by user "User Two" using the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -92,9 +92,9 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
-    And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
+    And the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
     Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -105,8 +105,8 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
-    And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
+    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
+    And the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
     Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -117,8 +117,8 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    And the user declines the share "simple-folder" offered by user "User Two" using the webUI
-    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    And the user declines share "simple-folder" offered by user "User Two" using the webUI
+    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should be listed in the files page on the webUI
@@ -129,7 +129,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user1" has logged in using the webUI
-    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should be listed in the files page on the webUI
@@ -139,7 +139,7 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user1" has logged in using the webUI
-    When the user declines the share "simple-folder" offered by user "User Two" using the webUI
+    When the user declines share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -148,10 +148,10 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
+    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     And the user has browsed to the files page
     And the user shares folder "simple-folder (2)" with group "grp1" using the webUI
-    And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
+    And the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -189,8 +189,8 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
-    And the user declines the share "testimage (2).jpg" offered by user "User Two" using the webUI
+    When the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
+    And the user declines share "testimage (2).jpg" offered by user "User Two" using the webUI
     And the user has browsed to the files page
     Then folder "simple-folder (2)" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
@@ -234,6 +234,6 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
     And user "user1" has logged in using the webUI
     When the user unshares folder "simple-folder-renamed" using the webUI
-    And the user accepts the share "simple-folder-renamed" offered by user "User Two" using the webUI
+    And the user accepts share "simple-folder-renamed" offered by user "User Two" using the webUI
     Then folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
     And folder "simple-folder-renamed" should be listed in the files page on the webUI

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -70,5 +70,5 @@ Feature: Creation of tags for the files and folders
       | tag1 | normal |
     When the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user deletes tag with name "tag1" using the webUI
-    Then tag "tag1" should not exist for "user1"
-    And tag "tag1" should not exist for "user2"
+    Then tag "tag1" should not exist for user "user1"
+    And tag "tag1" should not exist for user "user2"

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -22,7 +22,7 @@ Feature: Suggestion for matching tag names
     When the user browses directly to display the details of file "lorem.txt" in folder "simple-folder"
     And the user types "sp" in the collaborative tags field using the webUI
     Then all the tags starting with "sp" in their name should be listed in the dropdown list on the webUI
-    But the tag "gham" should not be listed in the dropdown list on the webUI
-    But the tag "notspam" should not be listed in the dropdown list on the webUI
-    And the tag "Violates T&C" should not be listed in the dropdown list on the webUI
-    And the tag "sponsored" should not be listed in the dropdown list on the webUI
+    But tag "gham" should not be listed in the dropdown list on the webUI
+    But tag "notspam" should not be listed in the dropdown list on the webUI
+    And tag "Violates T&C" should not be listed in the dropdown list on the webUI
+    And tag "sponsored" should not be listed in the dropdown list on the webUI


### PR DESCRIPTION
## Description
In the acceptance tests:
1) when mentioning a tag by name, just say ``tag "name-of-tag"`` rather than ``the tag "name-of-tag"``
2) adjust link share test steps so they read better

## Motivation and Context
Standardize reference to tags and link shares.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
