### PR TITLE
[stable10] List compatible apps instead of missing

### DIFF
--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -184,7 +184,7 @@ class Apps implements IRepairStep {
 
 					// Try to update compatible apps
 					if (!empty($appsToUpgrade[self::KEY_COMPATIBLE])) {
-						$output->info('Attempting to update the following existing compatible apps from market: ' . \implode(', ', $appsToUpgrade[self::KEY_MISSING]));
+						$output->info('Attempting to update the following existing compatible apps from market: ' . \implode(', ', $appsToUpgrade[self::KEY_COMPATIBLE]));
 						$failedCompatibleApps = $this->getAppsFromMarket(
 							$output,
 							$appsToUpgrade[self::KEY_COMPATIBLE],


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/33709

## Description
Found while debugging https://github.com/owncloud/market/issues/423

## Motivation and Context
wrong list of apps are printed

```
2018-11-30T11:11:26+00:00 Repair info: Attempting to update the following existing compatible apps from market: 
2018-11-30T11:11:34+00:00 Repair info: Fetching app from market: comments
```
the list of apps after the colon should be **existing compatible apps**
in my case it is eempty as there are no incompatible apps on this instance

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
