### PR TITLE
Test file_versions with chunking upload

### DIFF
--- a/tests/acceptance/features/apiMain/fileVersions.feature
+++ b/tests/acceptance/features/apiMain/fileVersions.feature
@@ -12,12 +12,38 @@ Feature: dav-versions
     When user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "user0" should contain "0" elements
 
+  Scenario: Upload file and no version is available using various chunking methods
+    When user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" with all mechanisms using the WebDAV API
+    Then the version folder of file "/davtest.txt-olddav-regular" for user "user0" should contain "0" elements
+    Then the version folder of file "/davtest.txt-newdav-regular" for user "user0" should contain "0" elements
+    Then the version folder of file "/davtest.txt-olddav-oldchunking" for user "user0" should contain "0" elements
+    Then the version folder of file "/davtest.txt-newdav-newchunking" for user "user0" should contain "0" elements
+
+  Scenario: Upload file and no version is available using async upload
+    Given the administrator has enabled async operations
+    When user "user0" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 3 chunks with new chunking and using the WebDAV API
+    Then the version folder of file "/davtest.txt" for user "user0" should contain "0" elements
+
   @smokeTest
   Scenario: Upload a file twice and versions are available
     When user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" using the WebDAV API
     And user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "user0" should contain "1" element
     And the content length of file "/davtest.txt" with version index "1" for user "user0" in versions folder should be "8"
+
+  Scenario: Upload a file twice and versions are available using various chunking methods
+    When user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" with all mechanisms using the WebDAV API
+    And user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" with all mechanisms using the WebDAV API
+    Then the version folder of file "/davtest.txt-olddav-regular" for user "user0" should contain "1" element
+    Then the version folder of file "/davtest.txt-newdav-regular" for user "user0" should contain "1" element
+    Then the version folder of file "/davtest.txt-olddav-oldchunking" for user "user0" should contain "1" element
+    Then the version folder of file "/davtest.txt-newdav-newchunking" for user "user0" should contain "1" element
+
+  Scenario: Upload a file twice and versions are available using async upload
+    Given the administrator has enabled async operations
+    When user "user0" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
+    And user "user0" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 3 chunks with new chunking and using the WebDAV API
+    Then the version folder of file "/davtest.txt" for user "user0" should contain "1" element
 
   @smokeTest
   Scenario: Remove a file
@@ -35,6 +61,27 @@ Feature: dav-versions
     And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
     When user "user0" restores version index "1" of file "/davtest.txt" using the WebDAV API
     Then the content of file "/davtest.txt" for user "user0" should be "123"
+
+  @smokeTest
+  Scenario Outline: Uploading a chunked file does create the correct version that can be restored
+    Given using <dav-path> DAV path
+    When user "user0" uploads file "filesForUpload/davtest.txt" to "/textfile0.txt" in 2 chunks using the WebDAV API
+    And user "user0" uploads file "filesForUpload/lorem.txt" to "/textfile0.txt" in 3 chunks using the WebDAV API
+    Then the version folder of file "/textfile0.txt" for user "user0" should contain "2" elements
+    When user "user0" restores version index "1" of file "/textfile0.txt" using the WebDAV API
+    Then the content of file "/textfile0.txt" for user "user0" should be "Dav-Test"
+    Examples:
+      | dav-path |
+      | new      |
+      | old      |
+
+  Scenario: Uploading a file asynchronously does create the correct version that can be restored
+    Given the administrator has enabled async operations
+    When user "user0" uploads file "filesForUpload/davtest.txt" asynchronously to "textfile0.txt" in 2 chunks using the WebDAV API
+    And user "user0" uploads file "filesForUpload/lorem.txt" asynchronously to "textfile0.txt" in 2 chunks using the WebDAV API
+    Then the version folder of file "/textfile0.txt" for user "user0" should contain "2" elements
+    When user "user0" restores version index "1" of file "/textfile0.txt" using the WebDAV API
+    Then the content of file "/textfile0.txt" for user "user0" should be "Dav-Test"
 
   @skipOnStorage:ceph @files_primary_s3-issue-156
   Scenario: Restore a file and check, if the content and correct checksum is now in the current file

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -209,7 +209,10 @@ trait WebDav {
 			// systemtags only exists since dav v2
 			return 2;
 		}
-
+		if ($for === 'file_versions') {
+			// file_versions only exists since dav v2
+			return 2;
+		}
 		if ($this->usingOldDavPath === true) {
 			return 1;
 		} else {
@@ -1532,10 +1535,10 @@ trait WebDav {
 				'{DAV:}getetag'
 			];
 		}
-
 		try {
 			$response = $client->propfind(
-				$this->makeSabrePathNotForFiles($path), $properties, $folderDepth
+				$this->makeSabrePathNotForFiles($path, 'file_versions'),
+				$properties, $folderDepth
 			);
 		} catch (Sabre\HTTP\ClientHttpException $e) {
 			$response = $e->getResponse();
@@ -1556,6 +1559,7 @@ trait WebDav {
 		$path, $user, $count
 	) {
 		$fileId = $this->getFileIdForPath($user, $path);
+		PHPUnit_Framework_Assert::assertNotNull($fileId, "file $path not found");
 		$elements = $this->listVersionFolder($user, "/meta/$fileId/v", 1);
 		PHPUnit_Framework_Assert::assertEquals($count, \count($elements) - 1);
 	}
@@ -1689,11 +1693,12 @@ trait WebDav {
 
 	/**
 	 * @param string $path
+	 * @param string $for the category of endpoint that the dav path will be used for
 	 *
 	 * @return string
 	 */
-	public function makeSabrePathNotForFiles($path) {
-		return $this->encodePath($this->getDavPath() . $path);
+	public function makeSabrePathNotForFiles($path, $for = null) {
+		return $this->encodePath($this->getDavPath($for) . $path);
 	}
 
 	/**
@@ -3102,15 +3107,15 @@ trait WebDav {
 	 */
 	public function userRestoresVersionIndexOfFile($user, $versionIndex, $path) {
 		$fileId = $this->getFileIdForPath($user, $path);
-		$client = $this->getSabreClient($user);
 		$versions = \array_keys(
 			$this->listVersionFolder($user, "/meta/$fileId/v", 1)
 		);
-		$client->request(
-			'COPY',
-			$versions[$versionIndex],
-			null,
-			['Destination' => $this->makeSabrePath($user, $path)]
+		//restoring the version only works with dav path v2
+		$destinationUrl = $this->getBaseUrl() . "/" .
+						  WebDavHelper::getDavPath($user, 2) . \trim($path, "/");
+		HttpRequestHelper::sendRequest(
+			$this->getBaseUrlWithoutPath() . $versions[$versionIndex],
+			'COPY', $user, $this->getPasswordForUser($user), ['Destination' => $destinationUrl]
 		);
 	}
 


### PR DESCRIPTION
## Description
various tests for file_versions in combination with chunking upload
some small fixes to the test code were needed because file_versions (list & restore) only work with the new webdav path

## Related Issue
- Fixes #33739

## How Has This Been Tested?
:robot:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
