### PR TITLE
Acceptance tests for groups excluded from sharing and sharee information

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -82,6 +82,9 @@ class ShareesController extends OCSController {
 	protected $shareWithMembershipGroupOnly = false;
 
 	/** @var bool */
+	protected $sharingDisabledForUser;
+
+	/** @var bool */
 	protected $shareeEnumeration = true;
 
 	/** @var bool */
@@ -541,6 +544,8 @@ class ShareesController extends OCSController {
 				'message' => 'Invalid page'];
 		}
 
+		$this->sharingDisabledForUser = $this->shareManager->sharingDisabledForUser($this->userSession->getUser()->getUID());
+
 		$shareTypes = [
 			Share::SHARE_TYPE_USER,
 		];
@@ -610,6 +615,11 @@ class ShareesController extends OCSController {
 		if ($itemType === null) {
 			return [ 'statuscode' => Http::STATUS_BAD_REQUEST,
 				'message' => 'Missing itemType'];
+		}
+
+		// Return empty dataset if User is excluded from sharing
+		if ($this->sharingDisabledForUser) {
+			return new DataResponse(['data' => $this->result]);
 		}
 
 		// Get users

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -257,6 +257,66 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (could match both users and groups)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a user)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a group)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | ShareeGroup |
+      | itemType | file        |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
   Scenario Outline: Search with exact match
     Given using OCS API version "<ocs-api-version>"
     When user "user1" gets the sharees using the sharing API with parameters

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -105,7 +105,17 @@ class ShareesContext implements Context {
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(), $shareeType
 		);
-		PHPUnit_Framework_Assert::assertEmpty($respondedArray);
+		if (isset($respondedArray[0])) {
+			// [0] is display name and [2] is user or group id
+			$firstEntry = $respondedArray[0][0] . " (" . $respondedArray[0][2] . ")";
+		} else {
+			$firstEntry = "";
+		}
+
+		PHPUnit_Framework_Assert::assertEmpty(
+			$respondedArray,
+			"'$shareeType' array should be empty, but it starts with $firstEntry"
+		);
 	}
 
 	/**


### PR DESCRIPTION
Add acceptance test scenarios that exclude a group from sharing, then for a user in that group:

1) try to request possible sharees for a string that could have multiple matches in users and groups

In current ``master`` this test case fails with:
```
    Examples:
      | ocs-api-version | ocs-status | http-status |
      | 1               | 100        | 200         |
        'users' array should be empty, but it starts with Sharee One (sharee1)
        Failed asserting that an array is empty.
      | 2               | 200        | 200         |
        'users' array should be empty, but it starts with Sharee One (sharee1)
        Failed asserting that an array is empty.

--- Failed scenarios:

    /home/phil/git/owncloud/core/tests/acceptance/features/apiSharees/sharees.feature:277
    /home/phil/git/owncloud/core/tests/acceptance/features/apiSharees/sharees.feature:278
```

2) try to request possible sharees for a string that could exactly match a user

In current ``master`` this test case fails with:
```
    Examples:
      | ocs-api-version | ocs-status | http-status |
      | 1               | 100        | 200         |
        'exact users' array should be empty, but it starts with Sharee One (sharee1)
        Failed asserting that an array is empty.
      | 2               | 200        | 200         |
        'exact users' array should be empty, but it starts with Sharee One (sharee1)
        Failed asserting that an array is empty.

--- Failed scenarios:

    /home/phil/git/owncloud/core/tests/acceptance/features/apiSharees/sharees.feature:297
    /home/phil/git/owncloud/core/tests/acceptance/features/apiSharees/sharees.feature:298
```

3) try to request possible sharees for a string that could exactly match a group

In current ``master`` this test case fails with:
```
    Examples:
      | ocs-api-version | ocs-status | http-status |
      | 1               | 100        | 200         |
        'exact groups' array should be empty, but it starts with ShareeGroup (ShareeGroup)
        Failed asserting that an array is empty.
      | 2               | 200        | 200         |
        'exact groups' array should be empty, but it starts with ShareeGroup (ShareeGroup)
        Failed asserting that an array is empty.

--- Failed scenarios:

    /home/phil/git/owncloud/core/tests/acceptance/features/apiSharees/sharees.feature:317
    /home/phil/git/owncloud/core/tests/acceptance/features/apiSharees/sharees.feature:318

2 scenarios (2 failed)
32 steps (24 passed, 2 failed, 6 skipped)
```

All test scenarios pass when run with the corrected code in PR #33728 

