### PR TITLE
Proposal: API to interact with dav properties

### DIFF
--- a/tests/lib/Files/FilePropertiesTest.php
+++ b/tests/lib/Files/FilePropertiesTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files;
+
+use OC\Files\View;
+use OCP\Files\Folder;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * Class FilePropertiesTest
+ *
+ * @package Test\Files
+ * @group DB
+ */
+class FilePropertiesTest extends TestCase {
+	use UserTrait;
+
+	private $userId;
+	private $file;
+
+	protected function tearDown() {
+		self::logout();
+		parent::tearDown();
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// create user
+		$this->userId = 'file-props-user';
+		$this->createUser($this->userId);
+		self::loginAsUser($this->userId);
+
+		// create file
+		$this->file = self::getUniqueID('file') . '.txt';
+		$fileName = "{$this->userId}/files/{$this->file}";
+		$view = new View();
+		$view->file_put_contents($fileName, '1234');
+	}
+
+	/**
+	 * @throws \Exception
+	 * @throws \OCP\Files\NotFoundException
+	 */
+	public function testFilePropertiesInNodeAPI() :void {
+
+		// work on node api
+		/** @var Folder $metaNodeOfFile */
+		$file = \OC::$server->getUserFolder($this->userId)->get($this->file);
+		$props = $file->getProperties();
+		self::assertEmpty($props);
+
+		$file->addProperty('{http://owncloud.org/ns}upload-time', '2018-11-29T00:47:24-08:00');
+
+		$props = $file->getProperties();
+		self::assertEquals($props, ['{http://owncloud.org/ns}upload-time' => '2018-11-29T00:47:24-08:00']);
+
+		$file->deleteProperty('{http://owncloud.org/ns}upload-time');
+
+		$props = $file->getProperties();
+		self::assertEmpty($props);
+	}
+}


### PR DESCRIPTION
## Description
We are more and more using dav properties and this is a proposal to add a PHP API to ownCloud which allows to get, set and remove properties of a file/folder

## Motivation and Context
Today each app which wants to interact with properties needs to write it's own database access.
This is bad.

## How Has This Been Tested?
- integration test added to show the API proposal

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport
- [ ] Implement the api once agreed on
