### PR TITLE
[stable10] Fix 500 when uploading in to share without write/edit permissions

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -151,11 +151,10 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 			} elseif (FutureFile::isFutureFile()) {
 				// Future file (chunked upload) requires fileinfo
 				$info = $this->fileView->getFileInfo($this->path . '/' . $name);
-			} else {
-				// For non-chunked upload it is enough to check if we can create a new file
-				if (!$this->fileView->isCreatable($this->path)) {
-					throw new SabreForbidden();
-				}
+			}
+
+			if (!$this->fileView->isCreatable($this->path)) {
+				throw new SabreForbidden();
 			}
 
 			$this->fileView->verifyPath($this->path, $name);

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -190,6 +190,7 @@ class File extends Node implements IFile, IFileNode {
 				}
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
+
 			$target = $partStorage->fopen($internalPartPath, 'wb');
 			if (!\is_resource($target)) {
 				\OCP\Util::writeLog('webdav', '\OC\Files\Filesystem::fopen() failed', \OCP\Util::ERROR);

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -446,4 +446,15 @@ class DirectoryTest extends \Test\TestCase {
 		$dir = $this->getDir();
 		$dir->createFile('foobar.txt', 'hello foo bar');
 	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testCreateFileForbidden() {
+		$this->view->expects($this->any())
+			->method('isCreatable')
+			->willThrowException(new \Sabre\DAV\Exception\Forbidden());
+		$dir = $this->getDir();
+		$dir->createFile('foobar.txt', 'hello foo bar');
+	}
 }

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -301,7 +301,7 @@ Feature: sharing
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
     And user "user1" has been created with default attributes
-    And user "user0" creates a folder "/READ_ONLY" using the WebDAV API
+    And user "user0" creates folder "/READ_ONLY" using the WebDAV API
     And user "user0" has created a share with settings
       | path        | /READ_ONLY |
       | shareType   | user       |

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -297,3 +297,17 @@ Feature: sharing
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
     When the public uploads file "test.txt" with content "test" using the public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+
+  Scenario: Uploading a file in to a shared folder without edit permissions
+    Given using new DAV path
+    And user "user1" has been created with default attributes
+    And user "user0" creates a folder "/READ_ONLY" using the WebDAV API
+    And user "user0" has created a share with settings
+      | path        | /READ_ONLY |
+      | shareType   | user       |
+      | permissions | read       |
+      | shareWith   | user1      |
+    When user "user1" uploads the following chunks to "/READ_ONLY/myfile.txt" with new chunking and using the WebDAV API
+      | 1 | hallo   |
+      | 2 | welt    |
+    Then the HTTP status code should be "403"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Throw Forbidden exception if part-storage is not writable before write attempt.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33416 

## How Has This Been Tested?
Acceptance test + manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
