### PR TITLE
Revert "merge teststeps"

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
@@ -121,4 +121,13 @@ Feature: upload file using new chunking
       | file-name |
       | &#?       |
       | TIÄFÜ     |
-      | 0         |
+
+	#this test should be integrated into the previous Scenario after fixing the issue
+  Scenario: Upload a file called "0" using new chunking
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "/0" using the WebDAV API
+    And as "user0" file "/0" should exist
+    And the content of file "/0" for user "user0" should be "AAAAABBBBBCCCCC"


### PR DESCRIPTION
Reverts owncloud/core#33680

Scenario: Upload a file called "0" using new chunking is a bug in core ``10.0.10``

So we do not want it to end up in the ``smokeTest`` scenario outline examples, because then it may get run against an "old" ``10.010`` system, and of course it will fail.

We cannot tag individual rows of an example table. So it can't be "fixed" in place.

After reverting this, we need to sort out how to tag this scenario appropriately, e.g. ``skipOnOcV10.0.10``