### PR TITLE
[stable10] Pass an additional parameter on the core update

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -73,7 +73,13 @@ class Upgrade extends Command {
 				null,
 				InputOption::VALUE_NONE,
 				'Skip disabling of third party apps.'
-			);
+			)
+			->addOption(
+				'--major',
+				null,
+				InputOption::VALUE_NONE,
+				'Automatically update apps to new major versions during minor updates of ownCloud Server'
+				);
 	}
 
 	/**
@@ -96,12 +102,15 @@ class Upgrade extends Command {
 				$output->setFormatter($timestampFormatter);
 			}
 
-			$self = $this;
 			$updater = new Updater(
 					$this->config,
 					\OC::$server->getIntegrityCodeChecker(),
 					$this->logger
 			);
+
+			if ($input->getOption('major')) {
+				$updater->setForceMajorUpgrade(true);
+			}
 
 			$dispatcher = \OC::$server->getEventDispatcher();
 			$progress = new ProgressBar($output);

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -195,7 +195,6 @@ class Repair implements IOutput {
 			new SqliteAutoincrement($connection),
 			new RepairOrphanedSubshare($connection),
 			new SearchLuceneTables(),
-			new Apps(\OC::$server->getAppManager(), \OC::$server->getEventDispatcher(), \OC::$server->getConfig(), new \OC_Defaults()),
 		];
 
 		//There is no need to delete all previews on every single update

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -31,12 +31,12 @@ use OCP\App\AppNotFoundException;
 use OCP\App\AppNotInstalledException;
 use OCP\App\AppUpdateNotFoundException;
 use OCP\App\IAppManager;
+use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use OCP\Util;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use OCP\IConfig;
 
 class Apps implements IRepairStep {
 	const KEY_COMPATIBLE = 'compatible';
@@ -46,7 +46,7 @@ class Apps implements IRepairStep {
 	/** @var  IAppManager */
 	private $appManager;
 
-	/** @var  EventDispatcher */
+	/** @var  EventDispatcherInterface */
 	private $eventDispatcher;
 
 	/** @var IConfig */
