### PR TITLE
Fix cancel upload and hide 'uploading' message for files_drop shared folders

### DIFF
--- a/apps/files_sharing/js/PublicUploadView.js
+++ b/apps/files_sharing/js/PublicUploadView.js
@@ -66,6 +66,7 @@
 				this,
 				'_onUploadBeforeAdd',
 				'_onUploadDone',
+				'_onUploadStop',
 				'_getUploadUrl'
 			);
 		},
@@ -81,6 +82,10 @@
 			this.$('.public-upload-view--completed ul').append(this.itemTemplate({
 				fileName: fileName
 			}));
+		},
+
+		_onUploadStop: function (e, data) {
+			this.$('#uploadprogresswrapper .stop, #uploadprogressbar .label').hide();
 		},
 
 		_getUploadUrl: function(fileName) {
@@ -127,6 +132,7 @@
 			});
 			this._uploader.on('beforeadd', this._onUploadBeforeAdd);
 			this._uploader.on('done', this._onUploadDone);
+			this._uploader.on('stop', this._onUploadStop);
 
 			return this;
 		},

--- a/apps/files_sharing/js/PublicUploadView.js
+++ b/apps/files_sharing/js/PublicUploadView.js
@@ -26,7 +26,7 @@
 		'        <input type="button" class="stop icon-close" style="display:none" value="" />' +
 		'    </div>' +
 		'    <label>' +
-		'        <input type="file" class="uploader hiddenuploadfield" name="files[]" />' +
+		'        <input type="file" id="file_upload_start" class="uploader hiddenuploadfield" name="files[]" />' +
 		'        <div class="public-upload-view--dropzone">' +
 		'            <span class="icon icon-upload"></span><span>{{uploadButtonLabel}}</span>' +
 		'        </div>' +
@@ -67,6 +67,7 @@
 				'_onUploadBeforeAdd',
 				'_onUploadDone',
 				'_onUploadStop',
+				'onUploadCancel',
 				'_getUploadUrl'
 			);
 		},
@@ -86,6 +87,10 @@
 
 		_onUploadStop: function (e, data) {
 			this.$('#uploadprogresswrapper .stop, #uploadprogressbar .label').hide();
+		},
+
+		onUploadCancel: function () {
+			this._uploader.cancelUploads();
 		},
 
 		_getUploadUrl: function(fileName) {
@@ -150,6 +155,9 @@
 		view.render();
 
 		$('#preview .uploadForm').append(view.$el);
+		$('#uploadprogresswrapper .stop').on('click', function () {
+			view.onUploadCancel();
+		});
 	});
 
 })(OC,OCA);

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -36,6 +36,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	protected $fileNamesXpath = "//span[@class='nametext']";
 	protected $fileNameMatchXpath = "//span[@class='nametext' and .=%s]";
 	protected $fileListXpath = ".//tbody[@id='fileList']";
+	protected $uploadFormXpath = "//div[@class='uploadForm']";
 	protected $emptyContentXpath = ".//div[@id='emptycontent']";
 	protected $addToYourOcBtnId = "save-button";
 	protected $singleFileDownloadBtnXpath = "//a[@id='downloadFile']";
@@ -335,6 +336,9 @@ class PublicLinkFilesPage extends FilesPageBasic {
 			$downloadButton = $this->find(
 				"xpath", $this->singleFileDownloadBtnXpath
 			);
+			$uploadForm = $this->find(
+				"xpath", $this->uploadFormXpath
+			);
 			if ($fileList !== null) {
 				try {
 					$fileListIsVisible = $fileList->isVisible();
@@ -381,6 +385,8 @@ class PublicLinkFilesPage extends FilesPageBasic {
 					}
 				}
 			} elseif ($downloadButton !== null) {
+				break;
+			} elseif ($uploadForm !== null) {
 				break;
 			}
 

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -102,3 +102,9 @@ Feature: File Upload
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then file "lorem.txt" should be listed on the webUI
     And the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"
+
+  Scenario: upload a file into files_drop share
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | upload |
+    And the public accesses the last created public link using the webUI
+    Then the user uploads file "lorem.txt" using the webUI


### PR DESCRIPTION
## Description
Fix not working `cancel upload` and hide 'Uploading' message after the upload is done.

## Related Issue
- Fixes #33177 

## Motivation and Context


## How Has This Been Tested?
https://github.com/owncloud/core/issues/33177#issue-369571133


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
