### PR TITLE
[stable10] Skip Help and Tips open link test scenario

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
+++ b/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
@@ -18,7 +18,7 @@ Feature: Help and tips page
       | Theming                           |
       | Hardening and security guidance   |
 
-  @skipOnOcV11 @issue-33634
+  @skip @issue-33639 @skipOnOcV11 @issue-33634
   Scenario Outline: Admin can open links in help and tips page
     When the administrator opens the link for "<linkName>"
     Then the user should be redirected to a webUI page with the title "<pageTitle>"


### PR DESCRIPTION
## Description
Skip the Help & Tips test scenario that is causing CI fails.
What to do can be discussed in the issue.

## Related Issue
#33639 

## Motivation and Context
There are tests that check that the links on the Settings, Help & Tips page can actually open.
Those tests fail if the real docs site is down, being reorganised or...

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
