### PR TITLE
Fix up grammar mistake in console output

### DIFF
--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -136,7 +136,7 @@ class SyncBackend extends Command {
 		}
 		$backend = $this->getBackend($backendClassName);
 		if ($backend === null) {
-			$output->writeln("<error>The backend <$backendClassName> does not exist. Did you miss to enable the app?</error>");
+			$output->writeln("<error>The backend <$backendClassName> does not exist. Did you forget to enable the app?</error>");
 			return 1;
 		}
 		if (!$backend->hasUserListings()) {

--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -141,7 +141,7 @@ class SyncBackendTest extends TestCase {
 		$outputInterface
 			->expects($this->at(0))
 			->method('writeln')
-			->with("<error>The backend <$backendClassName> does not exist. Did you miss to enable the app?</error>");
+			->with("<error>The backend <$backendClassName> does not exist. Did you forget to enable the app?</error>");
 
 		$this->assertEquals(1, static::invokePrivate($this->command, 'execute', [$inputInterface, $outputInterface]));
 	}


### PR DESCRIPTION
## Description

Correct grammar in console output in SyncBackend

## Related Issue

n/a

## Motivation and Context

All output from core should be correct, no matter what it is or where it comes from.

## How Has This Been Tested?

- Updated `tests/lib/Command/User/SyncBackendTest.php`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 