### PR TITLE
Calculate the proper location of the tests/acceptance/features dir

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -122,9 +122,6 @@ pipeline:
     pull: true
     commands:
       - ./tests/drone/install-server.sh
-      - git clone https://github.com/owncloud/testing.git $$DRONE_WORKSPACE/apps/testing
-      - php occ a:l
-      - php occ a:e testing
       - php occ a:l
       - php occ config:system:set trusted_domains 1 --value=server
       - php occ config:system:set trusted_domains 2 --value=federated
@@ -135,6 +132,18 @@ pipeline:
     when:
       matrix:
         INSTALL_SERVER: true
+
+  install-testing-app:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - git clone https://github.com/owncloud/testing.git $$DRONE_WORKSPACE/apps/testing
+      - php occ a:l
+      - php occ a:e testing
+      - php occ a:l
+    when:
+      matrix:
+        INSTALL_TESTING-APP: true
 
   prepare-objectstore:
     image: owncloudci/php:${PHP_VERSION}
@@ -741,6 +750,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -750,6 +760,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -759,6 +770,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -770,6 +782,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -779,6 +792,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -788,6 +802,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -797,6 +812,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -806,6 +822,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -815,6 +832,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -824,6 +842,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -833,6 +852,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
       INSTALL_NOTIFICATIONS-APP: true
 
     - PHP_VERSION: 7.1
@@ -843,6 +863,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -852,6 +873,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -861,6 +883,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: api
@@ -870,6 +893,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
   # CLI Provisioning Acceptance tests
     - PHP_VERSION: 7.1
@@ -880,6 +904,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
       USE_EMAIL: true
 
   # CLI Main Acceptance tests
@@ -891,6 +916,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
   # CLI Background Acceptance tests
     - PHP_VERSION: 7.1
@@ -901,6 +927,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
   # CLI Trashbin Acceptance tests
     - PHP_VERSION: 7.1
@@ -911,6 +938,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
   # UI Acceptance tests
     - PHP_VERSION: 7.1
@@ -921,6 +949,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
       USE_EMAIL: true
 
     - PHP_VERSION: 7.1
@@ -931,6 +960,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -940,6 +970,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -949,6 +980,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -958,6 +990,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
       USE_EMAIL: true
 
     - PHP_VERSION: 7.1
@@ -968,6 +1001,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -977,6 +1011,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
       USE_EMAIL: true
 
     - PHP_VERSION: 7.1
@@ -987,6 +1022,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -996,6 +1032,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -1005,6 +1042,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -1016,6 +1054,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
       USE_EMAIL: true
 
     - PHP_VERSION: 7.1
@@ -1026,6 +1065,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -1035,6 +1075,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -1044,6 +1085,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
       USE_EMAIL: true
       INSTALL_NOTIFICATIONS-APP: true
 
@@ -1055,6 +1097,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -1064,6 +1107,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -1073,6 +1117,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     # caldav test
     - PHP_VERSION: 7.1

--- a/.drone.yml
+++ b/.drone.yml
@@ -611,6 +611,7 @@ matrix:
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: mysql
@@ -618,6 +619,7 @@ matrix:
       MYSQL_IMAGE: mysql:5.7
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       # mb4 support by default
@@ -625,6 +627,7 @@ matrix:
       TEST_SUITE: phpunit
       COVERAGE: false
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
 #    - PHP_VERSION: 7.1
 #      DB_TYPE: mariadb
@@ -637,6 +640,7 @@ matrix:
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: postgres
@@ -644,6 +648,7 @@ matrix:
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: mariadb
@@ -652,18 +657,21 @@ matrix:
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: oracle
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
 
     # PHP 7.2
@@ -671,11 +679,13 @@ matrix:
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.2
       DB_TYPE: mariadb
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     #- PHP_VERSION: 7.2
     #  DB_TYPE: mysql
@@ -697,12 +707,13 @@ matrix:
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.3
       DB_TYPE: mariadb
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-
+      INSTALL_TESTING-APP: true
 
   # test on objectstore
     - PHP_VERSION: 7.1
@@ -711,6 +722,7 @@ matrix:
       COVERAGE: true
       TEST_OBJECTSTORAGE: true
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
 
   # Files External
     - PHP_VERSION: 7.1
@@ -718,6 +730,7 @@ matrix:
       COVERAGE: true
       DB_TYPE: sqlite
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
       FILES_EXTERNAL_TYPE: webdav_apache
 
     - PHP_VERSION: 7.1
@@ -725,6 +738,7 @@ matrix:
       COVERAGE: true
       DB_TYPE: sqlite
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
       FILES_EXTERNAL_TYPE: smb_samba
 
     - PHP_VERSION: 7.1
@@ -732,6 +746,7 @@ matrix:
       COVERAGE: true
       DB_TYPE: sqlite
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
       FILES_EXTERNAL_TYPE: smb_windows
 
     - PHP_VERSION: 7.1
