### PR TITLE
[stable10] Backport of Update activity listener for static tags

### DIFF
--- a/apps/systemtags/lib/Activity/Extension.php
+++ b/apps/systemtags/lib/Activity/Extension.php
@@ -327,6 +327,8 @@ class Extension implements IExtension {
 					return '<parameter>' . $l->t('%s (restricted)', $matches[1]) . '</parameter>';
 				case 'invisible':
 					return '<parameter>' . $l->t('%s (invisible)', $matches[1]) . '</parameter>';
+				case 'not-editable':
+					return '<parameter>' . $l->t('%s (static)', $matches[1]) . '</parameter>';
 			}
 		}
 

--- a/apps/systemtags/lib/Activity/Listener.php
+++ b/apps/systemtags/lib/Activity/Listener.php
@@ -221,6 +221,8 @@ class Listener {
 			return '{{{' . $tag->getName() . '|||invisible}}}';
 		} elseif (!$tag->isUserAssignable()) {
 			return '{{{' . $tag->getName() . '|||not-assignable}}}';
+		} elseif (!$tag->isUserEditable() && $tag->isUserAssignable()) {
+			return '{{{' . $tag->getName() . '|||not-editable}}}';
 		} else {
 			return '{{{' . $tag->getName() . '|||assignable}}}';
 		}

--- a/apps/systemtags/tests/ExtensionTest.php
+++ b/apps/systemtags/tests/ExtensionTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\SystemTags\Tests;
+
+use OCA\SystemTags\Activity\Extension;
+use OCP\Activity\IManager;
+use OCP\L10N\IFactory;
+use Test\TestCase;
+
+/**
+ * Class ExtensionTest
+ *
+ * @package OCA\SystemTags\Tests
+ * @group DB
+ */
+class ExtensionTest extends TestCase {
+	/** @var IFactory */
+	private $languageFactory;
+
+	/** @var IManager */
+	private $activityManager;
+
+	/** @var Extension */
+	private $extension;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->languageFactory = $this->createMock(IFactory::class);
+		$this->activityManager = $this->createMock(IManager::class);
+
+		$this->extension = new Extension($this->languageFactory, $this->activityManager);
+	}
+
+	public function providesParameterToTag() {
+		return [
+			["<parameter>{{{staticTag|||not-editable}}}</parameter>", "<parameter>staticTag (static)</parameter>"],
+			["<parameter>{{{visibleTag|||assignable}}}</parameter>", "<parameter>visibleTag</parameter>"],
+			["<parameter>{{{restrictTag|||not-assignable}}}</parameter>", "<parameter>restrictTag (restricted)</parameter>"],
+			["<parameter>{{{invisibleTag|||invisible}}}</parameter>", "<parameter>invisibleTag (invisible)</parameter>"],
+			["<parameter>{{{unknownTag|||unknown}}</parameter>", "<parameter>{{{unknownTag|||unknown}}</parameter>"]
+		];
+	}
+
+	/**
+	 * @dataProvider providesParameterToTag
+	 */
+	public function testConvertParameterToTag($parameter, $expectedResult) {
+		$l10n = \OC::$server->getL10N('systemtag');
+		$result = $this->invokePrivate($this->extension, 'convertParameterToTag', [$parameter, $l10n]);
+		$this->assertEquals($result, $expectedResult);
+	}
+}

--- a/apps/systemtags/tests/ListenerTest.php
+++ b/apps/systemtags/tests/ListenerTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\SystemTags\Tests;
+
+use OC\SystemTag\SystemTag;
+use OCA\SystemTags\Activity\Listener;
+use OCP\Activity\IManager;
+use OCP\App\IAppManager;
+use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\IRootFolder;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use OCP\SystemTag\ISystemTagManager;
+use Test\TestCase;
+
+class ListenerTest extends TestCase {
+	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $groupManager;
+	/** @var IManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $activityManager;
+	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	private $userSession;
+	/** @var ISystemTagManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $tagManager;
+	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $appManager;
+	/** @var IMountProviderCollection | \PHPUnit_Framework_MockObject_MockObject */
+	private $mountCollection;
+	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	private $rootFolder;
+	/** @var Listener */
+	private $listener;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->activityManager = $this->createMock(IManager::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->tagManager = $this->createMock(ISystemTagManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->mountCollection = $this->createMock(IMountProviderCollection::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->listener = new Listener($this->groupManager, $this->activityManager,
+			$this->userSession, $this->tagManager, $this->appManager,
+			$this->mountCollection, $this->rootFolder);
+	}
+
+	public function prepareTagAsParameterProvider() {
+		return [
+			[new SystemTag('1', 'visibleTag', true, true, true), "{{{visibleTag|||assignable}}}"],
+			[new SystemTag('2', 'invisibleTag', false, false, false), "{{{invisibleTag|||invisible}}}"],
+			[new SystemTag('3', 'restrictTag', true, false, false), "{{{restrictTag|||not-assignable}}}"],
+			[new SystemTag('3', 'staticTag', true, true, false), "{{{staticTag|||not-editable}}}"],
+		];
+	}
+
+	/**
+	 * @dataProvider prepareTagAsParameterProvider
+	 */
+	public function testPrepareTagAsParameter(SystemTag $tag, $expectedResult) {
+		$result = $this->invokePrivate($this->listener, 'prepareTagAsParameter', [$tag]);
+		$this->assertEquals($expectedResult, $result);
+	}
+}


### PR DESCRIPTION
Update activity listener for static tags

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add static tags to the activity listeners. Creation, updation activity of the static tags should be seen in the activity app, just like other tags: restricted, visible and invisible.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add static tags to the activity listener.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Tested in the UI as shown: 
![gifrecord_2018-12-12_112539](https://user-images.githubusercontent.com/3600427/49849849-5805d600-fe01-11e8-964e-00bf5bd94101.gif)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
