### PR TITLE
Install testing app when running webUIWebdavLocks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1143,6 +1143,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
+      INSTALL_TESTING-APP: true
 
     # caldav test
     - PHP_VERSION: 7.1


### PR DESCRIPTION
## Description
A recent PR that added the test suite ``webUIWebdavLocks`` missed a recent refactoring of the steps in ``.drone.yml`` that install the testing app - https://github.com/owncloud/core/pull/33929/commits/5bc6f0382dd5ee4cad5beede97212339a3a1f0fd
So the PR managed to get merged without a conflict being reported, but the new matrix entry in ``.drone.yml`` was missing:
```
INSTALL_TESTING-APP: true
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
