### PR TITLE
Improve speed accessing all apps by caching result of integrity check

### DIFF
--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -461,6 +461,8 @@ class Checker {
 		}
 
 		$this->setAppValue(self::CACHE_KEY, \json_encode($resultArray));
+		//Set cache for each app
+		$this->cache->set($scope, \json_encode($resultArray));
 		$this->cache->set(self::CACHE_KEY, \json_encode($resultArray));
 	}
 
@@ -533,6 +535,29 @@ class Checker {
 		if ($this->config !== null) {
 			$this->config->deleteAppValue('core', $key);
 		}
+	}
+
+	/**
+	 * Get the verified apps from the cache, if the result is cached.
+	 * If the app result is not cached, then verification result will get cached
+	 * and then returned.
+	 *
+	 * The reason for introducing this method:
+	 * verifyAppSignature() internally calls verify() which does call phpseclib
+	 * routines like validateSignature(). validateSignature is taking lot of memory.
+	 * Hence its better to cache the results to avoid huge memory consumption.
+	 *
+	 * @param string $appId
+	 * @param string $path Optional path. If none is given it will be guessed.
+	 * @param bool $force force check even if disabled
+	 * @return array
+	 */
+	public function getVerifiedAppsFromCache($appId, $path = '', $force = false) {
+		$cacheVal = $this->cache->get($appId);
+		if ($cacheVal !== null) {
+			return $cacheVal;
+		}
+		return $this->verifyAppSignature($appId, $path, $force);
 	}
 
 	/**

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -762,7 +762,7 @@ class OC_App {
 					$info['level'] = self::officialApp;
 					$info['removable'] = false;
 				} else {
-					$result = \OC::$server->getIntegrityCodeChecker()->verifyAppSignature($app, '', true);
+					$result = \OC::$server->getIntegrityCodeChecker()->getVerifiedAppsFromCache($app, '', true);
 					if (empty($result)) {
 						$info['level'] = self::approvedApp;
 						$info['removable'] = false;


### PR DESCRIPTION
The integrity check is causing an over head during
execution. And hence it affects the speed of accessing
apps. This change address this issue by caching the
app signature results.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
There is an issue noticed when the `OC_App::listAllApps()` is executed. It takes a little long time to get the apps. The major time is consumed in the Integrity checker. So to overcome this issue, this change tries to cache the signature of the app when the integrity check is called. Once it is cached, the integrity checker does not execute the code which causes the program to wait for long time to get the result.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/33248

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In this change the app signature results are cached. And hence it speeds the result to get the apps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Install redis and memcache as mentioned at https://doc.owncloud.org/server/10.0/admin_manual/configuration/server/caching_configuration.html.
- Added the configuration mentioned below in the config.php
```
  'memcache.locking' => '\\OC\\Memcache\\Redis',
  'memcache.local' => '\\OC\\Memcache\\Redis',
  'redis' =>
  array (
    'host' => 'localhost',
    'port' => 6379,
    'timeout' => 0.0,
    'dbindex' => 0,
  ),
  'memcached_servers' => [
          ['localhost', 11211],
  ],
```
- Now access the Apps in the settings page of the UI. It would be slow as it needs to cache the results first.
- Try for the second time. The performace should increase.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
