### PR TITLE
Fix #33630. Fix cannot set 0 as value on files_external through OCC command

### DIFF
--- a/apps/files_external/lib/Command/Config.php
+++ b/apps/files_external/lib/Command/Config.php
@@ -72,7 +72,8 @@ class Config extends Base {
 		}
 
 		$value = $input->getArgument('value');
-		if ($value) {
+
+		if ($value !== null) {
 			$this->setOption($mount, $key, $value, $output);
 		} else {
 			$this->getOption($mount, $key, $output);

--- a/apps/files_external/tests/Command/ConfigCommandTest.php
+++ b/apps/files_external/tests/Command/ConfigCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @author Saugat Pachhai <saugat@jankaritech.com>
+ * @author Artur Neumann <artur@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Tests\Command;
+
+use OCA\Files_External\Command\Config;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ConfigCommandTest extends CommandTest {
+	private function getInstance($storageService) {
+		return new Config($storageService);
+	}
+
+	/**
+	 * @dataProvider optionsProvider
+	 *
+	 * @param mixed $value
+	 *
+	 * @return void
+	 */
+	public function testGetConfigValue($value) {
+		$mount = $this->getMount(1, '', '', [], ['filesystem_check_changes' => $value]);
+
+		$storageService = $this->getGlobalStorageService([$mount]);
+		$command = $this->getInstance($storageService);
+
+		$input = $this->getInput(
+			$command,
+			[
+			'mount_id' => 1,
+			'key' => 'filesystem_check_changes'
+			],
+			['output' => 'json']
+		);
+
+		$result = \trim($this->executeCommand($command, $input));
+		$this->assertEquals($value, $result);
+	}
+
+	/**
+	 * @dataProvider optionsProvider
+	 *
+	 * @param mixed $value
+	 *
+	 * @return void
+	 */
+	public function testSetConfigValue($value) {
+		$mount = $this->getMount(1, '', '');
+
+		$storageService = $this->getGlobalStorageService([$mount]);
+		$command = $this->getInstance($storageService);
+
+		$input = $this->getInput(
+			$command,
+			[
+			'mount_id' => 1,
+			'key' => 'filesystem_check_changes',
+			'value' => $value
+			],
+			[ 'output' => 'json']
+		);
+
+		$result = \trim($this->executeCommand($command, $input));
+		$this->assertEquals('', $result);
+
+		$output = new BufferedOutput();
+		$result = $this->invokePrivate($command, 'getOption', [$mount, 'filesystem_check_changes', $output]);
+		$this->assertEquals($value, \trim($output->fetch()));
+	}
+	
+	public function optionsProvider() {
+		return [
+			[0], [1], ['true']
+		];
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The OCC command didn't allow us to set value 0 due to the use of `if ($value)` checks. Now, This PR modifies it to check for null value only.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33630 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
