### PR TITLE
Touch last login time when using auth modules

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -996,6 +996,7 @@ class Session implements IUserSession, Emitter {
 
 			$this->setUser($user);
 			$this->setLoginName($user->getDisplayName());
+			$user->updateLastLoginTimestamp();
 
 			$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
 

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1547,6 +1547,8 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->any())
 			->method('isEnabled')
 			->willReturn(true);
+		$iUser->expects($this->atLeastOnce())
+			->method('updateLastLoginTimestamp');
 
 		$result = $this->invokePrivate($userSession, 'loginUser', [$iUser, 'foo']);
 		$this->assertTrue($result);
@@ -1584,6 +1586,8 @@ class SessionTest extends TestCase {
 			->willReturn(false);
 		$iUser->method('getUID')
 			->willReturn('foo');
+		$iUser->expects($this->never())
+			->method('updateLastLoginTimestamp');
 
 		$failedEvent = new GenericEvent(null, ['user' => 'foo']);
 		$eventDispatcher->expects($this->once())


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Auth modules do not update the lastLoginTime in oc_accounts. 

## Related Issue
-

## Motivation and Context
Last Login is used to detect 'seen' users, without this some users can never get a last_login time and will not be included in other processes. 

## How Has This Been Tested?
Tried with oAuth since this uses an auth module, however the time was not updated, past the initial connection - but I expected it to be. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
