### PR TITLE
Copying a file case sensitive test

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/copyFile.feature
@@ -32,9 +32,9 @@ Feature: copy file
 
   Scenario Outline: Copying a file when 2 files exist with different case
     Given using <dav_version> DAV path
-    And user "user0" has copied file "/welcome.txt" to "/textfile1.txt" using the WebDAV API
-    And user "user0" has copied file "/welcome.txt" to "/TextFile1.txt" using the WebDAV API
-    Then the HTTP status code should be "204"
+    And user "user0" has copied file "/welcome.txt" to "/textfile1.txt"
+    When user "user0" copies file "/welcome.txt" to "/TextFile1.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And the downloaded content when downloading file "/textfile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
     And the downloaded content when downloading file "/TextFile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
     Examples:

--- a/tests/acceptance/features/apiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/copyFile.feature
@@ -32,11 +32,11 @@ Feature: copy file
 
   Scenario Outline: Copying a file when 2 files exist with different case
     Given using <dav_version> DAV path
-    And user "user0" has copied file "/welcome.txt" to "/textfile1.txt"
-    When user "user0" copies file "/welcome.txt" to "/TextFile1.txt" using the WebDAV API
+    # "/textfile1.txt" already exists in the skeleton, make another with only case differences in the file name
+    When user "user0" copies file "/textfile0.txt" to "/TextFile1.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the downloaded content when downloading file "/textfile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
-    And the downloaded content when downloading file "/TextFile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
+    And the content of file "/textfile1.txt" for user "user0" should be "ownCloud test text file 1" plus end-of-line
+    And the content of file "/TextFile1.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | dav_version |
       | old         |


### PR DESCRIPTION
## Description
Adjust the test scenario so that the 2 files ``textfile1.txt`` and ``TextFile1.txt`` have different content.
Then check that the correct content is downloaded when downloading each file.

## Related Issue
- Part of #32357 
- follows on from PR #33605 

## Motivation and Context
Improve the test

## How Has This Been Tested?
Local test run

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
