### PR TITLE
[stable10] Members of excluded groups should not get any information about sharees

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -534,6 +534,14 @@ class ShareesController extends OCSController {
 				'message' => 'Invalid page'];
 		}
 
+		$sharingDisabledForUser = $this->shareManager->sharingDisabledForUser(
+			$this->userSession->getUser()->getUID()
+		);
+		// Return empty dataset if User is excluded from sharing
+		if ($sharingDisabledForUser) {
+			return new DataResponse(['data' => $this->result]);
+		}
+
 		$shareTypes = [
 			Share::SHARE_TYPE_USER,
 		];

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -257,6 +257,66 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (could match both users and groups)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a user)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sharee1 |
+      | itemType | file    |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
+  Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a group)
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["ShareeGroup2"]'
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | ShareeGroup |
+      | itemType | file        |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |
+
   Scenario Outline: Search with exact match
     Given using OCS API version "<ocs-api-version>"
     When user "user1" gets the sharees using the sharing API with parameters

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -105,7 +105,17 @@ class ShareesContext implements Context {
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(), $shareeType
 		);
-		PHPUnit_Framework_Assert::assertEmpty($respondedArray);
+		if (isset($respondedArray[0])) {
+			// [0] is display name and [2] is user or group id
+			$firstEntry = $respondedArray[0][0] . " (" . $respondedArray[0][2] . ")";
+		} else {
+			$firstEntry = "";
+		}
+
+		PHPUnit_Framework_Assert::assertEmpty(
+			$respondedArray,
+			"'$shareeType' array should be empty, but it starts with $firstEntry"
+		);
 	}
 
 	/**


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/33728

# Description

Original issue owncloud/enterprise#3024

Members of excluded groups should not get any information about sharees. They cannot use the autocomplete field in the UI, but directly using the api works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/426