### PR TITLE
Test files:scan

### DIFF
--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -100,6 +100,9 @@ trait Auth {
 	public function sendRequest(
 		$url, $method, $authHeader = null, $useCookies = false
 	) {
+		// reset responseXml
+		$this->responseXml = '';
+
 		$fullUrl = $this->getBaseUrl() . $url;
 
 		$cookies = null;

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -540,6 +540,13 @@ trait BasicStructure {
 	public function getSourceIpAddress() {
 		return $this->sourceIpAddress;
 	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getStorageId() {
+		return $this->storageId;
+	}
 	
 	/**
 	 * @param string $sourceIpAddress
@@ -1640,6 +1647,28 @@ trait BasicStructure {
 	 */
 	public function theAdministratorRequestsStatusPhp() {
 		$this->response = $this->getStatusPhp();
+	}
+
+	/**
+	 * @When the administrator creates file :path with content :content in local storage using the testing API
+	 *
+	 * @param string $path
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function theAdministratorCreatesFileUsingTheTestingApi($path, $content) {
+		$user = $this->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->getBaseUrl(),
+			$user,
+			$this->getAdminPassword(),
+			'POST',
+			"/apps/testing/api/v1/file",
+			['file' => LOCAL_STORAGE_DIR_ON_REMOTE_SERVER . "/$path", 'content' => $content],
+			$this->getOcsApiVersion()
+		);
+		$this->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -622,6 +622,48 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @When the administrator scans the filesystem for user :user using the occ command
+	 * @Given the administrator has scanned the filesystem for user :user
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theAdministratorScansTheFilesystemForUserUsingTheOccCommand($user) {
+		$this->featureContext->invokingTheCommand(
+			"files:scan $user"
+		);
+	}
+
+	/**
+	 * @When the administrator scans the filesystem in path :path using the occ command
+	 * @Given the administrator scans the filesystem in path :path
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function theAdministratorScansTheFilesystemInPathUsingTheOccCommand($path) {
+		$this->featureContext->invokingTheCommand(
+			"files:scan --path='$path'"
+		);
+	}
+
+	/**
+	 * @When the administrator scans the filesystem for group :group using the occ command
+	 * @Given the administrator has scanned the filesystem for group :group
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function theAdministratorScansTheFilesystemForGroupUsingTheOccCommand($group) {
+		$this->featureContext->invokingTheCommand(
+			"files:scan --group=$group"
+		);
+	}
+
+	/**
 	 * @Then the app name returned by the occ command should be :appName
 	 *
 	 * @param string $appName

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -586,6 +586,42 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has set the external storage to be never scanned automatically
+	 * @When the administrator sets the external storage to be never scanned automatically using the occ command
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasSetTheExternalStorageToBeNeverScannedUsingTheOccCommand() {
+		$command = "files:external:option";
+
+		$mountId = $this->featureContext->getStorageId();
+
+		// $mountId should have been set. If not, @local_storage BeforeScenario never ran
+		\assert($mountId !== null);
+
+		$key = "filesystem_check_changes";
+
+		// "0" is "Never", "1" is "Once every direct access"
+		$value = 0;
+
+		$this->featureContext->invokingTheCommand(
+			"$command $mountId $key $value"
+		);
+	}
+
+	/**
+	 * @When the administrator scans the filesystem for all users using the occ command
+	 * @Given the administrator has scanned the filesystem for all users
+	 *
+	 * @return void
+	 */
+	public function theAdministratorScansTheFilesystemForAllUsersUsingTheOccCommand() {
+		$this->featureContext->invokingTheCommand(
+			"files:scan --all"
+		);
+	}
+
+	/**
 	 * @Then the app name returned by the occ command should be :appName
 	 *
 	 * @param string $appName

--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -1,11 +1,11 @@
 @cli @local_storage
 Feature: Files Operations command
 
-  Scenario: Adding a file to local storage and running scan should show new files.
+  Scenario: Adding a file to local storage and running scan should add files.
     Given using new DAV path
-    Given user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes
     And the administrator has set the external storage to be never scanned automatically
-    # HACK: Need to re-scan. Config change doesn't come into effect until once scanned
+    # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
     And the administrator has scanned the filesystem for all users
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
@@ -16,5 +16,58 @@ Feature: Files Operations command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result of "user0" should contain these entries:
       | /local_storage/hello1.txt |
-    Then the propfind result of "user0" should not contain these entries:
+    But the propfind result of "user0" should not contain these entries:
       | /local_storage/hello2.txt |
+
+  Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
+    Given using new DAV path
+    And user "user0" has been created with default attributes
+    And the administrator has set the external storage to be never scanned automatically
+    And user "user0" has created a folder "/local_storage/folder1"
+    And user "user0" has created a folder "/local_storage/folder2"
+    # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
+    And the administrator has scanned the filesystem for all users
+    When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
+    And the administrator creates file "folder2/hello2.txt" with content "<? php :(" in local storage using the testing API
+    And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should not contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should not contain these entries:
+      | /local_storage/folder2/hello2.txt |
+    When the administrator scans the filesystem in path "/user0/files/local_storage/folder1" using the occ command
+    And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should not contain these entries:
+      | /local_storage/folder2/hello2.txt |
+
+  Scenario: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
+    Given using new DAV path
+    And these users have been created with default attributes:
+      | username |
+      | user0    |
+      | user1    |
+    And group "newgroup" has been created
+    And user "user0" has been added to group "newgroup"
+    And user "user1" has been added to group "newgroup"
+    And user "user0" has created a folder "/local_storage/folder1"
+    And the administrator has set the external storage to be never scanned automatically
+    And user "user0" has shared folder "/local_storage/folder1" with group "newgroup"
+    And the administrator has scanned the filesystem for all users
+    And the administrator has scanned the filesystem for group "newgroup"
+    When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
+    And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should not contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should not contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When the administrator scans the filesystem for group "newgroup" using the occ command
+    And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When user "user1" requests "/remote.php/dav/files/user1/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of "user1" should contain these entries:
+      | /folder1/hello1.txt |

--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -1,0 +1,20 @@
+@cli @local_storage
+Feature: Files Operations command
+
+  Scenario: Adding a file to local storage and running scan should show new files.
+    Given using new DAV path
+    Given user "user0" has been created with default attributes
+    And the administrator has set the external storage to be never scanned automatically
+    # HACK: Need to re-scan. Config change doesn't come into effect until once scanned
+    And the administrator has scanned the filesystem for all users
+    When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
+    And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should not contain these entries:
+      | /local_storage/hello1.txt |
+    When the administrator scans the filesystem for all users using the occ command
+    And the administrator creates file "hello2.txt" with content "<? php :(" in local storage using the testing API
+    And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
+    Then the propfind result of "user0" should contain these entries:
+      | /local_storage/hello1.txt |
+    Then the propfind result of "user0" should not contain these entries:
+      | /local_storage/hello2.txt |


### PR DESCRIPTION
This commit, although a bit hacky, adds the test for the `files:scan`
in the Occ. The config didn't seem to have come into effect when set.
But, i noticed that the config was coming into effect when it was
force-scanned. Needs further investigation if `files_external:option`
is the problem or not.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #33617

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
