### PR TITLE
[stable10] Change username for CleanPropertiesTest

### DIFF
--- a/apps/dav/lib/BackgroundJob/CleanProperties.php
+++ b/apps/dav/lib/BackgroundJob/CleanProperties.php
@@ -69,7 +69,7 @@ class CleanProperties extends TimedJob {
 	}
 
 	/**
-	 * Gathers the fileid which are orphan in the oc_properties table
+	 * Gathers the fileid which are orphaned in the oc_properties table
 	 * and then deletes them
 	 */
 	private function processProperties() {
@@ -79,7 +79,7 @@ class CleanProperties extends TimedJob {
 		/**
 		 * select prop.fileid from oc_properties prop
 		 * left join oc_filecache fc on fc.fileid = prop.fileid
-		 * where fc.fileid is not null limit 200
+		 * where fc.fileid is not null limit CHUNK_SIZE
 		 */
 		$qb->select('prop.fileid')
 			->from('properties', 'prop')

--- a/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
@@ -48,12 +48,12 @@ class CleanPropertiesTest extends TestCase {
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->logger = \OC::$server->getLogger();
 		$this->cleanProperties = new CleanProperties($this->connection, $this->logger);
-		$this->createUser('user1');
-		$this->loginAsUser('user1');
+		$this->createUser('userCleanPropertiesTest');
+		$this->loginAsUser('userCleanPropertiesTest');
 	}
 
 	public function testDeleteOrphanEntries() {
-		$userFolder = \OC::$server->getUserFolder('user1');
+		$userFolder = \OC::$server->getUserFolder('userCleanPropertiesTest');
 		$userFolder->newFile('a.txt');
 		$userFolder->newFile('b.txt');
 		$userFolder->newFile('c.txt');
@@ -103,7 +103,7 @@ class CleanPropertiesTest extends TestCase {
 	 * @dataProvider providesDeleteLargeOrphans
 	 */
 	public function testDeleteLargeOrphans($totalFiles, $deletedFiles, $expectedResult) {
-		$userFolder = \OC::$server->getUserFolder('user1');
+		$userFolder = \OC::$server->getUserFolder('userCleanPropertiesTest');
 
 		for ($i = 1; $i <= $totalFiles; $i++) {
 			$fileName = 'a' . (string) $i . '.txt';

--- a/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
@@ -98,7 +98,8 @@ class CleanPropertiesTest extends TestCase {
 		];
 	}
 	/**
-	 * Delete large orphans lets say 300 entries out of 310 entries
+	 * Delete large orphans to confirm that the CHUNK_SIZE processing is working
+	 * in CleanProperties.
 	 *
 	 * @dataProvider providesDeleteLargeOrphans
 	 */
@@ -135,8 +136,8 @@ class CleanPropertiesTest extends TestCase {
 		$results = $qb->execute()->fetchAll();
 
 		/**
-		 * 10 result should be there.
-		 * And the fileid should match with the file which is not deleted.
+		 * The expected number of files should remain.
+		 * And the fileid should match with the files which were not deleted.
 		 */
 		$this->assertCount($expectedResult, $results);
 


### PR DESCRIPTION
## Description
This demonstrates that using a different username works around the unit test problem.
``user1`` is also used in ``EncryptAllTest.php`` ``testEncryptFileFileId()``

This workaround is a hack. Proper cleanup of the user by the test needs to be investigated.

## Related Issue

## Motivation and Context
Make CI great again.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
(i.e. forward-port to ``master`` to keep this code in sync)