### PR TITLE
skipOnOcV10.0 filename chunking scenario for filename 0

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
@@ -122,7 +122,9 @@ Feature: upload file using new chunking
       | &#?       |
       | TIÄFÜ     |
 
-	#this test should be integrated into the previous Scenario after fixing the issue
+  # The bug for this scenario was fixed by https://github.com/owncloud/core/pull/33276
+  # The fix is released in 10.1 - all 10.0.* versions will fail this scenario
+  @skipOnOcV10.0
   Scenario: Upload a file called "0" using new chunking
     When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
     And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API


### PR DESCRIPTION
## Description
Test  Scenario: Upload a file called "0" using new chunking is only fixed for ownCloud 10.1 or later.

Tag the scenario to be skipped on any 10.0.* system. This will prevent it accidentally being run when the target system is running 10.0.*

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
