### PR TITLE
Use parenthesis for lock owner

### DIFF
--- a/lib/private/Lock/Persistent/LockManager.php
+++ b/lib/private/Lock/Persistent/LockManager.php
@@ -60,7 +60,7 @@ class LockManager {
 			if ($user !== null) {
 				$owner = $user->getDisplayName();
 				if ($user->getEMailAddress() !== null) {
-					$owner .= " <{$user->getEMailAddress()}>";
+					$owner .= " ({$user->getEMailAddress()})";
 				}
 			}
 		}

--- a/tests/lib/Lock/Persistent/LockManagerTest.php
+++ b/tests/lib/Lock/Persistent/LockManagerTest.php
@@ -93,7 +93,7 @@ class LockManagerTest extends TestCase {
 				$this->assertNull($lock->getPath());
 				$this->assertEquals(0, $lock->getDepth());
 				$this->assertEquals(ILock::LOCK_SCOPE_EXCLUSIVE, $lock->getScope());
-				$this->assertEquals('Alice <alice@example.net>', $lock->getOwner());
+				$this->assertEquals('Alice (alice@example.net)', $lock->getOwner());
 				$this->assertEquals(999, $lock->getOwnerAccountId());
 				$this->assertEquals(123456, $lock->getCreatedAt());
 			});


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bypasses Sabre serializer issue with lock owner


## Related Issue
- Fixes https://github.com/owncloud/core/issues/33822

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test with this PR and https://github.com/owncloud/core/pull/32250

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
