### PR TITLE
improve uploading file in chunks

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -214,4 +214,27 @@ class WebDavHelper {
 		$url = \preg_replace("/([^:]\/)\/+/", '$1', $url);
 		return $url;
 	}
+
+	/**
+	 * decides if the proposed dav version and chunking version are
+	 * a valid combination.
+	 * If no chunkingVersion is specified, then any dav version is valid.
+	 * If a chunkingVersion is specified, then it has to match the dav version.
+	 * Note: in future the dav and chunking versions might or might not
+	 * move together and/or be supported together. So a more complex
+	 * matrix could be needed here.
+	 *
+	 * @param string|int $davPathVersion
+	 * @param string|int|null $chunkingVersion
+	 *
+	 * @return boolean is this a valid combination
+	 */
+	public static function isValidDavChunkingCombination(
+		$davPathVersion, $chunkingVersion
+	) {
+		return (
+			($chunkingVersion === 'no' || $chunkingVersion === null) ||
+			($davPathVersion === $chunkingVersion)
+		);
+	}
 }

--- a/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
@@ -47,12 +47,14 @@ Feature: upload file using new chunking
   Scenario: Checking file id after a move overwrite using new chunking endpoint
     Given user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
     And user "user0" has stored id of file "/existingFile.txt"
-    When user "user0" uploads the following chunks to "/existingFile.txt" with new chunking and using the WebDAV API
-      | 1 | AAAAA |
-      | 2 | BBBBB |
-      | 3 | CCCCC |
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "/existingFile.txt" in 3 chunks with new chunking and using the WebDAV API
     Then user "user0" file "/existingFile.txt" should have the previously stored id
-    And the content of file "/existingFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+    And the content of file "/existingFile.txt" for user "user0" should be:
+      """
+      This is a testfile.
+      
+      Cheers.
+      """
     And the log file should not contain any log-entries containing these attributes:
       | app |
       | dav |
@@ -104,13 +106,14 @@ Feature: upload file using new chunking
 
   @smokeTest
   Scenario Outline: Upload files with difficult names using new chunking
-    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
-    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
-    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
-    And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>" using the WebDAV API
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "/<file-name>" in 3 chunks with new chunking and using the WebDAV API
     Then as "user0" file "/<file-name>" should exist
-    And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
+    And the content of file "/<file-name>" for user "user0" should be:
+      """
+      This is a testfile.
+      
+      Cheers.
+      """
     And the log file should not contain any log-entries containing these attributes:
       | app |
       | dav |

--- a/tests/acceptance/features/apiWebdavOperations/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileUsingOldChunking.feature
@@ -8,6 +8,8 @@ Feature: upload file using old chunking
     Given using OCS API version "1"
     And using old DAV path
     And user "user0" has been created with default attributes
+    And the owncloud log level has been set to debug
+    And the owncloud log has been cleared
 
   Scenario: Upload chunked file asc
     When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
@@ -33,16 +35,36 @@ Feature: upload file using old chunking
     Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
+  Scenario: Checking file id after a move overwrite using old chunking endpoint
+    Given user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
+    And user "user0" has stored id of file "/existingFile.txt"
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "/existingFile.txt" in 3 chunks with old chunking and using the WebDAV API
+    Then user "user0" file "/existingFile.txt" should have the previously stored id
+    And the content of file "/existingFile.txt" for user "user0" should be:
+      """
+      This is a testfile.
+      
+      Cheers.
+      """
+    And the log file should not contain any log-entries containing these attributes:
+      | app |
+      | dav |
+
   @smokeTest
   Scenario Outline: Chunked upload files with difficult name
-    When user "user0" uploads the following "3" chunks to "/<file-name>" with old chunking and using the WebDAV API
-      | 1 | AAAAA |
-      | 2 | BBBBB |
-      | 3 | CCCCC |
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "/<file-name>" in 3 chunks using the WebDAV API
     Then as "user0" file "/<file-name>" should exist
-    And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
+    And the content of file "/<file-name>" for user "user0" should be:
+      """
+      This is a testfile.
+      
+      Cheers.
+      """
+    And the log file should not contain any log-entries containing these attributes:
+      | app |
+      | dav |
     Examples:
       | file-name |
-      | 0         |
       | &#?       |
       | TIÄFÜ     |
+      | 0         |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -24,11 +24,13 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Ring\Exception\ConnectException;
 use GuzzleHttp\Stream\StreamInterface;
+use Guzzle\Http\Exception\BadResponseException;
 use Sabre\DAV\Client as SClient;
 use Sabre\DAV\Xml\Property\ResourceType;
 use Sabre\Xml\LibXMLException;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
