### PR TITLE
[stable10] Backport of Replace notification with confirm dialog for u…

### DIFF
--- a/settings/js/users/deleteHandler.js
+++ b/settings/js/users/deleteHandler.js
@@ -45,27 +45,6 @@ DeleteHandler.TIMEOUT_MS = 7000;
 DeleteHandler.prototype._timeout = null;
 
 /**
- * The function to be called after successfully marking the object for deletion
- * @callback markCallback
- * @param {string} oid the ID of the specific user or group
- */
-
-/**
- * The function to be called after successful delete. The id of the object will
- * be passed as argument. Unsuccessful operations will display an error using
- * OC.dialogs, no callback is fired.
- * @callback removeCallback
- * @param {string} oid the ID of the specific user or group
- */
-
-/**
- * This callback is fired after "undo" was clicked so the consumer can update
- * the web interface
- * @callback undoCallback
- * @param {string} oid the ID of the specific user or group
- */
-
-/**
  * enabled the notification system. Required for undo UI.
  *
  * @param {object} notifier Usually OC.Notification
@@ -112,54 +91,13 @@ DeleteHandler.prototype.showNotification = function() {
 };
 
 /**
- * hides the Undo Notification
- */
-DeleteHandler.prototype.hideNotification = function() {
-	if(this.notifier !== false) {
-		$('#notification').removeData(this.notificationDataID);
-		this.notifier.hide();
-	}
-};
-
-/**
  * initializes the delete operation for a given object id
  *
  * @param {string} oid the object id
  */
 DeleteHandler.prototype.mark = function(oid) {
-	if(this.oidToDelete !== false) {
-		// passing true to avoid hiding the notification
-		// twice and causing the second notification
-		// to disappear immediately
-		this.deleteEntry(true);
-	}
 	this.oidToDelete = oid;
-	this.canceled = false;
-	this.markCallback(oid);
-	this.showNotification();
-	if (this._timeout) {
-		clearTimeout(this._timeout);
-		this._timeout = null;
-	}
-	if (DeleteHandler.TIMEOUT_MS > 0) {
-		this._timeout = window.setTimeout(
-				_.bind(this.deleteEntry, this),
-			   	DeleteHandler.TIMEOUT_MS
-		);
-	}
-};
-
-/**
- * cancels a delete operation
- */
-DeleteHandler.prototype.cancel = function() {
-	if (this._timeout) {
-		clearTimeout(this._timeout);
-		this._timeout = null;
-	}
-
-	this.canceled = true;
-	this.oidToDelete = false;
+	this.markCallback(decodeURIComponent(oid));
 };
 
 /**
@@ -173,18 +111,13 @@ DeleteHandler.prototype.cancel = function() {
  */
 DeleteHandler.prototype.deleteEntry = function(keepNotification) {
 	var deferred = $.Deferred();
-	if(this.canceled || this.oidToDelete === false) {
+	if(this.oidToDelete === false) {
 		return deferred.resolve().promise();
 	}
 
 	var dh = this;
 	if(!keepNotification && $('#notification').data(this.notificationDataID) === true) {
 		dh.hideNotification();
-	}
-
-	if (this._timeout) {
-		clearTimeout(this._timeout);
-		this._timeout = null;
 	}
 
 	var payload = {};
@@ -199,10 +132,9 @@ DeleteHandler.prototype.deleteEntry = function(keepNotification) {
 
 			//TODO: following line
 			dh.removeCallback(dh.oidToDelete);
-			dh.canceled = true;
 		},
 		error: function (jqXHR) {
-			OC.dialogs.alert(jqXHR.responseJSON.data.message, t('settings', 'Unable to delete {objName}', {objName: dh.oidToDelete}));
+			OC.dialogs.alert(jqXHR.responseJSON.data.message, t('settings', 'Unable to delete {objName}', {objName: decodeURIComponent(dh.oidToDelete)}));
 			dh.undoCallback(dh.oidToDelete);
 
 		}

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -269,22 +269,25 @@ GroupList = {
 		GroupDeleteHandler = new DeleteHandler('/settings/users/groups', 'groupname',
 			GroupList.hide, GroupList.remove);
 
-		//configure undo
-		OC.Notification.hide();
 		var msg = escapeHTML(t('settings', 'deleted {groupName}', {groupName: '%oid'})) + '<span class="undo">' +
 			escapeHTML(t('settings', 'undo')) + '</span>';
 		GroupDeleteHandler.setNotification(OC.Notification, 'deletegroup', msg,
-			GroupList.show);
+			GroupList.remove);
 
 		//when to mark user for delete
 		$userGroupList.on('click', '.delete', function () {
 			// Call function for handling delete/undo
-			GroupDeleteHandler.mark(encodeURIComponent(GroupList.getElementGID(this)).toString());
-		});
-
-		//delete a marked user when leaving the page
-		$(window).on('beforeunload', function () {
-			GroupDeleteHandler.deleteEntry();
+			var groupName = encodeURIComponent(GroupList.getElementGID(this)).toString();
+			OC.dialogs.confirm(
+				t('settings', 'You are about to delete a group. This action can\'t be undone and is permanent. Are you sure that you want to permanently delete {groupName}?', {groupName:decodeURIComponent(groupName)}),
+				t('settings', 'Delete group'),
+				function (confirmation) {
+					if (confirmation) {
+						GroupDeleteHandler.mark(groupName);
+						GroupDeleteHandler.deleteEntry();
+					}
+				}
+			);
 		});
 	},
 

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -377,12 +377,16 @@ var UserList = {
 		$userListBody.on('click', '.delete', function () {
 			// Call function for handling delete/undo
 			var uid = UserList.getUID(this);
-			UserDeleteHandler.mark(uid);
-		});
-
-		//delete a marked user when leaving the page
-		$(window).on('beforeunload', function () {
-			UserDeleteHandler.deleteEntry();
+			OC.dialogs.confirm(
+				t('settings', 'You are about to delete a user. This action can\'t be undone and is permanent. All user data, files and shares will be deleted. Are you sure that you want to permanently delete {userName}?', {userName: uid}),
+				t('settings', 'Delete user'),
+				function (confirmation) {
+					if (confirmation) {
+						UserDeleteHandler.mark(uid);
+						UserDeleteHandler.deleteEntry();
+					}
+				}
+			);
 		});
 	},
 	update: function (gid, limit) {
@@ -912,12 +916,7 @@ $(document).ready(function () {
 			}
 		}
 
-		var promise;
-		if (UserDeleteHandler) {
-			promise = UserDeleteHandler.deleteEntry();
-		} else {
-			promise = $.Deferred().resolve().promise();
-		}
+		var promise = $.Deferred().resolve().promise();
 
 		promise.then(function() {
 			var groups = $('#newuser .groups').data('groups') || [];

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -149,19 +149,31 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 
 	/**
 	 *
-	 * @When the administrator deletes the group named :name using the webUI
+	 * @When the administrator deletes the group named :name using the webUI and confirms the deletion using the webUI
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 */
 	public function theAdminDeletesTheGroupUsingTheWebUI($name) {
-		$this->usersPage->deleteGroup($name, $this->getSession());
+		$this->usersPage->deleteGroup($name, $this->getSession(), true);
 		$this->featureContext->rememberThatGroupIsNotExpectedToExist($name);
 	}
 
 	/**
-	 * @When the administrator deletes these groups using the webUI:
+	 * @When the administrator deletes the group named :name using the webUI and cancels the deletion using the webUI
+	 *
+	 * @param string $name
+	 *
+	 * @return void
+	 */
+	public function theAdminDeletesDoesNotDeleteGroupUsingWebUI($name) {
+		$this->usersPage->deleteGroup($name, $this->getSession(), false);
+		$this->featureContext->rememberThatGroupIsNotExpectedToExist($name);
+	}
+
+	/**
+	 * @When the administrator deletes these groups and confirms the deletion using the webUI:
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param TableNode $table
@@ -171,6 +183,20 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	public function theAdminDeletesTheseGroupsUsingTheWebUI(TableNode $table) {
 		foreach ($table as $row) {
 			$this->theAdminDeletesTheGroupUsingTheWebUI($row['groupname']);
+		}
+	}
+
+	/**
+	 * @When the administrator deletes these groups and and cancels the deletion using the webUI:
+	 * expects a table of groups with the heading "groupname"
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdminDeletesDoesNotTheseGroupsUsingTheWebUI(TableNode $table) {
+		foreach ($table as $row) {
+			$this->theAdminDeletesDoesNotDeleteGroupUsingWebUI($row['groupname']);
 		}
 	}
 
@@ -269,14 +295,26 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes user :username using the webUI
+	 * @When the administrator deletes user :username using the webUI and confirms the deletion using the webUI
 	 *
 	 * @param string $username
 	 *
 	 * @return void
 	 */
 	public function theAdministratorDeletesTheUser($username) {
-		$this->usersPage->deleteUser($username);
+		$this->usersPage->deleteUser($username, true);
+		$this->featureContext->rememberThatUserIsNotExpectedToExist($username);
+	}
+
+	/**
+	 * @When the administrator deletes user :username using the webUI and cancels the deletion using the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function theAdministratorDoesNotDeleteTheUser($username) {
+		$this->usersPage->deleteUser($username, false);
 		$this->featureContext->rememberThatUserIsNotExpectedToExist($username);
 	}
 

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -43,6 +43,10 @@ class GroupList extends OwncloudPage {
 	protected $addGroupXpath = '//span[text()[normalize-space()="Add Group"]]';
 	protected $addNewGroupInputBoxId = 'newgroupname';
 	protected $addNewGroupButtonXpath = '//input[@class="button icon-add"]';
+	protected $deleteConfirmButtonXpath
+		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style,'display: none')])]//button[text()='Yes']";
+	protected $deleteNotConfirmButtonXpath
+		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style,'display: none')])]//button[text()='No']";
 
 	/**
 	 * sets the NodeElement for the current group list
@@ -86,11 +90,12 @@ class GroupList extends OwncloudPage {
 	 * deletes a group in the UI
 	 *
 	 * @param string $name
+	 * @param bool $confirm
 	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
-	public function deleteGroup($name) {
+	public function deleteGroup($name, $confirm) {
 		$groupLi = $this->selectGroup($name);
 		$deleteButton = $groupLi->find("xpath", $this->deleteBtnXpath);
 		if ($deleteButton === null) {
@@ -101,6 +106,22 @@ class GroupList extends OwncloudPage {
 			);
 		}
 		$deleteButton->click();
+
+		if ($confirm) {
+			$confirmButton = $this->find("xpath", $this->deleteConfirmButtonXpath);
+		} else {
+			$confirmButton = $this->find("xpath", $this->deleteNotConfirmButtonXpath);
+		}
+
+		if ($confirmButton === null) {
+			$xpathSelector = ($confirm) ? $this->deleteConfirmButtonXpath : $this->deleteNotConfirmButtonXpath;
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $xpathSelector " .
+				"could not find delete confirm button"
+			);
+		}
+		$confirmButton->click();
 	}
 
 	/**

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -112,7 +112,7 @@ Feature: add users
 
   Scenario: recreating a user with same name after deletion sends a new token to new address
     When the administrator creates a user with the name "guiusr1" and the email "mistake@owncloud" without a password using the webUI
-    And the administrator deletes user "guiusr1" using the webUI
+    And the administrator deletes user "guiusr1" using the webUI and confirms the deletion using the webUI
     And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "correct@owncloud" using the webUI
@@ -122,7 +122,7 @@ Feature: add users
 
   Scenario: recreating a user with same name after deletion makes the first token invalid
     When the administrator creates a user with the name "guiusr1" and the email "mistake@owncloud" without a password using the webUI
-    And the administrator deletes user "guiusr1" using the webUI
+    And the administrator deletes user "guiusr1" using the webUI and confirms the deletion using the webUI
     And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "mistake@owncloud" using the webUI
@@ -131,7 +131,7 @@ Feature: add users
 
   Scenario: when recreating a user with same second token can be used even if someone tried to use the first one
     When the administrator creates a user with the name "guiusr1" and the email "mistake@owncloud" without a password using the webUI
-    And the administrator deletes user "guiusr1" using the webUI
+    And the administrator deletes user "guiusr1" using the webUI and confirms the deletion using the webUI
     And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "mistake@owncloud" using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -13,9 +13,13 @@ Feature: delete users
     And the administrator has browsed to the users page
 
   Scenario: use the webUI to delete a simple user
-    When the administrator deletes user "user1" using the webUI
+    When the administrator deletes user "user1" using the webUI and confirms the deletion using the webUI
     And the deleted user "user1" tries to login using the password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user has browsed to the login page
     And user "user2" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+  Scenario: use the webUI to cancel deletion of user
+    When the administrator deletes user "user1" using the webUI and cancels the deletion using the webUI
+    Then user "user1" should exist

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -17,7 +17,7 @@ Feature: manage groups
       | false          |
       | do-not-delete2 |
     And the administrator has browsed to the users page
-    When the administrator deletes these groups using the webUI:
+    When the administrator deletes these groups and confirms the deletion using the webUI:
       | groupname |
       | 0         |
       | false     |
@@ -50,7 +50,7 @@ Feature: manage groups
       | q?mark         |
       | do-not-delete2 |
     And the administrator has browsed to the users page
-    When the administrator deletes these groups using the webUI:
+    When the administrator deletes these groups and confirms the deletion using the webUI:
       | groupname |
       | a/slash   |
       | per%cent  |
@@ -88,7 +88,7 @@ Feature: manage groups
       | quotes"        |
       | do-not-delete2 |
     And the administrator has browsed to the users page
-    When the administrator deletes these groups using the webUI:
+    When the administrator deletes these groups and confirms the deletion using the webUI:
       | groupname   |
       | grp1        |
       | space group |
@@ -115,3 +115,45 @@ Feature: manage groups
       | space group |
       | quotes'     |
       | quotes"     |
+
+  Scenario: cancel deletion of a group
+    Given these groups have been created:
+      | groupname      |
+      | do-not-delete  |
+      | grp1           |
+      | space group    |
+      | quotes'        |
+      | quotes"        |
+      | do-not-delete2 |
+    And the administrator has browsed to the users page
+    When the administrator deletes the group named "space group" using the webUI and cancels the deletion using the webUI
+    And the administrator reloads the users page
+    Then group "space group" should exist
+
+  Scenario: cancel deletion of groups
+    Given these groups have been created:
+      | groupname      |
+      | do-not-delete  |
+      | grp1           |
+      | space group    |
+      | quotes'        |
+      | quotes"        |
+      | do-not-delete2 |
+      | a\slash        |
+    And the administrator has browsed to the users page
+    When the administrator deletes these groups and and cancels the deletion using the webUI:
+      | groupname   |
+      | grp1        |
+      | space group |
+      | quotes'     |
+      | a\slash     |
+    And the administrator reloads the users page
+    Then these groups should be listed on the webUI:
+      | groupname      |
+      | do-not-delete  |
+      | grp1           |
+      | space group    |
+      | quotes'        |
+      | quotes"        |
+      | do-not-delete2 |
+      | a\slash        |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Replace the notification when a user/group is deleted from the users page, with a confirmation dialog.
- The confirmation dialog will be popped up, when a delete action is triggered from the users page on a user or a group.
- If user clicks button yes of the confirmation dialog, the user/group would be deleted. 
- If button no is clicked of the confirmation dialog, the delete operation will not happen, for the user/group.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Replace the notification when a user/group is deleted from the users page, with a confirmation dialog.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] All the webUI tests were conducted from the users page.
- [x] Did simple tests in the webUI by creating users and deleting them. Verified with the occ command if the users were deleted.
- [x] Did simple tests in the webUI by creating users and cancling the delete operation. Verified with the occ command if the users were still available.
- [x] Created groups and deleted them from webUI. Verified the same with occ command.
- [x] Created groups and cancelled the delete operation done on them. Verified the same with occ command, if the groups were still available.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
