### PR TITLE
[stable10] Backport of Acceptance test for static tags

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagMappingNode.php
+++ b/apps/dav/lib/SystemTag/SystemTagMappingNode.php
@@ -159,6 +159,14 @@ class SystemTagMappingNode implements \Sabre\DAV\INode {
 			if (!$this->tagManager->canUserAssignTag($this->tag, $this->user)) {
 				throw new Forbidden('No permission to unassign tag ' . $this->tag->getId());
 			}
+			/**
+			 * static tags cannot be unassigned by users who are not part of the group
+			 * whitelisted in the static tags.
+			 */
+			if ((!$this->tag->isUserEditable() && $this->tag->isUserAssignable())
+				&& !$this->tagManager->canUserUseStaticTagInGroup($this->tag, $this->user)) {
+				throw new Forbidden('No permission to unassign tag ' . $this->tag->getId());
+			}
 			$this->tagMapper->unassignTags($this->objectId, $this->objectType, $this->tag->getId());
 		} catch (TagNotFoundException $e) {
 			// can happen if concurrent deletion occurred

--- a/apps/dav/lib/SystemTag/SystemTagNode.php
+++ b/apps/dav/lib/SystemTag/SystemTagNode.php
@@ -127,6 +127,12 @@ class SystemTagNode implements \Sabre\DAV\INode {
 
 			// only admin is able to change permissions, regular users can only rename
 			if (!$this->isAdmin) {
+				// renaming is forbidden for static tags for regular users
+				if (($userEditable === $this->tag->isUserEditable() && !$userEditable)
+					&& ($userAssignable === $this->tag->isUserAssignable())
+					&& !$this->tagManager->canUserUseStaticTagInGroup($this->tag, $this->user)) {
+					throw new Forbidden('No permission to update permissions for tag ' . $this->tag->getId());
+				}
 				// only renaming is allowed for regular users
 				if ($userVisible !== $this->tag->isUserVisible()
 					|| $userAssignable !== $this->tag->isUserAssignable()
@@ -161,6 +167,14 @@ class SystemTagNode implements \Sabre\DAV\INode {
 			}
 			if (!$this->tagManager->canUserAssignTag($this->tag, $this->user)) {
 				throw new Forbidden('No permission to delete tag ' . $this->tag->getId());
+			}
+			if (!$this->isAdmin) {
+				// Deleting static tag by regular users is forbidden
+				if (!$this->tag->isUserEditable()
+					&& $this->tag->isUserAssignable()
+					&& !$this->tagManager->canUserUseStaticTagInGroup($this->tag, $this->user)) {
+					throw new Forbidden('No permission to delete tag ' . $this->tag->getId());
+				}
 			}
 
 			$this->tagManager->deleteTags($this->tag->getId());

--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -196,7 +196,7 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 		}
 
-		if ($userVisible === false || $userAssignable === false || !empty($groups)) {
+		if ($userVisible === false || $userAssignable === false || $userEditable === false || !empty($groups)) {
 			if (!$this->userSession->isLoggedIn() || !$this->groupManager->isAdmin($this->userSession->getUser()->getUID())) {
 				throw new BadRequest('Not sufficient permissions');
 			}

--- a/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
@@ -97,6 +97,14 @@ class SystemTagsObjectMappingCollection implements ICollection {
 			if (!$this->tagManager->canUserAssignTag($tag, $this->user)) {
 				throw new Forbidden('No permission to assign tag ' . $tagId);
 			}
+			/**
+			 * regular user who do not belong to whitelisted groups of static tags
+			 * can not assign static tags
+			 */
+			if ((!$tag->isUserEditable() && $tag->isUserAssignable())
+				&& !$this->tagManager->canUserUseStaticTagInGroup($tag, $this->user)) {
+				throw new Forbidden('No permission to assign tag ' . $tagId);
+			}
 
 			$this->tagMapper->assignTags($this->objectId, $this->objectType, $tagId);
 		} catch (TagNotFoundException $e) {

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -85,6 +85,8 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($node->getSystemTag())
 			->will($this->returnValue(true));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 		$this->tagManager->expects($this->never())
 			->method('deleteTags');
 		$this->tagMapper->expects($this->once())
@@ -151,10 +153,27 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($tag)
 			->will($this->returnValue($tag->isUserAssignable()));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 		$this->tagMapper->expects($this->once())
 			->method('unassignTags')
 			->with(123, 'files', 1)
 			->will($this->throwException(new TagNotFoundException()));
+
+		$this->getMappingNode($tag)->delete();
+	}
+
+	/**
+	 * @expectedException  \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testeDeteteTagNotAllowedStaticTag() {
+		$tag = new SystemTag(1, 'Test', true, true, false);
+		$this->tagManager->method('canUserSeeTag')
+			->willReturn(true);
+		$this->tagManager->method('canUserAssignTag')
+			->willReturn(true);
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(false);
 
 		$this->getMappingNode($tag)->delete();
 	}

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -115,6 +115,8 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($originalTag)
 			->will($this->returnValue($originalTag->isUserAssignable() || $isAdmin));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 		$this->tagManager->expects($this->once())
 			->method('updateTag')
 			->with(1, $changedArgs[0], $changedArgs[1], $changedArgs[2]);
@@ -203,10 +205,28 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($tag)
 			->will($this->returnValue(true));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 		$this->tagManager->expects($this->once())
 			->method('updateTag')
 			->with(1, 'Renamed', true, true)
 			->will($this->throwException(new TagAlreadyExistsException()));
+		$this->getTagNode(false, $tag)->update('Renamed', true, true);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testStaticTagUpdateFail() {
+		$tag = new SystemTag(1, 'tag1', true, true, false);
+		$this->tagManager->expects($this->any())
+			->method('canUserSeeTag')
+			->with($tag)
+			->will($this->returnValue(true));
+		$this->tagManager->expects($this->any())
+			->method('canUserAssignTag')
+			->with($tag)
+			->will($this->returnValue(true));
 		$this->getTagNode(false, $tag)->update('Renamed', true, true);
 	}
 
@@ -223,6 +243,8 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($tag)
 			->will($this->returnValue(true));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 		$this->tagManager->expects($this->once())
 			->method('updateTag')
 			->with(1, 'Renamed', true, true)
@@ -243,6 +265,8 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($tag)
 			->will($this->returnValue(true));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 		$this->tagManager->expects($this->once())
 			->method('deleteTags')
 			->with('1');
@@ -301,10 +325,28 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($tag)
 			->will($this->returnValue($tag->isUserAssignable()));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 		$this->tagManager->expects($this->once())
 			->method('deleteTags')
 			->with('1')
 			->will($this->throwException(new TagNotFoundException()));
+		$this->getTagNode(false, $tag)->delete();
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testStaticTagExceptionForDelete() {
+		$tag = new SystemTag(1, 'tag1', true, true, false);
+		$this->tagManager->expects($this->any())
+			->method('canUserSeeTag')
+			->with($tag)
+			->will($this->returnValue($tag->isUserVisible()));
+		$this->tagManager->expects($this->any())
+			->method('canUserAssignTag')
+			->with($tag)
+			->will($this->returnValue($tag->isUserAssignable()));
 		$this->getTagNode(false, $tag)->delete();
 	}
 }

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -372,9 +372,9 @@ class SystemTagPluginTest extends \Test\TestCase {
 
 	public function createTagInsufficientPermissionsProvider() {
 		return [
-			[true, false, ''],
-			[false, true, ''],
-			[true, true, 'group1|group2'],
+			[true, false, false, ''],
+			[false, true, false, ''],
+			[true, true, false, 'group1|group2'],
 		];
 	}
 	/**
@@ -382,7 +382,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	 * @expectedException \Sabre\DAV\Exception\BadRequest
 	 * @expectedExceptionMessage Not sufficient permissions
 	 */
-	public function testCreateNotAssignableTagAsRegularUser($userVisible, $userAssignable, $groups) {
+	public function testCreateNotAssignableTagAsRegularUser($userVisible, $userAssignable, $userEditable, $groups) {
 		$this->user->expects($this->once())
 			->method('getUID')
 			->willReturn('admin');
@@ -396,6 +396,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 			'name' => 'Test',
 			'userVisible' => $userVisible,
 			'userAssignable' => $userAssignable,
+			'userEditable' => $userEditable
 		];
 		if (!empty($groups)) {
 			$requestData['groups'] = $groups;
@@ -445,6 +446,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 			'name' => 'Test',
 			'userVisible' => true,
 			'userAssignable' => true,
+			'userEditable' => true
 		]);
 
 		$node = $this->getMockBuilder('\OCA\DAV\SystemTag\SystemTagsByIdCollection')

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -72,6 +72,8 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 			->method('canUserAssignTag')
 			->with($tag)
 			->will($this->returnValue(true));
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(true);
 
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
@@ -122,6 +124,26 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		}
 
 		$this->assertInstanceOf($expectedException, $thrown);
+	}
+
+	/**
+	 * @expectedException  \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage No permission to assign tag 555
+	 */
+	public function testStaticTagAssignNoPermission() {
+		$tag = new SystemTag('1', 'Test', true, true, false);
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['555'])
+			->will($this->returnValue([$tag]));
+		$this->tagManager->method('canUserSeeTag')
+			->willReturn(true);
+		$this->tagManager->method('canUserAssignTag')
+			->willReturn(true);
+		$this->tagManager->method('canUserUseStaticTagInGroup')
+			->willReturn(false);
+
+		$this->getNode()->createFile('555');
 	}
 
 	/**

--- a/lib/private/SystemTag/SystemTag.php
+++ b/lib/private/SystemTag/SystemTag.php
@@ -58,7 +58,7 @@ class SystemTag implements ISystemTag {
 	 * @param string $name tag name
 	 * @param bool $userVisible whether the tag is user visible
 	 * @param bool $userAssignable whether the tag is user assignable
-	 * @param bool $userEditable whether the tag is user assignable
+	 * @param bool $userEditable whether the tag is user editable
 	 */
 	public function __construct($id, $name, $userVisible, $userAssignable, $userEditable = false) {
 		$this->id = $id;

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -239,6 +239,9 @@ class TagsHelper {
 			case 'not user-visible':
 				$userVisible = "0";
 				break;
+			case 'static':
+				$userEditable = "0";
+				break;
 			default:
 				throw new \Exception('Unsupported type');
 		}

--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -52,6 +52,17 @@ Feature: Assign tags to file/folder
     And file "/myFileToTag.txt" shared by the user should have the following tags
       | JustARegularTagName | not user-assignable |
 
+  Scenario: Assigning a static tag to a file shared by someone else as regular user belongs to tag's groups should work
+    Given group "group1" has been created
+    And user "user1" has been added to group "group1"
+    And the administrator has created a "static" tag with name "StaticTagName" and groups "group1"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    When user "user1" adds tag "StaticTagName" to file "/myFileToTag.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And file "/myFileToTag.txt" shared by the user should have the following tags
+      | StaticTagName | static |
+
   Scenario: Assigning a not user-visible tag to a file shared by someone else as regular user should fail
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-visible" tag with name "MySecondTag"
@@ -62,6 +73,19 @@ Feature: Assign tags to file/folder
     Then the HTTP status code should be "412"
     And file "/myFileToTag.txt" shared by the user should have the following tags
       | MyFirstTag | normal |
+
+  Scenario: Assigning a static tag to a file shared by someone else as regular user does not belong to tag's group should fail
+    Given group "group1" has been created
+    And user "user0" has been added to group "group1"
+    And the administrator has created a "normal" tag with name "NormalTag"
+    And the administrator has created a "static" tag with name "StaticTag" and groups "group1"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    When the user adds tag "NormalTag" to file "/myFileToTag.txt" using the WebDAV API
+    And user "user1" adds tag "StaticTag" to file "/myFileToTag.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And file "/myFileToTag.txt" shared by the user should have the following tags
+      | NormalTag | normal |
 
   Scenario: Assigning a not user-visible tag to a file shared by someone else as admin user should work
     Given the administrator has created a "normal" tag with name "MyFirstTag"

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -13,6 +13,13 @@ Feature: Title of your feature
     Then the HTTP status code should be "201"
     And the user should be able to assign the "not user-assignable" tag with name "TagWithGroups"
 
+  Scenario: User can assign static tags when in the tag's groups
+    Given group "group1" has been created
+    And user "user0" has been added to group "group1"
+    When the administrator creates a "static" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the user should be able to assign the "static" tag with name "TagWithGroups"
+
   Scenario: User cannot assign tags when not in the tag's groups
     When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -30,6 +30,11 @@ Feature: Creation of tags
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for the administrator
 
+  Scenario: Creating a static tag as regular user should fail
+    When the user creates a "static" tag with name "StaticTagName" using the WebDAV API
+    Then the HTTP status code should be "400"
+    And tag "StaticTagName" should not exist for the administrator
+
   Scenario: Creating a not user-visible tag as regular user should fail
     When the user creates a "not user-visible" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
@@ -52,6 +57,12 @@ Feature: Creation of tags
     Then the HTTP status code should be "201"
     And the following tags should exist for the administrator
       | JustARegularTagName | not user-visible |
+
+  Scenario: Creating a static tag as administrator should work
+    When the administrator creates a "static" tag with name "StaticTagName" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the following tags should exist for the administrator
+      | StaticTagName | static |
 
   @smokeTest
   Scenario: Creating a not user-assignable tag with groups as admin should work
@@ -82,4 +93,9 @@ Feature: Creation of tags
   Scenario: Overwriting existing not user-visible tags should fail
     Given the administrator has created a "not user-visible" tag with name "MyFirstTag"
     When the administrator creates a "not user-visible" tag with name "MyFirstTag" using the WebDAV API
+    Then the HTTP status code should be "409"
+
+  Scenario: Overwriting existing static tags should fail
+    Given the administrator has created a "static" tag with name "StaticTag"
+    When the administrator creates a "static" tag with name "StaticTag" using the WebDAV API
     Then the HTTP status code should be "409"

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -37,6 +37,13 @@ Feature: Deletion of tags
     And the following tags should exist for the administrator
       | JustARegularTagName | not user-visible |
 
+  Scenario: Deleting a static tag as regular user should fail
+    Given the administrator has created a "static" tag with name "StaticTagName"
+    When the user deletes the tag with name "StaticTagName" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And the following tags should exist for the administrator
+      | StaticTagName | static |
+
   Scenario: Deleting a not user-assignable tag as admin should work
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When the administrator deletes the tag with name "JustARegularTagName" using the WebDAV API
@@ -48,3 +55,9 @@ Feature: Deletion of tags
     When the administrator deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for the administrator
+
+  Scenario: Deleting a static tag as admin should work
+    Given the administrator has created a "static" tag with name "StaticTagName"
+    When the administrator deletes the tag with name "StaticTagName" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And tag "StaticTagName" should not exist for the administrator

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -25,6 +25,12 @@ Feature: Editing the tags
     Then the following tags should exist for the administrator
       | JustARegularTagName | not user-assignable |
 
+  Scenario: Renaming a static tag as regular user should fail
+    Given the administrator has created a "static" tag with name "StaticTagName"
+    When the user edits the tag with name "StaticTagName" and sets its name to "AnotherTagName" using the WebDAV API
+    Then the following tags should exist for the administrator
+      | StaticTagName | static |
+
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When the user edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -45,10 +51,22 @@ Feature: Editing the tags
       | AnotherTagName | not user-visible |
     And tag "JustARegularTagName" should not exist for the administrator
 
+  Scenario: Renaming a static tag as administrator should work
+    Given the administrator has created a "static" tag with name "StaticTagName"
+    When the administrator edits the tag with name "StaticTagName" and sets its name to "AnotherTagName" using the WebDAV API
+    Then the following tags should exist for the administrator
+      | AnotherTagName | static |
+    And tag "StaticTagName" should not exist for the administrator
+
   Scenario: Editing tag groups as admin should work
     Given the administrator has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When the administrator edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group3"
+
+  Scenario: Editing static tag groups as admin should work
+    Given the administrator has created a "static" tag with name "StaticTagWithGroups" and groups "group1|group2"
+    When the administrator edits the tag with name "StaticTagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
+    Then the "static" tag with name "StaticTagWithGroups" should have the groups "group1|group3"
 
   Scenario: Editing tag groups as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -15,3 +15,12 @@ Feature: tags
     Then file "/myFileToTag.txt" should have the following tags for the user
       | MyFirstTag | normal |
     And the HTTP status when user "user1" requests tags for file "/myFileToTag.txt" owned by "user0" should be "404"
+
+  Scenario: Static tags should be available while accessing the file if it is assigned to file
+    Given the administrator has created a "static" tag with name "StaticTag"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with the administrator
+    When the administrator adds tag "StaticTag" to file "/myFileToTag.txt" using the WebDAV API
+    Then file "/myFileToTag.txt" should have the following tags for the user
+      | StaticTag | static |
+    And the HTTP status when user "user1" requests tags for file "/myFileToTag.txt" owned by "user0" should be "404"

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -51,6 +51,23 @@ Feature: Unassigning tags from file/folder
       | MyFirstTag  | not user-visible |
       | MySecondTag | normal           |
 
+  Scenario: Unassigning a static tag from a file and not part of static tags group shared by someone else as regular user should fail
+    Given the administrator has created a "static" tag with name "StaticTag"
+    And the user has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with the administrator
+    And the administrator has added tag "StaticTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When user "user1" removes tag "StaticTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And file "/myFileToTag.txt" should have the following tags for the user
+      | MySecondTag | normal |
+      | StaticTag   | static |
+    And file "/myFileToTag.txt" should have the following tags for the administrator
+      | StaticTag   | static |
+      | MySecondTag | normal |
+
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as admin should work
     Given the administrator has created a "not user-visible" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -60,6 +77,21 @@ Feature: Unassigning tags from file/folder
     And the administrator has added tag "MyFirstTag" to file "/myFileToTag.txt"
     And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
     When the administrator removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And file "/myFileToTag.txt" should have the following tags for the user
+      | MySecondTag | normal |
+    And file "/myFileToTag.txt" should have the following tags for the administrator
+      | MySecondTag | normal |
+
+  Scenario: Unassigning a static tag from a file shared by someone else as admin should work
+    Given the administrator has created a "static" tag with name "StaticTag"
+    And the administrator has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with the administrator
+    And the administrator has added tag "StaticTag" to file "/myFileToTag.txt"
+    And the user has added tag "MySecondTag" to file "/myFileToTag.txt"
+    When the administrator removes tag "StaticTag" from file "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for the user
       | MySecondTag | normal |

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -647,6 +647,7 @@ trait Tags {
 						'{http://owncloud.org/ns}display-name',
 						'{http://owncloud.org/ns}user-visible',
 						'{http://owncloud.org/ns}user-assignable',
+						'{http://owncloud.org/ns}user-editable',
 						'{http://owncloud.org/ns}can-assign'
 					  ];
 		$appPath = '/systemtags-relations/files/';

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -9,6 +9,8 @@ Feature: Suggestion for matching tag names
       | username |
       | user1    |
     Given user "user1" has created a "normal" tag with name "spam"
+    And group "group1" has been created
+    And user "user1" has been added to group "group1"
     And user "user1" has created a "normal" tag with name "ham"
     And user "user1" has created a "normal" tag with name "notspam"
     And user "user1" has created a "normal" tag with name "gham"
@@ -26,3 +28,14 @@ Feature: Suggestion for matching tag names
     But tag "notspam" should not be listed in the dropdown list on the webUI
     And tag "Violates T&C" should not be listed in the dropdown list on the webUI
     And tag "sponsored" should not be listed in the dropdown list on the webUI
+
+  Scenario: User of static tags group should get suggestion for static tags
+    When the user browses directly to display the details of file "lorem.txt" in folder "simple-folder"
+    And the administrator has created a "static" tag with name "StaticTagName" and groups "group1"
+    And the user types "St" in the collaborative tags field using the webUI
+    Then all the tags starting with "St" in their name should be listed in the dropdown list on the webUI
+    But tag "gham" should not be listed in the dropdown list on the webUI
+    But tag "notspam" should not be listed in the dropdown list on the webUI
+    And tag "Violates T&C" should not be listed in the dropdown list on the webUI
+    And tag "sponsored" should not be listed in the dropdown list on the webUI
+    And the tag "StaticTagName" should be listed in the dropdown list on the webUI


### PR DESCRIPTION
Acceptance test added for static tags

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add acceptance test for the static tags. 
- This does bring changes to the dav. The reason for this change is, we did not touched the dav code for static tags, for the static tags task. And hence while adding acceptance tests, it was found that these changes were required to make it work as per the static tags requirement.
- acceptance tests were added. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/33443

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change adds new acceptance test fof the new static tags introduced in core. Also made changes for the dav code to make it work as per the static tags requirement.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- acceptance test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
