### PR TITLE
Use chunks of arrays to pass to SQL query instead of big list

### DIFF
--- a/tests/lib/SystemTag/SystemTagObjectMapperTest.php
+++ b/tests/lib/SystemTag/SystemTagObjectMapperTest.php
@@ -119,6 +119,28 @@ class SystemTagObjectMapperTest extends TestCase {
 		$query->delete(SystemTagManager::TAG_TABLE)->execute();
 	}
 
+	/**
+	 * Test large array of object ids by splitting into chunks
+	 */
+	public function testGetTagIdsForObjectsWithChunks() {
+		$systemTags = [];
+		$objIds = [];
+		$expectedTagIDs = [];
+		$systemTagManager = \OC::$server->getSystemTagManager();
+		$tagMapper = new SystemTagObjectMapper($this->connection, $systemTagManager, $this->dispatcher);
+
+		for ($i = 1; $i <= 1300; $i++) {
+			$tagName = 'testTag' . (string)$i;
+			$systemTags[] = $systemTagManager->createTag($tagName, true, true, true);
+			$tagMapper->assignTags((string)$i, 'chunktest', $systemTags[$i-1]->getId());
+			$objIds[] = (string)$i;
+			$expectedTagIDs[$i][] = (string)$systemTags[$i-1]->getId();
+		}
+
+		$tagIdMap = $tagMapper->getTagIdsForObjects($objIds, 'chunktest');
+		$this->assertEquals($expectedTagIDs, $tagIdMap);
+	}
+
 	public function testGetTagIdsForObjects() {
 		$tagIdMapping = $this->tagMapper->getTagIdsForObjects(
 			['1', '2', '3', '4'],


### PR DESCRIPTION
Use chunks of arrays to pass to SQL query instead of
passing huge list obtained.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
While passing lists to SQL `IN` statements its better to chunk the list into sublist ( or arrays to sub arrays ), and then pass to the query. This way we can get results without exception. An issue was found with oracle db, where the maximum number of expressions in a list supported by oracle is 1000. And without chunking lists if we pass to the SQL query, it would cause exception. A unit test is also added to support the chunking.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Chunk the list to sublists while passing to `IN` statement of SQL query. Else there are chances of execptiopn from the doctrine.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested using the unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
