### PR TITLE
Add email validation to core utility

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -428,6 +428,21 @@ var OC = {
 	},
 
 	/**
+	 * Returns true if the email regexp matches the email address else false returned
+	 * For example if email is "abc@foo.com", it will return true.
+	 * If email address is "abc@foo.c", then false will be returned.
+	 *
+	 * @param emailAddress
+	 * @returns {boolean}
+	 *
+	 * @since 10.1.0
+	 */
+	validateEmail: function(emailAddress) {
+		var emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@\.]{2,}$/;
+		return (emailRegex.exec(emailAddress) !== null);
+	},
+
+	/**
 	 * Returns the dir name of the given path.
 	 * For example for "/abc/somefile.txt" it will return "/abc"
 	 *

--- a/core/js/sharedialogmailview.js
+++ b/core/js/sharedialogmailview.js
@@ -137,7 +137,7 @@
 			if (email.length === 0)
 				return true
 
-			return email.match(/^[A-Za-z0-9\._%+-]+@(?:[A-Za-z0-9-]+\.)+[a-z]{2,}$/);
+			return OC.validateEmail(email);
 		},
 
 		sendEmails: function() {

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -35,6 +35,29 @@ describe('Core base tests', function() {
 			expect(OC.appswebroots).toBeDefined();
 		});
 	});
+	describe('validateEmail', function () {
+		it('Returns false for search abc@foo', function () {
+			expect(OC.validateEmail('abc@foo')).toEqual(false);
+		});
+		it('Returns false for search abc@foo.', function () {
+			expect(OC.validateEmail('abc@foo.')).toEqual(false);
+		});
+		it('Returns false for search abc', function () {
+			expect(OC.validateEmail('abc')).toEqual(false);
+		});
+		it('Returns false for search abc@foo.a', function () {
+			expect(OC.validateEmail('abc@foo.a')).toEqual(false);
+		});
+		it('Returns true for search abc@foo.aa', function () {
+			expect(OC.validateEmail('abc@foo.aa')).toEqual(true);
+		});
+		it('Returns true for search abc@f.aaa', function () {
+			expect(OC.validateEmail('abc@f.aaa')).toEqual(true);
+		});
+		it('Returns true for search müller@Émile.诶西艾弗.буки', function () {
+			expect(OC.validateEmail('müller@Émile.诶西艾弗.буки')).toEqual(true);
+		});
+	});
 	describe('basename', function() {
 		it('Returns the nothing if no file name given', function() {
 			expect(OC.basename('')).toEqual('');

--- a/core/js/tests/specs/sharedialogmailviewSpec.js
+++ b/core/js/tests/specs/sharedialogmailviewSpec.js
@@ -102,14 +102,13 @@ describe('OC.Share.ShareDialogMailView', function() {
 
 	describe('validating addresses', function() {
 		it('works as expected', function() {
-			expect(view.validateEmail('Ada.Wong@umbrella.com')[0]).toEqual('Ada.Wong@umbrella.com');
-			expect(view.validateEmail('Albert.Wesker@umbrella.sub-domain.com')[0]).toEqual('Albert.Wesker@umbrella.sub-domain.com');
-			expect(view.validateEmail('Albert_Wesker@umbrella.sub-domain.com')[0]).toEqual('Albert_Wesker@umbrella.sub-domain.com');
-			expect(view.validateEmail('Albert-Wesker@umbrella-new.sub-domain.com')[0]).toEqual('Albert-Wesker@umbrella-new.sub-domain.com');
+			expect(view.validateEmail('Ada.Wong@umbrella.com')).toEqual(true);
+			expect(view.validateEmail('Albert.Wesker@umbrella.sub-domain.com')).toEqual(true);
+			expect(view.validateEmail('Albert_Wesker@umbrella.sub-domain.com')).toEqual(true);
+			expect(view.validateEmail('Albert-Wesker@umbrella-new.sub-domain.com')).toEqual(true);
+			expect(view.validateEmail('Jill.Valentine@um#rella.com')).toEqual(true);
 
-			expect(view.validateEmail('Jill.Valentine@umbrella..com')).toEqual(null);
-			expect(view.validateEmail('Jill.Valentine@um#rella.com')).toEqual(null);
-			expect(view.validateEmail('Jürgen.Sörensen@umbrella.com')).toEqual(null);
+			expect(view.validateEmail('Jill.Valentine@umbrella..c')).toEqual(false);
 		});
 	});
 


### PR DESCRIPTION
This would help us to re-use the email validation
in places where required, by just calling,
OC.validateEmail(). In this change, email
validation for public link is using the new
method.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add email validation to the core utility. This would help app developers to reuse `OC.validateEmail(email)` to validate the email address used in the apps. Idea here is not to duplicate the email validation code across the code base. `OC.validateEmail(email)` would return true if the email address matches with the regex else it would return false.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding `OC.validateEmail()` to the core. This would help us to re-use email validation in other apps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified the email address in the public link.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
