### PR TITLE
remove deprecated acceptance test time constant names

### DIFF
--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -60,8 +60,3 @@ const TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER = ACCEPTANCE_TEST_DIR_ON_REMOTE_SER
 // The following directory is created, used, and deleted by tests that need to
 // use some "local external storage" on the server.
 const LOCAL_STORAGE_DIR_ON_REMOTE_SERVER = TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/local_storage";
-
-// Deprecated forms of constants
-// ToDo: remove these after app acceptance tests have been adjusted
-const STANDARDSLEEPTIMEMICROSEC = STANDARD_SLEEP_TIME_MILLISEC * 1000;
-const STANDARDUIWAITTIMEOUTMILLISEC = 10000;

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -384,7 +384,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 				break;
 			}
 
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 


### PR DESCRIPTION
## Description
Remove the deprecated acceptance test constants ``STANDARDSLEEPTIMEMICROSEC`` and ``STANDARDUIWAITTIMEOUTMILLISEC``
They have been removed from apps.

## Motivation and Context
Clen up crud.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
