### PR TITLE
Auto accept incoming federated shares from trusted servers

### DIFF
--- a/apps/federatedfilesharing/js/settings-admin.js
+++ b/apps/federatedfilesharing/js/settings-admin.js
@@ -5,7 +5,8 @@ $(document).ready(function() {
 		if (this.checked) {
 			value = 'yes';
 		}
-		OC.AppConfig.setValue('files_sharing', $(this).attr('name'), value);
+		var app = (this.id !== 'autoAcceptTrusted') ? 'files_sharing' : 'federatedfilesharing';
+		OC.AppConfig.setValue(app, $(this).attr('name'), value);
 	});
 
 	$('.section .icon-info').tipsy({gravity: 'w'});

--- a/apps/federatedfilesharing/lib/AdminPanel.php
+++ b/apps/federatedfilesharing/lib/AdminPanel.php
@@ -20,6 +20,7 @@
  */
 namespace OCA\FederatedFileSharing;
 
+use OCP\IConfig;
 use OCP\Settings\ISettings;
 use OCP\Template;
 
@@ -28,13 +29,17 @@ class AdminPanel implements ISettings {
 	/** @var FederatedShareProvider */
 	protected $shareProvider;
 
+	/** @var IConfig */
+	protected $config;
+
 	/**
 	 * AdminPanel constructor.
 	 *
 	 * @param FederatedShareProvider $shareProvider
 	 */
-	public function __construct(FederatedShareProvider $shareProvider) {
+	public function __construct(FederatedShareProvider $shareProvider, IConfig $config) {
 		$this->shareProvider = $shareProvider;
+		$this->config = $config;
 	}
 
 	public function getPriority() {
@@ -49,6 +54,10 @@ class AdminPanel implements ISettings {
 		$tmpl = new Template('federatedfilesharing', 'settings-admin');
 		$tmpl->assign('outgoingServer2serverShareEnabled', $this->shareProvider->isOutgoingServer2serverShareEnabled());
 		$tmpl->assign('incomingServer2serverShareEnabled', $this->shareProvider->isIncomingServer2serverShareEnabled());
+		$tmpl->assign(
+			'autoAcceptTrusted',
+			$this->config->getAppValue('federatedfilesharing', 'auto_accept_trusted', 'no')
+		);
 		return $tmpl;
 	}
 }

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -200,6 +200,7 @@ class Application extends App {
 
 		$this->federatedShareProvider = new FederatedShareProvider(
 			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getEventDispatcher(),
 			$addressHandler,
 			$notifications,
 			$tokenHandler,

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -29,4 +29,14 @@ script('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Allow users on this server to receive shares from other servers'));?>
 		</label><br/>
 	</p>
+
+	<p>
+		<input type="checkbox" name="auto_accept_trusted" id="autoAcceptTrusted" class="checkbox"
+			   value="1" <?php if ($_['autoAcceptTrusted']) {
+	print_unescaped('checked="checked"');
+} ?> />
+		<label for="autoAcceptTrusted">
+			<?php p($l->t('Automatically accept remote shares from trusted servers'));?>
+		</label><br/>
+	</p>
 </div>

--- a/apps/federatedfilesharing/tests/AdminPanelTest.php
+++ b/apps/federatedfilesharing/tests/AdminPanelTest.php
@@ -23,6 +23,7 @@ namespace OCA\FederatedFileSharing\Tests;
 
 use OCA\FederatedFileSharing\AdminPanel;
 use OCA\FederatedFileSharing\FederatedShareProvider;
+use OCP\IConfig;
 
 /**
  * @package OCA\FederatedFileSharing\Tests
@@ -33,13 +34,16 @@ class AdminPanelTest extends \Test\TestCase {
 	private $panel;
 	/** @var  FederatedShareProvider */
 	private $shareProvider;
+	/** @var IConfig */
+	private $config;
 
 	public function setUp() {
 		parent::setUp();
 		$this->shareProvider = $this->getMockBuilder(FederatedShareProvider::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->panel = new AdminPanel($this->shareProvider);
+		$this->config = $this->createMock(IConfig::class);
+		$this->panel = new AdminPanel($this->shareProvider, $this->config);
 	}
 
 	public function testGetSection() {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -39,6 +39,8 @@ use OCP\Share\IManager;
 use OCP\Share\IShare;
 use OCP\Files\Folder;
 use OCP\IUser;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class FederatedShareProviderTest
@@ -50,6 +52,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 	/** @var IDBConnection */
 	protected $connection;
+	/** @var EventDispatcherInterface */
+	protected $eventDispatcher;
 	/** @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject */
 	protected $addressHandler;
 	/** @var Notifications | \PHPUnit_Framework_MockObject_MockObject */
@@ -76,6 +80,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$this->notifications = $this->getMockBuilder('OCA\FederatedFileSharing\Notifications')
 			->disableOriginalConstructor()
 			->getMock();
@@ -91,13 +98,13 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->rootFolder = $this->createMock('OCP\Files\IRootFolder');
 		$this->config = $this->createMock('OCP\IConfig');
 		$this->userManager = $this->createMock('OCP\IUserManager');
-		//$this->addressHandler = new AddressHandler(\OC::$server->getURLGenerator(), $this->l);
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')->disableOriginalConstructor()->getMock();
 
 		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
 
 		$this->provider = new FederatedShareProvider(
 			$this->connection,
+			$this->eventDispatcher,
 			$this->addressHandler,
 			$this->notifications,
 			$this->tokenHandler,
@@ -464,10 +471,11 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	 *
 	 */
 	public function testUpdate($owner, $sharedBy) {
-		$this->provider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
+		$this->provider = $this->getMockBuilder(FederatedShareProvider::class)
 			->setConstructorArgs(
 				[
 					$this->connection,
+					\OC::$server->getEventDispatcher(),
 					$this->addressHandler,
 					$this->notifications,
 					$this->tokenHandler,
@@ -883,5 +891,51 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$returnedShare = $this->provider->updateForRecipient($share, 'recipient1');
 
 		$this->assertEquals($share, $returnedShare);
+	}
+
+	/**
+	 * @dataProvider dataTestGetAccepted
+	 *
+	 */
+	public function testGetAccepted($autoAddServers, $autoAccept, $isRemoteTrusted, $expected) {
+		$this->config->method('getAppValue')
+			->with('federatedfilesharing', 'auto_accept_trusted', 'no')
+			->willReturn($autoAccept);
+
+		$event = new GenericEvent(
+			'',
+			[
+				'autoAddServers' => $autoAddServers,
+				'isRemoteTrusted' => $isRemoteTrusted
+			]
+		);
+		$this->eventDispatcher->method('dispatch')
+			->with('remoteshare.received', $this->anything())
+			->willReturn($event);
+
+		$shouldAutoAccept = $this->invokePrivate(
+			$this->provider,
+			'getAccepted',
+			['remote']
+		);
+
+		$this->assertEquals($expected, $shouldAutoAccept);
+	}
+
+	public function dataTestGetAccepted() {
+		return [
+			// never autoaccept when auto add to trusted is on
+			[true, 'yes', true, false],
+			[true, 'yes', false, false],
+			[true, 'no', true, false],
+			[true, 'no', false, false],
+			// never autoaccept when auto autoaccept is off
+			[false, 'no', false, false],
+			[false, 'no', true, false],
+			// never autoaccept when remote is not trusted
+			[false, 'yes', false, false],
+			// autoaccept
+			[false, 'yes', true, true],
+		];
 	}
 }

--- a/apps/federation/lib/AppInfo/Application.php
+++ b/apps/federation/lib/AppInfo/Application.php
@@ -120,6 +120,16 @@ class Application extends \OCP\AppFramework\App {
 				}
 			}
 		});
+
+		$dispatcher->addListener(
+			'remoteshare.received',
+			function ($event) use ($container) {
+				$remote = $event->getArgument('remote');
+				$trustedServers = $container->query('TrustedServers');
+				$event->setArgument('autoAddServers', $trustedServers->getAutoAddServers());
+				$event->setArgument('isRemoteTrusted', $trustedServers->isTrustedServer($remote));
+			}
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -10,6 +10,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And using server "LOCAL"
     And user "user1" has been created with default attributes
     And user "user1" has logged in using the webUI
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
   Scenario: test the single steps of sharing a folder to a remote server
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
@@ -52,6 +53,17 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user declines the offered remote shares using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+
+    Scenario: automatically accept a federation share when it is allowed by the config
+      Given parameter "autoAddServers" of app "federation" has been set to "1"
+      And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+      And user "user1" from server "LOCAL" has accepted the last pending share
+      And the user has reloaded the current page of the webUI
+      And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+      And parameter "autoAddServers" of app "federation" has been set to "0"
+      When user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
+      And the user has reloaded the current page of the webUI
+      Then file "lorem (2).txt" should be listed on the webUI
 
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives


### PR DESCRIPTION
## Description
All incoming shares from remote servers are accepted automatically when:
- federation app `autoAddServers` config option is set to '0' (default)
`occ config:app:set federation auto_accept_trusted --value '0'`
- federatedfilesharing app `auto_accept_trusted` config option is set to 'yes'
`occ config:app:set federatedfilesharing auto_accept_trusted --value 'yes'`
- remote server is listed as trusted in the federation app


## Related Issue
Closes https://github.com/owncloud/core/issues/27653 https://github.com/owncloud/enterprise/issues/3051


## How Has This Been Tested?



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/542

## Open tasks:
- [x] add UI
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
