### PR TITLE
[stable10] Relax AppsListTest::testCommandInput - necessary to pass update testing

### DIFF
--- a/tests/Core/Command/Apps/AppsListTest.php
+++ b/tests/Core/Command/Apps/AppsListTest.php
@@ -57,7 +57,7 @@ class AppsListTest extends TestCase {
 
 	public function providesAppIds() {
 		return [
-			[[], '- files: 1.5.2'],
+			[[], '- files: 1.5'],
 			[['--shipped' => 'true'], '- dav: 0.4.0'],
 			[['--shipped' => 'false'], '- testing:'],
 			[['search-pattern' => 'dav'], '- dav: 0.4.0']


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/33253 to stable10

For https://github.com/owncloud/update-testing/pull/16