### PR TITLE
[stable10] Fix bugs in checksum verify command

### DIFF
--- a/apps/files/lib/Command/VerifyChecksums.php
+++ b/apps/files/lib/Command/VerifyChecksums.php
@@ -90,6 +90,7 @@ class VerifyChecksums extends Command {
 		if ($pathOption && $userName) {
 			$output->writeln('<error>Please use either path or user exclusively</error>');
 			$this->exitStatus = self::EXIT_INVALID_ARGS;
+			return $this->exitStatus;
 		}
 
 		$walkFunction = function (Node $node) use ($input, $output) {

--- a/apps/files/lib/Command/VerifyChecksums.php
+++ b/apps/files/lib/Command/VerifyChecksums.php
@@ -96,34 +96,34 @@ class VerifyChecksums extends Command {
 		$walkFunction = function (Node $node) use ($input, $output) {
 			$path = $node->getInternalPath();
 			$currentChecksums = $node->getChecksum();
-			$owner = $node->getOwner()->getUID();
 			$storage = $node->getStorage();
+			$storageId = $storage->getId();
 
 			if ($storage->instanceOfStorage(ISharedStorage::class) || $storage->instanceOfStorage(FailedStorage::class)) {
 				return;
 			}
 
 			if (!self::fileExistsOnDisk($node)) {
-				$output->writeln("Skipping $owner/$path => File is in file-cache but doesn't exist on storage/disk", OutputInterface::VERBOSITY_VERBOSE);
+				$output->writeln("Skipping $storageId/$path => File is in file-cache but doesn't exist on storage/disk", OutputInterface::VERBOSITY_VERBOSE);
 				return;
 			}
 
 			if (!$node->isReadable()) {
-				$output->writeln("Skipping $owner/$path => File not readable", OutputInterface::VERBOSITY_VERBOSE);
+				$output->writeln("Skipping $storageId/$path => File not readable", OutputInterface::VERBOSITY_VERBOSE);
 				return;
 			}
 
 			// Files without calculated checksum can't cause checksum errors
 			if (empty($currentChecksums)) {
-				$output->writeln("Skipping $owner/$path => No Checksum", OutputInterface::VERBOSITY_VERBOSE);
+				$output->writeln("Skipping $storageId/$path => No Checksum", OutputInterface::VERBOSITY_VERBOSE);
 				return;
 			}
 
-			$output->writeln("Checking $owner/$path => $currentChecksums", OutputInterface::VERBOSITY_VERBOSE);
+			$output->writeln("Checking $storageId/$path => $currentChecksums", OutputInterface::VERBOSITY_VERBOSE);
 			$actualChecksums = self::calculateActualChecksums($path, $node->getStorage());
 			if ($actualChecksums !== $currentChecksums) {
 				$output->writeln(
-					"<info>Mismatch for $owner/$path:\n Filecache:\t$currentChecksums\n Actual:\t$actualChecksums</info>"
+					"<info>Mismatch for $storageId/$path:\n Filecache:\t$currentChecksums\n Actual:\t$actualChecksums</info>"
 				);
 
 				$this->exitStatus = self::EXIT_CHECKSUM_ERRORS;


### PR DESCRIPTION
- Fixes a bug where paths are not correctly printed when the command is run in verbose mode (storageId is now prefixed)
- Fixes a bug where verification runs when both path and user parameters are given despite this constellation not being supported.

Closes https://github.com/owncloud/enterprise/issues/2952


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
