### PR TITLE
[stable10] Backport of Add new capability string for public share

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -22,6 +22,7 @@ namespace OCA\Files_Sharing;
 
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\Util\UserSearch;
 
 /**
@@ -39,15 +40,19 @@ class Capabilities implements ICapability {
 	 */
 	private $userSearch;
 
+	/** @var IL10N */
+	private $l10n;
+
 	/**
 	 * Capabilities constructor.
 	 *
 	 * @param IConfig $config
 	 * @param UserSearch $userSearch
 	 */
-	public function __construct(IConfig $config, UserSearch $userSearch) {
+	public function __construct(IConfig $config, UserSearch $userSearch, IL10N $l10n) {
 		$this->config = $config;
 		$this->userSearch = $userSearch;
+		$this->l10n = $l10n;
 	}
 
 	/**
@@ -92,6 +97,7 @@ class Capabilities implements ICapability {
 				$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
 				$public['multiple'] = true;
 				$public['supports_upload_only'] = true;
+				$public['defaultPublicLinkShareName'] = $this->l10n->t('Public link');
 			}
 			$res["public"] = $public;
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -23,6 +23,7 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\Capabilities;
+use OCP\IL10N;
 
 /**
  * Class CapabilitiesTest
@@ -36,6 +37,9 @@ class CapabilitiesTest extends \Test\TestCase {
 	 */
 	protected $userSearch;
 
+	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	private $l10n;
+
 	/**
 	 *
 	 */
@@ -48,6 +52,10 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->userSearch->expects($this->any())
 			->method('getSearchMinLength')
 			->willReturn(1);
+
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')
+			->willReturn('Public link');
 	}
 
 	/**
@@ -73,7 +81,7 @@ class CapabilitiesTest extends \Test\TestCase {
 	private function getResults(array $map) {
 		$stub = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
 		$stub->method('getAppValue')->will($this->returnValueMap($map));
-		$cap = new Capabilities($stub, $this->userSearch);
+		$cap = new Capabilities($stub, $this->userSearch, $this->l10n);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());
 		return $result;
 	}
@@ -446,5 +454,6 @@ class CapabilitiesTest extends \Test\TestCase {
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('public', $result);
 		$this->assertTrue($result['public']['multiple']);
+		$this->assertEquals('Public link', $result['public']['defaultPublicLinkShareName']);
 	}
 }

--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -131,7 +131,7 @@
 
 		_generateName: function() {
 			var index = 1;
-			var baseName = t('core', 'Public link', null, {escape: false});
+			var baseName = OC.getCapabilities()['files_sharing']["public"]["defaultPublicLinkShareName"];
 			var name = baseName;
 
 			while (this.collection.findWhere({name: name})) {

--- a/core/js/tests/specs/sharedialoglinklistviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinklistviewSpec.js
@@ -28,6 +28,7 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 	var view;
 	var tooltipStub;
 	var showPopupStub;
+	var publicLinkStub;
 
 	beforeEach(function() {
 		configModel = new OC.Share.ShareConfigModel();
@@ -48,6 +49,14 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 			fileInfoModel: fileInfoModel
 		});
 
+		publicLinkStub = sinon.stub(OC, 'getCapabilities');
+		publicLinkStub.returns({
+			'files_sharing': {
+				'public': {
+					'defaultPublicLinkShareName': 'Public link'
+				}
+			}
+		});
 		tooltipStub = sinon.stub($.fn, 'tooltip');
 		/* jshint camelcase: false */
 		collection = new OC.Share.SharesCollection([{
@@ -83,6 +92,7 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 	afterEach(function() { 
 		tooltipStub.restore(); 
 		showPopupStub.restore();
+		publicLinkStub.restore();
 	});
 
 	describe('rendering', function() {


### PR DESCRIPTION
The default name for the public share is
Public link. And this needs to be reflected
in the files_sharing capabilites. This change
introduces name defaultPublicLinkShareName for
this.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add `defaultPublicLinkShareName` to the files_sharing capabilities. `defaultPublicLinkShareName` will help the users know that by default public link share name is `Public link`. The translation is enabled for `Public link`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding capabilities `defaultPublicLinkShareName => Public link` to the files_sharing capabilities. Added translation for `Public **link`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added unit test.
- Verified by executing `curl --silent -u admin:admin 'http://localhost/testing3/ocs/v1.php/cloud/capabilities?format=json' | json_pp > /tmp/test10.txt` and the file is here 
[test10.txt](https://github.com/owncloud/core/files/2699640/test10.txt)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
