### PR TITLE
Bump phpstan 0.10.3=>0.10.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ $(PHAN_BIN):
 	cd build && curl -s -L https://github.com/phan/phan/releases/download/0.12.10/phan.phar -o phan.phar;
 
 $(PHPSTAN_BIN):
-	cd build && curl -s -L https://github.com/phpstan/phpstan/releases/download/0.10.3/phpstan.phar -o phpstan.phar;
+	cd build && curl -s -L https://github.com/phpstan/phpstan/releases/download/0.10.6/phpstan.phar -o phpstan.phar;
 #
 # ownCloud core PHP dependencies
 #


### PR DESCRIPTION
## Description
Bump ``phpstan`` used in core code analysis from version ``0.10.3`` to ``0.10.6``

## Related Issue
- Part 1 of #33902 

## Motivation and Context
Fixes ``phpstan`` crash with ``doctrine/dbal`` - see issue for details

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