@@ -739,6 +754,7 @@ matrix:
       COVERAGE: true
       DB_TYPE: sqlite
       INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
       FILES_EXTERNAL_TYPE: swift
 
   # API Acceptance tests

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -509,6 +509,30 @@ then
 	BEHAT_SUITE=`basename ${FEATURE_PATH}`
 fi
 
+if [ -z "${BEHAT_YML}" ]
+then
+	# Look for a behat.yml somewhere below the current working directory
+	# This saves app acceptance tests being forced to specify BEHAT_YML
+	BEHAT_YML="config/behat.yml"
+	if [ ! -f "${BEHAT_YML}" ]
+	then
+		BEHAT_YML="acceptance/config/behat.yml"
+	fi
+	if [ ! -f "${BEHAT_YML}" ]
+	then
+		BEHAT_YML="tests/acceptance/config/behat.yml"
+	fi
+	# If no luck above, then use the core behat.yml that should live below this script
+	if [ ! -f "${BEHAT_YML}" ]
+	then
+		BEHAT_YML="${SCRIPT_PATH}/config/behat.yml"
+	fi
+fi
+
+BEHAT_CONFIG_DIR=$(dirname "${BEHAT_YML}")
+ACCEPTANCE_DIR=$(dirname "${BEHAT_CONFIG_DIR}")
+BEHAT_FEATURES_DIR="${ACCEPTANCE_DIR}/features"
+
 declare -a BEHAT_SUITES
 if [ -n "${BEHAT_SUITE}" ]
 then
@@ -516,7 +540,7 @@ then
 else
 	if [ -n "${RUN_PART}" ]
 	then
-		ALL_SUITES=`find features/ -type d -iname ${ACCEPTANCE_TEST_TYPE}* | sort | cut -d"/" -f2`
+		ALL_SUITES=`find ${BEHAT_FEATURES_DIR}/ -type d -iname ${ACCEPTANCE_TEST_TYPE}* | sort | rev | cut -d"/" -f1 | rev`
 		COUNT_ALL_SUITES=`echo "${ALL_SUITES}" | wc -l`
 		#divide the suites letting it round down (could be zero)
 		MIN_SUITES_PER_RUN=$((${COUNT_ALL_SUITES} / ${DIVIDE_INTO_NUM_PARTS}))
@@ -578,26 +602,6 @@ then
 	BEHAT_FILTER_TAGS="${TEST_TYPE_TAG}"
 else
 	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&${TEST_TYPE_TAG}"
-fi
-
-if [ -z "${BEHAT_YML}" ]
-then
-	# Look for a behat.yml somewhere below the current working directory
-	# This saves app acceptance tests being forced to specify BEHAT_YML
-	BEHAT_YML="config/behat.yml"
-	if [ ! -f "${BEHAT_YML}" ]
-	then
-		BEHAT_YML="acceptance/config/behat.yml"
-	fi
-	if [ ! -f "${BEHAT_YML}" ]
-	then
-		BEHAT_YML="tests/acceptance/config/behat.yml"
-	fi
-	# If no luck above, then use the core behat.yml that should live below this script
-	if [ ! -f "${BEHAT_YML}" ]
-	then
-		BEHAT_YML="${SCRIPT_PATH}/config/behat.yml"
-	fi
 fi
 
 # MAILHOG_HOST defines where the system-under-test can find the MailHog server


### PR DESCRIPTION
## Description
- move the logic that selects a default for ``BEHAT_YML`` up higher in ``run.sh`` so that it is available earlier
- calculate the ``features`` dir from ``BEHAT_YML``, which typically ends in ``config/behat.yml``, by going up a directory and down to the ``features`` directory. This is the standard directory layout of the Behat framework that we use everywhere.

## Related Issue
https://github.com/owncloud/encryption/issues/81

## Motivation and Context
Acceptance tests can use the ``run.sh`` environment variables ``DIVIDE_INTO_NUM_PARTS`` and ``RUN_PART`` to control automatically splitting up the available test suites into sub-sets to run them in a number of jobs.

Currently such apps, e.g. ``encryption`` and ``files_primary_s3``, are doing stuff like:
```
cd /var/www/owncloud/tests/acceptance/
```
to make sure they are in the core ``tests/acceptance`` directory before executing ``run.sh``

``tests/acceptance/run.sh`` scans the ``features`` directory to find out the names of the possible test suites. Unfortunately it looks from the current working directory, which might be off in another app.

We are supposed to be able to execute ``run.sh`` without first having to ``cd`` to its ``tests/acceptance`` folder. 

## How Has This Been Tested?
Locally running some app acceptance tests with different values of ``BEHAT_YML`` and see that the script finds the relevant ``features`` dir.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
