### PR TITLE
Refactor acceptance test create folder steps

### DIFF
--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -68,7 +68,7 @@ Feature: Comments
       | user0 | My first comment |
 
   Scenario: Creating a comment on a shared folder belonging to another user
-    Given the user has created a folder "/FOLDER_TO_SHARE"
+    Given the user has created folder "/FOLDER_TO_SHARE"
     And the user has shared folder "/FOLDER_TO_SHARE" with user "user1"
     When user "user1" comments with content "A comment from sharee" on folder "/FOLDER_TO_SHARE" using the WebDAV API
     And the user comments with content "A comment from sharer" on folder "/FOLDER_TO_SHARE" using the WebDAV API
@@ -80,7 +80,7 @@ Feature: Comments
   Scenario: sharee comments on a group shared folder
     Given group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And the user has created a folder "/FOLDER_TO_COMMENT"
+    And the user has created folder "/FOLDER_TO_COMMENT"
     And the user has shared folder "/FOLDER_TO_COMMENT" with group "grp1"
     When user "user1" comments with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT" using the WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -38,14 +38,14 @@ Feature: Comments
     And user "user1" should have 1 comments on file "/myFileToComment.txt"
 
   Scenario: Deleting my own comments on a folder belonging to myself
-    Given the user has created a folder "/FOLDER_TO_COMMENT_AND_DELETE"
+    Given the user has created folder "/FOLDER_TO_COMMENT_AND_DELETE"
     And the user has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT_AND_DELETE"
     When the user deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
     And the user should have 0 comments on folder "/FOLDER_TO_COMMENT_AND_DELETE"
 
   Scenario: Deleting a comment on a file belonging to myself having several comments
-    Given the user has created a folder "/FOLDER_TO_COMMENT"
+    Given the user has created folder "/FOLDER_TO_COMMENT"
     And the user has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT"
     And the user has commented with content "My second comment" on folder "/FOLDER_TO_COMMENT"
     And the user has commented with content "My third comment" on folder "/FOLDER_TO_COMMENT"
@@ -55,7 +55,7 @@ Feature: Comments
     And the user should have 3 comments on folder "/FOLDER_TO_COMMENT"
 
   Scenario: Deleting my own comments on a file shared by somebody else
-    Given the user has created a folder "/FOLDER_TO_COMMENT"
+    Given the user has created folder "/FOLDER_TO_COMMENT"
     And the user has shared folder "/FOLDER_TO_COMMENT" with user "user1"
     And the user has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
     And user "user1" has commented with content "Sharee comment" on folder "/FOLDER_TO_COMMENT"
@@ -67,14 +67,14 @@ Feature: Comments
     And user "user1" should have 1 comments on folder "/FOLDER_TO_COMMENT"
 
   Scenario: deleting a folder removes existing comments on the folder
-    Given the user has created a folder "/FOLDER_TO_DELETE"
+    Given the user has created folder "/FOLDER_TO_DELETE"
     When the user comments with content "This should be deleted" on folder "/FOLDER_TO_DELETE" using the WebDAV API
     And the user deletes folder "/FOLDER_TO_DELETE" using the WebDAV API
-    And the user has created a folder "/FOLDER_TO_DELETE"
+    And the user has created folder "/FOLDER_TO_DELETE"
     Then the user should have 0 comments on folder "/FOLDER_TO_DELETE"
 
   Scenario: deleting a user does not remove the comment
-    Given the user has created a folder "/FOLDER_TO_COMMENT"
+    Given the user has created folder "/FOLDER_TO_COMMENT"
     And the user has shared folder "/FOLDER_TO_COMMENT" with user "user1"
     And user "user1" has commented with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT"
     When the administrator deletes user "user1" using the provisioning API
@@ -83,9 +83,9 @@ Feature: Comments
       | deleted_users | Comment from sharee |
 
   Scenario: deleting a content owner deletes the comment
-    Given the user has created a folder "/FOLDER_TO_COMMENT"
+    Given the user has created folder "/FOLDER_TO_COMMENT"
     And the user has commented with content "Comment from owner" on folder "/FOLDER_TO_COMMENT"
     And user "user0" has been deleted
     And user "user0" has been created with default attributes
-    When the user creates a folder "/FOLDER_TO_COMMENT" using the WebDAV API
+    When the user creates folder "/FOLDER_TO_COMMENT" using the WebDAV API
     Then the user should have 0 comments on folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -37,7 +37,7 @@ Feature: Comments
       | user1 | Sharee comment |
 
   Scenario: Edit my own comments on a folder belonging to myself
-    Given the user has created a folder "/FOLDER_TO_COMMENT"
+    Given the user has created folder "/FOLDER_TO_COMMENT"
     And the user has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
     When the user edits the last created comment with content "My edited comment" using the WebDAV API
     Then the HTTP status code should be "207"

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -63,7 +63,7 @@ Feature: favorite
 
   Scenario Outline: Get favorited elements of a subfolder
     Given using <dav_version> DAV path
-    And the user has created a folder "/subfolder"
+    And the user has created folder "/subfolder"
     And the user has moved file "/textfile0.txt" to "/subfolder/textfile0.txt"
     And the user has moved file "/textfile1.txt" to "/subfolder/textfile1.txt"
     And the user has moved file "/textfile2.txt" to "/subfolder/textfile2.txt"
@@ -82,7 +82,7 @@ Feature: favorite
   Scenario Outline: moving a favorite file out of a share keeps favorite state
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And the user has created a folder "/shared"
+    And the user has created folder "/shared"
     And the user has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And the user has shared folder "/shared" with user "user1"
     And user "user1" has favorited element "/shared/shared_file.txt"
@@ -96,7 +96,7 @@ Feature: favorite
 
   Scenario Outline: Get favorited elements paginated
     Given using <dav_version> DAV path
