### PR TITLE
move response xml parser to helper

### DIFF
--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -84,7 +84,9 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		$this->response = HttpRequestHelper::get(
 			$davUrl, $user, $this->featureContext->getPasswordForUser($user)
 		);
-		$this->featureContext->parseResponseIntoXml($this->response);
+		$this->featureContext->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 	}
 
 	/**
@@ -148,7 +150,9 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 			$this->featureContext->getPasswordForUser($user), null, $body
 		);
 		$this->theCalDavHttpStatusCodeShouldBe(201);
-		$this->featureContext->parseResponseIntoXml($this->response);
+		$this->featureContext->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -84,7 +84,9 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		$this->response = HttpRequestHelper::get(
 			$davUrl, $user, $this->featureContext->getPasswordForUser($user)
 		);
-		$this->featureContext->parseResponseIntoXml($this->response);
+		$this->featureContext->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 	}
 
 	/**
@@ -129,7 +131,9 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 			$headers, $body
 		);
 		$this->theCardDavHttpStatusCodeShouldBe(201);
-		$this->featureContext->parseResponseIntoXml($this->response);
+		$this->featureContext->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -27,7 +27,6 @@ use GuzzleHttp\Stream\StreamInterface;
 use Guzzle\Http\Exception\BadResponseException;
 use Sabre\DAV\Client as SClient;
 use Sabre\DAV\Xml\Property\ResourceType;
-use Sabre\Xml\LibXMLException;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
@@ -92,6 +91,15 @@ trait WebDav {
 	private $httpRequestTimeout = 0;
 
 	private $chunkingToUse = null;
+
+	/**
+	 * @param array $responseXml
+	 *
+	 * @return void
+	 */
+	public function setResponseXml($responseXml) {
+		$this->responseXml = $responseXml;
+	}
 
 	/**
 	 * @param ResponseInterface[] $uploadResponses
@@ -237,33 +245,6 @@ trait WebDav {
 		}
 
 		return $this->getNewDavPath();
-	}
-
-	/**
-	 * parses the body content of $response and sets $this->responseXml
-	 *
-	 * @param ResponseInterface|null $response if null $this->response will be used
-	 *
-	 * @return void
-	 */
-	public function parseResponseIntoXml($response = null) {
-		if ($response === null) {
-			$response = $this->response;
-		}
-		$body = $response->getBody()->getContents();
-		if ($body && \substr($body, 0, 1) === '<') {
-			try {
-				$reader = new Sabre\Xml\Reader();
-				$reader->xml($body);
-				$this->responseXml = $reader->parse();
-			} catch (LibXMLException $e) {
-				// Sometimes the body can be a real page of HTML and text.
-				// So it may not be a complete ordinary piece of XML.
-				// The XML parse might fail with an exception message like:
-				// Opening and ending tag mismatch: link line 31 and head.
-				$this->responseXml = [];
-			}
-		}
 	}
 
 	/**
@@ -460,7 +441,9 @@ trait WebDav {
 			$this->response = $this->makeDavRequest(
 				$user, "MOVE", $fileSource, $headers, null, "files", null, null, $stream
 			);
-			$this->parseResponseIntoXml();
+			$this->setResponseXml(
+				HttpRequestHelper::parseResponseAsXml($this->response)
+			);
 		} catch (ConnectException $e) {
 		}
 	}
@@ -502,7 +485,9 @@ trait WebDav {
 		$this->response = $this->makeDavRequest(
 			$user, "COPY", $fileSource, $headers
 		);
-		$this->parseResponseIntoXml();
+		$this->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 	}
 
 	/**
@@ -1544,7 +1529,9 @@ trait WebDav {
 			$user, "PUT", $destination, [], $file
 		);
 		$this->lastUploadTime = \time();
-		$this->parseResponseIntoXml();
+		$this->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 	}
 
 	/**
@@ -2062,7 +2049,9 @@ trait WebDav {
 		$this->response = $this->makeDavRequest(
 			$user, "MKCOL", $destination, []
 		);
-		$this->parseResponseIntoXml();
+		$this->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 	}
 
 	/**
@@ -2663,7 +2652,9 @@ trait WebDav {
 		//if we are using that step the second time in a scenario e.g. 'But ... should not'
 		//then don't parse the result again, because the result in a ResponseInterface
 		if (empty($this->responseXml)) {
-			$this->parseResponseIntoXml();
+			$this->setResponseXml(
+				HttpRequestHelper::parseResponseAsXml($this->response)
+			);
 		}
 		$multistatusResults = $this->responseXml["value"];
 		PHPUnit_Framework_Assert::assertEquals((int)$numFiles, \count($multistatusResults));
@@ -2704,7 +2695,9 @@ trait WebDav {
 		//if we are using that step the second time in a scenario e.g. 'But ... should not'
 		//then don't parse the result again, because the result in a ResponseInterface
 		if (empty($this->responseXml)) {
-			$this->parseResponseIntoXml();
+			$this->setResponseXml(
+				HttpRequestHelper::parseResponseAsXml($this->response)
+			);
 		}
 		$multistatusResults = $this->responseXml["value"];
 		$results = [];


### PR DESCRIPTION
## Description
move the helper function to parse the content of a response as xml to the helper

## Related Issue
part of #33690 
fixes #33990

## Motivation and Context
simplify `WebDav.php` trait

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
