### PR TITLE
Remove parameter from time() calls in EmailHelper

### DIFF
--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -83,7 +83,7 @@ class EmailHelper {
 		$numEmails = 1,
 		$waitTimeSec = EMAIL_WAIT_TIMEOUT_SEC
 	) {
-		$currentTime = \time(true);
+		$currentTime = \time();
 		$end = $currentTime + $waitTimeSec;
 
 		while ($currentTime <= $end) {
@@ -104,7 +104,7 @@ class EmailHelper {
 				}
 			}
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC * 50);
-			$currentTime = \time(true);
+			$currentTime = \time();
 		}
 		throw new \Exception("Could not find the email to the address: " . $address);
 	}
@@ -126,7 +126,7 @@ class EmailHelper {
 		$numEmails = 1,
 		$waitTimeSec = EMAIL_WAIT_TIMEOUT_SEC
 	) {
-		$currentTime = \time(true);
+		$currentTime = \time();
 		$end = $currentTime + $waitTimeSec;
 
 		while ($currentTime <= $end) {
@@ -142,7 +142,7 @@ class EmailHelper {
 				}
 			}
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC * 50);
-			$currentTime = \time(true);
+			$currentTime = \time();
 		}
 		throw new \Exception("Could not find the email to the address: " . $address);
 	}


### PR DESCRIPTION
## Description
PHP 7.3 complains about bonus parameters given in a function call:
```
Warning: time() expects exactly 0 parameters, 1 given in /drone/src/tests/TestHelpers/EmailHelper.php line 86
```

``microtime()`` takes a boolean parameter. ``time()`` does not. Fix it.

## Motivation and Context
Make sure acceptance tests run with PHP 7.3

## How Has This Been Tested?
CI with PHP 7.3

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