-    And the user has created a folder "/subfolder"
+    And the user has created folder "/subfolder"
     And the user has copied file "/textfile0.txt" to "/subfolder/textfile0.txt"
     And the user has copied file "/textfile0.txt" to "/subfolder/textfile1.txt"
     And the user has copied file "/textfile0.txt" to "/subfolder/textfile2.txt"

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -9,7 +9,7 @@ Feature: external-storage
   Scenario: Share by public link a file inside a local external storage
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/foo"
+    And user "user0" has created folder "/local_storage/foo"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
     And user "user0" has shared folder "/local_storage/foo" with user "user1"
     When user "user1" creates a public link share using the sharing API with settings
@@ -25,7 +25,7 @@ Feature: external-storage
   Scenario: Move a file into storage
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/foo1"
+    And user "user0" has created folder "/local_storage/foo1"
     When user "user0" moves file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt" using the WebDAV API
     Then as "user1" file "/local_storage/foo1/textfile0.txt" should exist
     And as "user0" file "/local_storage/foo1/textfile0.txt" should exist
@@ -33,7 +33,7 @@ Feature: external-storage
   Scenario: Move a file out of storage
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/foo2"
+    And user "user0" has created folder "/local_storage/foo2"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
     When user "user1" moves file "/local_storage/foo2/textfile0.txt" to "/local.txt" using the WebDAV API
     Then as "user1" file "/local_storage/foo2/textfile0.txt" should not exist
@@ -42,7 +42,7 @@ Feature: external-storage
 
   Scenario: Download a file that exists in filecache but not storage fails with 404
     Given user "user0" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/foo3"
+    And user "user0" has created folder "/local_storage/foo3"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
     And file "foo3/textfile0.txt" has been deleted from local storage on the server
     When user "user0" downloads file "local_storage/foo3/textfile0.txt" using the WebDAV API

--- a/tests/acceptance/features/apiMain/fileVersions.feature
+++ b/tests/acceptance/features/apiMain/fileVersions.feature
@@ -84,7 +84,7 @@ Feature: dav-versions
 
   Scenario: sharer can restore a file inside a shared folder modified by sharee
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -95,7 +95,7 @@ Feature: dav-versions
 
   Scenario: sharee can restore a file inside a shared folder modified by sharee
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -106,7 +106,7 @@ Feature: dav-versions
 
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -117,7 +117,7 @@ Feature: dav-versions
 
   Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -128,7 +128,7 @@ Feature: dav-versions
 
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
     And user "user1" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
@@ -139,7 +139,7 @@ Feature: dav-versions
 
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
@@ -150,11 +150,11 @@ Feature: dav-versions
 
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
-    And user "user1" has created a folder "/received"
+    And user "user1" has created folder "/received"
     And user "user1" has moved folder "/sharingfolder" to "/received/sharingfolder"
     When user "user1" restores version index "1" of file "/received/sharingfolder/sharefile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -166,7 +166,7 @@ Feature: dav-versions
     And user "user0" has uploaded file with content "old content" to "/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharefile.txt"
     And user "user0" has shared file "/sharefile.txt" with user "user1"
-    And user "user1" has created a folder "/received"
+    And user "user1" has created folder "/received"
     And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
     When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -175,11 +175,11 @@ Feature: dav-versions
 
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
     Given user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
     And user "user0" has shared file "/sharingfolder/sharefile.txt" with user "user1"
-    And user "user1" has created a folder "/received"
+    And user "user1" has created folder "/received"
     And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
     When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -192,7 +192,7 @@ Feature: dav-versions
     And group "newgroup" has been created
     And user "user1" has been added to group "newgroup"
     And user "user2" has been added to group "newgroup"
-    And user "user0" has created a folder "/sharingfolder"
+    And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with group "newgroup"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -63,7 +63,7 @@ Feature: quota
     And user "user1" has been created with default attributes
     And the quota of user "user0" has been set to "20 B"
     And the quota of user "user1" has been set to "10 MB"
-    And user "user1" has created a folder "/testquota"
+    And user "user1" has created folder "/testquota"
     And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
     When user "user0" uploads file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
@@ -78,7 +78,7 @@ Feature: quota
     And user "user1" has been created with default attributes
     And the quota of user "user0" has been set to "10 MB"
     And the quota of user "user1" has been set to "20 B"
-    And user "user1" has created a folder "/testquota"
+    And user "user1" has created folder "/testquota"
     And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
     When user "user0" uploads file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
@@ -94,7 +94,7 @@ Feature: quota
     And user "user1" has been created with default attributes
     And the quota of user "user0" has been set to "20 B"
     And the quota of user "user1" has been set to "10 MB"
-    And user "user1" has created a folder "/testquota"
+    And user "user1" has created folder "/testquota"
     And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
     When user "user0" overwrites file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
@@ -110,7 +110,7 @@ Feature: quota
     And user "user1" has been created with default attributes
     And the quota of user "user0" has been set to "10 MB"
     And the quota of user "user1" has been set to "20 B"
-    And user "user1" has created a folder "/testquota"
+    And user "user1" has created folder "/testquota"
     And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
     When user "user0" overwrites file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -30,7 +30,7 @@ Feature: transfer-ownership
   Scenario: transferring ownership of a folder
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
@@ -53,7 +53,7 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
     When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -64,7 +64,7 @@ Feature: transfer-ownership
   Scenario: transferring ownership of folder shared with transfer recipient
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -80,7 +80,7 @@ Feature: transfer-ownership
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
     And user "user2" has been added to group "group1"
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with group "group1" with permissions 31
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
@@ -93,7 +93,7 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user2" has created a folder "/test"
+    And user "user2" has created folder "/test"
     And user "user2" has shared folder "/test" with user "user0" with permissions 31
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
@@ -114,8 +114,8 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/sub"
-    And user "user0" has created a folder "/sub/test"
+    And user "user0" has created folder "/sub"
+    And user "user0" has created folder "/sub/test"
     And user "user0" has shared folder "/sub/test" with user "user2" with permissions 31
     And user "user0" has deleted folder "/sub"
     When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -138,7 +138,7 @@ Feature: transfer-ownership
   Scenario: transferring ownership of only a single folder containing a file
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
     Then the command should have been successful