+use TestHelpers\UploadHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use Sabre\DAV\Xml\Property\Complex;
@@ -87,6 +89,9 @@ trait WebDav {
 	private $responseXml = [];
 
 	private $httpRequestTimeout = 0;
+
+	private $chunkingToUse = null;
+
 	/**
 	 * @Given /^using dav path "([^"]*)"$/
 	 *
@@ -1797,65 +1802,103 @@ trait WebDav {
 		$this->userUploadsAFileTo($user, $source, $destination);
 		$this->usingServer($previousServer);
 	}
-	
+
 	/**
+	 * @When /^user "([^"]*)" uploads file "([^"]*)" to "([^"]*)" in (\d+) chunks (?:with (new|old|v1|v2) chunking and)?\s?using the WebDAV API$/
 	 * @When user :user uploads file :source to :destination with chunks using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
-	 * @param string $chunkingVersion null for autodetect, "old" with old style, "new" for new style
+	 * @param int $noOfChunks
+	 * @param string $chunkingVersion old|v1|new|v2 null for autodetect
+	 * @param bool $async use asynchronous move at the end or not
 	 *
 	 * @return void
 	 */
 	public function userUploadsAFileToWithChunks(
-		$user, $source, $destination, $chunkingVersion = null
+		$user, $source, $destination, $noOfChunks = 2, $chunkingVersion = null, $async = false
 	) {
-		$size = \filesize(
-			$this->acceptanceTestsDirLocation() . $source
+		PHPUnit_Framework_Assert::assertGreaterThan(
+			0, $noOfChunks, "What does it mean to have $noOfChunks chunks?"
 		);
-		$contents = \file_get_contents(
-			$this->acceptanceTestsDirLocation() . $source
+		//use the chunking version that works with the set dav version
+		if ($chunkingVersion === null) {
+			if ($this->usingOldDavPath) {
+				$chunkingVersion = "v1";
+			} else {
+				$chunkingVersion = "v2";
+			}
+		}
+		$this->useSpecificChunking($chunkingVersion);
+		PHPUnit_Framework_Assert::assertTrue(
+			WebDavHelper::isValidDavChunkingCombination(
+				($this->usingOldDavPath) ? 1 : 2,
+				$this->chunkingToUse
+			),
+			"invalid chunking/webdav version combination"
 		);
 
-		// use two chunks for the sake of testing
-		$chunks = [];
-		$chunks[] = \substr($contents, 0, $size / 2);
-		$chunks[] = \substr($contents, $size / 2);
-
-		$this->uploadChunks($user, $chunks, $destination, $chunkingVersion);
+		$headers = [];
+		if ($async === true) {
+			$headers = ['OC-LazyOps' => 'true'];
+		}
+		try {
+			$this->responseXml = [];
+			$this->response = UploadHelper::upload(
+				$this->getBaseUrl(),
+				$this->getActualUsername($user),
+				$this->getUserPassword($user),
+				$this->acceptanceTestsDirLocation() . $source,
+				$destination,
+				$headers,
+				($this->usingOldDavPath) ? 1 : 2,
+				$this->chunkingToUse,
+				$noOfChunks
+			);
+		} catch (BadResponseException $e) {
+			// 4xx and 5xx responses cause an exception
+			$this->response = $e->getResponse();
+		}
 	}
 
 	/**
+	 * @When /^user "([^"]*)" uploads file "([^"]*)" asynchronously to "([^"]*)" in (\d+) chunks (?:with (new|old|v1|v2) chunking and)?\s?using the WebDAV API$/
+	 *
 	 * @param string $user
-	 * @param array $chunks
+	 * @param string $source
 	 * @param string $destination
-	 * @param string|null $chunkingVersion null for autodetect, "old" with old style, "new" for new style
+	 * @param int  $noOfChunks
+	 * @param string $chunkingVersion old|v1|new|v2 null for autodetect
 	 *
 	 * @return void
 	 */
-	public function uploadChunks(
-		$user, $chunks, $destination, $chunkingVersion = null
+	public function userUploadsAFileAsyncToWithChunks(
+		$user, $source, $destination, $noOfChunks = 2, $chunkingVersion = null
 	) {
-		if ($chunkingVersion === null) {
-			if ($this->usingOldDavPath) {
-				$chunkingVersion = 'old';
-			} else {
-				$chunkingVersion = 'new';
-			}
-		}
-		if ($chunkingVersion === 'old') {
-			foreach ($chunks as $index => $chunkContent) {
-				$this->userUploadsChunkedFile(
-					$user, $index + 1, \count($chunks), $chunkContent, $destination
-				);
-			}
+		$this->userUploadsAFileToWithChunks(
+			$user, $source, $destination, $noOfChunks, $chunkingVersion, true
+		);
+	}
+	 
+	/**
+	 * sets the chunking version from human readable format
+	 *
+	 * @param string $version (no|v1|v2|new|old)
+	 *
+	 * @return void
+	 */
+	public function useSpecificChunking($version) {
+		if ($version === "v1" || $version === "old") {
+			$this->chunkingToUse = 1;
+		} elseif ($version === "v2" || $version === "new") {
+			$this->chunkingToUse = 2;
+		} elseif ($version === "no") {
+			$this->chunkingToUse = null;
 		} else {
-			$chunkDetails = [];
-			foreach ($chunks as $index => $chunkContent) {
-				$chunkDetails[] = [$index + 1, $chunkContent];
-			}
-			$this->userUploadsChunksUsingNewChunking($user, $destination, 'chunking-43', $chunkDetails);
+			throw new InvalidArgumentException(
+				"cannot set chunking version to $version"
+			);
 		}
 	}
 
@@ -1937,7 +1980,7 @@ trait WebDav {
 				}
 				
 				$this->userUploadsAFileToWithChunks(
-					$user, $source, $destination . $suffix, 'old'
+					$user, $source, $destination . $suffix, 2, 'old'
 				);
 				$responses[] = $this->response;
 			}
@@ -1946,7 +1989,7 @@ trait WebDav {
 					$suffix = "-{$dav}dav-newchunking";
 				}
 				$this->userUploadsAFileToWithChunks(
-					$user, $source, $destination . $suffix, 'new'
+					$user, $source, $destination . $suffix, 2, 'new'
 				);
 				$responses[] = $this->response;
 			}


### PR DESCRIPTION
## Description
improve the step that does split a file and uploads it in chunks

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #31616

## Motivation and Context
be able to do https://github.com/owncloud/files_classifier/issues/114

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
