### PR TITLE
[acceptance tests] do not use deprecated function

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -63,7 +63,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	private function getLoginSuccessPageTitle() {
 		// When the login succeeds, we end up on the Files page
-		return "Files - " . $this->webUIGeneralContext->getProductName();
+		return "Files - " . $this->featureContext->getProductNameFromStatus();
 	}
 
 	/**
@@ -72,7 +72,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	private function getLoginFailedPageTitle() {
 		// When the login fails, we end up at a page with a title that is the
 		// themed product name, e.g. "ownCloud"
-		return $this->webUIGeneralContext->getProductName();
+		return $this->featureContext->getProductNameFromStatus();
 	}
 
 	/**


### PR DESCRIPTION
## Description
`getProductName()` does not exist any-more 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #33871

## Motivation and Context
function was deleted in #33797 but this usages were forgotten 

## How Has This Been Tested?
run user_ldap tests that use the function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
