### PR TITLE
Add cascade delete to oc_persistent_locks

### DIFF
--- a/core/Migrations/Version20180607072706.php
+++ b/core/Migrations/Version20180607072706.php
@@ -66,8 +66,17 @@ class Version20180607072706 implements ISchemaMigration {
 
 		$table->setPrimaryKey(['id']);
 		$table->addUniqueIndex(['token_hash']);
-		$table->addForeignKeyConstraint("{$prefix}filecache", ['file_id'], ['fileid']);
-		$table->addForeignKeyConstraint("{$prefix}accounts", ['owner_account_id'], ['id']);
-		// TODO: cascade delete
+		$table->addForeignKeyConstraint(
+			"{$prefix}filecache",
+			['file_id'],
+			['fileid'],
+			['onDelete' => 'CASCADE']
+		);
+		$table->addForeignKeyConstraint(
+			"{$prefix}accounts",
+			['owner_account_id'],
+			['id'],
+			['onDelete' => 'CASCADE']
+		);
 	}
 }


### PR DESCRIPTION
## Description
Add cascade delete to oc_persistent_locks.
The foreign keyy were missing it.

## Related Issue
Fixes https://github.com/owncloud/core/issues/33769

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Ran unit test locally with MariaDB before and after the fix.
A unit test was added to validate that cascade delete is properly set and working on all DBs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
