### PR TITLE
Members of excluded groups should not get any information about sharees

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -541,6 +541,14 @@ class ShareesController extends OCSController {
 				'message' => 'Invalid page'];
 		}
 
+		$sharingDisabledForUser = $this->shareManager->sharingDisabledForUser(
+			$this->userSession->getUser()->getUID()
+		);
+		// Return empty dataset if User is excluded from sharing
+		if ($sharingDisabledForUser) {
+			return new DataResponse(['data' => $this->result]);
+		}
+
 		$shareTypes = [
 			Share::SHARE_TYPE_USER,
 		];

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1910,4 +1910,60 @@ class ShareesTest extends TestCase {
 		$this->assertEquals($expected, $result['users']);
 		$this->assertCount((int) 1, $this->invokePrivate($this->sharees, 'reachedEndFor'));
 	}
+
+	/**
+	 * Test with User from an excluded group
+	 *
+	 */
+	public function testExcludedGroups() {
+		$user = $this->getUserMock(self::getUniqueID(), 'test');
+		$this->session
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+
+		$this->shareManager
+			->expects($this->once())
+			->method('sharingDisabledForUser')
+			->with($user->getUID())
+			->willReturn(true);
+
+		/** @var ShareesController | \PHPUnit_Framework_MockObject_MockObject $sharees */
+		$sharees = $this->getMockBuilder(ShareesController::class)
+			->setConstructorArgs([
+				'files_sharing',
+				$this->getMockBuilder(IRequest::class)->disableOriginalConstructor()->getMock(),
+				$this->groupManager,
+				$this->userManager,
+				$this->contactsManager,
+				$this->config,
+				$this->session,
+				$this->getMockBuilder(IURLGenerator::class)->disableOriginalConstructor()->getMock(),
+				$this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock(),
+				$this->shareManager,
+				$this->sharingBlacklist,
+				$this->getMockBuilder(FederatedShareProvider::class)->disableOriginalConstructor()->getMock()
+			])
+			->setMethods(['getUsers', 'getGroups', 'getRemote'])
+			->getMock();
+
+		$sharees
+			->expects($this->never())
+			->method('getUsers');
+		$sharees
+			->expects($this->never())
+			->method('getGroups');
+		$sharees
+			->expects($this->never())
+			->method('getRemote');
+
+		$result = $sharees->search($user->getUID(), 'file');
+		$data = $result->getData();
+		self::assertEmpty($data['data']['exact']['users']);
+		self::assertEmpty($data['data']['exact']['groups']);
+		self::assertEmpty($data['data']['exact']['remotes']);
+		self::assertEmpty($data['data']['users']);
+		self::assertEmpty($data['data']['groups']);
+		self::assertEmpty($data['data']['remotes']);
+	}
 }

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -257,6 +257,66 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (could match both users and groups)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a user)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a group)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | ShareeGroup |
+      | itemType | file        |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
   Scenario Outline: Search with exact match
     Given using OCS API version "<ocs-api-version>"
     When user "user1" gets the sharees using the sharing API with parameters

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -105,7 +105,17 @@ class ShareesContext implements Context {
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(), $shareeType
 		);
-		PHPUnit_Framework_Assert::assertEmpty($respondedArray);
+		if (isset($respondedArray[0])) {
+			// [0] is display name and [2] is user or group id
+			$firstEntry = $respondedArray[0][0] . " (" . $respondedArray[0][2] . ")";
+		} else {
+			$firstEntry = "";
+		}
+
+		PHPUnit_Framework_Assert::assertEmpty(
+			$respondedArray,
+			"'$shareeType' array should be empty, but it starts with $firstEntry"
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Original issue https://github.com/owncloud/enterprise/issues/3024

Members of excluded groups should not get any information about sharees. They cannot use the autocomplete field in the UI, but directly using the api works.

## Related Issue


## Motivation and Context
Members of excluded groups should not get any information about sharees. This is a privacy issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local Test:
- Create User 1:
- Create Group "restricted":
- Make User 1 member of group "restricted"
- Try to call `http://localhost/ocs/v1.php/apps/files_sharing/api/v1/sharees?format=json&search=admin&perPage=400&itemType=file`
- Result should return no users

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
