### PR TITLE
Refactor sends HTTP method to use specific methods

### DIFF
--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -196,15 +196,17 @@ class UserHelper {
 	 * @param string $group
 	 * @param string $adminUser
 	 * @param string $adminPassword
+	 * @param integer $ocsApiVersion (1|2)
 	 *
 	 * @return ResponseInterface
 	 */
 	public static function addUserToGroup(
-		$baseUrl, $user, $group, $adminUser, $adminPassword
+		$baseUrl, $user, $group, $adminUser, $adminPassword, $ocsApiVersion = 2
 	) {
 		return OcsApiHelper::sendRequest(
 			$baseUrl, $adminUser, $adminPassword, "POST",
-			"/cloud/users/" . $user . "/groups", ['groupid' => $group]
+			"/cloud/users/" . $user . "/groups", ['groupid' => $group],
+			$ocsApiVersion
 		);
 	}
 
@@ -215,15 +217,17 @@ class UserHelper {
 	 * @param string $group
 	 * @param string $adminUser
 	 * @param string $adminPassword
+	 * @param integer $ocsApiVersion (1|2)
 	 *
 	 * @return ResponseInterface
 	 */
 	public static function removeUserFromGroup(
-		$baseUrl, $user, $group, $adminUser, $adminPassword
+		$baseUrl, $user, $group, $adminUser, $adminPassword, $ocsApiVersion = 2
 	) {
 		return OcsApiHelper::sendRequest(
 			$baseUrl, $adminUser, $adminPassword, "DELETE",
-			"/cloud/users/" . $user . "/groups", ['groupid' => $group]
+			"/cloud/users/" . $user . "/groups", ['groupid' => $group],
+			$ocsApiVersion
 		);
 	}
 

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -52,7 +52,7 @@ Feature: federated
 
   Scenario: Remote sharee can see the pending share
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
-    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending"
+    When user "user1" gets the list of pending federated cloud shares using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the fields of the last response should include
@@ -150,7 +150,7 @@ Feature: federated
   Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
     Given using server "LOCAL"
     And using OCS API version "2"
-    When user "UNAUTHORIZED_USER" sends HTTP method "POST" to OCS API endpoint "/apps/federation/api/v1/request-shared-secret"
+    When user "UNAUTHORIZED_USER" requests shared secret using the federation API
     Then the HTTP status code should be "403"
 
   Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -77,8 +77,7 @@ Feature: add groups
 
   Scenario: normal user tries to create a group
     Given user "brand-new-user" has been created with default attributes
-    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-      | groupid | new-group |
+    When user "brand-new-user" tries to send a group creation request for group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "new-group" should not exist
@@ -87,8 +86,7 @@ Feature: add groups
     Given user "subadmin" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-      | groupid | another-group |
+    When user "subadmin" tries to send a group creation request for group "another-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "another-group" should not exist

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -11,8 +11,7 @@ Feature: add users to group
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     Examples:
@@ -24,8 +23,7 @@ Feature: add users to group
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     Examples:
@@ -51,8 +49,7 @@ Feature: add users to group
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     Examples:
@@ -64,8 +61,7 @@ Feature: add users to group
 
   Scenario: normal user tries to add himself to a group
     Given user "brand-new-user" has been created with default attributes
-    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "brand-new-user" tries to add himself to group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
@@ -73,16 +69,14 @@ Feature: add users to group
   Scenario: admin tries to add user to a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | not-group |
+    When the administrator tries to add user "brand-new-user" to group "not-group" using the provisioning API
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"
     And the API should not return any data
 
   Scenario: admin tries to add user to a group without sending the group
     Given user "brand-new-user" has been created with default attributes
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid |  |
+    When the administrator tries to add user "brand-new-user" to group "" using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And the API should not return any data
@@ -90,8 +84,7 @@ Feature: add users to group
   Scenario: admin tries to add a user which does not exist to a group
     Given user "not-user" has been deleted
     And group "new-group" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
-      | groupid | new-group |
+    When the administrator tries to add user "not-user" to group "new-group" using the provisioning API
     Then the OCS status code should be "103"
     And the HTTP status code should be "200"
     And the API should not return any data
@@ -101,8 +94,7 @@ Feature: add users to group
     And user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "subadmin" tries to add user "brand-new-user" to group "new-group" using the provisioning API
     Then the OCS status code should be "104"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "new-group"
@@ -113,8 +105,7 @@ Feature: add users to group
     And group "new-group" has been created
     And group "other-group" has been created
     And user "other-subadmin" has been made a subadmin of group "other-group"
-    When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "other-subadmin" tries to add user "brand-new-user" to group "new-group" using the provisioning API
     Then the OCS status code should be "104"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -11,8 +11,7 @@ Feature: create a subadmin
   Scenario: admin creates a subadmin
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | new-group |
+    When the administrator makes user "brand-new-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should be a subadmin of group "new-group"
@@ -20,8 +19,7 @@ Feature: create a subadmin
   Scenario: admin tries to create a subadmin using a user which does not exist
     Given user "not-user" has been deleted
     And group "new-group" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
-      | groupid | new-group |
+    When the administrator makes user "not-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And user "not-user" should not be a subadmin of group "new-group"
@@ -29,8 +27,7 @@ Feature: create a subadmin
   Scenario: admin tries to create a subadmin using a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | not-group |
+    When the administrator makes user "brand-new-user" a subadmin of group "not-group" using the provisioning API
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"
     And the API should not return any data
@@ -40,10 +37,8 @@ Feature: create a subadmin
     And user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    And the administrator has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
-    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | new-group |
+    And user "brand-new-user" has been added to group "new-group"
+    When user "subadmin" makes user "brand-new-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "brand-new-user" should not be a subadmin of group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -63,7 +63,7 @@ Feature: delete groups
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
-    When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    When user "brand-new-user" tries to delete group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "new-group" should exist
@@ -72,7 +72,7 @@ Feature: delete groups
     Given user "subadmin" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    When user "subadmin" tries to delete group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "new-group" should exist

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -10,7 +10,7 @@ Feature: delete users
   @smokeTest
   Scenario: Delete a user
     Given user "brand-new-user" has been created with default attributes
-    When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
+    When the administrator deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
@@ -22,7 +22,7 @@ Feature: delete users
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
+    When user "subadmin" deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
@@ -30,7 +30,7 @@ Feature: delete users
   Scenario: normal user tries to delete a user
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
+    When user "user1" deletes user "user2" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "user2" should exist

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -10,7 +10,7 @@ Feature: disable user
   @smokeTest
   Scenario: admin disables an user
     Given user "user1" has been created with default attributes
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    When the administrator disables user "user1" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should be disabled
@@ -23,7 +23,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And user "user1" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    When user "subadmin" disables user "user1" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should be disabled
@@ -36,7 +36,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And user "user1" has been added to group "another-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    When user "subadmin" disables user "user1" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "user1" should be enabled
@@ -49,7 +49,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And user "another-admin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    When user "subadmin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "another-admin" should be enabled
@@ -57,7 +57,7 @@ Feature: disable user
   Scenario: Admin can disable another admin user
     Given user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    When the administrator disables user "another-admin" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "another-admin" should be disabled
@@ -68,7 +68,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    When the administrator disables user "subadmin" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "subadmin" should be disabled
@@ -76,7 +76,7 @@ Feature: disable user
   Scenario: Admin user cannot disable himself
     Given user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
-    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    When user "another-admin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And user "another-admin" should be enabled
@@ -84,7 +84,7 @@ Feature: disable user
   Scenario: disable an user with a regular user
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
+    When user "user1" disables user "user2" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "user2" should be enabled
@@ -94,7 +94,7 @@ Feature: disable user
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    When user "subadmin" disables user "subadmin" using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And user "subadmin" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -11,7 +11,7 @@ Feature: enable user
   Scenario: admin enables an user
     Given user "user1" has been created with default attributes
     And user "user1" has been disabled
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
+    When the administrator enables user "user1" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should be enabled
@@ -20,7 +20,7 @@ Feature: enable user
     Given user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    When the administrator enables user "another-admin" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "another-admin" should be enabled
@@ -32,7 +32,7 @@ Feature: enable user
     And the administrator has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "subadmin" has been disabled
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enable"
+    When the administrator enables user "subadmin" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "subadmin" should be enabled
@@ -41,14 +41,14 @@ Feature: enable user
     And user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
-    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    When user "another-admin" tries to enable user "another-admin" using the provisioning API
     Then user "another-admin" should be disabled
 
   Scenario: normal user tries to enable other user
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
     And user "user2" has been disabled
-    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
+    When user "user1" tries to enable user "user2" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "user2" should be disabled
@@ -59,7 +59,7 @@ Feature: enable user
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "subadmin" has been disabled
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
+    When user "subadmin" tries to enable user "subadmin" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "subadmin" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -9,7 +9,7 @@ Feature: get app info
 
   @smokeTest
   Scenario: admin gets app info
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
+    When the administrator gets the info of app "files"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the XML "data" "id" value should be "files"

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -9,7 +9,7 @@ Feature: get apps
 
   @smokeTest @comments-app-required @files_trashbin-app-required @files_versions-app-required @systemtags-app-required
   Scenario: admin gets enabled apps
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    When the administrator gets all enabled apps using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the apps returned by the API should include
@@ -27,7 +27,7 @@ Feature: get apps
       | files_external       |
 
   Scenario: admin gets enabled apps - check for the minimal list of apps
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    When the administrator gets all enabled apps using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the apps returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
@@ -14,7 +14,7 @@ Feature: get group
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "123" has been added to group "new-group"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When the administrator gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the users returned by the API should be
@@ -23,7 +23,7 @@ Feature: get group
 
   Scenario: admin tries to get users in the empty group
     Given group "new-group" has been created
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When the administrator gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the list of users returned by the API should be empty
@@ -37,7 +37,7 @@ Feature: get group
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "user1" has been added to group "new-group"
     And user "user2" has been added to group "new-group"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When user "subadmin" gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the users returned by the API should be
@@ -49,13 +49,13 @@ Feature: get group
     And group "new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
+    When user "subadmin" gets all the members of group "another-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
   Scenario: normal user tries to get users in their group
     Given user "newuser" has been created with default attributes
     And group "new-group" has been created
-    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When user "newuser" gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
@@ -12,7 +12,7 @@ Feature: get groups
     Given group "0" has been created
     And group "new-group" has been created
     And group "España" has been created
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
+    When the administrator gets all the groups using the provisioning API
     Then the groups returned by the API should be
       | España    |
       | admin     |

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
@@ -12,7 +12,7 @@ Feature: get subadmin groups
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
+    When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
     Then the subadmin groups returned by the API should be
       | new-group |
     And the OCS status code should be "100"
@@ -21,7 +21,7 @@ Feature: get subadmin groups
   Scenario: admin tries to get subadmin groups of a user which do not exist
     Given user "not-user" has been deleted
     And group "new-group" has been created
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
+    When the administrator gets all the groups where user "not-user" is subadmin using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -12,7 +12,7 @@ Feature: get subadmins
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    When the administrator gets all the subadmins of group "new-group" using the provisioning API
     Then the subadmin users returned by the API should be
       | brand-new-user |
     And the OCS status code should be "100"
@@ -21,7 +21,7 @@ Feature: get subadmins
   Scenario: admin tries to get subadmin users of a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
+    When the administrator gets all the subadmins of group "not-group" using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And the API should not return any data
@@ -32,7 +32,7 @@ Feature: get subadmins
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newsubadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    When user "subadmin" gets all the subadmins of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
@@ -42,7 +42,7 @@ Feature: get subadmins
     And user "subadmin" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    When user "newuser" gets all the subadmins of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -21,7 +21,7 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
     And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
     And user "brand-new-user" has been added to group "नेपाली"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
       | new-group            |
       | 0                    |
@@ -52,7 +52,7 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "Mgmt/Sydney"
     And user "brand-new-user" has been added to group "var/../etc"
     And user "brand-new-user" has been added to group "priv/subadmins/1"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
       | new-group            |
       | 0                    |
@@ -74,7 +74,7 @@ Feature: get user groups
     And user "subadmin" has been made a subadmin of group "newgroup"
     And user "newuser" has been added to group "newgroup"
     And user "newuser" has been added to group "anothergroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    When user "subadmin" gets all the groups of user "newuser" using the provisioning API
     Then the groups returned by the API should include "newgroup"
     And the groups returned by the API should not include "anothergroup"
     And the OCS status code should be "100"
@@ -85,7 +85,7 @@ Feature: get user groups
     And user "anotheruser" has been created with default attributes
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
-    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    When user "anotheruser" gets all the groups of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
@@ -93,7 +93,7 @@ Feature: get user groups
   Scenario: admin gets groups of an user who is not in any groups
     Given user "brand-new-user" has been created with default attributes
     And group "unused-group" has been created
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the list of groups returned by the API should be empty

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -10,7 +10,7 @@ Feature: get users
   @smokeTest
   Scenario: admin gets all users
     Given user "brand-new-user" has been created with default attributes
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the users returned by the API should be
@@ -24,7 +24,7 @@ Feature: get users
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    When user "brand-new-user" gets the list of all users using the provisioning API
     Then the users returned by the API should be
       | brand-new-user |
     And the OCS status code should be "100"
@@ -33,7 +33,7 @@ Feature: get users
   Scenario: normal user tries to get other users
     Given user "normaluser" has been created with default attributes
     And user "newuser" has been created with default attributes
-    When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    When user "normaluser" gets the list of all users using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -12,8 +12,7 @@ Feature: remove a user from a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
@@ -27,8 +26,7 @@ Feature: remove a user from a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
@@ -56,8 +54,7 @@ Feature: remove a user from a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
@@ -71,8 +68,7 @@ Feature: remove a user from a group
   Scenario: admin tries to remove a user from a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | not-group |
+    When the administrator removes user "brand-new-user" from group "not-group" using the provisioning API
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"
     And the API should not return any data
@@ -84,8 +80,7 @@ Feature: remove a user from a group
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "subadmin" removes user "brand-new-user" from group "new-group" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "new-group"
@@ -97,8 +92,7 @@ Feature: remove a user from a group
     And group "other-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "other-subadmin" has been made a subadmin of group "other-group"
-    When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "other-subadmin" removes user "brand-new-user" from group "new-group" using the provisioning API
     Then the OCS status code should be "104"
     And the HTTP status code should be "200"
     And user "brand-new-user" should belong to group "new-group"
@@ -109,8 +103,7 @@ Feature: remove a user from a group
     And group "new-group" has been created
     And user "newuser" has been added to group "new-group"
     And user "anotheruser" has been added to group "new-group"
-    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
-      | groupid | new-group |
+    When user "newuser" tries to remove user "another-user" from group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "anotheruser" should belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -12,8 +12,7 @@ Feature: remove subadmin
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | new-group |
+    When the administrator removes user "brand-new-user" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not be a subadmin of group "new-group"
@@ -24,8 +23,7 @@ Feature: remove subadmin
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newsubadmin" has been created with default attributes
     And user "newsubadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
-      | groupid | new-group |
+    When user "subadmin" removes user "newsubadmin" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "newsubadmin" should be a subadmin of group "new-group"
@@ -36,8 +34,7 @@ Feature: remove subadmin
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newuser" has been added to group "new-group"
-    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
-      | groupid | new-group |
+    When user "newuser" removes user "subadmin" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "subadmin" should be a subadmin of group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -78,8 +78,7 @@ Feature: add groups
   @issue-31276
   Scenario: normal user tries to create a group
     Given user "brand-new-user" has been created with default attributes
-    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-      | groupid | new-group |
+    When user "brand-new-user" tries to send a group creation request for group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -89,8 +88,7 @@ Feature: add groups
     Given user "subadmin" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
-      | groupid | another-group |
+    When user "subadmin" tries to send a group creation request for group "another-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "another-group" should not exist

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -11,8 +11,7 @@ Feature: add users to group
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     Examples:
@@ -24,8 +23,7 @@ Feature: add users to group
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     Examples:
@@ -51,8 +49,7 @@ Feature: add users to group
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     Examples:
@@ -65,8 +62,7 @@ Feature: add users to group
   @issue-31276
   Scenario: normal user tries to add himself to a group
     Given user "brand-new-user" has been created with default attributes
-    When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "brand-new-user" tries to add himself to group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -75,16 +71,14 @@ Feature: add users to group
   Scenario: admin tries to add user to a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | not-group |
+    When the administrator tries to add user "brand-new-user" to group "not-group" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
 
   Scenario: admin tries to add user to a group without sending the group
     Given user "brand-new-user" has been created with default attributes
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid |  |
+    When the administrator tries to add user "brand-new-user" to group "" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
@@ -92,8 +86,7 @@ Feature: add users to group
   Scenario: admin tries to add a user which does not exist to a group
     Given user "not-user" has been deleted
     And group "new-group" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
-      | groupid | new-group |
+    When the administrator tries to add user "not-user" to group "new-group" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
@@ -103,8 +96,7 @@ Feature: add users to group
     And user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "subadmin" tries to add user "brand-new-user" to group "new-group" using the provisioning API
     Then the OCS status code should be "403"
     And the HTTP status code should be "403"
     And user "brand-new-user" should not belong to group "new-group"
@@ -115,8 +107,7 @@ Feature: add users to group
     And group "new-group" has been created
     And group "other-group" has been created
     And user "other-subadmin" has been made a subadmin of group "other-group"
-    When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "other-subadmin" tries to add user "brand-new-user" to group "new-group" using the provisioning API
     Then the OCS status code should be "403"
     And the HTTP status code should be "403"
     And user "brand-new-user" should not belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -11,8 +11,7 @@ Feature: create a subadmin
   Scenario: admin creates a subadmin
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | new-group |
+    When the administrator makes user "brand-new-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should be a subadmin of group "new-group"
@@ -20,8 +19,7 @@ Feature: create a subadmin
   Scenario: admin tries to create a subadmin using a user which does not exist
     Given user "not-user" has been deleted
     And group "new-group" has been created
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
-      | groupid | new-group |
+    When the administrator makes user "not-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And user "not-user" should not be a subadmin of group "new-group"
@@ -29,8 +27,7 @@ Feature: create a subadmin
   Scenario: admin tries to create a subadmin using a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | not-group |
+    When the administrator makes user "brand-new-user" a subadmin of group "not-group" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
 
@@ -40,10 +37,8 @@ Feature: create a subadmin
     And user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    And the administrator has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
-    When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | new-group |
+    And user "brand-new-user" has been added to group "new-group"
+    When user "subadmin" makes user "brand-new-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -64,7 +64,7 @@ Feature: delete groups
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
-    When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    When user "brand-new-user" tries to delete group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -75,7 +75,7 @@ Feature: delete groups
     Given user "subadmin" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
+    When user "subadmin" tries to delete group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -10,7 +10,7 @@ Feature: delete users
   @smokeTest
   Scenario: Delete a user
     Given user "brand-new-user" has been created with default attributes
-    When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
+    When the administrator deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
@@ -22,7 +22,7 @@ Feature: delete users
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
+    When user "subadmin" deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
@@ -31,7 +31,7 @@ Feature: delete users
   Scenario: normal user tries to delete a user
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
+    When user "user1" deletes user "user2" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -10,7 +10,7 @@ Feature: disable user
   @smokeTest
   Scenario: admin disables an user
     Given user "user1" has been created with default attributes
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    When the administrator disables user "user1" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "user1" should be disabled
@@ -23,7 +23,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And user "user1" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    When user "subadmin" disables user "user1" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "user1" should be disabled
@@ -37,7 +37,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And user "user1" has been added to group "another-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+    When user "subadmin" disables user "user1" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -52,7 +52,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And user "another-admin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    When user "subadmin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -61,7 +61,7 @@ Feature: disable user
   Scenario: Admin can disable another admin user
     Given user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    When the administrator disables user "another-admin" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "another-admin" should be disabled
@@ -72,7 +72,7 @@ Feature: disable user
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    When the administrator disables user "subadmin" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "subadmin" should be disabled
@@ -80,7 +80,7 @@ Feature: disable user
   Scenario: Admin user cannot disable himself
     Given user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
-    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+    When user "another-admin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And user "another-admin" should be enabled
@@ -89,7 +89,7 @@ Feature: disable user
   Scenario: disable an user with a regular user
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
+    When user "user1" disables user "user2" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -100,7 +100,7 @@ Feature: disable user
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+    When user "subadmin" disables user "subadmin" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And user "subadmin" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -11,7 +11,7 @@ Feature: enable user
   Scenario: admin enables an user
     Given user "user1" has been created with default attributes
     And user "user1" has been disabled
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
+    When the administrator enables user "user1" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "user1" should be enabled
@@ -20,7 +20,7 @@ Feature: enable user
     Given user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    When the administrator enables user "another-admin" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "another-admin" should be enabled
@@ -32,7 +32,7 @@ Feature: enable user
     And the administrator has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "subadmin" has been disabled
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enable"
+    When the administrator enables user "subadmin" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "subadmin" should be enabled
@@ -41,7 +41,7 @@ Feature: enable user
     Given user "another-admin" has been created with default attributes
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
-    When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+    When user "another-admin" tries to enable user "another-admin" using the provisioning API
     Then user "another-admin" should be disabled
 
   @issue-31276
@@ -49,7 +49,7 @@ Feature: enable user
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
     And user "user2" has been disabled
-    When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
+    When user "user1" tries to enable user "user2" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -61,7 +61,7 @@ Feature: enable user
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "subadmin" has been disabled
-    When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
+    When user "subadmin" tries to enable user "subadmin" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "subadmin" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -9,7 +9,7 @@ Feature: get app info
 
   @smokeTest
   Scenario: admin gets app info
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
+    When the administrator gets the info of app "files"
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the XML "data" "id" value should be "files"

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -9,7 +9,7 @@ Feature: get apps
 
   @smokeTest @comments-app-required @files_trashbin-app-required @files_versions-app-required @systemtags-app-required
   Scenario: admin gets enabled apps
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    When the administrator gets all enabled apps using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the apps returned by the API should include
@@ -27,7 +27,7 @@ Feature: get apps
       | files_external       |
 
   Scenario: admin gets enabled apps - check for the minimal list of apps
-    When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+    When the administrator gets all enabled apps using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the apps returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
@@ -14,7 +14,7 @@ Feature: get group
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "123" has been added to group "new-group"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When the administrator gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the users returned by the API should be
@@ -23,7 +23,7 @@ Feature: get group
 
   Scenario: admin tries to get users in the empty group
     Given group "new-group" has been created
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When the administrator gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the list of users returned by the API should be empty
@@ -37,7 +37,7 @@ Feature: get group
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "user1" has been added to group "new-group"
     And user "user2" has been added to group "new-group"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When user "subadmin" gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the users returned by the API should be
@@ -50,7 +50,7 @@ Feature: get group
     And group "new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
+    When user "subadmin" gets all the members of group "another-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -59,7 +59,7 @@ Feature: get group
   Scenario: normal user tries to get users in their group
     Given user "newuser" has been created with default attributes
     And group "new-group" has been created
-    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+    When user "newuser" gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
@@ -12,7 +12,7 @@ Feature: get groups
     Given group "0" has been created
     And group "new-group" has been created
     And group "España" has been created
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
+    When the administrator gets all the groups using the provisioning API
     Then the groups returned by the API should be
       | España    |
       | admin     |

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
@@ -12,7 +12,7 @@ Feature: get subadmin groups
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
+    When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
     Then the subadmin groups returned by the API should be
       | new-group |
     And the OCS status code should be "200"
@@ -21,7 +21,7 @@ Feature: get subadmin groups
   Scenario: admin tries to get subadmin groups of a user which do not exist
     Given user "not-user" has been deleted
     And group "new-group" has been created
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
+    When the administrator gets all the groups where user "not-user" is subadmin using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -12,7 +12,7 @@ Feature: get subadmins
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    When the administrator gets all the subadmins of group "new-group" using the provisioning API
     Then the subadmin users returned by the API should be
       | brand-new-user |
     And the OCS status code should be "200"
@@ -21,7 +21,7 @@ Feature: get subadmins
   Scenario: admin tries to get subadmin users of a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
+    When the administrator gets all the subadmins of group "not-group" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
@@ -33,7 +33,7 @@ Feature: get subadmins
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newsubadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    When user "subadmin" gets all the subadmins of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -45,7 +45,7 @@ Feature: get subadmins
     And user "subadmin" has been created with default attributes
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+    When user "newuser" gets all the subadmins of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -21,7 +21,7 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
     And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
     And user "brand-new-user" has been added to group "नेपाली"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
       | new-group            |
       | 0                    |
@@ -52,7 +52,7 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "Mgmt/Sydney"
     And user "brand-new-user" has been added to group "var/../etc"
     And user "brand-new-user" has been added to group "priv/subadmins/1"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
       | new-group            |
       | 0                    |
@@ -74,7 +74,7 @@ Feature: get user groups
     And user "subadmin" has been made a subadmin of group "newgroup"
     And user "newuser" has been added to group "newgroup"
     And user "newuser" has been added to group "anothergroup"
-    When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    When user "subadmin" gets all the groups of user "newuser" using the provisioning API
     Then the groups returned by the API should include "newgroup"
     And the groups returned by the API should not include "anothergroup"
     And the OCS status code should be "200"
@@ -86,7 +86,7 @@ Feature: get user groups
     And user "anotheruser" has been created with default attributes
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
-    When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
+    When user "anotheruser" gets all the groups of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -10,7 +10,7 @@ Feature: get users
   @smokeTest
   Scenario: admin gets all users
     Given user "brand-new-user" has been created with default attributes
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the users returned by the API should be
@@ -24,7 +24,7 @@ Feature: get users
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    When user "brand-new-user" gets the list of all users using the provisioning API
     Then the users returned by the API should be
       | brand-new-user |
     And the OCS status code should be "200"
@@ -34,7 +34,7 @@ Feature: get users
   Scenario: normal user tries to get other users
     Given user "normaluser" has been created with default attributes
     And user "newuser" has been created with default attributes
-    When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+    When user "normaluser" gets the list of all users using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -12,8 +12,7 @@ Feature: remove a user from a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
@@ -27,8 +26,7 @@ Feature: remove a user from a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
@@ -56,8 +54,7 @@ Feature: remove a user from a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | <group_id> |
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
@@ -71,8 +68,7 @@ Feature: remove a user from a group
   Scenario: admin tries to remove a user from a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | not-group |
+    When the administrator removes user "brand-new-user" from group "not-group" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
@@ -84,8 +80,7 @@ Feature: remove a user from a group
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "subadmin" removes user "brand-new-user" from group "new-group" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "new-group"
@@ -97,8 +92,7 @@ Feature: remove a user from a group
     And group "other-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "other-subadmin" has been made a subadmin of group "other-group"
-    When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
-      | groupid | new-group |
+    When user "other-subadmin" removes user "brand-new-user" from group "new-group" using the provisioning API
     Then the OCS status code should be "403"
     And the HTTP status code should be "403"
     And user "brand-new-user" should belong to group "new-group"
@@ -110,8 +104,7 @@ Feature: remove a user from a group
     And group "new-group" has been created
     And user "newuser" has been added to group "new-group"
     And user "anotheruser" has been added to group "new-group"
-    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
-      | groupid | new-group |
+    When user "newuser" tries to remove user "another-user" from group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -12,8 +12,7 @@ Feature: remove subadmin
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
-      | groupid | new-group |
+    When the administrator removes user "brand-new-user" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not be a subadmin of group "new-group"
@@ -25,8 +24,7 @@ Feature: remove subadmin
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newsubadmin" has been created with default attributes
     And user "newsubadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
-      | groupid | new-group |
+    When user "subadmin" removes user "newsubadmin" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -39,8 +37,7 @@ Feature: remove subadmin
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newuser" has been added to group "new-group"
-    When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
-      | groupid | new-group |
+    When user "newuser" removes user "subadmin" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -127,10 +127,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
     And user "user0" has been disabled
-    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-      | path      | welcome.txt |
-      | shareWith | user1       |
-      | shareType | 0           |
+    When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "401"
     Examples:
@@ -142,10 +139,7 @@ Feature: sharing
     Given using OCS API version "2"
     And user "user1" has been created with default attributes
     And user "user0" has been disabled
-    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-      | path      | welcome.txt |
-      | shareWith | user1       |
-      | shareType | 0           |
+    When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiShareManagement/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagement/deleteShare.feature
@@ -126,11 +126,7 @@ Feature: sharing
     Given using OCS API version "1"
     And user "user0" has created a folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-    And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-      | path        | shared |
-      | shareWith   | user1  |
-      | shareType   | 0      |
-      | permissions | 1      |
+    And user "user0" has shared folder "shared" with user "user1" with permissions 1
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "user1" file "/shared/shared_file.txt" should exist
@@ -139,11 +135,7 @@ Feature: sharing
     Given using OCS API version "1"
     And user "user0" has created a folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-    And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-      | path        | shared |
-      | shareWith   | user1  |
-      | shareType   | 0      |
-      | permissions | 4      |
+    And user "user0" has shared folder "shared" with user "user1" with permissions 4
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "user0" file "/shared/shared_file.txt" should exist
@@ -151,11 +143,7 @@ Feature: sharing
   Scenario: sharee of an upload-only shared folder tries to delete their file in the folder
     Given using OCS API version "1"
     And user "user0" has created a folder "/shared"
-    And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-      | path        | shared |
-      | shareWith   | user1  |
-      | shareType   | 0      |
-      | permissions | 4      |
+    And user "user0" has shared folder "shared" with user "user1" with permissions 4
     When user "user1" uploads file "filesForUpload/textfile.txt" to "shared/textfile.txt" using the WebDAV API
     And user "user1" deletes file "/shared/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -10,7 +10,7 @@ Feature: sharing
   Scenario Outline: Sharee can see the share
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has shared file "textfile0.txt" with user "user1"
-    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+    When user "user1" gets all the shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the last share_id should be included in the response
@@ -24,7 +24,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user0" has shared file "textfile1.txt" with user "user1"
-    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
+    When user "user1" gets all the shares shared with him that are received as file "textfile1 (2).txt" using the provisioning API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the last share_id should be included in the response
@@ -38,7 +38,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user0" has shared file "textfile1.txt" with user "user1"
-    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
+    When user "user1" gets all the shares shared with him that are received as file "textfile0 (2).txt" using the provisioning API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the last share_id should not be included in the response
@@ -53,7 +53,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "textfile0.txt" with group "grp1"
-    When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+    When user "user1" gets all the shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the last share_id should be included in the response

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -11,7 +11,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
     And user "user0" has shared file "file_to_share.txt" with user "user1"
-    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    When user "user0" gets all shares shared by him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And file "file_to_share.txt" should be included in the response
@@ -23,7 +23,7 @@ Feature: sharing
   Scenario Outline: getting all shares of a user using another user
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has shared file "textfile0.txt" with user "user1"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    When the administrator gets all shares shared by him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And file "textfile0.txt" should not be included in the response
@@ -39,7 +39,7 @@ Feature: sharing
     And user "user3" has been created with default attributes
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user0" has shared file "textfile0.txt" with user "user2"
-    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=textfile0.txt"
+    When user "user0" gets all the shares from the file "textfile0.txt" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And user "user1" should be included in the response
@@ -57,7 +57,7 @@ Feature: sharing
     And user "user3" has been created with default attributes
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user1" has shared file "textfile0 (2).txt" with user "user2"
-    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
+    When user "user0" gets all the shares with reshares from the file "textfile0.txt" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And user "user1" should be included in the response
@@ -78,7 +78,7 @@ Feature: sharing
     And user "user2" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user2" has shared folder "/shared" with user "user1"
     And user "user1" has shared folder "/shared" with group "grp1"
-    When user "user2" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+    When user "user2" gets all the shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the last share_id should not be included in the response
@@ -156,7 +156,7 @@ Feature: sharing
   Scenario Outline: getting all the shares inside the folder
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has shared file "PARENT/parent.txt" with user "user1"
-    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=PARENT&subfiles=true"
+    When user "user0" gets all the shares inside the folder "PARENT" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And file "parent.txt" should be included in the response

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -102,16 +102,9 @@ class FederationContext implements Context {
 	 */
 	public function userFromServerAcceptsLastPendingShareUsingTheSharingAPI($user, $server) {
 		$previous = $this->featureContext->usingServer($server);
-		$url = "/apps/files_sharing/api/v1/remote_shares/pending";
-		$this->featureContext->asUser($user);
-		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
-			'GET',
-			$url,
-			null
-		);
-		$errorMessage = "Error when requesting $url information";
-		$this->featureContext->theHTTPStatusCodeShouldBe('200', $errorMessage);
-		$this->featureContext->theOCSStatusCodeShouldBe('100', $errorMessage);
+		$this->userGetsTheListOfPendingFederatedCloudShares($user);
+		$this->featureContext->theHTTPStatusCodeShouldBe('200');
+		$this->featureContext->theOCSStatusCodeShouldBe('100');
 		$share_id = $this->featureContext->getResponseXml()->data[0]->element[0]->id;
 		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
 			'POST',
@@ -135,6 +128,40 @@ class FederationContext implements Context {
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
 		$this->featureContext->theOCSStatusCodeShouldBe('100');
+	}
+
+	/**
+	 * @When /^user "([^"]*)" gets the list of pending federated cloud shares using the sharing API$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userGetsTheListOfPendingFederatedCloudShares($user) {
+		$url = "/apps/files_sharing/api/v1/remote_shares/pending";
+		$this->featureContext->asUser($user);
+		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
+			'GET',
+			$url,
+			null
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" requests shared secret using the federation API$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userRequestsSharedSecretUsingTheFederationApi($user) {
+		$url  = '/apps/federation/api/v1/request-shared-secret';
+		$this->featureContext->asUser($user);
+		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
+			'POST',
+			$url,
+			null
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1248,6 +1248,120 @@ trait Sharing {
 	}
 
 	/**
+	 * @When user :user gets all the shares shared with him using the sharing API
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userGetsAllTheSharesSharedWithHimUsingTheSharingApi($user) {
+		$url = "/apps/files_sharing/api/v1/shares?shared_with_me=true";
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
+			'GET',
+			$url,
+			null
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" gets all the shares shared with him that are received as (?:file|folder|entry) "([^"]*)" using the provisioning API$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function userGetsAllSharesSharedWithHimFromFileOrFolderUsingTheProvisioningApi($user, $path) {
+		$url = "/apps/files_sharing/api/"
+		. "v{$this->sharingApiVersion}/shares?shared_with_me=true&path=$path";
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
+			'GET',
+			$url,
+			null
+		);
+	}
+
+	/**
+	 * @When user :user gets all shares shared by him using the sharing API
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userGetsAllSharesSharedByHimUsingTheSharingApi($user) {
+		$fullUrl = $this->getBaseUrl()
+		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+		. "v{$this->sharingApiVersion}/shares";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $user, $this->getPasswordForUser($user)
+		);
+	}
+
+	/**
+	 * @When the administrator gets all shares shared by him using the sharing API
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsAllSharesSharedByHimUsingTheSharingApi() {
+		$this->userGetsAllSharesSharedByHimUsingTheSharingApi($this->getAdminUsername());
+	}
+
+	/**
+	 * @When user :user gets all the shares from the file :path using the sharing API
+	 *
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function userGetsAllTheSharesFromTheFileUsingTheSharingApi($user, $path) {
+		$fullUrl = $this->getBaseUrl()
+		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+		. "v{$this->sharingApiVersion}/shares?path=$path";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $user, $this->getPasswordForUser($user)
+		);
+	}
+
+	/**
+	 * @When user :user gets all the shares with reshares from the file :path using the sharing API
+	 *
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function userGetsAllTheSharesWithResharesFromTheFileUsingTheSharingApi(
+		$user, $path
+	) {
+		$fullUrl = $this->getBaseUrl()
+		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+		. "v{$this->sharingApiVersion}/shares?reshares=true&path=$path";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $user, $this->getPasswordForUser($user)
+		);
+	}
+
+	/**
+	 * @When user :user gets all the shares inside the folder :path using the sharing API
+	 *
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function userGetsAllTheSharesInsideTheFolderUsingTheSharingApi($user, $path) {
+		$fullUrl = $this->getBaseUrl()
+		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+		. "v{$this->sharingApiVersion}/shares?path=$path&subfiles=true";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $user, $this->getPasswordForUser($user)
+		);
+	}
+
+	/**
 	 * @Then /^the response when user "([^"]*)" gets the info of the last share should include$/
 	 *
 	 * @param string $user
@@ -1302,13 +1416,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userShouldNotSeeShareIdOfLastShare($user) {
-		$url = "/apps/files_sharing/api/v1/shares?shared_with_me=true";
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
-			$user,
-			'GET',
-			$url,
-			null
-		);
+		$this->userGetsAllTheSharesSharedWithHimUsingTheSharingApi($user);
 		$this->checkingLastShareIDIsNotIncluded();
 	}
 


### PR DESCRIPTION
## Description
Refactor behat setps like `user sends HTTP method 'PUT' to endpoint '/cloud/xyz'` to more specific methods, hiding endpoints from behat steps definitions.

Related issue: #33364
## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.