### PR TITLE
[WIP] Alert user about db migration in the upgrade command

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -132,7 +132,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\SingleUser(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
 
-	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger()));
+	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger(), new \Symfony\Component\Console\Helper\QuestionHelper()));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
 		new \OC\Repair(\OC\Repair::getRepairSteps(), \OC::$server->getEventDispatcher()), \OC::$server->getConfig(),
 		\OC::$server->getEventDispatcher()));

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -295,8 +295,12 @@ class Updater extends BasicEmitter {
 	protected function doCoreUpgrade() {
 		$this->emit('\OC\Updater', 'dbUpgradeBefore');
 
+		$dispatcher = \OC::$server->getEventDispatcher();
+		$appEvent = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['appid' => 'core']);
+		$dispatcher->dispatch('before.app.migration', $appEvent);
+		$appEvent->stopPropagation();
 		// execute core migrations
-		if (\is_dir(\OC::$SERVERROOT."/core/Migrations")) {
+		if (\is_dir(\OC::$SERVERROOT."/core/Migrations") && !$appEvent->hasArgument('discontinue')) {
 			$ms = new \OC\DB\MigrationService('core', \OC::$server->getDatabaseConnection());
 			$ms->migrate();
 		}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -969,7 +969,14 @@ class OC_App {
 		}
 		$appData = self::getAppInfo($appId);
 		self::executeRepairSteps($appId, $appData['repair-steps']['pre-migration']);
+		$dispatcher = \OC::$server->getEventDispatcher();
+		$appEvent = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['appid' => $appId]);
 		if (isset($appData['use-migrations']) && $appData['use-migrations'] === 'true') {
+			$dispatcher->dispatch('before.app.migration', $appEvent);
+			$appEvent->stopPropagation();
+			if ($appEvent->hasArgument('discontinue') && ($appEvent->getArgument('discontinue') === 'true')) {
+				return true;
+			}
 			$ms = new \OC\DB\MigrationService($appId, \OC::$server->getDatabaseConnection());
 			$ms->migrate();
 		} else {


### PR DESCRIPTION
When oc instance is upgraded using upgrade command
allow users to know when db migration is going to
be applied, by prompting "yes/no" in the command
line.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When user tries to upgrade the oc instance, it would be nice to share the information that migration is going to be applied. This change set brings an option to the `upgrade` command. When this option is passed to the command, for db migrations of core and apps, question is prompt in the command line. If user provides `yes`, the migrations are applied. If  `no` is provided, no migration is applied.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/33541

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change brings an additional option to the upgrade command. When passed the option, it will allow the user to know when db migration is being applied. User could provide `yes/no` to the query.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
