### PR TITLE
Correction to default apps folder in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -713,7 +713,7 @@ $CONFIG = array(
 
 /**
  * If you want to store apps in a custom directory instead of ownCloud’s default 
- * `/app`, you need to modify the `apps_paths` key. There, you need to add a 
+ * `/apps`, you need to modify the `apps_paths` key. There, you need to add a 
  * new associative array that contains three elements. These are:
  *
  * - `path`      The absolute file system path to the custom app folder.


### PR DESCRIPTION
The default folder for apps is called ``apps``

## Description
Fix the documented default apps folder.

## Motivation and Context
The string was wrong in the comment.

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
