### PR TITLE
[stable10] Backport of Use 'Public link' instead of file name in the …

### DIFF
--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -131,9 +131,7 @@
 
 		_generateName: function() {
 			var index = 1;
-			var baseName = t('core', '{fileName} link', {
-				fileName: this.fileInfoModel.get('name')
-			}, null, {escape: false});
+			var baseName = t('core', 'Public link', null, {escape: false});
 			var name = baseName;
 
 			while (this.collection.findWhere({name: name})) {

--- a/core/js/tests/specs/sharedialoglinklistviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinklistviewSpec.js
@@ -138,7 +138,7 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 			defaultDateStub.returns('2017-03-03');
 			var popup = showPopup();
 			expect(popup.model.toJSON()).toEqual({
-				name: 'shared_file_name.txt link',
+				name: 'Public link',
 				password: '',
 				permissions: OC.PERMISSION_READ,
 				expireDate: '2017-03-03',
@@ -153,13 +153,13 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 		it('deduplicates default link name', function() {
 			view.collection.set([{
 				id: 1,
-				name: 'shared_file_name.txt link'
+				name: 'Public link'
 			}, {
 				id: 2,
-				name: 'shared_file_name.txt link (2)'
+				name: 'Public link (2)'
 			}]);
 			var popup = showPopup();
-			expect(popup.model.get('name')).toEqual('shared_file_name.txt link (3)');
+			expect(popup.model.get('name')).toEqual('Public link (3)');
 		});
 		it('adds model to collection and rerender after saving', function() {
 			var popup = showPopup();

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -84,13 +84,6 @@ Feature: Share by public link
     And the public tries to access the last created public link with wrong password "pass12" using the webUI
     Then the public should not get access to the publicly shared file
 
-  Scenario: user tries to create a public link with name longer than 64 chars
-    Given user "user1" has moved file "/lorem.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
-    And the user has reloaded the current page of the webUI
-    When the user tries to create a new public link for file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI
-    Then the user should see an error message on the public link share dialog saying "Share name cannot be more than 64 characters"
-    And the public link should not have been generated
-
   Scenario: user shares a public link with folder longer than 64 chars and shorter link name
     Given user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And the user has reloaded the current page of the webUI
@@ -228,7 +221,7 @@ Feature: Share by public link
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | email   | foo1234@bar.co|
       | password| pass123       |
-    When the user opens the edit public link share popup for the link named "simple-folder link"
+    When the user opens the edit public link share popup for the link named "Public link"
     And the user enters the password "qwertyui" on the edit public link share popup for the link
     And the user does not save any changes in the edit public link share popup
     And the public tries to access the last created public link with wrong password "qwertyui" using the webUI
@@ -253,7 +246,7 @@ Feature: Share by public link
   Scenario: user edits a name of an already existing public link
     Given the user has created a new public link for folder "simple-folder" using the webUI
     And the user has opened the public link share tab
-    When the user renames the public link name from "simple-folder link" to "simple-folder Share"
+    When the user renames the public link name from "Public link" to "simple-folder Share"
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
@@ -267,21 +260,21 @@ Feature: Share by public link
   Scenario: user edits the password of an already existing public link
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
-    When the user changes the password of the public link named "simple-folder link" to "pass1234"
+    When the user changes the password of the public link named "Public link" to "pass1234"
     And the public accesses the last created public link with password "pass1234" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link and tries to access with old password
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
-    When the user changes the password of the public link named "simple-folder link" to "pass1234"
+    When the user changes the password of the public link named "Public link" to "pass1234"
     And the public tries to access the last created public link with wrong password "pass123" using the webUI
     Then the public should not get access to the publicly shared file
 
   Scenario: user edits the permission of an already existing public link from read-write to read
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
-    When the user changes the permission of the public link named "simple-folder link" to "read"
+    When the user changes the permission of the public link named "Public link" to "read"
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And it should not be possible to delete file "lorem.txt" using the webUI
@@ -289,7 +282,7 @@ Feature: Share by public link
   Scenario: user edits the permission of an already existing public link from read to read-write
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read |
-    When the user changes the permission of the public link named "simple-folder link" to "read-write"
+    When the user changes the permission of the public link named "Public link" to "read-write"
     And the public accesses the last created public link using the webUI
     And the user deletes the following elements using the webUI
       | name                                  |


### PR DESCRIPTION
…dialog

Use 'Public link' instead of file name while
creating public links. The dialog window opens
up with 'Public link' for the first link for
the file, 'Public link (2)' for second link of
file and so on.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Using file names in the public link share dialog window as `Link name` was causing issue when the file name is large. Especially when the file name size is more than 64 characters. This change set tries to set the `Link name` to `Public link` for the first link created for the file. For the next link created for the same file it would be `Public link (2)` and so on. For new files again the same pattern follows.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is to fix the issue caused with `Link name` length limitation. The solution used here is to use `Public link` instead of file name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The test done as per https://github.com/owncloud/core/pull/33872. Also I here is the screenshot :



## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
