### PR TITLE
Test creating users with various passwords using the Provisioning API

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -14,6 +14,7 @@ Feature: add user
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file
 
   Scenario: admin tries to create an existing user
     Given user "brand-new-user" has been created
@@ -36,3 +37,32 @@ Feature: add user
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "newuser" should belong to group "newgroup"
+    And user "newuser" should be able to access a skeleton file
+
+  Scenario Outline: admin creates a user and specifies a password with special characters
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file
+    Examples:
+      | password                     | comment                     |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
+      | España                       | special European characters |
+      | नेपाली                       | Unicode                     |
+
+  Scenario: admin creates a user and specifies an invalid password, containing just space
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password " " using the provisioning API
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
+
+  Scenario: admin creates a user and specifies a password containing spaces
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "spaces in my password" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -8,12 +8,13 @@ Feature: add user
     Given using OCS API version "2"
 
   @smokeTest
-  Scenario: Create a user
+  Scenario: admin creates a user
     Given user "brand-new-user" has been deleted
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file
 
   Scenario: admin tries to create an existing user
     Given user "brand-new-user" has been created
@@ -36,3 +37,32 @@ Feature: add user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "newuser" should belong to group "newgroup"
+    And user "newuser" should be able to access a skeleton file
+
+  Scenario Outline: admin creates a user and specifies a password with special characters
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "<password>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file
+    Examples:
+      | password                     | comment                     |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
+      | España                       | special European characters |
+      | नेपाली                       | Unicode                     |
+
+  Scenario: admin creates a user and specifies an invalid password, containing just space
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password " " using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And user "brand-new-user" should not exist
+
+  Scenario: admin creates a user and specifies a password containing spaces
+    Given user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "spaces in my password" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file


### PR DESCRIPTION
## Description
Add test scenarios to verify that users can be created with various unusual passwords using the Provisioning API, and that a password with just space is invalid.

## Related Issue
- Part of issue #33570 

## Motivation and Context
See issue

## How Has This Been Tested?
Local run of test scenarios

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
