### PR TITLE
Bypass apps blocking for daily/git channel

### DIFF
--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -205,7 +205,7 @@ class Apps implements IRepairStep {
 		}
 
 		$hasBlockingMissingApps = \count($failedMissingApps);
-		$hasBlockingIncompatibleApps = \count($failedIncompatibleApps);
+		$hasBlockingIncompatibleApps = $this->hasBlockingIncompatibleApps($failedIncompatibleApps);
 
 		if ($hasBlockingIncompatibleApps || $hasBlockingMissingApps) {
 			// fail
@@ -310,6 +310,17 @@ class Apps implements IRepairStep {
 			$appList
 		);
 		return "\n" . \implode("\n", $appList);
+	}
+
+	/**
+	 * @param string[] $failedIncompatibleApps
+	 *
+	 * @return bool
+	 */
+	protected function hasBlockingIncompatibleApps($failedIncompatibleApps) {
+		$skipBlockingAppsCheck = \in_array(Util::getChannel(), ['git', 'daily'], true);
+		$hasBlockingIncompatibleApps = $skipBlockingAppsCheck === false && \count($failedIncompatibleApps);
+		return $hasBlockingIncompatibleApps;
 	}
 
 	/**

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -79,6 +79,33 @@ class AppsTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->repair, 'requiresMarketEnable'));
 	}
 
+	public function dataTestHasBlockingIncompatibleApps() {
+		return [
+			['git', [], false],
+			['daily', [], false],
+			['stable', [], false],
+			['git', ['someapp'], false],
+			['daily', ['someapp'], false],
+			['stable', ['someapp'], true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestHasBlockingIncompatibleApps
+	 * @param string $channel
+	 * @param string[] $blockingApps
+	 * @param bool $expectedResult
+	 */
+	public function testHasBlockingIncompatibleApps($channel, $blockingApps, $expectedResult) {
+		$oldChannel = \OCP\Util::getChannel();
+		\OCP\Util::setChannel($channel);
+		$this->assertEquals(
+			$expectedResult,
+			$this->invokePrivate($this->repair, 'hasBlockingIncompatibleApps', [$blockingApps])
+		);
+		\OCP\Util::setChannel($oldChannel);
+	}
+
 	public function dataTestUpdateEvent() {
 		return [
 			['10.1.0.0', [10, 1, 3, 7], false, false], // same major version


### PR DESCRIPTION
## Description
As agreed in #33360, we skip max-version check for the git and daily channel on install.
We should also do so when running occ upgrade and any related operations.

## Related Issue

- Fixes https://github.com/owncloud/core/issues/33819

## Motivation and Context


## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
