### PR TITLE
write Login failed entry and emit event for per PasswordLoginForbiddenException

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -351,12 +351,11 @@ class Session implements IUserSession, Emitter {
 		if ($user === null || \trim($user) === '') {
 			throw new \InvalidArgumentException('$user cannot be empty');
 		}
-		if (!$isTokenPassword && $this->isTokenAuthEnforced()) {
+		if (!$isTokenPassword
+			&& ($this->isTokenAuthEnforced() || $this->isTwoFactorEnforced($user))
+		) {
 			$this->logger->warning("Login failed: '$user' (Remote IP: '{$request->getRemoteAddress()}')", ['app' => 'core']);
 			$this->emitFailedLogin($user);
-			throw new PasswordLoginForbiddenException();
-		}
-		if (!$isTokenPassword && $this->isTwoFactorEnforced($user)) {
 			throw new PasswordLoginForbiddenException();
 		}
 		if (!$this->login($user, $password)) {


### PR DESCRIPTION
## Description
If two-factor authentication is mandatory, a failed_login event emitted and a login failed entry is written to the log so that fail2ban and brute_force_protection app can handle this case.

## Related Issue
- Fixes #32654 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- unit tests executed
- manually

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
