### PR TITLE
Add webUI acceptance tests for checking set and delete profile pic (avatar)

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -244,6 +244,71 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
+	 * @When the user sets profile picture to :filename from their cloud files using the webUI
+	 *
+	 * @param string $filename
+	 *
+	 * @return void
+	 */
+	public function theUserSetsProfilePictureToFromTheirCloudFiles($filename) {
+		$this->personalGeneralSettingsPage->setProfilePicture($filename, $this->getSession());
+	}
+
+	/**
+	 * @Given the user has set profile picture to :filename from their cloud files
+	 *
+	 * @param string $filename
+	 *
+	 * @return void
+	 */
+	public function theUserHasSetProfilePictureToFromTheirCloudFiles($filename) {
+		$this->theUserSetsProfilePictureToFromTheirCloudFiles($filename);
+		$this->thePreviewOfTheProfilePictureShouldBeShownInTheWebui("");
+	}
+
+	/**
+	 * @Then /^the preview of the profile picture should (not|)\s?be shown in the webUI$/
+	 *
+	 * @param string $shouldOrNot
+	 *
+	 * @return void
+	 */
+	public function thePreviewOfTheProfilePictureShouldBeShownInTheWebui($shouldOrNot) {
+		if ($shouldOrNot !== "not") {
+			PHPUnit_Framework_Assert::assertTrue(
+				$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
+			);
+		} else {
+			PHPUnit_Framework_Assert::assertFalse(
+				$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
+			);
+		}
+	}
+
+	/**
+	 * @When the user deletes the existing profile picture
+	 *
+	 * @return void
+	 */
+	public function theUserDeletesTheExistingProfilePicture() {
+		if ($this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()) {
+			$this->personalGeneralSettingsPage->deleteProfilePicture($this->getSession());
+		}
+	}
+
+	/**
+	 * @Given the user has deleted any existing profile picture
+	 *
+	 * @return void
+	 */
+	public function theUserHasDeletedAnyExistingProfilePicture() {
+		$this->theUserDeletesTheExistingProfilePicture();
+		PHPUnit_Framework_Assert::assertFalse(
+			$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
+		);
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -50,6 +50,14 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	protected $federatedCloudIDXpath = "//*[@id='fileSharingSettings']/p/strong";
 	protected $groupListXpath = "//div[@id='OC\\Settings\\Panels\\Personal\\Profile']/div[@id='groups']";
 
+	protected $setProfilePicFromFilesBtnXpath = "//*[@id='selectavatar']";
+	protected $setProfilePicFileListXpath = "//*[@id='oc-dialog-filepicker-content']//ul[@class='filelist']";
+	protected $fileListElementMatchXpath = "//li[@data-entryname='%s']";
+	protected $setProfilePicChooseFileBtnXpath = "//*[@class='oc-dialog-buttonrow onebutton']//button";
+	protected $setProfilePicBtnXpath = "//*[@id='sendcropperbutton']";
+	protected $profilePicPreviewXpath = "//*[@id='displayavatar']/div[@class='avatardiv']/img";
+	protected $profilePicDeleteBtnXpath = "//*[@id='removeavatar']";
+
 	/**
 	 * @param string $language
 	 *
@@ -187,5 +195,93 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Set profile Pic from uploaded images using the webUI
+	 *
+	 * @param string $fileName
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function setProfilePicture($fileName, Session $session) {
+		$this->waitTillElementIsNotNull($this->setProfilePicFromFilesBtnXpath);
+		$profilePicBtn = $this->find('xpath', $this->setProfilePicFromFilesBtnXpath);
+		$this->assertElementNotNull(
+			$profilePicBtn,
+			__METHOD__ . " Profile Picture Button not found"
+		);
+		$profilePicBtn->focus();
+		$profilePicBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+
+		$this->waitTillElementIsNotNull(
+			$this->setProfilePicFileListXpath .
+			\sprintf(
+				$this->fileListElementMatchXpath,
+				$fileName
+			)
+		);
+		$file = $this->find(
+			'xpath',
+			$this->setProfilePicFileListXpath .
+			\sprintf($this->fileListElementMatchXpath, $fileName)
+		);
+		$this->assertElementNotNull(
+			$file,
+			__METHOD__ . " the file with name $fileName not found"
+		);
+		$file->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+
+		$chooseBtn = $this->find('xpath', $this->setProfilePicChooseFileBtnXpath);
+		$this->assertElementNotNull(
+			$chooseBtn,
+			__METHOD__ . " The button to choose profile picture was not found"
+		);
+		$chooseBtn->focus();
+		$chooseBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+
+		$setBtn = $this->find('xpath', $this->setProfilePicBtnXpath);
+		$this->assertElementNotNull(
+			$setBtn,
+			__METHOD__ . " The button to set profile picture was not found"
+		);
+		$setBtn->focus();
+		$setBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * Check if the preview of the profile pic is shown in the webui
+	 *
+	 * @return void
+	 */
+	public function isProfilePicturePreviewDisplayed() {
+		$profilePicPreview = $this->find('xpath', $this->profilePicPreviewXpath);
+		if ($profilePicPreview === null) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Delete the current profile pic
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteProfilePicture(Session $session) {
+		$deleteBtn = $this->find('xpath', $this->profilePicDeleteBtnXpath);
+		$this->assertElementNotNull(
+			$deleteBtn,
+			__METHOD__ . " Profile Picture delete Button not found"
+		);
+		$deleteBtn->focus();
+		$deleteBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 }

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -45,3 +45,13 @@ Feature: personal general settings
     And the federated cloud id for user "user1" should be displayed on the personal general settings page in the webUI
     And group "new-group" should be displayed on the personal general settings page in the webUI
     And group "another-group" should be displayed on the personal general settings page in the webUI
+
+  Scenario: User sets profile picture from their existing cloud file
+    Given the user has deleted any existing profile picture
+    When the user sets profile picture to "testimage.jpg" from their cloud files using the webUI
+    Then the preview of the profile picture should be shown in the webUI
+
+  Scenario: User deletes the existing profile picture
+    Given the user has set profile picture to "testimage.jpg" from their cloud files
+    When the user deletes the existing profile picture
+    Then the preview of the profile picture should not be shown in the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add webui test for checking profile picture
1. Set profile picture from uploaded files
2. Delete existing profile picture 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to #32850

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