@@ -55,19 +55,23 @@ class Apps implements IRepairStep {
 	/** @var \OC_Defaults */
 	private $defaults;
 
+	/** @var bool */
+	private $forceMajorUpgrade;
+
 	/**
 	 * Apps constructor.
 	 *
 	 * @param IAppManager $appManager
-	 * @param EventDispatcher $eventDispatcher
+	 * @param EventDispatcherInterface $eventDispatcher
 	 * @param IConfig $config
 	 * @param \OC_Defaults $defaults
 	 */
-	public function __construct(IAppManager $appManager, EventDispatcher $eventDispatcher, IConfig $config, \OC_Defaults $defaults) {
+	public function __construct(IAppManager $appManager, EventDispatcherInterface $eventDispatcher, IConfig $config, \OC_Defaults $defaults, $forceMajorUpgrade = false) {
 		$this->appManager = $appManager;
 		$this->eventDispatcher = $eventDispatcher;
 		$this->config = $config;
 		$this->defaults = $defaults;
+		$this->forceMajorUpgrade = $forceMajorUpgrade;
 	}
 
 	/**
@@ -83,12 +87,32 @@ class Apps implements IRepairStep {
 	 */
 	private function isCoreUpdate() {
 		$installedVersion = $this->config->getSystemValue('version', '0.0.0');
-		$currentVersion = \implode('.', Util::getVersion());
+		$currentVersion = \implode('.', $this->getSourcesVersion());
 		$versionDiff = \version_compare($currentVersion, $installedVersion);
 		if ($versionDiff > 0) {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Is it a major core update
+	 *
+	 * @return bool
+	 */
+	private function isMajorCoreUpdate() {
+		if ($this->forceMajorUpgrade === true) {
+			return true;
+		}
+
+		$installedVersion = $this->config->getSystemValue('version', '0.0.0');
+		$installedVersionArray = \explode('.', $installedVersion);
+		$installedVersionMajor = (int) $installedVersionArray[0];
+		$targetVersionArray = $this->getSourcesVersion();
+		$targetVersionMajor = (int) $targetVersionArray[0];
+		$majorUpgrade = $targetVersionMajor !== $installedVersionMajor;
+
+		return $majorUpgrade;
 	}
 
 	/**
@@ -218,7 +242,10 @@ class Apps implements IRepairStep {
 			try {
 				$this->eventDispatcher->dispatch(
 					\sprintf('%s::%s', IRepairStep::class, $event),
-					new GenericEvent($app)
+					new GenericEvent(
+						$app,
+						['isMajorUpdate' => $this->isMajorCoreUpdate()]
+					)
 				);
 			} catch (AppAlreadyInstalledException $e) {
 				$output->info($e->getMessage());
@@ -386,5 +413,12 @@ class Apps implements IRepairStep {
 				]);
 			}
 		}
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function getSourcesVersion() {
+		return Util::getVersion();
 	}
 }

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -19,10 +19,12 @@
  *
  */
 namespace Test\Repair;
+
 use OC\Repair\Apps;
 use OCP\App\IAppManager;
 use OCP\IConfig;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 /**
@@ -32,11 +34,11 @@ use Test\TestCase;
  */
 class AppsTest extends TestCase {
 
-	/** @var Apps */
+	/** @var Apps | \PHPUnit_Framework_MockObject_MockObject */
 	protected $repair;
 	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
 	protected $appManager;
-	/** @var  EventDispatcher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
 	protected $eventDispatcher;
 	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject*/
 	protected $config;
@@ -45,12 +47,16 @@ class AppsTest extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->defaults = $this->createMock(\OC_Defaults::class);
-		$this->eventDispatcher = $this->createMock(EventDispatcher::class);
+		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$this->config = $this->createMock(IConfig::class);
-		$this->repair = new Apps($this->appManager, $this->eventDispatcher, $this->config, $this->defaults);
+		$this->repair = new Apps(
+			$this->appManager,
+			$this->eventDispatcher,
+			$this->config,
+			$this->defaults
+		);
 	}
 
 	public function testMarketEnableVersionCompare10() {
@@ -71,5 +77,65 @@ class AppsTest extends TestCase {
 	public function testMarketEnableVersionCompareCurrent() {
 		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->willReturn('10.0.1');
 		$this->assertFalse($this->invokePrivate($this->repair, 'requiresMarketEnable'));
+	}
+
+	public function dataTestUpdateEvent() {
+		return [
+			['10.1.0.0', [10, 1, 3, 7], false, false], // same major version
+			['10.1.0.0', [10, 1, 3, 7], true, true],   // same major version, but major forced
+			['10.1.0.0', [11, 0, 2, 0], false, true],  // different major version
+			['10.1.0.0', [10, 0, 2, 0], true, true],  // different major version, major forced
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestUpdateEvent
+	 * @param string $installedVersion
+	 * @param int[] $sourcesVersion
+	 * @param bool $forceMajorUpdate
+	 * @param bool $expectedIsMajorUpdate
+	 */
+	public function testUpdateAppEvent($installedVersion, $sourcesVersion, $forceMajorUpdate, $expectedIsMajorUpdate) {
+		$appName = 'fakeapp';
+
+		$this->config->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn($installedVersion);
+		$this->configureRepair(['getSourcesVersion'], $forceMajorUpdate);
+
+		$this->repair->method('getSourcesVersion')
+			->willReturn($sourcesVersion);
+
+		$this->eventDispatcher->expects($this->once())->method('dispatch')
+			->willReturnCallback(
+				function ($eventName, $event) use ($appName) {
+					$this->assertEquals($appName, $event->getSubject());
+					$this->assertEquals(true, $event->getArgument('isMajorUpdate'));
+				}
+			);
+		$this->invokePrivate(
+			$this->repair,
+			'getAppsFromMarket',
+			[
+				new \OC\Migration\ConsoleOutput(new NullOutput()),
+				[ $appName ],
+				'john'
+			]
+		);
+	}
+
+	private function configureRepair($mockedMethods, $forceMajorUpgrade = false) {
+		$this->repair = $this->getMockBuilder(Apps::class)
+			->setConstructorArgs(
+				[
+					$this->appManager,
+					$this->eventDispatcher,
+					$this->config,
+					$this->defaults,
+					$forceMajorUpgrade
+				]
+			)
+			->setMethods($mockedMethods)
+			->getMock();
 	}
 }


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/32491

## Description
pass the additional argument that shows whether major core update in progress

## Related Issue
- Fixes https://github.com/owncloud/market/issues/387

## Motivation and Context
Minor ownCloud upgrades should not trigger minor app updates

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests


