### PR TITLE
fix invalid test step

### DIFF
--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -301,7 +301,7 @@ Feature: sharing
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
     And user "user1" has been created with default attributes
-    And user "user0" creates a folder "/READ_ONLY" using the WebDAV API
+    And user "user0" creates folder "/READ_ONLY" using the WebDAV API
     And user "user0" has created a share with settings
       | path        | /READ_ONLY |
       | shareType   | user       |


### PR DESCRIPTION
that was introduced by https://github.com/owncloud/core/pull/33734/files#diff-ec180067294622fa5caf79bc2f9222c6

It happened because that PR passed CI some time ago, and acceptance test step text has been refactored since then.

Note: backport of that PR is still in progress. The fix here will be forced to happen in the backport PR #33640  