### PR TITLE
Remove unused acceptance test method adminMakesUserNotSubadminOfGroup…

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1652,30 +1652,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator makes user "([^"]*)" not a subadmin of group "([^"]*)" using the provisioning API$/
-	 * @Given /^user "([^"]*)" has been made not a subadmin of group "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $group
-	 *
-	 * @return void
-	 */
-	public function adminMakesUserNotSubadminOfGroupUsingTheProvisioningApi(
-		$user, $group
-	) {
-		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
-		$this->response = HttpRequestHelper::get(
-			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
-		);
-		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
-		\sort($respondedArray);
-		PHPUnit_Framework_Assert::assertNotContains($user, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(
-			200, $this->response->getStatusCode()
-		);
-	}
-
-	/**
 	 * @Then /^the users returned by the API should be$/
 	 *
 	 * @param TableNode $usersList


### PR DESCRIPTION
…UsingTheProvisioningApi

## Description
The code does not actually do what it says. It just checks is the given user is a subadmin of the group.
We do not want someone to use this method (in this state), so delete it.

## Motivation and Context
Deleted code is debugged code.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
