### PR TITLE
Offset expiry from last share time in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -75,6 +75,13 @@ trait Sharing {
 	}
 
 	/**
+	 * @return int
+	 */
+	public function getServerLastShareTime() {
+		return (int) $this->lastShareData->data->stime;
+	}
+
+	/**
 	 * @return void
 	 */
 	private function waitToCreateShare() {
@@ -785,9 +792,15 @@ trait Sharing {
 		if ($data === null) {
 			$data = $this->getResponseXml()->data[0];
 		}
-		if ((string)$field == 'expiration') {
+		if ((string) $field === 'expiration') {
 			$contentExpected
-				= \date('Y-m-d', \strtotime($contentExpected)) . " 00:00:00";
+				= \date(
+					'Y-m-d',
+					\strtotime(
+						$contentExpected,
+						$this->getServerLastShareTime()
+					)
+				) . " 00:00:00";
 		}
 		if (\count($data->element) > 0) {
 			foreach ($data as $element) {

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -104,6 +104,7 @@ trait Sharing {
 	 * @param string $user
 	 * @param TableNode|null $body
 	 *    TableNode $body should not have any heading and can have following rows    |
+	 *       | path            | The folder or file path to be shared                |
 	 *       | name            | A (human-readable) name for the share,              |
 	 *       |                 | which can be up to 64 characters in length.         |
 	 *       | publicUpload    | Whether to allow public upload to a public          |
@@ -156,10 +157,8 @@ trait Sharing {
 			}
 		}
 
-		$this->response = SharingHelper::createShare(
-			$this->getBaseUrl(),
+		$this->response = $this->createShare(
 			$user,
-			$this->getPasswordForUser($user),
 			$fd['path'],
 			$fd['shareType'],
 			$fd['shareWith'],
@@ -167,11 +166,8 @@ trait Sharing {
 			$fd['password'],
 			$fd['permissions'],
 			$fd['name'],
-			$fd['expireDate'],
-			$this->ocsApiVersion,
-			$this->sharingApiVersion
+			$fd['expireDate']
 		);
-		$this->lastShareData = $this->getResponseXml();
 	}
 
 	/**
@@ -259,10 +255,8 @@ trait Sharing {
 		$linkName = null,
 		$expireDate = null
 	) {
-		$this->response = SharingHelper::createShare(
-			$this->getBaseUrl(),
+		$this->response = $this->createShare(
 			$user,
-			$this->getPasswordForUser($user),
 			$path,
 			'public',
 			null, // shareWith
@@ -270,11 +264,8 @@ trait Sharing {
 			$sharePassword,
 			$permissions,
 			$linkName,
-			$expireDate,
-			$this->ocsApiVersion,
-			$this->sharingApiVersion
+			$expireDate
 		);
-		$this->lastShareData = $this->getResponseXml();
 	}
 
 	/**
@@ -744,7 +735,7 @@ trait Sharing {
 	 * @param string $shareType
 	 * @param string $shareWith
 	 * @param string $publicUpload
-	 * @param string $password
+	 * @param string $sharePassword
 	 * @param int $permissions
 	 * @param string $linkName
 	 * @param string $expireDate
@@ -757,7 +748,7 @@ trait Sharing {
 		$shareType = null,
 		$shareWith = null,
 		$publicUpload = null,
-		$password = null,
+		$sharePassword = null,
 		$permissions = null,
 		$linkName = null,
 		$expireDate = null
@@ -771,7 +762,7 @@ trait Sharing {
 			$shareType,
 			$shareWith,
 			$publicUpload,
-			$password,
+			$sharePassword,
 			$permissions,
 			$linkName,
 			$expireDate,

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -157,7 +157,7 @@ trait Sharing {
 			}
 		}
 
-		$this->response = $this->createShare(
+		$this->createShare(
 			$user,
 			$fd['path'],
 			$fd['shareType'],
@@ -255,7 +255,7 @@ trait Sharing {
 		$linkName = null,
 		$expireDate = null
 	) {
-		$this->response = $this->createShare(
+		$this->createShare(
 			$user,
 			$path,
 			'public',


### PR DESCRIPTION
## Description
- add method ``getServerLastShareTime()`` to find out the time that the server created the last share
- when calculating expected share expiration in later steps, offset it from the actual last share time on the server, rather than from "now" (this avoids the "unlucky" event when "now" turns out to be 1 or 2 seconds later than the time that the server created the share, and midnight happened - or the test-runner time is quite a bit different from the time on the system-under-test)
- refactor other methods that directly call ``SharingHelper::createShare`` so that they call through the local ``createShare``. This ensures that they all get the ``waitToCreateShare()`` check and save ``lastShareData``

## Related Issue
#33975 

## Motivation and Context
See issue description. Make sharing tests with expiry date checks more reliable.

## How Has This Been Tested?
Local runs of relevant test scenarios plus CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
