### PR TITLE
upload helper has to use the set headers

### DIFF
--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -133,7 +133,7 @@ class UploadHelper {
 		//finish upload for new chunking
 		if ($chunkingVersion === 2) {
 			$source = $v2ChunksDestination . '/.file';
-			$finalDestination = $baseUrl . "/" .
+			$headers['Destination'] = $baseUrl . "/" .
 				WebDavHelper::getDavPath($user, $davPathVersionToUse) .
 				$destination;
 			$result = WebDavHelper::makeDavRequest(
@@ -142,7 +142,7 @@ class UploadHelper {
 				$password,
 				'MOVE',
 				$source,
-				['Destination' => $finalDestination ],
+				$headers,
 				null, null,
 				$davPathVersionToUse,
 				"uploads"


### PR DESCRIPTION
## Description
use the passed in header variable also in the final MOVE

## Related Issue
needed for owncloud/files_classifier#114

## Motivation and Context
async move does not work otherwise

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
