### PR TITLE
Test that editing a public link name and not saving it does not changes anything

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -230,7 +230,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws ElementNotFoundException
 	 */
-	public function theUserOpensThePublicLinkEditDialogOfThe($oldName, $newName) {
+	public function theUserHasRenamedThePublicLinkNameFromOldNameToNewName($oldName, $newName) {
 		$session = $this->getSession();
 		$this->publicShareTab->editLink($session, $oldName, $newName);
 
@@ -238,6 +238,40 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($newName);
 		$this->addToListOfCreatedPublicLinks($newName, $linkUrl);
+	}
+
+	/**
+	 * @Given the user has opened the edit public link share popup for the link named :linkName
+	 * @When the user opens the edit public link share popup for the link named :linkName
+	 *
+	 * @param string $linkName
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function theUserOpensThePublicLinkEditDialogForTheLinkName($linkName) {
+		$this->publicSharingPopup = $this->publicShareTab->openSharingPopupByLinkName($linkName, $this->getSession());
+	}
+
+	/**
+	 * @When the user does not save any changes in the edit public link share popup
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function theUserDoesNotSaveAnyChangeInEditPublicLinkSharePopup() {
+		$this->publicSharingPopup->cancel();
+	}
+
+	/**
+	 * @When the user enters the password :password on the edit public link share popup for the link
+	 *
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function theUserEntersThePasswordForTheLink($password) {
+		$this->publicSharingPopup->setLinkPassword($password);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -46,6 +46,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	private $emailInputCloseXpath = "//a[@class='select2-search-choice-close']";
 	private $personalMessageInputXpath = "//*[@class='public-link-modal--input emailPrivateLinkForm--emailBodyField']";
 	private $shareButtonXpath = ".//button[contains(text(), 'Share') or contains(text(), 'Save')]";
+	private $cancelButtonXpath = ".//button[contains(text(), 'Cancel')]";
 	private $permissionLabelXpath = [
 		'read' => ".//label[contains(@for, 'sharingDialogAllowPublicRead')]",
 		'read-write' => ".//label[contains(@for, 'sharingDialogAllowPublicReadWrite')]",
@@ -275,6 +276,23 @@ class EditPublicLinkPopup extends OwncloudPage {
 		);
 
 		$saveButton->click();
+	}
+
+	/**
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function cancel() {
+		$cancelButton = $this->popupElement->find("xpath", $this->cancelButtonXpath);
+		$this->assertElementNotNull(
+			$cancelButton,
+			__METHOD__ .
+			" xpath $this->cancelButtonXpath" .
+			" could not find cancel button on the public link popup"
+		);
+
+		$cancelButton->click();
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -198,6 +198,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @param string $password
 	 * @param string $expirationDate
 	 * @param string $email
+	 * @param string $save
 	 *
 	 * @return void
 	 * @throws ElementNotFoundException
@@ -209,14 +210,10 @@ class PublicLinkTab extends OwncloudPage {
 		$permissions = null,
 		$password = null,
 		$expirationDate = null,
-		$email = null
+		$email = null,
+		$save = true
 	) {
-		$linkEntry = $this->findLinkEntryByName($name);
-		$editLinkBtn = $linkEntry->find("xpath", $this->linkEditBtnXpath);
-
-		$editLinkBtn->click();
-
-		$this->updateSharingPopup($session);
+		$this->openSharingPopupByLinkName($name, $session);
 
 		if ($newName !== null) {
 			$this->editPublicLinkPopupPageObject->setLinkName($newName);
@@ -227,7 +224,32 @@ class PublicLinkTab extends OwncloudPage {
 		if ($permissions !== null) {
 			$this->editPublicLinkPopupPageObject->setLinkPermissions($permissions);
 		}
-		$this->editPublicLinkPopupPageObject->save();
+
+		if ($save === true) {
+			$this->editPublicLinkPopupPageObject->save();
+		} else {
+			$this->editPublicLinkPopupPageObject->cancel();
+		}
+	}
+
+	/**
+	 * Open Sharing Popup from given link name
+	 *
+	 * @param string $name
+	 * @param Session $session
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function openSharingPopupByLinkName($name, $session) {
+		$linkEntry = $this->findLinkEntryByName($name);
+		$editLinkBtn = $linkEntry->find("xpath", $this->linkEditBtnXpath);
+
+		$editLinkBtn->click();
+
+		$this->updateSharingPopup($session);
+
+		return $this->editPublicLinkPopupPageObject;
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -206,6 +206,18 @@ Feature: Share by public link
     But the email address "foo1234@bar.co" should not have received an email
     And the email address "foo5678@barr.co" should not have received an email
 
+  Scenario: user edits a public link and does not save the changes
+    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And the user has reloaded the current page of the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
+      | email   | foo1234@bar.co|
+      | password| pass123       |
+    When the user opens the edit public link share popup for the link named "simple-folder link"
+    And the user enters the password "qwertyui" on the edit public link share popup for the link
+    And the user does not save any changes in the edit public link share popup
+    And the public tries to access the last created public link with wrong password "qwertyui" using the webUI
+    Then the public should not get access to the publicly shared file
+
   Scenario: user shares a public link via email with a personal message
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user has reloaded the current page of the webUI


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Tests that editing a pre-existing public link but not saving any changes does not affect the public link

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33590

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
