### PR TITLE
Clear locks on remote server after test scenarios

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -2324,6 +2324,24 @@ trait BasicStructure {
 	}
 
 	/**
+	 *
+	 * @param string $serverUrl
+	 *
+	 * @return void
+	 */
+	public function clearFileLocksForServer($serverUrl) {
+		$response = OcsApiHelper::sendRequest(
+			$serverUrl,
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			'delete',
+			"/apps/testing/api/v1/lockprovisioning",
+			["global" => "true"]
+		);
+		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+	}
+
+	/**
 	 * After Scenario. clear file locks
 	 *
 	 * @AfterScenario
@@ -2332,15 +2350,10 @@ trait BasicStructure {
 	 */
 	public function clearFileLocks() {
 		$this->deleteTokenAuthEnforcedAfterScenario();
-		$response = OcsApiHelper::sendRequest(
-			$this->getBaseUrl(),
-			$this->getAdminUsername(),
-			$this->getAdminPassword(),
-			'delete',
-			"/apps/testing/api/v1/lockprovisioning",
-			["global" => "true"]
-		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		$this->clearFileLocksForServer($this->getBaseUrl());
+		if ($this->remoteBaseUrl !== $this->localBaseUrl) {
+			$this->clearFileLocksForServer($this->getRemoteBaseUrl());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
After each test scenario we already clear locks on the local server-under-test, just in case locks were left behind from a previous test. As described in the issue, we are sometimes seeing a problem with creating the skeleton files for a user on the federated remote server. e.g.:
```
{"reqId":"Foibv1jn71eRNlN6FCPU","level":0,"time":"2018-12-19T05:51:20+00:00","remoteAddr":"172.26.0.9","user":"user1","app":"files_skeleton","method":"GET","url":"\/ocs\/v1.php\/cloud\/users\/user1","message":"copying skeleton for user1 from \/drone\/src\/tests\/acceptance\/..\/..\/apps\/testing\/data\/webUISkeleton to \/user1\/files\/"}
{"reqId":"Foibv1jn71eRNlN6FCPU","level":3,"time":"2018-12-19T05:51:21+00:00","remoteAddr":"172.26.0.9","user":"user1","app":"PHP","method":"GET","url":"\/ocs\/v1.php\/cloud\/users\/user1","message":"OCP\\Lock\\LockedException: \"'single'quotes.txt\" is locked at \/drone\/fed-server\/lib\/private\/Files\/View.php#2021"}
```
https://drone.owncloud.com/owncloud/core/13700/621

Also clear locks on the remote federated server (if it exists).

## Related Issue
- Issue #33932 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
