### PR TITLE
reducing the use of sabre in acceptance tests

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -73,6 +73,48 @@ class WebDavHelper {
 	/**
 	 *
 	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $path
+	 * @param string[] $properties
+	 * @param int $folderDepth
+	 * @param string $type
+	 * @param int $davPathVersionToUse
+	 *
+	 * @throws Exception
+	 *
+	 * @return ResponseInterface
+	 */
+	public static function propfind(
+		$baseUrl,
+		$user,
+		$password,
+		$path,
+		$properties,
+		$folderDepth = 0,
+		$type = "files",
+		$davPathVersionToUse = 2
+	) {
+		$headers = ['Depth' => $folderDepth];
+		$body = '<?xml version="1.0"?>
+				<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+					<d:prop>';
+		foreach ($properties as $property) {
+			$body .= "<d:$property/>";
+		}
+
+		$body .= '</d:prop></d:propfind>';
+
+		$response = self::makeDavRequest(
+			$baseUrl, $user, $password, "PROPFIND", $path, $headers, $body,
+			null, $davPathVersionToUse, $type
+		);
+		return $response;
+	}
+
+	/**
+	 *
+	 * @param string $baseUrl
 	 * URL of owncloud e.g. http://localhost:8080
 	 * should include the subfolder if owncloud runs in a subfolder
 	 * e.g. http://localhost:8080/owncloud-core

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -106,8 +106,7 @@ Feature: transfer-ownership
     And user "user1" has been created with default attributes
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
-    And using received transfer folder of "user1" as dav path
-    And as "user1" folder "/local_storage" should not exist
+    And as "user1" folder "/%last_transfer_path%/local_storage" should not exist
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not fail with shared trashed files
@@ -268,8 +267,7 @@ Feature: transfer-ownership
     And user "user0" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
     Then the command should have been successful
-    And using received transfer folder of "user1" as dav path
-    And as "user1" folder "/local_storage" should not exist
+    And as "user1" folder "/%last_transfer_path%/local_storage" should not exist
 
   Scenario: transferring ownership fails with invalid source user
     Given user "user0" has been created with default attributes

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -2065,6 +2065,14 @@ trait BasicStructure {
 				],
 				"parameter" => []
 			],
+			[
+				"code" => "%last_transfer_path%",
+				"function" => [
+					$this,
+					"getLastTransferPath"
+				],
+				"parameter" => []
+			],
 		];
 
 		foreach ($substitutions as $substitution) {

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -40,6 +40,24 @@ trait CommandLine {
 	 */
 	private $lastStdErr;
 
+	private $lastTransferPath;
+
+	/**
+	 * @return string
+	 */
+	public function getLastTransferPath() {
+		return $this->lastTransferPath;
+	}
+
+	/**
+	 * @param string $lastTransferPath
+	 *
+	 * @return void
+	 */
+	public function setLastTransferPath($lastTransferPath) {
+		$this->lastTransferPath = $lastTransferPath;
+	}
+
 	/**
 	 * get the exit status of the last occ command
 	 * app acceptance tests that have their own step code may need to process this
@@ -475,8 +493,6 @@ trait CommandLine {
 		PHPUnit_Framework_Assert::assertEquals(\trim($this->lastStdOut), "[]");
 		PHPUnit_Framework_Assert::assertEmpty($this->lastStdErr);
 	}
-
-	private $lastTransferPath;
 
 	/**
 	 * @param string $sourceUser

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1170,14 +1170,15 @@ trait WebDav {
 	 * @throws \Exception
 	 */
 	public function asFileOrFolderShouldNotExist($user, $entry, $path) {
-		$client = $this->getSabreClient($user);
-		$response = $client->request(
-			'GET', $this->makeSabrePath($user, $path)
+		$path = $this->substituteInLineCodes($path);
+		$response = WebDavHelper::makeDavRequest(
+			$this->baseUrl, $this->getActualUsername($user),
+			$this->getPasswordForUser($user), 'GET', $path, []
 		);
-		if ($response['statusCode'] < 401 || $response['statusCode'] > 404) {
+		if ($response->getStatusCode() < 401 || $response->getStatusCode() > 404) {
 			throw new \Exception(
 				"$entry '$path' expected to not exist " .
-				"(status code {$response['statusCode']}, expected 401 - 404)"
+				"(status code {$response->getStatusCode()}, expected 401 - 404)"
 			);
 		}
 
@@ -1195,6 +1196,7 @@ trait WebDav {
 	 * @throws \Exception
 	 */
 	public function asFileOrFolderShouldExist($user, $entry, $path) {
+		$path = $this->substituteInLineCodes($path);
 		$this->response = $this->listFolder($user, $path, 0);
 		try {
 			$this->thePropertiesResponseShouldContainAnEtag();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
reducing the use of sabre in acceptance tests

## Related Issue
part of #34000

## Motivation and Context
see issue

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
