### PR TITLE
[stable10] [acceptance tests] remember user init-time as upload time 

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1096,6 +1096,7 @@ trait Provisioning {
 		$url = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user";
 		HttpRequestHelper::get($url, $user, $password);
+		$this->lastUploadTime = \time();
 	}
 
 	/**


### PR DESCRIPTION
backport of #33805