### PR TITLE
Acceptance test to verify that checksum of restored file is calculated

### DIFF
--- a/tests/acceptance/features/apiMain/fileVersions.feature
+++ b/tests/acceptance/features/apiMain/fileVersions.feature
@@ -36,6 +36,14 @@ Feature: dav-versions
     When user "user0" restores version index "1" of file "/davtest.txt" using the WebDAV API
     Then the content of file "/davtest.txt" for user "user0" should be "123"
 
+  Scenario: Restore a file and check, if the content and correct checksum is now in the current file
+    Given user "user0" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
+    And user "user0" has uploaded file "data/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
+    When user "user0" restores version index "1" of file "/davtest.txt" using the WebDAV API
+    Then the content of file "/davtest.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+    And as user "user0" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
+
   Scenario: User cannot access meta folder of a file which is owned by somebody else
     Given user "user1" has been created
     And user "user0" has uploaded file with content "123" to "/davtest.txt"

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -59,6 +59,30 @@ trait Checksums {
 	}
 
 	/**
+	 * @When user :user uploads file with content :content and checksum :checksum to :destination using the WebDAV API
+	 * @Given user :user has uploaded file with content :content and checksum :checksum to :destination
+	 *
+	 * @param string $user
+	 * @param string $content
+	 * @param string $checksum
+	 * @param string $destination
+	 *
+	 * @return void
+	 */
+	public function userUploadsFileWithContentAndChecksumToUsingTheAPI(
+		$user, $content, $checksum, $destination
+	) {
+		$this->response = $this->makeDavRequest(
+			$user,
+			'PUT',
+			$destination,
+			['OC-Checksum' => $checksum],
+			$content,
+			"files"
+		);
+	}
+
+	/**
 	 * @Then the webdav response should have a status code :statusCode
 	 *
 	 * @param int $statusCode


### PR DESCRIPTION
## Description
Add a test scenario that creates 2 versions of a file, including checksums. Restore the old version, verify that the checksum of the restored version exists and is correct.

## Related Issue
#33566 

## Motivation and Context
We do not seem to have any version restore acceptance tests that verify that the checksum of the old version is restored (or recreated, or whatever)

## How Has This Been Tested?
Local run of acceptance test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
