### PR TITLE
skip tests on encryption that fail because of encryption issue 74

### DIFF
--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -62,6 +62,7 @@ Feature: deleting files and folders
       | &and#hash       |
 
   @smokeTest
+  @skipOnEncryption @encryption-issue-74
   Scenario: Delete multiple files at once
     When the user batch deletes these files using the webUI
       | name          |
@@ -74,6 +75,7 @@ Feature: deleting files and folders
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
+  @skipOnEncryption @encryption-issue-74
   Scenario: Delete all files at once
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI
@@ -84,6 +86,7 @@ Feature: deleting files and folders
     And the folder should be empty on the webUI
     And the folder should be empty on the webUI after a page reload
 
+  @skipOnEncryption @encryption-issue-74
   Scenario: Delete all except for a few files at once
     When the user marks all files for batch action using the webUI
     And the user unmarks these files for batch action using the webUI
@@ -196,6 +199,7 @@ Feature: deleting files and folders
       | question?       |
       | &and#hash       |
 
+  @skipOnEncryption @encryption-issue-74
   Scenario: Delete multiple files at once on a public share
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |


### PR DESCRIPTION
## Description
this tests fail because of https://github.com/owncloud/encryption/issues/74

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes  #33325

## Motivation and Context
make CI pass  reliable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
