### PR TITLE
View-only dav plugin using IShare attributes

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -30,6 +30,7 @@ namespace OCA\DAV\Connector\Sabre;
 
 use OCA\DAV\DAV\FileCustomPropertiesBackend;
 use OCA\DAV\DAV\FileCustomPropertiesPlugin;
+use OCA\DAV\DAV\ViewOnlyPlugin;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\FileLocksBackend;
 use OCP\Files\Mount\IMountManager;
@@ -161,6 +162,11 @@ class ServerFactory {
 				)
 			);
 			$server->addPlugin(new \OCA\DAV\Connector\Sabre\QuotaPlugin($view));
+
+			// Allow view-only plugin for webdav requests
+			$server->addPlugin(new ViewOnlyPlugin(
+				\OC::$server->getLogger()
+			));
 
 			if ($this->userSession->isLoggedIn()) {
 				$server->addPlugin(new \OCA\DAV\Connector\Sabre\TagsPlugin($objectTree, $this->tagManager));

--- a/apps/dav/lib/DAV/ViewOnlyPlugin.php
+++ b/apps/dav/lib/DAV/ViewOnlyPlugin.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @author Piotr Mrowczynski piotr@owncloud.com
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\DAV;
+
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use OCA\DAV\Connector\Sabre\File as DavFile;
+use OCA\DAV\Meta\MetaFile;
+use OCP\Files\FileInfo;
+use OCP\Files\NotFoundException;
+use OCP\ILogger;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\DAV\Exception\NotFound;
+
+/**
+ * Sabre plugin for restricting file share receiver download:
+ */
+class ViewOnlyPlugin extends ServerPlugin {
+
+	/** @var Server $server */
+	private $server;
+
+	/** @var ILogger $logger */
+	private $logger;
+
+	/**
+	 * @param ILogger $logger
+	 */
+	public function __construct(ILogger $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by Sabre\DAV\Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param Server $server
+	 * @return void
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+		//priority 90 to make sure the plugin is called before
+		//Sabre\DAV\CorePlugin::httpGet
+		$this->server->on('method:GET', [$this, 'checkViewOnly'], 90);
+	}
+
+	/**
+	 * Disallow download via DAV Api in case file being received share
+	 * and having special permission
+	 *
+	 * @param RequestInterface $request request object
+	 * @return boolean
+	 * @throws Forbidden
+	 * @throws NotFoundException
+	 */
+	public function checkViewOnly(
+		RequestInterface $request
+	) {
+		$path = $request->getPath();
+
+		try {
+			$davNode = $this->server->tree->getNodeForPath($path);
+			if (!($davNode instanceof DavFile || $davNode instanceof MetaFile)) {
+				return true;
+			}
+			// Restrict view-only to nodes which are shared
+			$node = $davNode->getNode();
+			if (!$node instanceof FileInfo) {
+				return true;
+			}
+
+			$storage = $node->getStorage();
+			// using string as we have no guarantee that "files_sharing" app is loaded
+			if (!$storage->instanceOfStorage('OCA\Files_Sharing\SharedStorage')) {
+				return true;
+			}
+			// Extract extra permissions
+			/** @var \OCA\Files_Sharing\SharedStorage $storage */
+			$share = $storage->getShare();
+
+			// Check if read-only and on whether permission can download is both set and disabled.
+			$canDownload = $share->getAttributes()->getAttribute('permissions', 'download');
+			if ($canDownload !== null && !$canDownload) {
+				throw new Forbidden('Access to this resource has been denied because it is in view-only mode.');
+			}
+		} catch (NotFound $e) {
+			$this->logger->warning($e->getMessage());
+		}
+
+		return true;
+	}
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -49,6 +49,7 @@ use OCA\DAV\DAV\FileCustomPropertiesPlugin;
 use OCA\DAV\DAV\LazyOpsPlugin;
 use OCA\DAV\DAV\MiscCustomPropertiesBackend;
 use OCA\DAV\DAV\PublicAuth;
+use OCA\DAV\DAV\ViewOnlyPlugin;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\FileLocksBackend;
 use OCA\DAV\Files\PreviewPlugin;
@@ -188,6 +189,11 @@ class Server {
 
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 		$this->server->addPlugin(new ChunkingPlugin());
+
+		// Allow view-only plugin for webdav requests
+		$this->server->addPlugin(new ViewOnlyPlugin(
+			\OC::$server->getLogger()
+		));
 
 		if (BrowserErrorPagePlugin::isBrowserRequest($request)) {
 			$this->server->addPlugin(new BrowserErrorPagePlugin());

--- a/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @author Piotr Mrowczynski piotr@owncloud.com
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Tests\unit\DAV;
+
+use OCA\DAV\DAV\ViewOnlyPlugin;
+use OCA\Files_Sharing\SharedStorage;
+use OCA\DAV\Connector\Sabre\File as DavFile;
+use OCP\Files\FileInfo;
+use OCP\Files\Storage\IStorage;
+use OCP\ILogger;
+use OCP\Share\IAttributes;
+use OCP\Share\IShare;
+use Sabre\DAV\Server;
+use Sabre\DAV\Tree;
+use Test\TestCase;
+use Sabre\HTTP\RequestInterface;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+
+class ViewOnlyPluginTest extends TestCase {
+
+	/** @var ViewOnlyPlugin */
+	private $plugin;
+	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
+	private $tree;
+	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
+	private $request;
+
+	public function setUp() {
+		$this->plugin = new ViewOnlyPlugin(
+			$this->createMock(ILogger::class)
+		);
+		$this->request = $this->createMock(RequestInterface::class);
+		$this->tree = $this->createMock(Tree::class);
+
+		$server = $this->createMock(Server::class);
+		$server->tree = $this->tree;
+
+		$this->plugin->initialize($server);
+	}
+
+	public function testCanGetNonDav() {
+		$this->request->expects($this->once())->method('getPath')->willReturn('files/test/target');
+		$this->tree->method('getNodeForPath')->willReturn(null);
+
+		$this->assertTrue($this->plugin->checkViewOnly($this->request));
+	}
+
+	public function testCanGetNonFileInfo() {
+		$this->request->expects($this->once())->method('getPath')->willReturn('files/test/target');
+		$davNode = $this->createMock(DavFile::class);
+		$this->tree->method('getNodeForPath')->willReturn($davNode);
+
+		$davNode->method('getNode')->willReturn(null);
+
+		$this->assertTrue($this->plugin->checkViewOnly($this->request));
+	}
+
+	public function testCanGetNonShared() {
+		$this->request->expects($this->once())->method('getPath')->willReturn('files/test/target');
+		$davNode = $this->createMock(DavFile::class);
+		$this->tree->method('getNodeForPath')->willReturn($davNode);
+
+		$fileInfo = $this->createMock(FileInfo::class);
+		$davNode->method('getNode')->willReturn($fileInfo);
+
+		$storage = $this->createMock(IStorage::class);
+		$fileInfo->method('getStorage')->willReturn($storage);
+		$storage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(false);
+
+		$this->assertTrue($this->plugin->checkViewOnly($this->request));
+	}
+
+	public function providesDataForCanGet() {
+		return [
+			// has attribute permissions-download enabled - can get file
+			[ $this->createMock(FileInfo::class), true, true],
+			// has no attribute permissions-download - can get file
+			[ $this->createMock(FileInfo::class), null, true],
+			// has attribute permissions-download disabled- cannot get the file
+			[ $this->createMock(FileInfo::class), false, false],
+		];
+	}
+
+	/**
+	 * @dataProvider providesDataForCanGet
+	 */
+	public function testCanGet($nodeInfo, $attrEnabled, $expectCanDownloadFile) {
+		$this->request->expects($this->once())->method('getPath')->willReturn('files/test/target');
+
+		$davNode = $this->createMock(DavFile::class);
+		$this->tree->method('getNodeForPath')->willReturn($davNode);
+
+		$davNode->method('getNode')->willReturn($nodeInfo);
+
+		$storage = $this->createMock(SharedStorage::class);
+		$share = $this->createMock(IShare::class);
+		$nodeInfo->method('getStorage')->willReturn($storage);
+		$storage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(true);
+		$storage->method('getShare')->willReturn($share);
+
+		$extAttr = $this->createMock(IAttributes::class);
+		$share->method('getAttributes')->willReturn($extAttr);
+		$extAttr->method('getAttribute')->with('permissions', 'download')->willReturn($attrEnabled);
+
+		if (!$expectCanDownloadFile) {
+			$this->expectException(Forbidden::class);
+		}
+		$this->plugin->checkViewOnly($this->request);
+	}
+}

--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -39,6 +39,17 @@ if (!\OC\Files\Filesystem::file_exists($filename)) {
 	exit;
 }
 
+//Dispatch an event to see if any apps have problem with download
+$event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['path' => $filename]);
+OC::$server->getEventDispatcher()->dispatch('file.beforeGetDirect', $event);
+if ($event->hasArgument('errorMessage')) {
+	\header("HTTP/1.0 403 Forbidden");
+	$tmpl = new OCP\Template('', '403', 'guest');
+	$tmpl->assign('file', $filename);
+	$tmpl->printPage();
+	exit;
+}
+
 $ftype=\OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
 
 \header('Content-Type:'.$ftype);

--- a/apps/files/js/fileinfomodel.js
+++ b/apps/files/js/fileinfomodel.js
@@ -80,6 +80,15 @@
 		},
 
 		/**
+		 * Returns the mimetype of the file
+		 *
+		 * @return {string} mimetype
+		 */
+		getMimeType: function() {
+			return this.get('mimetype');
+		},
+
+		/**
 		 * Reloads missing properties from server and set them in the model.
 		 * @param properties array of properties to be reloaded
 		 * @return ajax call object

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -159,7 +159,8 @@ class Application extends App {
 				$c->getServer()->getUrlGenerator(),
 				$c->getServer()->getEventDispatcher(),
 				$c->getServer()->getShareManager(),
-				$c->query(NotificationPublisher::class)
+				$c->query(NotificationPublisher::class),
+				$c->getServer()->getUserSession()
 			);
 		});
 

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -28,6 +28,7 @@ namespace OCA\Files_Sharing;
 use OC\Files\Filesystem;
 use OCP\IURLGenerator;
 use OCP\Files\IRootFolder;
+use OCP\IUserSession;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use OCP\Share\IShare;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -46,6 +47,11 @@ class Hooks {
 	private $rootFolder;
 
 	/**
+	 * @var IUserSession|null
+	 */
+	private $userSession;
+
+	/**
 	 * @var EventDispatcher
 	 */
 	private $eventDispatcher;
@@ -60,13 +66,25 @@ class Hooks {
 	 */
 	private $notificationPublisher;
 
+	/**
+	 * Hooks constructor.
+	 *
+	 * @param IRootFolder $rootFolder
+	 * @param IURLGenerator $urlGenerator
+	 * @param EventDispatcher $eventDispatcher
+	 * @param \OCP\Share\IManager $shareManager
+	 * @param NotificationPublisher $notificationPublisher
+	 * @param IUserSession|null $userSession
+	 */
 	public function __construct(
 		IRootFolder $rootFolder,
 		IUrlGenerator $urlGenerator,
 		EventDispatcher $eventDispatcher,
 		\OCP\Share\IManager $shareManager,
-		NotificationPublisher $notificationPublisher
+		NotificationPublisher $notificationPublisher,
+		$userSession
 	) {
+		$this->userSession = $userSession;
 		$this->rootFolder = $rootFolder;
 		$this->urlGenerator = $urlGenerator;
 		$this->eventDispatcher = $eventDispatcher;
@@ -131,6 +149,65 @@ class Hooks {
 				$this->notificationPublisher->discardNotification($shareObject);
 			}
 		);
+
+		$this->eventDispatcher->addListener(
+			'file.beforeGetDirect',
+			function (GenericEvent $event) {
+				$pathsToCheck[] = $event->getArgument('path');
+
+				// Check only for user/group shares. Don't restrict e.g. share links
+				if ($uid = $this->getCurrentUserUid()) {
+					$viewOnlyHandler = new ViewOnly(
+						$this->rootFolder->getUserFolder($uid)
+					);
+					if (!$viewOnlyHandler->check($pathsToCheck)) {
+						$event->setArgument('errorMessage', 'Access to this resource or one of its sub-items has been denied.');
+					}
+				}
+			}
+		);
+
+		$this->eventDispatcher->addListener(
+			'file.beforeCreateZip',
+			function (GenericEvent $event) {
+				$dir = $event->getArgument('dir');
+				$files = $event->getArgument('files');
+
+				$pathsToCheck = [];
+				if (\is_array($files)) {
+					foreach ($files as $file) {
+						$pathsToCheck[] = $dir . '/' . $file;
+					}
+				} elseif (\is_string($files)) {
+					$pathsToCheck[] = $dir . '/' . $files;
+				}
+
+				// Check only for user/group shares. Don't restrict e.g. share links
+				$uid = $this->getCurrentUserUid();
+				if ($uid !== null) {
+					$viewOnlyHandler = new ViewOnly(
+						$this->rootFolder->getUserFolder($uid)
+					);
+					if (!$viewOnlyHandler->check($pathsToCheck)) {
+						$event->setArgument('errorMessage', 'Access to this resource or one of its sub-items has been denied.');
+						$event->setArgument('run', false);
+					} else {
+						$event->setArgument('run', true);
+					}
+				} else {
+					$event->setArgument('run', true);
+				}
+			}
+		);
+	}
+
+	private function getCurrentUserUid() {
+		// User session can be null when installing oc and Hook is triggered, or
+		// user is not logged in
+		if ($this->userSession && $this->userSession->isLoggedIn()) {
+			return $this->userSession->getUser()->getUID();
+		}
+		return null;
 	}
 
 	private function filterSharesByFileId($shares, $fileId) {

--- a/apps/files_sharing/lib/ViewOnly.php
+++ b/apps/files_sharing/lib/ViewOnly.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @author Piotr Mrowczynski piotr@owncloud.com
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing;
+
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+
+/**
+ * Handles restricting for download of files
+ */
+class ViewOnly {
+
+	/** @var Folder */
+	private $userFolder;
+
+	public function __construct(Folder $userFolder) {
+		$this->userFolder = $userFolder;
+	}
+
+	/**
+	 * @param string[] $pathsToCheck
+	 * @return bool
+	 */
+	public function check($pathsToCheck) {
+		// If any of elements cannot be downloaded, prevent whole download
+		foreach ($pathsToCheck as $file) {
+			try {
+				$info = $this->userFolder->get($file);
+				if ($info instanceof File) {
+					// access to filecache is expensive in the loop
+					if (!$this->checkFileInfo($info)) {
+						return false;
+					}
+				} elseif ($info instanceof Folder) {
+					// get directory content is rather cheap query
+					if (!$this->dirRecursiveCheck($info)) {
+						return false;
+					}
+				}
+			} catch (NotFoundException $e) {
+				continue;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * @param Folder $dirInfo
+	 * @return bool
+	 * @throws NotFoundException
+	 */
+	private function dirRecursiveCheck(Folder $dirInfo) {
+		if (!$this->checkFileInfo($dirInfo)) {
+			return false;
+		}
+		// If any of elements cannot be downloaded, prevent whole download
+		$files = $dirInfo->getDirectoryListing();
+		foreach ($files as $file) {
+			if ($file instanceof File) {
+				if (!$this->checkFileInfo($file)) {
+					return false;
+				}
+			} elseif ($file instanceof Folder) {
+				return $this->dirRecursiveCheck($file);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param Node $fileInfo
+	 * @return bool
+	 * @throws NotFoundException
+	 */
+	private function checkFileInfo(Node $fileInfo) {
+		// Restrict view-only to nodes which are shared
+		$storage = $fileInfo->getStorage();
+		if (!$storage->instanceOfStorage(SharedStorage::class)) {
+			return true;
+		}
+
+		// Extract extra permissions
+		/** @var \OCA\Files_Sharing\SharedStorage $storage */
+		$share = $storage->getShare();
+
+		// Check if read-only and on whether permission can download is both set and disabled.
+
+		$canDownload = $share->getAttributes()->getAttribute('permissions', 'download');
+		if ($canDownload !== null && !$canDownload) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/apps/files_sharing/tests/HooksTest.php
+++ b/apps/files_sharing/tests/HooksTest.php
@@ -22,6 +22,14 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\Hooks;
+use OCA\Files_Sharing\SharedStorage;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\NotFoundException;
+use OCP\Files\Storage\IStorage;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Share\IAttributes;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use OCP\Share\IShare;
 use OCP\IURLGenerator;
@@ -45,6 +53,11 @@ class HooksTest extends TestCase {
 	 * @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $urlGenerator;
+
+	/**
+	 * @var IUserSession | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $userSession;
 
 	/**
 	 * @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject
@@ -72,13 +85,15 @@ class HooksTest extends TestCase {
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->shareManager = $this->createMock(\OCP\Share\IManager::class);
 		$this->notificationPublisher = $this->createMock(NotificationPublisher::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 
 		$this->hooks = new Hooks(
 			$this->rootFolder,
 			$this->urlGenerator,
 			$this->eventDispatcher,
 			$this->shareManager,
-			$this->notificationPublisher
+			$this->notificationPublisher,
+			$this->userSession
 		);
 		$this->hooks->registerListeners();
 	}
@@ -170,5 +185,159 @@ class HooksTest extends TestCase {
 			'shareObject' => $share,
 		]);
 		$this->eventDispatcher->dispatch('share.afterDelete', $event);
+	}
+
+	public function providesDataForCanGet() {
+		// normal file (sender) - can download directly
+		$senderFileStorage = $this->createMock(IStorage::class);
+		$senderFileStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(false);
+		$senderFile = $this->createMock(File::class);
+		$senderFile->method('getStorage')->willReturn($senderFileStorage);
+		$senderUserFolder = $this->createMock(Folder::class);
+		$senderUserFolder->method('get')->willReturn($senderFile);
+
+		$result[] = [ '/bar.txt', $senderUserFolder, true ];
+
+		// shared file (receiver) with attribute secure-view-enabled set false -
+		// can download directly
+		$receiverFileShareAttributes = $this->createMock(IAttributes::class);
+		$receiverFileShareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(true);
+		$receiverFileShare = $this->createMock(IShare::class);
+		$receiverFileShare->method('getAttributes')->willReturn($receiverFileShareAttributes);
+		$receiverFileStorage = $this->createMock(SharedStorage::class);
+		$receiverFileStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(true);
+		$receiverFileStorage->method('getShare')->willReturn($receiverFileShare);
+		$receiverFile = $this->createMock(File::class);
+		$receiverFile->method('getStorage')->willReturn($receiverFileStorage);
+		$receiverUserFolder = $this->createMock(Folder::class);
+		$receiverUserFolder->method('get')->willReturn($receiverFile);
+
+		$result[] = [ '/share-bar.txt', $receiverUserFolder, true ];
+
+		// shared file (receiver) with attribute secure-view-enabled set true -
+		// cannot download directly
+		$secureReceiverFileShareAttributes = $this->createMock(IAttributes::class);
+		$secureReceiverFileShareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(false);
+		$secureReceiverFileShare = $this->createMock(IShare::class);
+		$secureReceiverFileShare->method('getAttributes')->willReturn($secureReceiverFileShareAttributes);
+		$secureReceiverFileStorage = $this->createMock(SharedStorage::class);
+		$secureReceiverFileStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(true);
+		$secureReceiverFileStorage->method('getShare')->willReturn($secureReceiverFileShare);
+		$secureReceiverFile = $this->createMock(File::class);
+		$secureReceiverFile->method('getStorage')->willReturn($secureReceiverFileStorage);
+		$secureReceiverUserFolder = $this->createMock(Folder::class);
+		$secureReceiverUserFolder->method('get')->willReturn($secureReceiverFile);
+
+		$result[] = [ '/secure-share-bar.txt', $secureReceiverUserFolder, false ];
+
+		return $result;
+	}
+
+	/**
+	 * @dataProvider providesDataForCanGet
+	 */
+	public function testCheckDirectCanBeDownloaded($path, $userFolder, $run) {
+		$user = $this->createMock(IUser::class);
+		$user->method("getUID")->willReturn("test");
+		$this->userSession->method("getUser")->willReturn($user);
+		$this->userSession->method("isLoggedIn")->willReturn(true);
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		// Simulate direct download of file
+		$event = new GenericEvent(null, [ 'path' => $path ]);
+		$this->eventDispatcher->dispatch('file.beforeGetDirect', $event);
+
+		$this->assertEquals($run, !$event->hasArgument('errorMessage'));
+	}
+
+	public function providesDataForCanZip() {
+		// Mock: Normal file/folder storage
+		$nonSharedStorage = $this->createMock(IStorage::class);
+		$nonSharedStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(false);
+
+		// Mock: Secure-view file/folder shared storage
+		$secureReceiverFileShareAttributes = $this->createMock(IAttributes::class);
+		$secureReceiverFileShareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(false);
+		$secureReceiverFileShare = $this->createMock(IShare::class);
+		$secureReceiverFileShare->method('getAttributes')->willReturn($secureReceiverFileShareAttributes);
+		$secureSharedStorage = $this->createMock(SharedStorage::class);
+		$secureSharedStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(true);
+		$secureSharedStorage->method('getShare')->willReturn($secureReceiverFileShare);
+
+		// 1. can download zipped 2 non-shared files inside non-shared folder
+		// 2. can download zipped non-shared folder
+		$sender1File = $this->createMock(File::class);
+		$sender1File->method('getStorage')->willReturn($nonSharedStorage);
+		$sender1Folder = $this->createMock(Folder::class);
+		$sender1Folder->method('getStorage')->willReturn($nonSharedStorage);
+		$sender1Folder->method('getDirectoryListing')->willReturn([$sender1File, $sender1File]);
+		$sender1RootFolder = $this->createMock(Folder::class);
+		$sender1RootFolder->method('getStorage')->willReturn($nonSharedStorage);
+		$sender1RootFolder->method('getDirectoryListing')->willReturn([$sender1Folder]);
+		$sender1UserFolder = $this->createMock(Folder::class);
+		$sender1UserFolder->method('get')->willReturn($sender1RootFolder);
+
+		$return[] = [ '/folder', ['bar1.txt', 'bar2.txt'], $sender1UserFolder, true ];
+		$return[] = [ '/', 'folder', $sender1UserFolder, true ];
+
+		// 3. cannot download zipped 1 non-shared file and 1 secure-shared inside non-shared folder
+		$receiver1File = $this->createMock(File::class);
+		$receiver1File->method('getStorage')->willReturn($nonSharedStorage);
+		$receiver1SecureFile = $this->createMock(File::class);
+		$receiver1SecureFile->method('getStorage')->willReturn($secureSharedStorage);
+		$receiver1Folder = $this->createMock(Folder::class);
+		$receiver1Folder->method('getStorage')->willReturn($nonSharedStorage);
+		$receiver1Folder->method('getDirectoryListing')->willReturn([$receiver1File, $receiver1SecureFile]);
+		$receiver1RootFolder = $this->createMock(Folder::class);
+		$receiver1RootFolder->method('getStorage')->willReturn($nonSharedStorage);
+		$receiver1RootFolder->method('getDirectoryListing')->willReturn([$receiver1Folder]);
+		$receiver1UserFolder = $this->createMock(Folder::class);
+		$receiver1UserFolder->method('get')->willReturn($receiver1RootFolder);
+
+		$return[] = [ '/folder', ['secured-bar1.txt', 'bar2.txt'], $receiver1UserFolder, false ];
+
+		// 4. cannot download zipped secure-shared folder
+		$receiver2Folder = $this->createMock(Folder::class);
+		$receiver2Folder->method('getStorage')->willReturn($secureSharedStorage);
+		$receiver2RootFolder = $this->createMock(Folder::class);
+		$receiver2RootFolder->method('getStorage')->willReturn($nonSharedStorage);
+		$receiver2RootFolder->method('getDirectoryListing')->willReturn([$receiver2Folder]);
+		$receiver2UserFolder = $this->createMock(Folder::class);
+		$receiver2UserFolder->method('get')->willReturn($receiver2RootFolder);
+
+		$return[] = [ '/', 'secured-folder', $receiver2UserFolder, false ];
+
+		return $return;
+	}
+
+	/**
+	 * @dataProvider providesDataForCanZip
+	 */
+	public function testCheckZipCanBeDownloaded($dir, $files, $userFolder, $run) {
+		$user = $this->createMock(IUser::class);
+		$user->method("getUID")->willReturn("test");
+		$this->userSession->method("getUser")->willReturn($user);
+		$this->userSession->method("isLoggedIn")->willReturn(true);
+
+		$this->rootFolder->method('getUserFolder')->with("test")->willReturn($userFolder);
+
+		// Simulate zip download of folder folder
+		$event = new GenericEvent(null, ['dir' => $dir, 'files' => $files, 'run' => true]);
+		$this->eventDispatcher->dispatch('file.beforeCreateZip', $event);
+
+		$this->assertEquals($run, $event->getArgument('run'));
+		$this->assertEquals($run, !$event->hasArgument('errorMessage'));
+	}
+
+	public function testCheckFileUserNotFound() {
+		$this->userSession->method("isLoggedIn")->willReturn(false);
+
+		// Simulate zip download of folder folder
+		$event = new GenericEvent(null, ['dir' => '/test', 'files' => ['test.txt'], 'run' => true]);
+		$this->eventDispatcher->dispatch('file.beforeCreateZip', $event);
+
+		// It should run as this would restrict e.g. share links otherwise
+		$this->assertTrue($event->getArgument('run'));
+		$this->assertFalse($event->hasArgument('errorMessage'));
 	}
 }

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -27,6 +27,7 @@ use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IUser;
+use OCP\Share\IAttributes as IShareAttributes;
 use OCP\Share\IManager;
 use OCA\Files_Sharing\SharedMount;
 use OCP\IUserManager;
@@ -69,11 +70,35 @@ class MountProviderTest extends TestCase {
 		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger);
 	}
 
-	private function makeMockShare($id, $nodeId, $owner = 'user2', $target = null, $permissions = 31, $state = null) {
+	private function makeMockShareAttributes($attrs) {
+		if ($attrs === null) {
+			return null;
+		}
+
+		$shareAttributes = $this->createMock(IShareAttributes::class);
+		$shareAttributes->method('toArray')->willReturn($attrs);
+		$shareAttributes->method('getAttribute')->will(
+			$this->returnCallback(function ($scope, $key) use ($attrs) {
+				$result = null;
+				foreach ($attrs as $attr) {
+					if ($attr['key'] === $key && $attr['scope'] === $scope) {
+						$result = $attr['enabled'];
+					}
+				}
+				return $result;
+			})
+		);
+		return $shareAttributes;
+	}
+
+	private function makeMockShare($id, $nodeId, $owner = 'user2', $target = null, $permissions = 31, $attributes = [], $state = null) {
 		$share = $this->createMock(IShare::class);
 		$share->expects($this->any())
 			->method('getPermissions')
 			->will($this->returnValue($permissions));
+		$share->expects($this->any())
+			->method('getAttributes')
+			->will($this->returnValue($this->makeMockShareAttributes($attributes)));
 		$share->expects($this->any())
 			->method('getShareOwner')
 			->will($this->returnValue($owner));
@@ -113,17 +138,19 @@ class MountProviderTest extends TestCase {
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userManager = $this->createMock(IUserManager::class);
 
+		$attr1 = [];
+		$attr2 = [["scope" => "permission", "key" => "download", "enabled" => true]];
 		$userShares = [
-			$this->makeMockShare(1, 100, 'user2', '/share2', 0),
-			$this->makeMockShare(2, 100, 'user2', '/share2', 31),
-			$this->makeMockShare(6, 100, 'user2', '/share2', 31, \OCP\Share::STATE_PENDING),
-			$this->makeMockShare(7, 100, 'user2', '/share2', 31, \OCP\Share::STATE_REJECTED),
+			$this->makeMockShare(1, 100, 'user2', '/share2', 0, $attr1),
+			$this->makeMockShare(2, 100, 'user2', '/share2', 31, $attr2),
+			$this->makeMockShare(6, 100, 'user2', '/share2', 31, $attr2, \OCP\Share::STATE_PENDING),
+			$this->makeMockShare(7, 100, 'user2', '/share2', 31, $attr2, \OCP\Share::STATE_REJECTED),
 		];
 
 		$groupShares = [
-			$this->makeMockShare(3, 100, 'user2', '/share2', 0),
-			$this->makeMockShare(4, 101, 'user2', '/share4', 31),
-			$this->makeMockShare(5, 100, 'user1', '/share4', 31),
+			$this->makeMockShare(3, 100, 'user2', '/share2', 0, $attr1),
+			$this->makeMockShare(4, 101, 'user2', '/share4', 31, $attr2),
+			$this->makeMockShare(5, 100, 'user1', '/share4', 31, $attr2),
 		];
 
 		$userGroupUserShares = \array_merge($userShares, $groupShares);
@@ -158,6 +185,7 @@ class MountProviderTest extends TestCase {
 		$this->assertEquals(100, $mountedShare1->getNodeId());
 		$this->assertEquals('/share2', $mountedShare1->getTarget());
 		$this->assertEquals(31, $mountedShare1->getPermissions());
+		$this->assertEquals(true, $mountedShare1->getAttributes()->getAttribute('permission', 'download'));
 
 		$mountedShare2 = $mounts[1]->getShare();
 		$this->assertEquals('4', $mountedShare2->getId());
@@ -165,6 +193,7 @@ class MountProviderTest extends TestCase {
 		$this->assertEquals(101, $mountedShare2->getNodeId());
 		$this->assertEquals('/share4', $mountedShare2->getTarget());
 		$this->assertEquals(31, $mountedShare2->getPermissions());
+		$this->assertEquals(true, $mountedShare2->getAttributes()->getAttribute('permission', 'download'));
 	}
 
 	public function mergeSharesDataProvider() {
@@ -174,27 +203,27 @@ class MountProviderTest extends TestCase {
 			// #0: share as outsider with "group1" and "user1" with same permissions
 			[
 				[
-					[1, 100, 'user2', '/share2', 31],
+					[1, 100, 'user2', '/share2', 31, null],
 				],
 				[
-					[2, 100, 'user2', '/share2', 31],
+					[2, 100, 'user2', '/share2', 31, null],
 				],
 				[
 					// combined, user share has higher priority
-					['1', 100, 'user2', '/share2', 31],
+					['1', 100, 'user2', '/share2', 31, []],
 				],
 			],
 			// #1: share as outsider with "group1" and "user1" with different permissions
 			[
 				[
-					[1, 100, 'user2', '/share', 31],
+					[1, 100, 'user2', '/share', 31, [["scope" => "permission", "key" => "download", "enabled" => true], ["scope" => "app", "key" => "attribute1", "enabled" => true]]],
 				],
 				[
-					[2, 100, 'user2', '/share', 15],
+					[2, 100, 'user2', '/share', 15, [["scope" => "permission", "key" => "download", "enabled" => false], ["scope" => "app", "key" => "attribute2", "enabled" => false]]],
 				],
 				[
 					// use highest permissions
-					['1', 100, 'user2', '/share', 31],
+					['1', 100, 'user2', '/share', 31, [["scope" => "permission", "key" => "download", "enabled" => true], ["scope" => "app", "key" => "attribute1", "enabled" => true], ["scope" => "app", "key" => "attribute2", "enabled" => false]]],
 				],
 			],
 			// #2: share as outsider with "group1" and "group2" with same permissions
@@ -202,12 +231,12 @@ class MountProviderTest extends TestCase {
 				[
 				],
 				[
-					[1, 100, 'user2', '/share', 31],
-					[2, 100, 'user2', '/share', 31],
+					[1, 100, 'user2', '/share', 31, null],
+					[2, 100, 'user2', '/share', 31, []],
 				],
 				[
 					// combined, first group share has higher priority
-					['1', 100, 'user2', '/share', 31],
+					['1', 100, 'user2', '/share', 31, []],
 				],
 			],
 			// #3: share as outsider with "group1" and "group2" with different permissions
@@ -215,12 +244,12 @@ class MountProviderTest extends TestCase {
 				[
 				],
 				[
-					[1, 100, 'user2', '/share', 31],
-					[2, 100, 'user2', '/share', 15],
+					[1, 100, 'user2', '/share', 31, [["scope" => "permission", "key" => "download", "enabled" => false]]],
+					[2, 100, 'user2', '/share', 15, [["scope" => "permission", "key" => "download", "enabled" => true]]],
 				],
 				[
-					// use higher permissions
-					['1', 100, 'user2', '/share', 31],
+					// use higher permissions (most permissive)
+					['1', 100, 'user2', '/share', 31, [["scope" => "permission", "key" => "download", "enabled" => true]]],
 				],
 			],
 			// #4: share as insider with "group1"
@@ -228,7 +257,7 @@ class MountProviderTest extends TestCase {
 				[
 				],
 				[
-					[1, 100, 'user1', '/share', 31],
+					[1, 100, 'user1', '/share', 31, []],
 				],
 				[
 					// no received share since "user1" is the sharer/owner
@@ -239,8 +268,8 @@ class MountProviderTest extends TestCase {
 				[
 				],
 				[
-					[1, 100, 'user1', '/share', 31],
-					[2, 100, 'user1', '/share', 15],
+					[1, 100, 'user1', '/share', 31, [["scope" => "permission", "key" => "download", "enabled" => true]]],
+					[2, 100, 'user1', '/share', 15, [["scope" => "permission", "key" => "download", "enabled" => false]]],
 				],
 				[
 					// no received share since "user1" is the sharer/owner
@@ -251,7 +280,7 @@ class MountProviderTest extends TestCase {
 				[
 				],
 				[
-					[1, 100, 'user2', '/share', 0],
+					[1, 100, 'user2', '/share', 0, []],
 				],
 				[
 					// no received share since "user1" opted out
@@ -260,40 +289,40 @@ class MountProviderTest extends TestCase {
 			// #7: share as outsider with "group1" and "user1" where recipient renamed in between
 			[
 				[
-					[1, 100, 'user2', '/share2-renamed', 31],
+					[1, 100, 'user2', '/share2-renamed', 31, []],
 				],
 				[
-					[2, 100, 'user2', '/share2', 31],
+					[2, 100, 'user2', '/share2', 31, []],
 				],
 				[
 					// use target of least recent share
-					['1', 100, 'user2', '/share2-renamed', 31],
+					['1', 100, 'user2', '/share2-renamed', 31, []],
 				],
 			],
 			// #8: share as outsider with "group1" and "user1" where recipient renamed in between
 			[
 				[
-					[2, 100, 'user2', '/share2', 31],
+					[2, 100, 'user2', '/share2', 31, []],
 				],
 				[
-					[1, 100, 'user2', '/share2-renamed', 31],
+					[1, 100, 'user2', '/share2-renamed', 31, []],
 				],
 				[
 					// use target of least recent share
-					['1', 100, 'user2', '/share2-renamed', 31],
+					['1', 100, 'user2', '/share2-renamed', 31, []],
 				],
 			],
 			// #9: share as outsider with "nullgroup" and "user1" where recipient renamed in between
 			[
 				[
-					[2, 100, 'user2', '/share2', 31],
+					[2, 100, 'user2', '/share2', 31, []],
 				],
 				[
-					[1, 100, 'nullgroup', '/share2-renamed', 31],
+					[1, 100, 'nullgroup', '/share2-renamed', 31, []],
 				],
 				[
 					// use target of least recent share
-					['1', 100, 'nullgroup', '/share2-renamed', 31],
+					['1', 100, 'nullgroup', '/share2-renamed', 31, []],
 				],
 				true
 			],
@@ -318,10 +347,10 @@ class MountProviderTest extends TestCase {
 		$userManager = $this->createMock(IUserManager::class);
 
 		$userShares = \array_map(function ($shareSpec) {
-			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4]);
+			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4], $shareSpec[5]);
 		}, $userShares);
 		$groupShares = \array_map(function ($shareSpec) {
-			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4]);
+			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4], $shareSpec[5]);
 		}, $groupShares);
 
 		$this->user->expects($this->any())
@@ -366,6 +395,11 @@ class MountProviderTest extends TestCase {
 			$this->assertEquals($expectedShare[2], $share->getShareOwner());
 			$this->assertEquals($expectedShare[3], $share->getTarget());
 			$this->assertEquals($expectedShare[4], $share->getPermissions());
+			if ($expectedShare[5] === null) {
+				$this->assertNull($share->getAttributes());
+			} else {
+				$this->assertEquals($expectedShare[5], $share->getAttributes()->toArray());
+			}
 		}
 	}
 }

--- a/core/Migrations/Version20181220085457.php
+++ b/core/Migrations/Version20181220085457.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Piotr Mrowczynski piotr@owncloud.com
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20181220085457 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+
+		if ($schema->hasTable("${prefix}share")) {
+			$shareTable = $schema->getTable("${prefix}share");
+
+			if (!$shareTable->hasColumn('attributes')) {
+				$shareTable->addColumn(
+					'attributes',
+					Type::JSON,
+					[
+						'default' => null,
+						'notnull' => false
+					]
+				);
+			}
+		}
+	}
+}

--- a/lib/private/Files/Meta/MetaFileVersionNode.php
+++ b/lib/private/Files/Meta/MetaFileVersionNode.php
@@ -178,4 +178,13 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 		$preview->setKeepAspect($keepAspect);
 		return $preview->getPreview();
 	}
+
+	public function getStorage() {
+		return $this->storage;
+	}
+
+	public function isUpdateable() {
+		// Versions are not updateable
+		return false;
+	}
 }

--- a/lib/private/Files/Meta/MetaVersionCollection.php
+++ b/lib/private/Files/Meta/MetaVersionCollection.php
@@ -63,7 +63,7 @@ class MetaVersionCollection extends AbstractFolder {
 	 * @inheritdoc
 	 */
 	public function isShared() {
-		return false;
+		return $this->node->isShared();
 	}
 
 	public function getDirectoryListing() {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -45,6 +45,7 @@ use OCP\Security\ISecureRandom;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\TransferSharesException;
+use OCP\Share\IAttributes;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
@@ -641,6 +642,7 @@ class Manager implements IManager {
 			'shareType' => $share->getShareType(),
 			'uidOwner' => $share->getSharedBy(),
 			'permissions' => $share->getPermissions(),
+			'attributes' => $share->getAttributes(),
 			'fileSource' => $share->getNode()->getId(),
 			'expiration' => $share->getExpirationDate(),
 			'token' => $share->getToken(),
@@ -668,6 +670,7 @@ class Manager implements IManager {
 			'shareType' => $share->getShareType(),
 			'uidOwner' => $share->getSharedBy(),
 			'permissions' => $share->getPermissions(),
+			'attributes' => $share->getAttributes(),
 			'fileSource' => $share->getNode()->getId(),
 			'expiration' => $share->getExpirationDate(),
 			'token' => $share->getToken(),
@@ -909,6 +912,11 @@ class Manager implements IManager {
 			$shareAfterUpdateEvent->setArgument('permissionupdate', true);
 			$shareAfterUpdateEvent->setArgument('oldpermissions', $originalShare->getPermissions());
 			$shareAfterUpdateEvent->setArgument('path', $userFolder->getRelativePath($share->getNode()->getPath()));
+			$update = true;
+		}
+
+		if ($this->hashAttributes($share->getAttributes()) !== $this->hashAttributes($originalShare->getAttributes())) {
+			$shareAfterUpdateEvent->setArgument('attributesupdate', true);
 			$update = true;
 		}
 
@@ -1382,7 +1390,7 @@ class Manager implements IManager {
 	 * @return \OCP\Share\IShare;
 	 */
 	public function newShare() {
-		return new \OC\Share20\Share($this->rootFolder, $this->userManager);
+		return new Share($this->rootFolder, $this->userManager);
 	}
 
 	/**
@@ -1542,5 +1550,17 @@ class Manager implements IManager {
 	 */
 	public function outgoingServer2ServerSharesAllowed() {
 		return $this->config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
+	}
+
+	/**
+	 * @param IAttributes|null $perms
+	 * @return string
+	 */
+	private function hashAttributes($perms) {
+		if ($perms === null || empty($perms->toArray())) {
+			return "";
+		}
+
+		return \md5(\json_encode($perms->toArray()));
 	}
 }

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -28,8 +28,10 @@ use OCP\Files\NotFoundException;
 use OCP\IUserManager;
 use OCP\Share\Exceptions\IllegalIDChangeException;
 use OC\Share\Constants;
+use OCP\Share\IAttributes;
+use OCP\Share\IShare;
 
-class Share implements \OCP\Share\IShare {
+class Share implements IShare {
 
 	/** @var string */
 	private $id;
@@ -51,6 +53,8 @@ class Share implements \OCP\Share\IShare {
 	private $shareOwner;
 	/** @var int */
 	private $permissions;
+	/** @var IAttributes */
+	private $attributes;
 	/** @var \DateTime */
 	private $expireDate;
 	/** @var string */
@@ -272,6 +276,28 @@ class Share implements \OCP\Share\IShare {
 	/**
 	 * @inheritdoc
 	 */
+	public function newAttributes() {
+		return new ShareAttributes();
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function setAttributes(IAttributes $attributes) {
+		$this->attributes = $attributes;
+		return $this;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getAttributes() {
+		return $this->attributes;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
 	public function setExpirationDate($expireDate) {
 		//TODO checks
 
@@ -362,7 +388,7 @@ class Share implements \OCP\Share\IShare {
 	 * Set the parent of this share
 	 *
 	 * @param int parent
-	 * @return \OCP\Share\IShare
+	 * @return IShare
 	 * @deprecated The new shares do not have parents. This is just here for legacy reasons.
 	 */
 	public function setParent($parent) {

--- a/lib/private/Share20/ShareAttributes.php
+++ b/lib/private/Share20/ShareAttributes.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20;
+
+use OCP\Share\IAttributes;
+
+class ShareAttributes implements IAttributes {
+
+	/** @var array */
+	private $attributes;
+
+	public function __construct() {
+		$this->attributes = [];
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function setAttribute($scope, $key, $enabled) {
+		if (!\array_key_exists($scope, $this->attributes)) {
+			$this->attributes[$scope] = [];
+		}
+		$this->attributes[$scope][$key] = $enabled;
+		return $this;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getAttribute($scope, $key) {
+		if (\array_key_exists($scope, $this->attributes) &&
+			\array_key_exists($key, $this->attributes[$scope])) {
+			return $this->attributes[$scope][$key];
+		}
+		return null;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function toArray() {
+		$result = [];
+		foreach ($this->attributes as $scope => $keys) {
+			foreach ($keys as $key => $enabled) {
+				$result[] = [
+					"scope" => $scope,
+					"key" => $key,
+					"enabled" => $enabled
+				];
+			}
+		}
+
+		return $result;
+	}
+}

--- a/lib/public/Share/IAttributes.php
+++ b/lib/public/Share/IAttributes.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP\Share;
+
+/**
+ * Interface IAttributes
+ *
+ * @package OCP\Share
+ * @since 10.2.0
+ */
+interface IAttributes {
+
+	/**
+	 * Sets an attribute enabled/disabled. If the key did not exist before it will be created.
+	 *
+	 * @param string $scope scope
+	 * @param string $key key
+	 * @param bool $enabled enabled
+	 * @return IAttributes The modified object
+	 * @since 10.2.0
+	 */
+	public function setAttribute($scope, $key, $enabled);
+
+	/**
+	 * Returns if attribute is enabled/disabled for given scope id and key.
+	 * If attribute does not exist, returns null
+	 *
+	 * @param string $scope scope
+	 * @param string $key key
+	 * @return bool|null
+	 * @since 10.2.0
+	 */
+	public function getAttribute($scope, $key);
+
+	/**
+	 * Formats the IAttributes object to array with the following format:
+	 * [
+	 * 	0 => [
+	 * 			"scope" => <string>,
+	 * 			"key" => <string>,
+	 * 			"enabled" => <bool>
+	 * 		],
+	 * 	...
+	 * ]
+	 *
+	 * @return array formatted IAttributes
+	 * @since 10.2.0
+	 */
+	public function toArray();
+}

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -170,7 +170,7 @@ interface IShare {
 	 * See \OCP\Constants::PERMISSION_*
 	 *
 	 * @param int $permissions
-	 * @return \OCP\Share\IShare The modified object
+	 * @return IShare The modified object
 	 * @since 9.0.0
 	 */
 	public function setPermissions($permissions);
@@ -183,6 +183,31 @@ interface IShare {
 	 * @since 9.0.0
 	 */
 	public function getPermissions();
+
+	/**
+	 * Create share attributes object
+	 *
+	 * @since 10.2.0
+	 * @return IAttributes;
+	 */
+	public function newAttributes();
+
+	/**
+	 * Set share attributes
+	 *
+	 * @param IAttributes $attributes
+	 * @since 10.2.0
+	 * @return IShare The modified object
+	 */
+	public function setAttributes(IAttributes $attributes);
+
+	/**
+	 * Get share attributes
+	 *
+	 * @since 10.2.0
+	 * @return IAttributes
+	 */
+	public function getAttributes();
 
 	/**
 	 * Set the expiration date

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -23,6 +23,8 @@ namespace Test\Share20;
 
 use OC\Authentication\Token\DefaultTokenMapper;
 use OC\Share20\DefaultShareProvider;
+use OC\Share20\ShareAttributes;
+use OCP\Share\IAttributes as IShareAttributes;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -689,6 +691,11 @@ class DefaultShareProviderTest extends TestCase {
 		$share->setShareOwner('shareOwner');
 		$share->setNode($path);
 		$share->setPermissions(1);
+
+		$attrs = new ShareAttributes();
+		$attrs->setAttribute("permissions", "download", true);
+		$share->setAttributes($attrs);
+
 		$share->setTarget('/target');
 
 		$share2 = $this->provider->create($share);
@@ -703,6 +710,16 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertSame('/target', $share2->getTarget());
 		$this->assertLessThanOrEqual(new \DateTime(), $share2->getShareTime());
 		$this->assertSame($path, $share2->getNode());
+		$this->assertSame(
+			[
+				[
+					"scope" => "permissions",
+					"key" => "download",
+					"enabled" => true
+				]
+			],
+			$share->getAttributes()->toArray()
+		);
 	}
 
 	public function testCreateGroupShare() {
@@ -737,6 +754,11 @@ class DefaultShareProviderTest extends TestCase {
 		$share->setShareOwner('shareOwner');
 		$share->setNode($path);
 		$share->setPermissions(1);
+
+		$attrs = new ShareAttributes();
+		$attrs->setAttribute("permissions", "download", true);
+		$share->setAttributes($attrs);
+
 		$share->setTarget('/target');
 
 		$share2 = $this->provider->create($share);
@@ -751,6 +773,16 @@ class DefaultShareProviderTest extends TestCase {
 		$this->assertSame('/target', $share2->getTarget());
 		$this->assertLessThanOrEqual(new \DateTime(), $share2->getShareTime());
 		$this->assertSame($path, $share2->getNode());
+		$this->assertSame(
+			[
+				[
+					"scope" => "permissions",
+					"key" => "download",
+					"enabled" => true
+				]
+			],
+			$share->getAttributes()->toArray()
+		);
 	}
 
 	public function testCreateLinkShare() {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -709,7 +709,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function createShare($id, $type, $path, $sharedWith, $sharedBy, $shareOwner,
-		$permissions, $expireDate = null, $password = null) {
+		$permissions, $expireDate = null, $password = null, $attributes = null) {
 		$share = $this->createMock(IShare::class);
 
 		$share->method('getShareType')->willReturn($type);
@@ -718,6 +718,7 @@ class ManagerTest extends \Test\TestCase {
 		$share->method('getShareOwner')->willReturn($shareOwner);
 		$share->method('getNode')->willReturn($path);
 		$share->method('getPermissions')->willReturn($permissions);
+		$share->method('getAttributes')->willReturn($attributes);
 		$share->method('getExpirationDate')->willReturn($expireDate);
 		$share->method('getPassword')->willReturn($password);
 
@@ -2359,6 +2360,7 @@ class ManagerTest extends \Test\TestCase {
 			'error' => '',
 			'itemTarget' => '/target',
 			'shareWith' => null,
+			'attributes' => null,
 		];
 
 		$hookListnerExpectsPost = [
@@ -2374,6 +2376,7 @@ class ManagerTest extends \Test\TestCase {
 			'itemTarget' => '/target',
 			'fileTarget' => '/target',
 			'shareWith' => null,
+			'attributes' => null,
 			'passwordEnabled' => true,
 		];
 
@@ -3142,6 +3145,8 @@ class ManagerTest extends \Test\TestCase {
 		$manager->expects($this->once())->method('getShareById')->with('foo:42')->willReturn($originalShare);
 
 		$share = $this->manager->newShare();
+		$attrs = $this->manager->newShare()->newAttributes();
+		$attrs->setAttribute('app1', 'perm1', true);
 		$share->setProviderId('foo')
 			->setId('42')
 			->setShareType(\OCP\Share::SHARE_TYPE_USER)
@@ -3149,6 +3154,7 @@ class ManagerTest extends \Test\TestCase {
 			->setShareOwner('newUser')
 			->setSharedBy('sharer')
 			->setPermissions(31)
+			->setAttributes($attrs)
 			->setNode($node);
 
 		$this->defaultProvider->expects($this->once())
@@ -3186,6 +3192,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertInstanceOf(GenericEvent::class, $calledAfterUpdate[1]);
 		$this->assertEquals('share.afterupdate', $calledAfterUpdate[0]);
 		$this->assertArrayHasKey('permissionupdate', $calledAfterUpdate[1]);
+		$this->assertArrayHasKey('attributesupdate', $calledAfterUpdate[1]);
 		$this->assertTrue($calledAfterUpdate[1]->getArgument('permissionupdate'));
 		$this->assertArrayHasKey('oldpermissions', $calledAfterUpdate[1]);
 		$this->assertEquals(1, $calledAfterUpdate[1]->getArgument('oldpermissions'));


### PR DESCRIPTION
- [x] Implement extra share permissions with IShare from Approach 3 here - https://github.com/owncloud/core/issues/33458
- [x] Implement view-only plugin using extra share permissions to restrict view-only permission for read-only files.
- [x] Allow apps to register extra share permissions in frontend
- [x] Clean the code
- [x] Add unit tests
- [x] Try JSON type in DB @DeepDiver1975 
- [x] Make sure PR works with custom groups

Would be also good to merge UX for Forbidden exception with view-only https://github.com/owncloud/core/pull/33992

@PVince81 @DeepDiver1975 @pmaier1 