### PR TITLE
CLI Acceptance tests to verify setting a password to valid and invalid values

### DIFF
--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -49,3 +49,23 @@ Feature: add a user using the using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The user "justauser" was created successfully'
     And user "justauser" should belong to group "newgroup"
+
+  Scenario Outline: Admin creates users having password with special characters
+    Given user "brand-new-user" has been deleted
+    When the administrator creates user "brand-new-user" password "<password>" group "brand-new-group" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'The user "brand-new-user" was created successfully'
+    And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file
+    Examples:
+      | password                     | comment                     |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
+      | España                       | special European characters |
+      | नेपाली                                                  | Unicode                     |
+      | password with spaces         | password with spaces        |
+
+  Scenario: admin creates a user and specifies an invalid password, containing just space
+    Given user "brand-new-user" has been deleted
+    When the administrator creates user "brand-new-user" password " " group "brand-new-group" using the occ command
+    Then the command should have failed with exit code 1
+    And user "brand-new-user" should not exist

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -31,3 +31,27 @@ Feature: edit users
     And user "brand-new-user" should exist
     And the user attributes returned by the API should include
       | quota definition | 12 MB |
+
+  Scenario Outline: Admin resets user password with special characters
+    Given user "brand-new-user" has been deleted
+    When the administrator creates user "brand-new-user" password "%alt1%" group "brand-new-group" using the occ command
+    And the administrator resets the password of user "brand-new-user" to "<password>" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Successfully reset password for brand-new-user'
+    And user "brand-new-user" should exist
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
+    Examples:
+      | password                     | comment                     |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
+      | España                       | special European characters |
+      | नेपाली                                                  | Unicode                     |
+      | password with spaces         | password with spaces        |
+
+  Scenario: admin creates a user and specifies an invalid password, containing just space
+    Given user "brand-new-user" has been deleted
+    When the administrator creates user "brand-new-user" password "%alt1%" group "brand-new-group" using the occ command
+    And the administrator resets the password of user "brand-new-user" to " " using the occ command
+    Then the command should have failed with exit code 1
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password " " should not be able to download file "textfile0.txt"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add CLI acceptance tests for checking creating user with different set of valid and invalid passwords and checking exptected behaviour

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33598

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