@@ -148,8 +148,8 @@ Feature: transfer-ownership
   Scenario: transferring ownership of only a single folder containing an empty folder
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
-    And user "user0" has created a folder "/test/subfolder"
+    And user "user0" has created folder "/test"
+    And user "user0" has created folder "/test/subfolder"
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
@@ -160,7 +160,7 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user0" has deleted everything from folder "/"
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
@@ -171,7 +171,7 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared file "/test/somefile.txt" with user "user2" with permissions 19
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
@@ -183,7 +183,7 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
     And user "user1" has created a public link share with settings
@@ -197,7 +197,7 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
@@ -208,7 +208,7 @@ Feature: transfer-ownership
   Scenario: transferring ownership of folder shared with transfer recipient
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
@@ -224,7 +224,7 @@ Feature: transfer-ownership
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
     And user "user2" has been added to group "group1"
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with group "group1" with permissions 31
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
@@ -236,8 +236,8 @@ Feature: transfer-ownership
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user2" has created a folder "/test"
-    And user "user0" has created a folder "/sub"
+    And user "user2" has created folder "/test"
+    And user "user0" has created folder "/sub"
     And user "user2" has shared folder "/test" with user "user0" with permissions 31
     And user "user0" has moved folder "/test" to "/sub/test"
     When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
@@ -249,8 +249,8 @@ Feature: transfer-ownership
   Scenario: transferring ownership of folder shared with transfer recipient and public link created of received share works
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
-    And user "user0" has created a folder "/test/foo"
+    And user "user0" has created folder "/test"
+    And user "user0" has created folder "/test/foo"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" creates a public link share using the sharing API with settings
       | path | /test/somefile.txt |
@@ -265,7 +265,7 @@ Feature: transfer-ownership
   Scenario: transferring ownership does not transfer external storage
     Given user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/sub"
+    And user "user0" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
     Then the command should have been successful
     And using received transfer folder of "user1" as dav path
@@ -273,14 +273,14 @@ Feature: transfer-ownership
 
   Scenario: transferring ownership fails with invalid source user
     Given user "user0" has been created with default attributes
-    And user "user0" has created a folder "/sub"
+    And user "user0" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "invalid_user" to "user0" using the occ command
     Then the command output should contain the text "Unknown source user"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with invalid destination user
     Given user "user0" has been created with default attributes
-    And user "user0" has created a folder "/sub"
+    And user "user0" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "user0" to "invalid_user" using the occ command
     Then the command output should contain the text "Unknown destination user"
     And the command should have failed with exit code 1

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -156,7 +156,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: move accepted share, decline it, accept again
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/PARENT/shared"
     When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
@@ -171,7 +171,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: move accepted share, decline it, delete parent folder, accept again
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/PARENT/shared"
     When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
@@ -187,10 +187,10 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive two shares with identical names from different users
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-    And user "user0" has created a folder "/shared"
-    And user "user0" has created a folder "/shared/user0"
-    And user "user1" has created a folder "/shared"
-    And user "user1" has created a folder "/shared/user1"
+    And user "user0" has created folder "/shared"
+    And user "user0" has created folder "/shared/user0"
+    And user "user1" has created folder "/shared"
+    And user "user1" has created folder "/shared/user1"
     When user "user0" shares folder "/shared" with user "user2" using the sharing API
     And user "user1" shares folder "/shared" with user "user2" using the sharing API
     Then user "user2" should see the following elements
@@ -269,7 +269,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: accept an accepted share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
     And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
@@ -350,10 +350,10 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive two shares with identical names from different users, accept one by one
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-    And user "user0" has created a folder "/shared"
-    And user "user0" has created a folder "/shared/user0"
-    And user "user1" has created a folder "/shared"
-    And user "user1" has created a folder "/shared/user1"
+    And user "user0" has created folder "/shared"
+    And user "user0" has created folder "/shared/user0"
+    And user "user1" has created folder "/shared"
+    And user "user1" has created folder "/shared/user1"
     And user "user0" has shared folder "/shared" with user "user2"
     And user "user1" has shared folder "/shared" with user "user2"
     When user "user2" accepts the share "/shared" offered by user "user1" using the sharing API

--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -147,7 +147,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user0" has created a folder "/afolder"
+    And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path | /afolder |
     Then the OCS status code should be "<ocs_status_code>"
@@ -165,7 +165,7 @@ Feature: sharing
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    And user "user0" has created a folder "/afolder"
+    And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path | /afolder |
     Then the OCS status code should be "<ocs_status_code>"
@@ -182,7 +182,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with edit permissions keeps it
     Given using OCS API version "<ocs_api_version>"
-    And user "user0" has created a folder "/afolder"
+    And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /afolder |
       | permissions | 15       |
@@ -276,8 +276,8 @@ Feature: sharing
     Given using OCS API version "1"
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/foo"
-    And user "user1" has created a folder "/foo"
+    And user "user0" has created folder "/foo"
+    And user "user1" has created folder "/foo"
     When user "user0" shares file "/foo" with user "user2" using the sharing API
     And user "user1" shares file "/foo" with user "user2" using the sharing API
     Then user "user2" should see the following elements
@@ -303,8 +303,8 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
     And group "grp1" has been created
-    And user "user0" has created a folder "/test"
-    And user "user0" has created a folder "/test/sub"
+    And user "user0" has created folder "/test"
+    And user "user0" has created folder "/test/sub"
     And user "user0" has shared file "/test" with group "grp1"
     When user "user0" shares file "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -320,8 +320,8 @@ Feature: sharing
     And user "user1" has been created with default attributes
     And group "grp1" has been created
     And user "user0" has been added to group "grp1"
-    And user "user0" has created a folder "/test"
-    And user "user0" has created a folder "/test/sub"
+    And user "user0" has created folder "/test"
+    And user "user0" has created folder "/test/sub"
     And user "user0" has shared file "/test" with group "grp1"
     When user "user0" shares file "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -338,10 +338,10 @@ Feature: sharing
     And user "user2" has been created with default attributes
     And user "user3" has been created with default attributes
     And user "user4" has been created with default attributes
-    And user "user0" has created a folder "/folder1"
+    And user "user0" has created folder "/folder1"
     And user "user0" has shared file "/folder1" with user "user1"
     And user "user0" has shared file "/folder1" with user "user2"
-    And user "user0" has created a folder "/folder1/folder2"
+    And user "user0" has created folder "/folder1/folder2"
     And user "user0" has shared file "/folder1/folder2" with user "user3"
     And user "user0" has shared file "/folder1/folder2" with user "user4"
     And as user "user0"
@@ -405,7 +405,7 @@ Feature: sharing
   Scenario Outline: user shares a folder with folder name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
     When user "user0" shares folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -421,7 +421,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "user1" has been created with default attributes
     And user "user1" has been added to group "grp1"
-    And user "user0" has created a folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
     When user "user0" shares folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -449,7 +449,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars
     Given using OCS API version "<ocs_api_version>"
-    And user "user0" has created a folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |

--- a/tests/acceptance/features/apiShareManagement/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagement/deleteShare.feature
@@ -37,8 +37,8 @@ Feature: sharing
   Scenario: orphaned shares
     Given using OCS API version "1"
     And a new browser session for "user0" has been started
-    And user "user0" has created a folder "/common"
-    And user "user0" has created a folder "/common/sub"
+    And user "user0" has created folder "/common"
+    And user "user0" has created folder "/common/sub"
     And user "user0" has shared folder "/common/sub" with user "user1"
     When user "user0" deletes folder "/common" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -49,10 +49,10 @@ Feature: sharing
     And user "user2" has been created with default attributes
     And user "user3" has been created with default attributes
     And user "user4" has been created with default attributes
-    And user "user0" has created a folder "/folder1"
+    And user "user0" has created folder "/folder1"
     And user "user0" has shared file "/folder1" with user "user1"
     And user "user0" has shared file "/folder1" with user "user2"
-    And user "user0" has created a folder "/folder1/folder2"
+    And user "user0" has created folder "/folder1/folder2"
     And user "user0" has shared file "/folder1/folder2" with user "user3"
     And user "user0" has shared file "/folder1/folder2" with user "user4"
     And as user "user0"
@@ -76,7 +76,7 @@ Feature: sharing
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
@@ -89,8 +89,8 @@ Feature: sharing
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "user0" has created a folder "/shared"
-    And user "user0" has created a folder "/shared/sub"
+    And user "user0" has created folder "/shared"
+    And user "user0" has created folder "/shared/sub"
     And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" deletes folder "/shared/sub" using the WebDAV API
@@ -124,7 +124,7 @@ Feature: sharing
 
   Scenario: sharee of a read-only share folder tries to delete the shared folder
     Given using OCS API version "1"
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "shared" with user "user1" with permissions 1
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
@@ -133,7 +133,7 @@ Feature: sharing
 
   Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
     Given using OCS API version "1"
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "shared" with user "user1" with permissions 4
     When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
@@ -142,7 +142,7 @@ Feature: sharing
 
   Scenario: sharee of an upload-only shared folder tries to delete their file in the folder
     Given using OCS API version "1"
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has shared folder "shared" with user "user1" with permissions 4
     When user "user1" uploads file "filesForUpload/textfile.txt" to "shared/textfile.txt" using the WebDAV API
     And user "user1" deletes file "/shared/textfile.txt" using the WebDAV API

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -11,14 +11,14 @@ Feature: sharing
 
   @smokeTest
   Scenario: Merging shares for recipient when shared from outside with group and member
-    Given user "user0" has created a folder "/merge-test-outside"
+    Given user "user0" has created folder "/merge-test-outside"
     When user "user0" shares folder "/merge-test-outside" with group "grp1" using the sharing API
     And user "user0" shares folder "/merge-test-outside" with user "user1" using the sharing API
     Then as "user1" folder "/merge-test-outside" should exist
     And as "user1" folder "/merge-test-outside (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
-    Given user "user0" has created a folder "/merge-test-outside-perms"
+    Given user "user0" has created folder "/merge-test-outside-perms"
     When user "user0" shares folder "/merge-test-outside-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the sharing API
     Then as user "user1" folder "/merge-test-outside-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
@@ -27,7 +27,7 @@ Feature: sharing
   Scenario: Merging shares for recipient when shared from outside with two groups
     Given group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    And user "user0" has created a folder "/merge-test-outside-twogroups"
+    And user "user0" has created folder "/merge-test-outside-twogroups"
     When user "user0" shares folder "/merge-test-outside-twogroups" with group "grp1" using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups" with group "grp4" using the sharing API
     Then as "user1" folder "/merge-test-outside-twogroups" should exist
@@ -36,7 +36,7 @@ Feature: sharing
   Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
     Given group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    And user "user0" has created a folder "/merge-test-outside-twogroups-perms"
+    And user "user0" has created folder "/merge-test-outside-twogroups-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp4" with permissions 31 using the sharing API
     Then as user "user1" folder "/merge-test-outside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
@@ -45,7 +45,7 @@ Feature: sharing
   Scenario: Merging shares for recipient when shared from outside with two groups and member
     Given group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    And user "user0" has created a folder "/merge-test-outside-twogroups-member-perms"
+    And user "user0" has created folder "/merge-test-outside-twogroups-member-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp4" with permissions 31 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the sharing API
@@ -53,7 +53,7 @@ Feature: sharing
     And as "user1" folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from inside with group
-    Given user "user1" has created a folder "/merge-test-inside-group"
+    Given user "user1" has created folder "/merge-test-inside-group"
     When user "user1" shares folder "/merge-test-inside-group" with group "grp1" using the sharing API
     Then as "user1" folder "/merge-test-inside-group" should exist
     And as "user1" folder "/merge-test-inside-group (2)" should not exist
@@ -61,7 +61,7 @@ Feature: sharing
   Scenario: Merging shares for recipient when shared from inside with two groups
     Given group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    And user "user1" has created a folder "/merge-test-inside-twogroups"
+    And user "user1" has created folder "/merge-test-inside-twogroups"
     When user "user1" shares folder "/merge-test-inside-twogroups" with group "grp1" using the sharing API
     And user "user1" shares folder "/merge-test-inside-twogroups" with group "grp4" using the sharing API
     Then as "user1" folder "/merge-test-inside-twogroups" should exist
@@ -71,7 +71,7 @@ Feature: sharing
   Scenario: Merging shares for recipient when shared from inside with group with less permissions
     Given group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    And user "user1" has created a folder "/merge-test-inside-twogroups-perms"
+    And user "user1" has created folder "/merge-test-inside-twogroups-perms"
     When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API
     And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp4" using the sharing API
     Then as user "user1" folder "/merge-test-inside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
@@ -80,7 +80,7 @@ Feature: sharing
 
   @skip @issue-29016 @skipOnLDAP
   Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
-    Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+    Given user "user0" has created folder "/merge-test-outside-groups-renamebeforesecondshare"
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
@@ -89,7 +89,7 @@ Feature: sharing
 
   @skipOnLDAP @user_ldap-issue-274
   Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
-    Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+    Given user "user0" has created folder "/merge-test-outside-groups-renamebeforesecondshare"
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -12,9 +12,9 @@ Feature: sharing
     Given group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
-    And user "user0" has created a folder "/TMP"
+    And user "user0" has created folder "/TMP"
     When user "user0" shares folder "TMP" with group "grp1" using the sharing API
-    And user "user1" creates a folder "/myFOLDER" using the WebDAV API
+    And user "user1" creates folder "/myFOLDER" using the WebDAV API
     And user "user1" moves folder "/TMP" to "/myFOLDER/myTMP" using the WebDAV API
     And the administrator deletes user "user2" using the provisioning API
     Then user "user1" should see the following elements
@@ -33,7 +33,7 @@ Feature: sharing
     Given user "user0" has uploaded file with content "foo" to "/sharefile.txt"
     And user "user0" has shared file "/sharefile.txt" with user "user1"
     And user "user0" has shared file "/sharefile.txt" with user "user2"
-    And user "user2" has created a folder "newfolder"
+    And user "user2" has created folder "newfolder"
     When user "user2" moves file "/sharefile.txt" to "/newfolder/sharefile.txt" using the WebDAV API
     Then as "user2" file "/newfolder/sharefile.txt" should exist
     And as "user0" file "/sharefile.txt" should exist

--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -49,7 +49,7 @@ Feature: sharing
   Scenario Outline: Do not allow reshare to exceed permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/TMP"
+    And user "user0" has created folder "/TMP"
     And user "user0" has created a share with settings
       | path        | /TMP  |
       | shareType   | 0     |
@@ -84,7 +84,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: resharing using a public link with read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 1
     When user "user1" creates a public link share using the sharing API with settings
       | path         | /test |
@@ -99,7 +99,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: resharing using a public link with read and write permissions only is not allowed
     Given using OCS API version "<ocs_api_version>"
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 15
     When user "user1" creates a public link share using the sharing API with settings
       | path         | /test |

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -11,7 +11,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/TMP"
+    And user "user0" has created folder "/TMP"
     And user "user0" has shared folder "TMP" with user "user1"
     And user "user1" has shared folder "TMP" with user "user2"
     When user "user1" updates the last share using the sharing API with
@@ -244,7 +244,7 @@ Feature: sharing
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 17
     And as user "user1"
     And the user has created a public link share with settings
@@ -276,9 +276,9 @@ Feature: sharing
   Scenario: Share ownership change after moving a shared file outside of an outer share
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/folder1"
-    And user "user0" has created a folder "/folder1/folder2"
-    And user "user1" has created a folder "/moved-out"
+    And user "user0" has created folder "/folder1"
+    And user "user0" has created folder "/folder1/folder2"
+    And user "user1" has created folder "/moved-out"
     And user "user0" has shared folder "/folder1" with user "user1" with permissions 31
     And user "user1" has shared folder "/folder1/folder2" with user "user2" with permissions 31
     When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the WebDAV API
@@ -303,9 +303,9 @@ Feature: sharing
   Scenario: Share ownership change after moving a shared file to another share
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And user "user0" has created a folder "/user0-folder"
-    And user "user0" has created a folder "/user0-folder/folder2"
-    And user "user2" has created a folder "/user2-folder"
+    And user "user0" has created folder "/user0-folder"
+    And user "user0" has created folder "/user0-folder/folder2"
+    And user "user2" has created folder "/user2-folder"
     And user "user0" has shared folder "/user0-folder" with user "user1" with permissions 31
     And user "user2" has shared folder "/user2-folder" with user "user1" with permissions 31
     When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the WebDAV API
@@ -331,7 +331,7 @@ Feature: sharing
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     And as user "user1"
     And the user has created a public link share with settings
@@ -351,7 +351,7 @@ Feature: sharing
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 17
     And as user "user1"
     And the user has created a public link share with settings
@@ -371,7 +371,7 @@ Feature: sharing
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     And as user "user1"
     And the user has created a public link share with settings

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -9,7 +9,7 @@ Feature: sharing
 
   @smokeTest
   Scenario: moving a file into a share as recipient
-    Given user "user0" has created a folder "/shared"
+    Given user "user0" has created folder "/shared"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the WebDAV API
     Then as "user1" file "/shared/shared_file.txt" should exist
@@ -17,7 +17,7 @@ Feature: sharing
 
   @smokeTest @files_trashbin-app-required
   Scenario: moving a file out of a share as recipient creates a backup for the owner
-    Given user "user0" has created a folder "/shared"
+    Given user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared file "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/shared_renamed"
@@ -28,8 +28,8 @@ Feature: sharing
 
   @files_trashbin-app-required
   Scenario: moving a folder out of a share as recipient creates a backup for the owner
-    Given user "user0" has created a folder "/shared"
-    And user "user0" has created a folder "/shared/sub"
+    Given user "user0" has created folder "/shared"
+    And user "user0" has created folder "/shared/sub"
     And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
     And user "user0" has shared file "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/shared_renamed"

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -21,8 +21,8 @@ Feature: sharing
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
-    And user "user0" has created a folder "/common"
-    And user "user0" has created a folder "/common/sub"
+    And user "user0" has created folder "/common"
+    And user "user0" has created folder "/common/sub"
     And user "user0" has shared folder "common" with group "grp1"
     And user "user1" has shared file "textfile0.txt" with user "user2"
     And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -110,7 +110,7 @@ Feature: sharing
 
   Scenario Outline: Correct webdav share-permissions for owned folder
     Given using <dav-path> DAV path
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     When user "user0" gets the following properties of folder "/" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
@@ -121,7 +121,7 @@ Feature: sharing
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions
     Given using <dav-path> DAV path
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | {http://open-collaboration-services.org/ns}share-permissions |
@@ -135,7 +135,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path      | tmp  |
       | shareType | 1    |
@@ -150,7 +150,7 @@ Feature: sharing
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but edit
     Given using <dav-path> DAV path
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 29 |
@@ -164,7 +164,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp  |
       | shareType   | 1    |
@@ -180,7 +180,7 @@ Feature: sharing
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but create
     Given using <dav-path> DAV path
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 27 |
@@ -194,7 +194,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp  |
       | shareType   | 1    |
@@ -210,7 +210,7 @@ Feature: sharing
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but delete
     Given using <dav-path> DAV path
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 23 |
@@ -224,7 +224,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp  |
       | shareType   | 1    |
@@ -240,7 +240,7 @@ Feature: sharing
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but share
     Given using <dav-path> DAV path
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 15 |
@@ -254,7 +254,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp  |
       | shareType   | 1    |

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -74,7 +74,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "user2" has been created with default attributes
     And user "user2" has been added to group "grp1"
-    And user "user2" has created a folder "/shared"
+    And user "user2" has created folder "/shared"
     And user "user2" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user2" has shared folder "/shared" with user "user1"
     And user "user1" has shared folder "/shared" with group "grp1"

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -23,7 +23,7 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: deleting a folder moves it to trashbin
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/tmp"
+    And user "user0" has created folder "/tmp"
     When user "user0" deletes folder "/tmp" using the WebDAV API
     Then as "user0" folder "/tmp" should exist in trash
     Examples:
@@ -34,7 +34,7 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: deleting a file in a folder moves it to the trashbin root
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/new-folder"
+    And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
@@ -49,7 +49,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
@@ -65,7 +65,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user0" deletes folder "/shared" using the WebDAV API
@@ -79,7 +79,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/renamed_shared"
@@ -94,7 +94,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved file "/shared" to "/renamed_shared"
@@ -109,8 +109,8 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/folderA"
-    And user "user0" has created a folder "/folderB"
+    And user "user0" has created folder "/folderA"
+    And user "user0" has created folder "/folderB"
     And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
     And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
     When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
@@ -127,8 +127,8 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/folderA"
-    And user "user0" has created a folder "/folderB"
+    And user "user0" has created folder "/folderA"
+    And user "user0" has created folder "/folderB"
     And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
     And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
     When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
@@ -149,7 +149,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
     Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -12,7 +12,7 @@ Feature: Restore deleted files/folders
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/shared"
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved file "/shared" to "/renamed_shared"
@@ -54,7 +54,7 @@ Feature: Restore deleted files/folders
   Scenario Outline: A file deleted from a folder can be restored to the original folder
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/new-folder"
+    And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
     And user "user0" has logged in to a web-style session
@@ -69,7 +69,7 @@ Feature: Restore deleted files/folders
   Scenario Outline: A file deleted from a folder is restored to root if the original folder does not exist
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/new-folder"
+    And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
     And user "user0" has deleted folder "/new-folder"
@@ -85,7 +85,7 @@ Feature: Restore deleted files/folders
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and restored
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/new-folder"
+    And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
     And user "user0" has deleted folder "/new-folder"
@@ -102,12 +102,12 @@ Feature: Restore deleted files/folders
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/new-folder"
+    And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
     And user "user0" has deleted folder "/new-folder"
     And user "user0" has logged in to a web-style session
-    When user "user0" creates a folder "/new-folder" using the WebDAV API
+    When user "user0" creates folder "/new-folder" using the WebDAV API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
     And as "user0" file "/new-folder/new-file.txt" should exist
@@ -123,7 +123,7 @@ Feature: Restore deleted files/folders
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
@@ -146,7 +146,7 @@ Feature: Restore deleted files/folders
     Given using old DAV path
     And the administrator has invoked occ command "files:scan --all"
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
@@ -163,7 +163,7 @@ Feature: Restore deleted files/folders
     Given using new DAV path
     And the administrator has invoked occ command "files:scan --all"
     And user "user0" has been created with default attributes
-    And user "user0" has created a folder "/local_storage/tmp"
+    And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has uploaded the following chunks to "/local_storage/tmp/textfile0.txt" with new chunking
       | 1 | AA |

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -20,8 +20,8 @@ Feature: delete folder
 
   Scenario Outline: delete a folder when 2 folder exist with different case
     Given using <dav_version> DAV path
-    And user "user0" creates a folder "/PARENT" using the WebDAV API
-    And user "user0" creates a folder "/parent" using the WebDAV API
+    And user "user0" creates folder "/PARENT" using the WebDAV API
+    And user "user0" creates folder "/parent" using the WebDAV API
     When user "user0" deletes folder "/PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "user0" folder "/PARENT" should not exist

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
@@ -11,7 +11,7 @@ Feature: delete folder contents
   Scenario Outline: Removing everything of a folder
     Given using <dav_version> DAV path
     And user "user0" has moved file "/welcome.txt" to "/FOLDER/welcome.txt"
-    And user "user0" has created a folder "/FOLDER/SUBFOLDER"
+    And user "user0" has created folder "/FOLDER/SUBFOLDER"
     And user "user0" has copied file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
     When user "user0" deletes everything from folder "/FOLDER/" using the WebDAV API
     Then user "user0" should see the following elements

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -6,9 +6,9 @@ Feature: Search
 
   Background:
     Given user "user0" has been created with default attributes
-    And user "user0" has created a folder "/just-a-folder"
-    And user "user0" has created a folder "/फनी näme"
-    And user "user0" has created a folder "/upload folder"
+    And user "user0" has created folder "/just-a-folder"
+    And user "user0" has created folder "/फनी näme"
+    And user "user0" has created folder "/upload folder"
     And user "user0" has uploaded file with content "does-not-matter" to "/upload.txt"
     And user "user0" has uploaded file with content "does-not-matter" to "/a-image.png"
     And user "user0" has uploaded file with content "does-not-matter" to "/just-a-folder/upload.txt"

--- a/tests/acceptance/features/apiWebdavOperations/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFile.feature
@@ -37,7 +37,7 @@ Feature: upload file
 
   Scenario Outline: upload a file into a folder and check download content
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "<folder_name>"
+    And user "user0" has created folder "<folder_name>"
     When user "user0" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the WebDAV API
     Then the content of file "<folder_name>/<file_name>" for user "user0" should be "uploaded content"
     Examples:

--- a/tests/acceptance/features/apiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/copyFile.feature
@@ -45,7 +45,7 @@ Feature: copy file
   Scenario Outline: Copying a file to a folder with no permissions
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And user "user1" has created a folder "/testshare"
+    And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
       | shareType   | 0         |
@@ -63,7 +63,7 @@ Feature: copy file
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And user "user1" has created a folder "/testshare"
+    And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
       | shareType   | 0         |

--- a/tests/acceptance/features/apiWebdavProperties/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/createFolder.feature
@@ -10,7 +10,7 @@ Feature: create folder
 
   Scenario Outline: create a folder
     Given using <dav_version> DAV path
-    When user "user0" creates a folder "<folder_name>" using the WebDAV API
+    When user "user0" creates folder "<folder_name>" using the WebDAV API
     Then as "user0" folder "<folder_name>" should exist
     Examples:
       | dav_version | folder_name     |
@@ -30,7 +30,7 @@ Feature: create folder
   @smokeTest
   Scenario Outline: Creating a folder
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/test_folder"
+    And user "user0" has created folder "/test_folder"
     When user "user0" gets the following properties of folder "/test_folder" using the WebDAV API
       | {DAV:}resourcetype |
     Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
@@ -41,7 +41,7 @@ Feature: create folder
 
   Scenario Outline: Creating a folder with special chars
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/test_folder:5"
+    And user "user0" has created folder "/test_folder:5"
     When user "user0" gets the following properties of folder "/test_folder:5" using the WebDAV API
       | {DAV:}resourcetype |
     Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
@@ -52,7 +52,7 @@ Feature: create folder
 
   Scenario Outline: Creating a directory which contains .part should not be possible
     Given using <dav_version> DAV path
-    When user "user0" creates a folder "/folder.with.ext.part" using the WebDAV API
+    When user "user0" creates folder "/folder.with.ext.part" using the WebDAV API
     Then the HTTP status code should be "400"
     And the DAV exception should be "OCA\DAV\Connector\Sabre\Exception\InvalidPath"
     And the DAV message should be "Can`t upload files with extension .part because these extensions are reserved for internal use."

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -39,7 +39,7 @@ Feature: get file properties
 
   Scenario Outline: Do a PROPFIND of various folder/file names
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "<folder_name>"
+    And user "user0" has created folder "<folder_name>"
     And user "user0" has uploaded file with content "uploaded content" to "<folder_name>/<file_name>"
     When user "user0" gets the properties of file "<folder_name>/<file_name>" using the WebDAV API
     Then the properties response should contain an etag
@@ -60,7 +60,7 @@ Feature: get file properties
 
   Scenario Outline: A file that is not shared does not have a share-types property
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
       | {http://owncloud.org/ns}share-types |
     Then the response should contain an empty property "{http://owncloud.org/ns}share-types"
@@ -72,7 +72,7 @@ Feature: get file properties
   Scenario Outline: A file that is shared to a user has a share-types property
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has created a share with settings
       | path        | test  |
       | shareType   | 0     |
@@ -90,7 +90,7 @@ Feature: get file properties
   Scenario Outline: A file that is shared to a group has a share-types property
     Given using <dav_version> DAV path
     And group "grp1" has been created
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has created a share with settings
       | path        | test |
       | shareType   | 1    |
@@ -108,7 +108,7 @@ Feature: get file properties
   @public_link_share-feature-required
   Scenario Outline: A file that is shared by link has a share-types property
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has created a public link share with settings
       | path        | test |
       | permissions | 31   |
@@ -126,7 +126,7 @@ Feature: get file properties
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
     And group "grp2" has been created
-    And user "user0" has created a folder "/test"
+    And user "user0" has created folder "/test"
     And user "user0" has created a share with settings
       | path        | test  |
       | shareType   | 0     |

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -32,7 +32,7 @@ Feature: get quota
     And user "user1" has been created with default attributes
     And user "user0" has been given unlimited quota
     And the quota of user "user1" has been set to "10 MB"
-    And user "user1" has created a folder "/testquota"
+    And user "user1" has created folder "/testquota"
     And user "user1" has created a share with settings
       | path        | testquota |
       | shareType   | 0         |

--- a/tests/acceptance/features/apiWebdavProperties/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/moveFile.feature
@@ -67,7 +67,7 @@ Feature: move (rename) file
   Scenario Outline: Moving a file to a folder with no permissions
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And user "user1" has created a folder "/testshare"
+    And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
       | shareType   | 0         |
@@ -85,7 +85,7 @@ Feature: move (rename) file
   Scenario Outline: Moving a file to overwrite a file in a folder with no permissions
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And user "user1" has created a folder "/testshare"
+    And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
       | shareType   | 0         |
@@ -142,13 +142,13 @@ Feature: move (rename) file
   Scenario Outline: Checking file id after a move between received shares
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And user "user0" has created a folder "/folderA"
-    And user "user0" has created a folder "/folderB"
+    And user "user0" has created folder "/folderA"
+    And user "user0" has created folder "/folderB"
     And user "user0" has shared folder "/folderA" with user "user1"
     And user "user0" has shared folder "/folderB" with user "user1"
-    And user "user1" has created a folder "/folderA/ONE"
+    And user "user1" has created folder "/folderA/ONE"
     And user "user1" has stored id of file "/folderA/ONE"
-    And user "user1" has created a folder "/folderA/ONE/TWO"
+    And user "user1" has created folder "/folderA/ONE/TWO"
     When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the WebDAV API
     Then as "user1" folder "/folderA" should exist
     And as "user1" folder "/folderA/ONE" should not exist

--- a/tests/acceptance/features/apiWebdavProperties/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavProperties/moveFileAsync.feature
@@ -85,7 +85,7 @@ Feature: move (rename) file
 
   Scenario: Moving a file to a folder with no permissions
     Given user "user1" has been created with default attributes
-    And user "user1" has created a folder "/testshare"
+    And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
       | shareType   | 0         |
@@ -103,7 +103,7 @@ Feature: move (rename) file
 
   Scenario: Moving a file to overwrite a file in a folder with no permissions
     Given user "user1" has been created with default attributes
-    And user "user1" has created a folder "/testshare"
+    And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
       | shareType   | 0         |
@@ -190,7 +190,7 @@ Feature: move (rename) file
     Given the administrator has enabled async operations
     And using <dav_version> DAV path
     And user "user1" has been created with default attributes
-    And user "user1" has created a folder "/testshare"
+    And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
       | shareType   | 0         |

--- a/tests/acceptance/features/apiWebdavProperties/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/moveFolder.feature
@@ -10,7 +10,7 @@ Feature: move (rename) folder
 
   Scenario Outline: Renaming a folder to a backslash encoded should return an error
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/testshare"
+    And user "user0" has created folder "/testshare"
     When user "user0" moves folder "/testshare" to "/%5C" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "user0" should see the following elements
@@ -22,7 +22,7 @@ Feature: move (rename) folder
 
   Scenario Outline: Renaming a folder beginning with a backslash encoded should return an error
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/testshare"
+    And user "user0" has created folder "/testshare"
     When user "user0" moves folder "/testshare" to "/%5Ctestshare" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "user0" should see the following elements
@@ -34,7 +34,7 @@ Feature: move (rename) folder
 
   Scenario Outline: Renaming a folder including a backslash encoded should return an error
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/testshare"
+    And user "user0" has created folder "/testshare"
     When user "user0" moves folder "/testshare" to "/hola%5Chola" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "user0" should see the following elements
@@ -46,7 +46,7 @@ Feature: move (rename) folder
 
   Scenario Outline: Renaming a folder into a banned name
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/testshare"
+    And user "user0" has created folder "/testshare"
     When user "user0" moves folder "/testshare" to "/.htaccess" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "user0" should see the following elements
@@ -58,7 +58,7 @@ Feature: move (rename) folder
 
   Scenario Outline: Move a folder into a not existing one
     Given using <dav_version> DAV path
-    And user "user0" has created a folder "/testshare"
+    And user "user0" has created folder "/testshare"
     When user "user0" moves folder "/testshare" to "/not-existing/testshare" using the WebDAV API
     Then the HTTP status code should be "409"
     And user "user0" should see the following elements

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2298,15 +2298,15 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user creates a folder :destination using the WebDAV API
-	 * @Given user :user has created a folder :destination
+	 * @When user :user creates folder :destination using the WebDAV API
+	 * @Given user :user has created folder :destination
 	 *
 	 * @param string $user
 	 * @param string $destination
 	 *
 	 * @return void
 	 */
-	public function userCreatesAFolder($user, $destination) {
+	public function userCreatesFolder($user, $destination) {
 		$destination = '/' . \ltrim($destination, '/');
 		$this->response = $this->makeDavRequest(
 			$user, "MKCOL", $destination, []
@@ -2315,15 +2315,15 @@ trait WebDav {
 	}
 
 	/**
-	 * @When the user creates a folder :destination using the WebDAV API
-	 * @Given the user has created a folder :destination
+	 * @When the user creates folder :destination using the WebDAV API
+	 * @Given the user has created folder :destination
 	 *
 	 * @param string $destination
 	 *
 	 * @return void
 	 */
-	public function theUserCreatesAFolder($destination) {
-		$this->userCreatesAFolder($this->getCurrentUser(), $destination);
+	public function theUserCreatesFolder($destination) {
+		$this->userCreatesFolder($this->getCurrentUser(), $destination);
 	}
 
 	/**

--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -23,8 +23,8 @@ Feature: Files Operations command
     Given using new DAV path
     And user "user0" has been created with default attributes
     And the administrator has set the external storage to be never scanned automatically
-    And user "user0" has created a folder "/local_storage/folder1"
-    And user "user0" has created a folder "/local_storage/folder2"
+    And user "user0" has created folder "/local_storage/folder1"
+    And user "user0" has created folder "/local_storage/folder2"
     # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
     And the administrator has scanned the filesystem for all users
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
@@ -52,7 +52,7 @@ Feature: Files Operations command
     And group "newgroup" has been created
     And user "user0" has been added to group "newgroup"
     And user "user1" has been added to group "newgroup"
-    And user "user0" has created a folder "/local_storage/folder1"
+    And user "user0" has created folder "/local_storage/folder1"
     And the administrator has set the external storage to be never scanned automatically
     And user "user0" has shared folder "/local_storage/folder1" with group "newgroup"
     And the administrator has scanned the filesystem for all users

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -39,9 +39,9 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users, accept one by one
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has created a folder "/simple-folder/from_user2"
+    And user "user2" has created folder "/simple-folder/from_user2"
     And user "user2" has shared folder "/simple-folder" with user "user3"
-    And user "user1" has created a folder "/simple-folder/from_user1"
+    And user "user1" has created folder "/simple-folder/from_user1"
     And user "user1" has shared folder "/simple-folder" with user "user3"
     And user "user3" has logged in using the webUI
     When the user accepts share "simple-folder" offered by user "User One" using the webUI


### PR DESCRIPTION
## Description
Remove the word ``a`` from ``creates a folder "abc"`` and ``has created a folder "abc"``

## Related Issue

## Motivation and Context
Consistent acceptance test steps.
We already have steps that say ``creates file "xyz.txt"`` and ``When user "user0" does something`` and ``adds user "user42" to group "grp1"`` - the words``a`` and ``the`` are not used in these cases.

I found a remaining inconsistent step with ``creates a folder "folder1"`` - to be consistent the word ``a`` should be removed.

This will make it easier when people are "guessing" the wording of acceptance test steps.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
