### PR TITLE
Fix conflict resolution of uploadFileWithHeaders

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1702,6 +1702,7 @@ trait WebDav {
 		}
 		try {
 			$this->responseXml = [];
+			$this->pauseUpload();
 			$this->response = UploadHelper::upload(
 				$this->getBaseUrl(),
 				$this->getActualUsername($user),
@@ -1713,6 +1714,7 @@ trait WebDav {
 				$chunkingVersion,
 				$noOfChunks
 			);
+			$this->lastUploadTime = \time();
 		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
@@ -1763,7 +1765,8 @@ trait WebDav {
 			$user,
 			$this->acceptanceTestsDirLocation() . $source,
 			$destination,
-			$headers
+			$headers,
+			$noOfChunks
 		);
 	}
 


### PR DESCRIPTION
## Description
- pass ``$noOfChunks`` to ``uploadFileWithHeaders()``
- add in the code related to ``pauseUpload()``

## Motivation and Context
Conflict resolution in #33784 missed changes that happened at a similar time for upload timing issues - adding ``pauseUpload()`` #33795 

Also the new call to ``uploadFileWithHeaders()`` needs to pass ``$noOfChunks``

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
