### PR TITLE
 Improve Files UX error handling

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -306,12 +306,14 @@
 		handleDownload: function(url, callback) {
 			var randomToken = Math.random().toString(36).substring(2),
 				checkForDownloadCookie = function() {
-					if (!OC.Util.isCookieSetToValue('ocDownloadStarted', randomToken)){
-						return false;
-					} else {
+					// Successfull request should return cookie with token, failed with -1
+					if (OC.Util.isCookieSetToValue('ocDownloadStarted', randomToken) ||
+						OC.Util.isCookieSetToValue('ocDownloadStarted', '-1')) {
 						callback();
 						return true;
 					}
+
+					return false
 				};
 
 			if (url.indexOf('?') >= 0) {

--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -129,19 +129,24 @@ describe('OCA.Files.Files tests', function() {
 			token = OC.parseQueryString(redirectStub.getCall(0).args[0]).downloadStartSecret;
 			expect(token).toBeDefined();
 
-			expect(cookieStub.calledOnce).toEqual(true);
-			cookieStub.returns(false);
+			expect(cookieStub.callCount).toEqual(2);
+			cookieStub.onCall(0).returns(false);
+			cookieStub.onCall(1).returns(false);
 			clock.tick(600);
 
-			expect(cookieStub.calledTwice).toEqual(true);
-			expect(cookieStub.getCall(1).args[0]).toEqual('ocDownloadStarted');
-			expect(cookieStub.getCall(1).args[1]).toEqual(token);
+			expect(cookieStub.callCount).toEqual(4);
+			expect(cookieStub.getCall(2).args[0]).toEqual('ocDownloadStarted');
+			expect(cookieStub.getCall(2).args[1]).toEqual(token);
+			expect(cookieStub.getCall(3).args[0]).toEqual('ocDownloadStarted');
+			expect(cookieStub.getCall(3).args[1]).toEqual('-1');
 			expect(callbackStub.notCalled).toEqual(true);
 
+			// now 1 ocDownloadStarted expected, with token argument
+			// should be called and return true
 			cookieStub.returns(true);
-			clock.tick(2000);
 
-			expect(cookieStub.callCount).toEqual(3);
+			clock.tick(2000);
+			expect(cookieStub.callCount).toEqual(5);
 			expect(callbackStub.calledOnce).toEqual(true);
 		});
 	});


### PR DESCRIPTION
This fixes a bug in which when e.g. Forbidden is thrown for file when "Download" is clicked, the loading wheel is still spinning

This
<img width="1153" alt="faileddownload" src="https://user-images.githubusercontent.com/13368647/50557995-8f71ef00-0cea-11e9-8222-733dca8a88d6.png">

Now will be 
<img width="982" alt="handledfaileddownload" src="https://user-images.githubusercontent.com/13368647/50558005-97ca2a00-0cea-11e9-9404-775eecac6f19.png">
