### PR TITLE
Enable phpcs for TestHelpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ test-php-lint: $(composer_dev_deps)
 .PHONY: test-php-style
 test-php-style: $(composer_dev_deps)
 	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --dry-run --allow-risky yes
-	$(composer_deps)/bin/phpcs --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance
+	$(composer_deps)/bin/phpcs --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance tests/TestHelpers
 	php build/OCPSinceChecker.php
 
 .PHONY: test-php-style-fix

--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -51,7 +51,6 @@ class EmailHelper {
 	/**
 	 *
 	 * @param string $localMailhogUrl
-	 *
 	 * @param string $address
 	 * @param int $waitTimeSec Time to wait for the email
 	 *

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -213,6 +213,7 @@ class LoggingHelper {
 	 * @param string $baseUrl
 	 * @param string $adminUsername
 	 * @param string $adminPassword
+	 *
 	 * @return void
 	 * @throws \Exception
 	 */

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -279,8 +279,7 @@ class SetupHelper {
 	 * @return string
 	 * @throws Exception
 	 */
-	private static function checkAdminUsername(
-		$adminUsername, $callerName) {
+	private static function checkAdminUsername($adminUsername, $callerName) {
 		if (self::$adminUsername === null
 			&& $adminUsername === null
 		) {
@@ -301,8 +300,7 @@ class SetupHelper {
 	 * @return string
 	 * @throws Exception
 	 */
-	private static function checkAdminPassword(
-		$adminPassword, $callerName) {
+	private static function checkAdminPassword($adminPassword, $callerName) {
 		if (self::$adminPassword === null
 			&& $adminPassword === null
 		) {
@@ -323,8 +321,7 @@ class SetupHelper {
 	 * @return string
 	 * @throws Exception
 	 */
-	private static function checkBaseUrl(
-		$baseUrl, $callerName) {
+	private static function checkBaseUrl($baseUrl, $callerName) {
 		if (self::$baseUrl === null
 			&& $baseUrl === null
 		) {

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -151,6 +151,7 @@ class TagsHelper {
 	 * @param string $name
 	 * @param bool $userVisible
 	 * @param bool $userAssignable
+	 * @param bool $userEditable
 	 * @param string $groups separated by "|"
 	 * @param int $davPathVersionToUse (1|2)
 	 *


### PR DESCRIPTION
## Description
``phpcs`` is already checking code and PHPdoc stuff in ``tests/acceptance``
Also check ``tests/TestHelpers`` because that code (should) also match that standard.

## Motivation and Context
Maintain code and PHPdoc quality.

## How Has This Been Tested?
Local run of ``make test-php-style``

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
