### PR TITLE
Adjust waitTillXpathIsVisible calls

### DIFF
--- a/tests/acceptance/features/lib/AdminAppsSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminAppsSettingsPage.php
@@ -97,6 +97,8 @@ class AdminAppsSettingsPage extends OwncloudPage {
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$this->waitForAjaxCallsToStartAndFinish($session);
-		$this->waitTillXpathIsVisible($session, $this->appEnableDisableButtonXpath);
+		$this->waitTillXpathIsVisible(
+			$this->appEnableDisableButtonXpath, $timeout_msec
+		);
 	}
 }

--- a/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
@@ -293,6 +293,8 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$this->waitForAjaxCallsToStartAndFinish($session);
-		$this->waitTillXpathIsVisible($session, $this->ownCloudVersionStringXpath);
+		$this->waitTillXpathIsVisible(
+			$this->ownCloudVersionStringXpath, $timeout_msec
+		);
 	}
 }

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -388,6 +388,8 @@ class AdminSharingSettingsPage extends OwncloudPage {
 		Session $session,
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
-		$this->waitTillXpathIsVisible($session, $this->shareApiCheckboxXpath);
+		$this->waitTillXpathIsVisible(
+			$this->shareApiCheckboxXpath, $timeout_msec
+		);
 	}
 }

--- a/tests/acceptance/features/lib/AdminStorageSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminStorageSettingsPage.php
@@ -335,6 +335,8 @@ class AdminStorageSettingsPage extends OwncloudPage {
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$this->waitForAjaxCallsToStartAndFinish($session);
-		$this->waitTillXpathIsVisible($session, $this->filesExternalFormXpath);
+		$this->waitTillXpathIsVisible(
+			$this->filesExternalFormXpath, $timeout_msec
+		);
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -74,10 +74,10 @@ class FileActionsMenu extends OwncloudPage {
 		$xpath = null
 	) {
 		if ($xpath === null) {
-			throw new \InvalidArgumentException('$xpath need to be set');
+			throw new \InvalidArgumentException('$xpath needs to be set');
 		}
 		$this->waitForOutstandingAjaxCalls($session);
-		$element = $this->waitTillXpathIsVisible($session, $xpath);
+		$element = $this->waitTillXpathIsVisible($xpath, $timeout_msec);
 		$this->setElement($element);
 	}
 

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -488,9 +488,9 @@ class SharingDialog extends OwncloudPage {
 		$xpath = null
 	) {
 		if ($xpath === null) {
-			throw new \InvalidArgumentException('$xpath need to be set');
+			throw new \InvalidArgumentException('$xpath needs to be set');
 		}
 		$this->waitForOutstandingAjaxCalls($session);
-		$this->waitTillXpathIsVisible($session, $xpath);
+		$this->waitTillXpathIsVisible($xpath, $timeout_msec);
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -327,10 +327,10 @@ class EditPublicLinkPopup extends OwncloudPage {
 		$xpath = null
 	) {
 		if ($xpath === null) {
-			throw new \InvalidArgumentException('$xpath need to be set');
+			throw new \InvalidArgumentException('$xpath needs to be set');
 		}
 		$this->waitForOutstandingAjaxCalls($session);
-		$popupElement = $this->waitTillXpathIsVisible($session, $xpath);
+		$popupElement = $this->waitTillXpathIsVisible($xpath, $timeout_msec);
 		$this->setElement($popupElement);
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -83,10 +83,10 @@ class PublicLinkTab extends OwncloudPage {
 		$xpath = null
 	) {
 		if ($xpath === null) {
-			throw new \InvalidArgumentException('$xpath need to be set');
+			throw new \InvalidArgumentException('$xpath needs to be set');
 		}
 		$this->waitForOutstandingAjaxCalls($session);
-		$element = $this->waitTillXpathIsVisible($session, $xpath);
+		$element = $this->waitTillXpathIsVisible($xpath, $timeout_msec);
 		$this->setElement($element);
 	}
 

--- a/tests/acceptance/features/lib/NotificationsAppDialog.php
+++ b/tests/acceptance/features/lib/NotificationsAppDialog.php
@@ -99,6 +99,8 @@ class NotificationsAppDialog extends OwncloudPage {
 		Session $session,
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
-		$this->waitTillXpathIsVisible($session, $this->notificationContainerXpath);
+		$this->waitTillXpathIsVisible(
+			$this->notificationContainerXpath, $timeout_msec
+		);
 	}
 }

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -146,14 +146,12 @@ class OwncloudPage extends Page {
 	/**
 	 * waits for the element located by the xpath to be visible
 	 *
-	 * @param Session $session
 	 * @param string $xpath the xpath of the element to wait for
 	 * @param int $timeout_msec
 	 *
 	 * @return NodeElement
 	 */
 	public function waitTillXpathIsVisible(
-		Session $session,
 		$xpath,
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
@@ -162,13 +160,13 @@ class OwncloudPage extends Page {
 			$element,
 			__METHOD__ .
 			" xpath: $xpath" .
-			" timeout waiting for element to be availiable"
+			" timeout waiting for element to be available"
 		);
-		$visibibity = $this->waitFor(
-			STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000,
+		$visibility = $this->waitFor(
+			$timeout_msec / 1000,
 			[$element, 'isVisible']
 		);
-		if ($visibibity !== true) {
+		if ($visibility !== true) {
 			throw new \Exception(
 				__METHOD__ .
 				" xpath: $xpath" .

--- a/tests/acceptance/features/lib/OwncloudPageElement/SettingsMenu.php
+++ b/tests/acceptance/features/lib/OwncloudPageElement/SettingsMenu.php
@@ -61,6 +61,6 @@ class SettingsMenu extends OwncloudPage {
 		Session $session,
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
-		$this->waitTillXpathIsVisible($session, $this->logoutButtonXpath);
+		$this->waitTillXpathIsVisible($this->logoutButtonXpath, $timeout_msec);
 	}
 }

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -83,7 +83,9 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 		Session $session,
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
-		$this->waitTillXpathIsVisible($session, $this->personalProfilePanelXpath);
+		$this->waitTillXpathIsVisible(
+			$this->personalProfilePanelXpath, $timeout_msec
+		);
 		$this->waitForOutstandingAjaxCalls($session);
 	}
 

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
@@ -150,6 +150,8 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$this->waitForOutstandingAjaxCalls($session);
-		$this->waitTillXpathIsVisible($session, $this->corsInputfieldXpath);
+		$this->waitTillXpathIsVisible(
+			$this->corsInputfieldXpath, $timeout_msec
+		);
 	}
 }


### PR DESCRIPTION
## Description
In acceptance tests, ``waitTillXpathIsVisible()`` had 
- unused parameter ``$session``
- parameter ``$timeout_msec`` that should be passed through to ``waitFor()`` but is not

The only things that call ``waitTillXpathIsVisible()`` are in core, so the change to the method signature should not break any app UI tests.

## Related Issue
#33938 

## Motivation and Context
Noticed while looking at related issue.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
