### PR TITLE
[acceptance tests] correct usage of TableNode

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1497,6 +1497,8 @@ trait WebDav {
 	 * @param int|null $limit
 	 *
 	 * @return array
+	 *
+	 * TODO: move into Helper
 	 */
 	public function reportFolder(
 		$user, $path, $properties, $filterRules, $offset = null, $limit = null
@@ -2766,13 +2768,13 @@ trait WebDav {
 	 *
 	 * @param string $user
 	 * @param string $folder
-	 * @param TableNode|null $expectedElements
+	 * @param TableNode $expectedElements
 	 *
 	 * @return void
 	 */
 	public function checkFavoritedElements($user, $folder, $expectedElements) {
 		$this->checkFavoritedElementsPaginated(
-			$user, $folder, $expectedElements, null, null
+			$user, $folder, null, null, $expectedElements
 		);
 	}
 
@@ -2780,13 +2782,13 @@ trait WebDav {
 	 * @Then /^the user in folder "([^"]*)" should have favorited the following elements$/
 	 *
 	 * @param string $folder
-	 * @param TableNode|null $expectedElements
+	 * @param TableNode $expectedElements
 	 *
 	 * @return void
 	 */
 	public function checkFavoritedElementsForCurrentUser($folder, $expectedElements) {
 		$this->checkFavoritedElementsPaginated(
-			$this->getCurrentUser(), $folder, $expectedElements, null, null
+			$this->getCurrentUser(), $folder, null, null, $expectedElements
 		);
 	}
 
@@ -2795,14 +2797,14 @@ trait WebDav {
 	 *
 	 * @param string $user
 	 * @param string $folder
-	 * @param TableNode|null $expectedElements
 	 * @param int $offset unused
 	 * @param int $limit unused
+	 * @param TableNode $expectedElements
 	 *
 	 * @return void
 	 */
 	public function checkFavoritedElementsPaginated(
-		$user, $folder, $expectedElements, $offset, $limit
+		$user, $folder, $offset, $limit, $expectedElements
 	) {
 		$elementList = $this->reportFolder(
 			$user,
@@ -2828,17 +2830,17 @@ trait WebDav {
 	 * @Then /^the user in folder "([^"]*)" should have favorited the following elements from offset ([\d*]) and limit ([\d*])$/
 	 *
 	 * @param string $folder
-	 * @param TableNode|null $expectedElements
 	 * @param int $offset unused
 	 * @param int $limit unused
+	 * @param TableNode $expectedElements
 	 *
 	 * @return void
 	 */
 	public function checkFavoritedElementsPaginatedForCurrentUser(
-		$folder, $expectedElements, $offset, $limit
+		$folder, $offset, $limit, $expectedElements
 	) {
 		$this->checkFavoritedElementsPaginated(
-			$this->getCurrentUser(), $folder, $expectedElements, $offset, $limit
+			$this->getCurrentUser(), $folder, $offset, $limit, $expectedElements
 		);
 	}
 


### PR DESCRIPTION
## Description
TableNode was taken from the wrong element in the regex, it has to be the last element of the function

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
