### PR TITLE
Fix php warning on webdav helper test regarding using InvalidArgumentException

### DIFF
--- a/tests/TestHelpers/Unit/WebDavHelperTest.php
+++ b/tests/TestHelpers/Unit/WebDavHelperTest.php
@@ -20,7 +20,6 @@
  *
  */
 
-use InvalidArgumentException;
 use TestHelpers\WebDavHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Subscriber\Mock;


### PR DESCRIPTION
Resolves #33934