### PR TITLE
Feature/allow cors header x request

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -92,6 +92,7 @@ class CorsPluginTest extends TestCase {
 			'X-Requested-With',
 			'Content-Type',
 			'Access-Control-Allow-Origin',
+			'X-Request-ID',
 			'X-OC-Mtime',
 			'OC-Checksum',
 			'OC-Total-Length',

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
         "zendframework/zend-servicemanager": "^3.3",
         "zendframework/zend-validator": "^2.10",
         "composer/semver": "^1.4",
-        "dg/composer-cleaner": "^2.0"
+        "dg/composer-cleaner": "^2.0",
+        "ext-json": "*"
     },
     "extra": {
         "cleaner-ignore": {

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -53,7 +53,7 @@ class OC_Response {
 				\header('Cache-Control: max-age='.$cache_time.', must-revalidate');
 			} else {
 				self::setExpiresHeader(0);
-				\header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+				\header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 			}
 		} else {
 			\header('Cache-Control: cache');
@@ -114,11 +114,13 @@ class OC_Response {
 	}
 
 	/**
-	* Set response expire time
-	* @param string|DateTime $expires date-time when the response expires
-	*  string for DateInterval from now
-	*  DateTime object when to expire response
-	*/
+	 * Set response expire time
+	 *
+	 * @param string|DateTime $expires date-time when the response expires
+	 *  string for DateInterval from now
+	 *  DateTime object when to expire response
+	 * @throws Exception
+	 */
 	public static function setExpiresHeader($expires) {
 		if (\is_string($expires) && $expires[0] == 'P') {
 			$interval = $expires;
@@ -288,17 +290,17 @@ class OC_Response {
 		}
 		// first check if any of the global CORS domains matches
 		$globalAllowedDomains = $config->getSystemValue('cors.allowed-domains', []);
-		$isCorsRequest = (\is_array($globalAllowedDomains) && \in_array($domain, $globalAllowedDomains));
+		$isCorsRequest = (\is_array($globalAllowedDomains) && \in_array($domain, $globalAllowedDomains, true));
 		if (!$isCorsRequest && $userId !== null) {
 			// check if any of the user specific CORS domains matches
 			$allowedDomains = \json_decode($config->getUserValue($userId, 'core', 'domains'));
-			$isCorsRequest = (\is_array($allowedDomains) && \in_array($domain, $allowedDomains));
+			$isCorsRequest = (\is_array($allowedDomains) && \in_array($domain, $allowedDomains, true));
 		}
 		if ($isCorsRequest) {
 			// TODO: infer allowed verbs from existing known routes
-			$allHeaders['Access-Control-Allow-Headers'] = ["authorization", "OCS-APIREQUEST", "Origin", "X-Requested-With", "Content-Type", "Access-Control-Allow-Origin"];
+			$allHeaders['Access-Control-Allow-Headers'] = ['authorization', 'OCS-APIREQUEST', 'Origin', 'X-Requested-With', 'Content-Type', 'Access-Control-Allow-Origin', 'X-Request-ID'];
 			$allHeaders['Access-Control-Allow-Origin'] = [$domain];
-			$allHeaders['Access-Control-Allow-Methods'] =["GET", "OPTIONS", "POST", "PUT", "DELETE", "MKCOL", "PROPFIND", "PATCH", "PROPPATCH", "REPORT"];
+			$allHeaders['Access-Control-Allow-Methods'] =['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE', 'MKCOL', 'PROPFIND', 'PATCH', 'PROPPATCH', 'REPORT'];
 
 			foreach ($headers as $key => $value) {
 				if (\array_key_exists($key, $allHeaders)) {
@@ -315,7 +317,7 @@ class OC_Response {
 	 * This function adds the CORS headers for all domains
 	 *
 	 * @param Sabre\HTTP\ResponseInterface $response
-	 * @param Array $headers
+	 * @param array $headers
 	 *
 	 * Format of $headers:
 	 * Array [
@@ -328,9 +330,9 @@ class OC_Response {
 	 */
 	public static function setOptionsRequestHeaders($response, $headers = []) {
 		// TODO: infer allowed verbs from existing known routes
-		$allHeaders['Access-Control-Allow-Headers'] = ["authorization", "OCS-APIREQUEST", "Origin", "X-Requested-With", "Content-Type", "Access-Control-Allow-Origin"];
+		$allHeaders['Access-Control-Allow-Headers'] = ['authorization', 'OCS-APIREQUEST', 'Origin', 'X-Requested-With', 'Content-Type', 'Access-Control-Allow-Origin', 'X-Request-ID'];
 		$allHeaders['Access-Control-Allow-Origin'] = ['*'];
-		$allHeaders['Access-Control-Allow-Methods'] =["GET", "OPTIONS", "POST", "PUT", "DELETE", "MKCOL", "PROPFIND", "PATCH", "PROPPATCH", "REPORT"];
+		$allHeaders['Access-Control-Allow-Methods'] =['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE', 'MKCOL', 'PROPFIND', 'PATCH', 'PROPPATCH', 'REPORT'];
 
 		foreach ($headers as $key => $value) {
 			if (\array_key_exists($key, $allHeaders)) {


### PR DESCRIPTION
## Description
X-Request-ID cannot be sent with a CORS request because the header is not allowed.

## Related Issue
- Refs https://github.com/owncloud/js-owncloud-client/issues/140

## How Has This Been Tested?
- :robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
