### PR TITLE
[stable10] remove deprecated acceptance test time constant names

### DIFF
--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -60,8 +60,3 @@ const TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER = ACCEPTANCE_TEST_DIR_ON_REMOTE_SER
 // The following directory is created, used, and deleted by tests that need to
 // use some "local external storage" on the server.
 const LOCAL_STORAGE_DIR_ON_REMOTE_SERVER = TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/local_storage";
-
-// Deprecated forms of constants
-// ToDo: remove these after app acceptance tests have been adjusted
-const STANDARDSLEEPTIMEMICROSEC = STANDARD_SLEEP_TIME_MILLISEC * 1000;
-const STANDARDUIWAITTIMEOUTMILLISEC = 10000;

--- a/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
@@ -76,7 +76,7 @@ class AdminEncryptionSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -84,7 +84,7 @@ class AdminEncryptionSettingsPage extends OwncloudPage {
 			if ($this->findById($this->enableEncryptionCheckboxId) !== null) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 		if ($currentTime > $end) {

--- a/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
@@ -65,7 +65,7 @@ class PersonalEncryptionSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -73,7 +73,7 @@ class PersonalEncryptionSettingsPage extends OwncloudPage {
 			if ($this->findById($this->userEnableRecoveryCheckboxId) !== null) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 		if ($currentTime > $end) {

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -384,7 +384,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 				break;
 			}
 
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 


### PR DESCRIPTION
Backport #33696 