### PR TITLE
[stable10] Adjust user_management tests to match app

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -88,7 +88,9 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theAdministratorSetsTheQuotaOfUserUsingTheWebUI($username, $quota) {
+	public function theAdministratorSetsTheQuotaOfUserUsingTheWebUI(
+		$username, $quota
+	) {
 		$this->usersPage->setQuotaOfUserTo($username, $quota, $this->getSession());
 	}
 
@@ -117,6 +119,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		$this->usersPage->createUser(
 			$this->getSession(), $username, $password, $email, $groups
 		);
+
 		$shouldExist = ($attemptTo === "");
 
 		$this->featureContext->addUserToCreatedUsersList(
@@ -237,7 +240,9 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theseGroupsShouldBeListedOnTheWebUI($shouldOrNot, TableNode $table) {
+	public function theseGroupsShouldBeListedOnTheWebUI(
+		$shouldOrNot, TableNode $table
+	) {
 		$should = ($shouldOrNot !== "not");
 		$groups = $this->usersPage->getAllGroups();
 		foreach ($table as $row) {
@@ -285,12 +290,14 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 */
 	public function theDisabledUserTriesToLogin($username, $password) {
 		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
+		$password = $this->featureContext->getActualPassword($password);
 		/**
 		 *
 		 * @var DisabledUserPage $disabledPage
 		 */
-		$password = $this->featureContext->getActualPassword($password);
-		$disabledPage = $this->loginPage->loginAs($username, $password, 'DisabledUserPage');
+		$disabledPage = $this->loginPage->loginAs(
+			$username, $password, 'DisabledUserPage'
+		);
 		$disabledPage->waitTillPageIsLoaded($this->getSession());
 	}
 
@@ -319,7 +326,6 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 *
 	 * @When the deleted user :username tries to login using the password :password using the webUI
 	 *
 	 * @param string $username
@@ -364,26 +370,27 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the administrator should be able to see email of the users in the User Management page as:$/
+	 * @Then /^the administrator should be able to see the email of these users in the User Management page:$/
 	 *
 	 * @param TableNode $table table of usernames and emails with a heading | username | and | email |
 	 *
 	 * @return void
 	 */
-	public function theAdministratorShouldBeAbleToSeeEmailOfTheUsersAs(TableNode $table) {
+	public function theAdministratorShouldBeAbleToSeeEmailOfTheseUsers(TableNode $table) {
 		foreach ($table as $row) {
 			$userEmail = $this->usersPage->getEmailOfUser($row['username']);
 			PHPUnit_Framework_Assert::assertEquals($row['email'], $userEmail);
 		}
 	}
+
 	/**
-	 * @Then /^the administrator should be able to see storage location of the users in the User Management page as:$/
+	 * @Then /^the administrator should be able to see the storage location of these users in the User Management page:$/
 	 *
 	 * @param TableNode $table table of usernames and storage locations with a heading | username | and | storage location |
 	 *
 	 * @return void
 	 */
-	public function theAdministratorShouldBeAbleToSeeStorageLocationOfTheUsersAs(
+	public function theAdministratorShouldBeAbleToSeeStorageLocationOfTheseUsers(
 		TableNode $table
 	) {
 		foreach ($table as $row) {
@@ -393,13 +400,13 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the administrator should be able to see last login of the users in the User Management page as:$/
+	 * @Then /^the administrator should be able to see the last login of these users in the User Management page:$/
 	 *
 	 * @param TableNode $table table of usernames and last logins with a heading | username | and | last logins |
 	 *
 	 * @return void
 	 */
-	public function theAdministratorShouldBeAbleToSeeLastLoginOfTheUsersAs(
+	public function theAdministratorShouldBeAbleToSeeLastLoginOfTheseUsers(
 		TableNode $table
 	) {
 		foreach ($table as $row) {
@@ -435,6 +442,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 			'umgmt_show_last_login' => '',
 			'umgmt_show_storage_location' => ''
 		];
+
 		if ($this->appParameterValues === null) {
 			// Get app config values
 			$appConfigs =  AppConfigHelper::getAppConfigs(

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -13,21 +13,21 @@ Feature: add users
 
    Scenario: administrator should be able to see email of a user
     When the administrator enables the setting "Show email address" in the User Management page using the webUI
-    Then the administrator should be able to see email of the users in the User Management page as:
+    Then the administrator should be able to see the email of these users in the User Management page:
       | username | email        |
       | user1    | u1@oc.com.np |
       | user2    | u2@oc.com.np |
 
    Scenario: administrator should be able to see storage location of a user
     When the administrator enables the setting "Show storage location" in the User Management page using the webUI
-    Then the administrator should be able to see storage location of the users in the User Management page as:
+    Then the administrator should be able to see the storage location of these users in the User Management page:
       | username  | storage location |
       | user1     | /data/user1      |
       | user2     | /data/user2      |
 
   Scenario: administrator should be able to see last login of a user when the user is not initialized
     When the administrator enables the setting "Show last log in" in the User Management page using the webUI
-    Then the administrator should be able to see last login of the users in the User Management page as:
+    Then the administrator should be able to see the last login of these users in the User Management page:
       | username | last login |
       | user1    | never      |
       | user2    | never      |
@@ -39,7 +39,7 @@ Feature: add users
     And the user logs out of the webUI
     And the administrator logs in using the webUI
     And the administrator browses to the users page
-    Then the administrator should be able to see last login of the users in the User Management page as:
+    Then the administrator should be able to see the last login of these users in the User Management page:
       | username | last login  |
       | user1    | seconds ago |
       | user2    | never       |


### PR DESCRIPTION
## Description
Apply relevant acceptance test code from the ``user_management`` app to core ``stable10``.

## Motivation and Context
The user management acceptance test code has got a bit out-of-sync between the ``user_management`` app and core ``stable10`` - e.g. some skipped tests have steps that are invalid:
https://drone.owncloud.com/owncloud/user_management/390/72
```
2 scenarios (2 undefined)
23 steps (2 undefined, 21 skipped)
0m0.62s (23.12Mb)

--- FeatureContext has missing steps. Define them with these snippets:

    /**
     * @When the administrator disables user :arg1 using the webUI
     */
    public function theAdministratorDisablesUserUsingTheWebui($arg1)
    {
        throw new PendingException();
    }

    /**
     * @When the user disables user :arg1 using the webUI
     */
    public function theUserDisablesUserUsingTheWebui($arg1)
    {
        throw new PendingException();
    }
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
No "backport". This code does not live in core ``master```. It is in the ``user_management`` app.