### PR TITLE
make listFolder function in WebDav.php to use Guzzle

### DIFF
--- a/tests/TestHelpers/Asserts/WebDav.php
+++ b/tests/TestHelpers/Asserts/WebDav.php
@@ -22,8 +22,8 @@
 namespace TestHelpers\Asserts;
 
 use PHPUnit_Framework_Assert;
+use SimpleXMLElement;
 use Behat\Gherkin\Node\TableNode;
-use \Sabre\HTTP\ResponseInterface as SabreResponseInterface;
 
 /**
  * WebDAV related asserts
@@ -60,38 +60,21 @@ class WebDav {
 
 	/**
 	 *
-	 * @param SabreResponseInterface $response
+	 * @param SimpleXMLElement $responseXmlObject
 	 * @param TableNode $expectedShareTypes
 	 *
-	 * @return bool
-	 *
-	 * @throws \Exception
+	 * @return void
 	 */
-	public static function assertSabreResponseContainsShareTypes(
-		$response, $expectedShareTypes
+	public static function assertResponseContainsShareTypes(
+		$responseXmlObject, $expectedShareTypes
 	) {
-		if (!\array_key_exists('{http://owncloud.org/ns}share-types', $response)) {
-			throw new \Exception(
-				"Cannot find property \"{http://owncloud.org/ns}share-types\""
+		foreach ($expectedShareTypes->getRows() as $row) {
+			$xmlPart = $responseXmlObject->xpath(
+				"//d:prop/oc:share-types/oc:share-type[.=" . $row[0] . "]"
+			);
+			PHPUnit_Framework_Assert::assertNotEmpty(
+				$xmlPart, "cannot find share-type '" . $row[0] . "'"
 			);
 		}
-
-		$foundTypes = [];
-		$data = $response['{http://owncloud.org/ns}share-types'];
-		foreach ($data as $item) {
-			if ($item['name'] !== '{http://owncloud.org/ns}share-type') {
-				throw new \Exception(
-					"Invalid property found: '{$item['name']}'"
-				);
-			}
-
-			//make the multi dimensional array so it looks like TableNode::getRows()
-			$foundTypes[] = [$item['value']];
-		}
-		PHPUnit_Framework_Assert::assertSame(
-			$expectedShareTypes->getRows(), $foundTypes,
-			"expected share types do not match the received share types"
-		);
-		return true;
 	}
 }

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -13,9 +13,9 @@ Feature: Comments
     And the user should have the following comments on file "/myFileToComment.txt"
       | user0 | My first comment |
     When the user gets the following properties of folder "/myFileToComment.txt" using the WebDAV API
-      | {http://owncloud.org/ns}comments-href   |
-      | {http://owncloud.org/ns}comments-count  |
-      | {http://owncloud.org/ns}comments-unread |
-    Then the single response should contain a property "{http://owncloud.org/ns}comments-count" with value "1"
-    And the single response should contain a property "{http://owncloud.org/ns}comments-unread" with value "0"
-    And the single response should contain a property "{http://owncloud.org/ns}comments-href" with value "a_comment_url"
+      | oc:comments-href   |
+      | oc:comments-count  |
+      | oc:comments-unread |
+    Then the single response should contain a property "oc:comments-count" with value "1"
+    And the single response should contain a property "oc:comments-unread" with value "0"
+    And the single response should contain a property "oc:comments-href" with value "a_comment_url"

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -21,7 +21,7 @@ Feature: sharing
     Given user "user0" has created folder "/merge-test-outside-perms"
     When user "user0" shares folder "/merge-test-outside-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the sharing API
-    Then as user "user1" folder "/merge-test-outside-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    Then as user "user1" folder "/merge-test-outside-perms" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "user1" folder "/merge-test-outside-perms (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups
@@ -39,7 +39,7 @@ Feature: sharing
     And user "user0" has created folder "/merge-test-outside-twogroups-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp4" with permissions 31 using the sharing API
-    Then as user "user1" folder "/merge-test-outside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    Then as user "user1" folder "/merge-test-outside-twogroups-perms" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "user1" folder "/merge-test-outside-twogroups-perms (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups and member
@@ -49,7 +49,7 @@ Feature: sharing
     When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions 1 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp4" with permissions 31 using the sharing API
     And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the sharing API
-    Then as user "user1" folder "/merge-test-outside-twogroups-member-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    Then as user "user1" folder "/merge-test-outside-twogroups-member-perms" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "user1" folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
 
   Scenario: Merging shares for recipient when shared from inside with group
@@ -74,7 +74,7 @@ Feature: sharing
     And user "user1" has created folder "/merge-test-inside-twogroups-perms"
     When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API
     And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp4" using the sharing API
-    Then as user "user1" folder "/merge-test-inside-twogroups-perms" should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
+    Then as user "user1" folder "/merge-test-inside-twogroups-perms" should contain a property "oc:permissions" with value "RDNVCK" or with value "RMDNVCK"
     And as "user1" folder "/merge-test-inside-twogroups-perms (2)" should not exist
     And as "user1" folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
@@ -84,7 +84,7 @@ Feature: sharing
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
-    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
 
   @skipOnLDAP @user_ldap-issue-274
@@ -93,5 +93,5 @@ Feature: sharing
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
-    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -11,8 +11,8 @@ Feature: sharing
     Given using <dav-path> DAV path
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     When user "user0" gets the following properties of file "/tmp.txt" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
       | dav-path |
       | old      |
@@ -23,8 +23,8 @@ Feature: sharing
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has shared file "/tmp.txt" with user "user1"
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
       | dav-path |
       | old      |
@@ -41,8 +41,8 @@ Feature: sharing
       | permissions | 19       |
       | shareWith   | grp1     |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
       | dav-path |
       | old      |
@@ -54,7 +54,7 @@ Feature: sharing
     And user "user0" has shared file "tmp.txt" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 3 |
-    Then as user "user1" file "/tmp.txt" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
+    Then as user "user1" file "/tmp.txt" should contain a property "ocs:share-permissions" with value "3"
     Examples:
       | dav-path |
       | old      |
@@ -71,8 +71,8 @@ Feature: sharing
       | permissions | 3        |
       | shareWith   | grp1     |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "3"
     Examples:
       | dav-path |
       | old      |
@@ -84,7 +84,7 @@ Feature: sharing
     And user "user0" has shared file "tmp.txt" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 17 |
-    Then as user "user1" file "/tmp.txt" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
+    Then as user "user1" file "/tmp.txt" should contain a property "ocs:share-permissions" with value "17"
     Examples:
       | dav-path |
       | old      |
@@ -101,8 +101,8 @@ Feature: sharing
       | permissions | 17       |
       | shareWith   | grp1     |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "17"
     Examples:
       | dav-path |
       | old      |
@@ -112,8 +112,8 @@ Feature: sharing
     Given using <dav-path> DAV path
     And user "user0" has created folder "/tmp"
     When user "user0" gets the following properties of folder "/" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
       | dav-path |
       | old      |
@@ -124,8 +124,8 @@ Feature: sharing
     And user "user0" has created folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
       | dav-path |
       | old      |
@@ -141,8 +141,8 @@ Feature: sharing
       | shareType | 1    |
       | shareWith | grp1 |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
       | dav-path |
       | old      |
@@ -154,7 +154,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 29 |
-    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
+    Then as user "user1" folder "/tmp" should contain a property "ocs:share-permissions" with value "29"
     Examples:
       | dav-path |
       | old      |
@@ -171,8 +171,8 @@ Feature: sharing
       | shareWith   | grp1 |
       | permissions | 29   |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "29"
     Examples:
       | dav-path |
       | old      |
@@ -184,7 +184,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 27 |
-    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
+    Then as user "user1" folder "/tmp" should contain a property "ocs:share-permissions" with value "27"
     Examples:
       | dav-path |
       | old      |
@@ -201,8 +201,8 @@ Feature: sharing
       | shareWith   | grp1 |
       | permissions | 27   |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "27"
     Examples:
       | dav-path |
       | old      |
@@ -214,7 +214,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 23 |
-    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
+    Then as user "user1" folder "/tmp" should contain a property "ocs:share-permissions" with value "23"
     Examples:
       | dav-path |
       | old      |
@@ -231,8 +231,8 @@ Feature: sharing
       | shareWith   | grp1 |
       | permissions | 23   |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "23"
     Examples:
       | dav-path |
       | old      |
@@ -244,7 +244,7 @@ Feature: sharing
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user0" updates the last share using the sharing API with
       | permissions | 15 |
-    Then as user "user1" folder "/tmp" should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+    Then as user "user1" folder "/tmp" should contain a property "ocs:share-permissions" with value "15"
     Examples:
       | dav-path |
       | old      |
@@ -261,8 +261,8 @@ Feature: sharing
       | shareWith   | grp1 |
       | permissions | 15   |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
-      | {http://open-collaboration-services.org/ns}share-permissions |
-    Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value "15"
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiWebdavProperties/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/createFolder.feature
@@ -32,8 +32,8 @@ Feature: create folder
     Given using <dav_version> DAV path
     And user "user0" has created folder "/test_folder"
     When user "user0" gets the following properties of folder "/test_folder" using the WebDAV API
-      | {DAV:}resourcetype |
-    Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
+      | d:resourcetype |
+    Then the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:
       | dav_version |
       | old         |
@@ -43,8 +43,8 @@ Feature: create folder
     Given using <dav_version> DAV path
     And user "user0" has created folder "/test_folder:5"
     When user "user0" gets the following properties of folder "/test_folder:5" using the WebDAV API
-      | {DAV:}resourcetype |
-    Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
+      | d:resourcetype |
+    Then the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -62,8 +62,8 @@ Feature: get file properties
     Given using <dav_version> DAV path
     And user "user0" has created folder "/test"
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
-      | {http://owncloud.org/ns}share-types |
-    Then the response should contain an empty property "{http://owncloud.org/ns}share-types"
+      | oc:share-types |
+    Then the response should contain an empty property "oc:share-types"
     Examples:
       | dav_version |
       | old         |
@@ -79,7 +79,7 @@ Feature: get file properties
       | permissions | 31    |
       | shareWith   | user1 |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
-      | {http://owncloud.org/ns}share-types |
+      | oc:share-types |
     Then the response should contain a share-types property with
       | 0 |
     Examples:
@@ -97,7 +97,7 @@ Feature: get file properties
       | permissions | 31   |
       | shareWith   | grp1 |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
-      | {http://owncloud.org/ns}share-types |
+      | oc:share-types |
     Then the response should contain a share-types property with
       | 1 |
     Examples:
@@ -113,7 +113,7 @@ Feature: get file properties
       | path        | test |
       | permissions | 31   |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
-      | {http://owncloud.org/ns}share-types |
+      | oc:share-types |
     Then the response should contain a share-types property with
       | 3 |
     Examples:
@@ -141,7 +141,7 @@ Feature: get file properties
       | path        | test |
       | permissions | 31   |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
-      | {http://owncloud.org/ns}share-types |
+      | oc:share-types |
     Then the response should contain a share-types property with
       | 0 |
       | 1 |
@@ -166,8 +166,8 @@ Feature: get file properties
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     When user "user0" gets the following properties of file "/somefile.txt" using the WebDAV API
-      | {http://owncloud.org/ns}privatelink |
-    Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
+      | oc:privatelink |
+    Then the single response should contain a property "oc:privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -11,7 +11,7 @@ Feature: get quota
   Scenario Outline: Retrieving folder quota when no quota is set
     Given using <dav_version> DAV path
     When the administrator gives unlimited quota to user "user0" using the provisioning API
-    Then as user "user0" folder "/" should contain a property "{DAV:}quota-available-bytes" with value "-3"
+    Then as user "user0" folder "/" should contain a property "d:quota-available-bytes" with value "-3"
     Examples:
       | dav_version |
       | old         |
@@ -21,7 +21,7 @@ Feature: get quota
   Scenario Outline: Retrieving folder quota when quota is set
     Given using <dav_version> DAV path
     When the administrator sets the quota of user "user0" to "10 MB" using the provisioning API
-    Then as user "user0" folder "/" should contain a property "{DAV:}quota-available-bytes" with value "10485406"
+    Then as user "user0" folder "/" should contain a property "d:quota-available-bytes" with value "10485406"
     Examples:
       | dav_version |
       | old         |
@@ -39,8 +39,8 @@ Feature: get quota
       | permissions | 31        |
       | shareWith   | user0     |
     When user "user0" gets the following properties of folder "/testquota" using the WebDAV API
-      | {DAV:}quota-available-bytes |
-    Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485406"
+      | d:quota-available-bytes |
+    Then the single response should contain a property "d:quota-available-bytes" with value "10485406"
     Examples:
       | dav_version |
       | old         |
@@ -51,8 +51,8 @@ Feature: get quota
     And the quota of user "user0" has been set to "1 KB"
     And user "user0" has uploaded file "/prueba.txt" of 93 bytes
     When user "user0" gets the following properties of folder "/" using the WebDAV API
-      | {DAV:}quota-available-bytes |
-    Then the single response should contain a property "{DAV:}quota-available-bytes" with value "577"
+      | d:quota-available-bytes |
+    Then the single response should contain a property "d:quota-available-bytes" with value "577"
     Examples:
       | dav_version |
       | old         |
@@ -65,8 +65,8 @@ Feature: get quota
     And user "user0" has uploaded file "/user0.txt" of 93 bytes
     And user "user0" has shared file "user0.txt" with user "user1"
     When user "user1" gets the following properties of folder "/" using the WebDAV API
-      | {DAV:}quota-available-bytes |
-    Then the single response should contain a property "{DAV:}quota-available-bytes" with value "670"
+      | d:quota-available-bytes |
+    Then the single response should contain a property "d:quota-available-bytes" with value "670"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -20,6 +20,7 @@
  */
 
 use TestHelpers\SetupHelper;
+use TestHelpers\WebDavHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -502,22 +503,19 @@ trait CommandLine {
 	 */
 	public function findLastTransferFolderForUser($sourceUser, $targetUser) {
 		$foundPaths = [];
-		$results = $this->listFolder($targetUser, '', 1);
-		foreach ($results as $path => $data) {
-			$path = \rawurldecode($path);
+		$responseXmlObject = $this->listFolder($targetUser, '', 1);
+		$transferredElements = $responseXmlObject->xpath(
+			"//d:response/d:href[contains(., '/transferred%20from%20$sourceUser%20on%')]"
+		);
+		foreach ($transferredElements as $transferredElement) {
+			$path = \rawurldecode($transferredElement);
 			$parts = \explode(' ', $path);
-			if (\basename($parts[0]) !== 'transferred') {
-				continue;
-			}
-			if (isset($parts[2]) && $parts[2] === $sourceUser) {
-				// store timestamp as key
-				$foundPaths[] = [
-					'date' => \strtotime(\trim($parts[4], '/')),
-					'path' => $path,
-				];
-			}
+			// store timestamp as key
+			$foundPaths[] = [
+				'date' => \strtotime(\trim($parts[4], '/')),
+				'path' => $path,
+			];
 		}
-
 		if (empty($foundPaths)) {
 			return null;
 		}

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -199,7 +199,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function asUserTheFileOrFolderShouldBeFavorited($user, $path, $expectedValue = 1) {
-		$property = "{http://owncloud.org/ns}favorite";
+		$property = "oc:favorite";
 		$this->featureContext->asUserFolderShouldContainAPropertyWithValue(
 			$user, $path, $property, $expectedValue
 		);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -87,6 +87,13 @@ trait WebDav {
 	 * @var array
 	 */
 	private $responseXml = [];
+	
+	/**
+	 * response content parsed into a SimpleXMLElement
+	 *
+	 * @var SimpleXMLElement
+	 */
+	private $responseXmlObject;
 
 	private $httpRequestTimeout = 0;
 
@@ -955,9 +962,7 @@ trait WebDav {
 	public function userGetsThePropertiesOfFolder(
 		$user, $path
 	) {
-		$this->response = $this->listFolder(
-			$user, $path, 0, []
-		);
+		$this->responseXmlObject = $this->listFolder($user, $path, 0);
 	}
 
 	/**
@@ -978,9 +983,7 @@ trait WebDav {
 				$properties[] = $row[0];
 			}
 		}
-		$this->response = $this->listFolder(
-			$user, $path, 0, $properties
-		);
+		$this->responseXmlObject = $this->listFolder($user, $path, 0, $properties);
 	}
 
 	/**
@@ -1100,7 +1103,7 @@ trait WebDav {
 	 */
 	public function asFileOrFolderShouldExist($user, $entry, $path) {
 		$path = $this->substituteInLineCodes($path);
-		$this->response = $this->listFolder($user, $path, 0);
+		$this->responseXmlObject = $this->listFolder($user, $path, 0);
 		try {
 			$this->thePropertiesResponseShouldContainAnEtag();
 		} catch (\Exception $e) {
@@ -1117,7 +1120,10 @@ trait WebDav {
 	 * @throws \Exception
 	 */
 	public function thePropertiesResponseShouldContainAnEtag() {
-		if (!\is_array($this->response) || !isset($this->response['{DAV:}getetag'])) {
+		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
+		if (!\is_array($xmlPart)
+			|| !\preg_match("/^\"[a-f0-9]{1,32}\"$/", $xmlPart[0]->__toString())
+		) {
 			throw new \Exception(
 				"getetag not found in response"
 			);
@@ -1154,40 +1160,45 @@ trait WebDav {
 	public function theSingleResponseShouldContainAPropertyWithValueAndAlternative(
 		$key, $expectedValue, $altExpectedValue
 	) {
-		$keys = $this->response;
-		if (!\array_key_exists($key, $keys)) {
-			throw new \Exception(
-				"Cannot find property \"$key\" with \"$expectedValue\""
-			);
-		}
-
-		$value = $keys[$key];
-		if ($value instanceof ResourceType) {
-			$value = $value->getValue();
-			if (empty($value)) {
-				$value = '';
-			} else {
-				$value = $value[0];
-			}
-		}
+		$xmlPart = $this->responseXmlObject->xpath("//d:prop/$key");
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find property \"$key\""
+		);
+		$value = $xmlPart[0]->__toString();
 
 		if ($expectedValue === "a_comment_url") {
 			$basePath = \ltrim($this->getBasePath() . "/", "/");
 			$expected = "#^/{$basePath}remote.php/dav/comments/files/([0-9]+)$#";
-			if (\preg_match($expected, $value)) {
-				return;
-			} else {
-				throw new \Exception(
-					"Property \"$key\" found with value \"$value\", expected \"$expectedValue\""
-				);
-			}
-		}
-
-		if ($value != $expectedValue && $value != $altExpectedValue) {
+			PHPUnit_Framework_Assert::assertRegExp(
+				$expected, $value,
+				"Property \"$key\" found with value \"$value\", expected \"$expectedValue\""
+			);
+		} elseif ($value != $expectedValue && $value != $altExpectedValue) {
 			throw new \Exception(
 				"Property \"$key\" found with value \"$value\", expected \"$expectedValue\""
 			);
 		}
+	}
+	
+	/**
+	 * @Then the single response should contain a property :property with a child property :childProperty
+	 *
+	 * @param string $property
+	 * @param string $childProperty
+	 *
+	 * @return void
+	 *
+	 * @throws \Exception
+	 */
+	public function theSingleResponseShouldContainAPropertyWithChildProperty(
+		$property, $childProperty
+	) {
+		$xmlPart = $this->responseXmlObject->xpath(
+			"//d:prop/$property/$childProperty"
+		);
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find property \"$property/$childProperty\""
+		);
 	}
 
 	/**
@@ -1204,9 +1215,7 @@ trait WebDav {
 	public function asUserFolderShouldContainAPropertyWithValueOrWithValue(
 		$user, $path, $property, $expectedValue, $altExpectedValue
 	) {
-		$this->response = $this->listFolder(
-			$user, $path, 0, [$property]
-		);
+		$this->responseXmlObject = $this->listFolder($user, $path, 0, [$property]);
 		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
 			$property, $expectedValue, $altExpectedValue
 		);
@@ -1242,26 +1251,15 @@ trait WebDav {
 	public function theSingleResponseShouldContainAPropertyWithValueLike(
 		$key, $regex
 	) {
-		$keys = $this->response;
-		if (!\array_key_exists($key, $keys)) {
-			throw new \Exception("Cannot find property \"$key\" with \"$regex\"");
-		}
-
-		$value = $keys[$key];
-		if ($value instanceof ResourceType) {
-			$value = $value->getValue();
-			if (empty($value)) {
-				$value = '';
-			} else {
-				$value = $value[0];
-			}
-		}
-
-		if (!\preg_match($regex, $value)) {
-			throw new \Exception(
-				"Property \"$key\" found with value \"$value\", expected \"$regex\""
-			);
-		}
+		$xmlPart = $this->responseXmlObject->xpath("//d:prop/$key");
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find property \"$key\""
+		);
+		$value = $xmlPart[0]->__toString();
+		PHPUnit_Framework_Assert::assertRegExp(
+			$regex, $value,
+			"Property \"$key\" found with value \"$value\", expected \"$regex\""
+		);
 	}
 
 	/**
@@ -1273,8 +1271,8 @@ trait WebDav {
 	 * @throws \Exception
 	 */
 	public function theResponseShouldContainAShareTypesPropertyWith($table) {
-		WebDavAssert::assertSabreResponseContainsShareTypes(
-			$this->response, $table
+		WebDavAssert::assertResponseContainsShareTypes(
+			$this->responseXmlObject, $table
 		);
 	}
 
@@ -1287,42 +1285,36 @@ trait WebDav {
 	 * @throws \Exception
 	 */
 	public function theResponseShouldContainAnEmptyProperty($property) {
-		$properties = $this->response;
-		if (!\array_key_exists($property, $properties)) {
-			throw new \Exception("Cannot find property \"$property\"");
-		}
-
-		if ($properties[$property] !== null) {
-			throw new \Exception("Property \"$property\" is not empty");
-		}
+		$xmlPart = $this->responseXmlObject->xpath("//d:prop/$property");
+		PHPUnit_Framework_Assert::assertCount(
+			1, $xmlPart, "Cannot find property \"$property\""
+		);
+		PHPUnit_Framework_Assert::assertEmpty(
+			$xmlPart[0], "Property \"$property\" is not empty"
+		);
 	}
 
 	/**
-	 * Returns the elements of a propfind
 	 *
 	 * @param string $user
 	 * @param string $path
 	 * @param int $folderDepth requires 1 to see elements without children
 	 * @param array|null $properties
 	 *
-	 * @return array|\Sabre\HTTP\ResponseInterface
+	 * @return SimpleXMLElement
 	 */
 	public function listFolder($user, $path, $folderDepth, $properties = null) {
-		$client = $this->getSabreClient($user);
-		if (!$properties) {
-			$properties = [
-				'{DAV:}getetag'
-			];
+		if ($this->customDavPath !== null) {
+			$path = $this->customDavPath . $path;
 		}
-
-		try {
-			$response = $client->propfind(
-				$this->makeSabrePath($user, $path), $properties, $folderDepth
-			);
-		} catch (Sabre\HTTP\ClientHttpException $e) {
-			$response = $e->getResponse();
-		}
-		return $response;
+		
+		return WebDavHelper::listFolder(
+			$this->getBaseUrl(),
+			$this->getActualUsername($user),
+			$this->getPasswordForUser($user),
+			$path, $folderDepth, $properties,
+			"files", ($this->usingOldDavPath) ? 1 : 2
+		);
 	}
 
 	/**
@@ -1395,16 +1387,22 @@ trait WebDav {
 				'$expectedElements has to be an instance of TableNode'
 			);
 		}
-		$elementList = $this->listFolder($user, '/', 3);
+		$responseXmlObject = $this->listFolder($user, "/", 3);
 		$elementRows = $elements->getRows();
 		$elementsSimplified = $this->simplifyArray($elementRows);
 		foreach ($elementsSimplified as $expectedElement) {
 			$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
-			if (!\array_key_exists($webdavPath, $elementList) && $expectedToBeListed) {
+			$element = $responseXmlObject->xpath(
+				"//d:response/d:href[text() = \"$webdavPath\"]"
+			);
+			if ($expectedToBeListed
+				&& (!isset($element[0]) || $element[0]->__toString() !== $webdavPath)
+			) {
 				PHPUnit_Framework_Assert::fail(
 					"$webdavPath is not in propfind answer but should"
 				);
-			} elseif (\array_key_exists($webdavPath, $elementList) && !$expectedToBeListed) {
+			} elseif (!$expectedToBeListed && isset($element[0])
+			) {
 				PHPUnit_Framework_Assert::fail(
 					"$webdavPath is in propfind answer but should not be"
 				);
@@ -2290,12 +2288,12 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userStoresEtagOfElement($user, $path) {
-		$propertiesTable = new TableNode([['{DAV:}getetag']]);
+		$propertiesTable = new TableNode([['getetag']]);
 		$this->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
-		$pathETAG[$path] = $this->response['{DAV:}getetag'];
-		$this->storedETAG[$user] = $pathETAG;
+		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
+		$this->storedETAG[$user][$path] = $xmlPart[0]->__toString();
 	}
 
 	/**
@@ -2307,12 +2305,13 @@ trait WebDav {
 	 * @return void
 	 */
 	public function etagOfElementOfUserShouldNotHaveChanged($path, $user) {
-		$propertiesTable = new TableNode([['{DAV:}getetag']]);
+		$propertiesTable = new TableNode([['getetag']]);
 		$this->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
+		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
 		PHPUnit_Framework_Assert::assertEquals(
-			$this->response['{DAV:}getetag'], $this->storedETAG[$user][$path]
+			$xmlPart[0]->__toString(), $this->storedETAG[$user][$path]
 		);
 	}
 
@@ -2325,12 +2324,13 @@ trait WebDav {
 	 * @return void
 	 */
 	public function etagOfElementOfUserShouldHaveChanged($path, $user) {
-		$propertiesTable = new TableNode([['{DAV:}getetag']]);
+		$propertiesTable = new TableNode([['getetag']]);
 		$this->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
+		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
 		PHPUnit_Framework_Assert::assertNotEquals(
-			$this->response['{DAV:}getetag'], $this->storedETAG[$user][$path]
+			$xmlPart[0]->__toString(), $this->storedETAG[$user][$path]
 		);
 	}
 
@@ -2437,15 +2437,13 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userDeletesEverythingInFolder($user, $folder) {
-		$elementList = $this->listFolder($user, $folder, 1);
+		$responseXmlObject = $this->listFolder($user, $folder, 1);
+		$elementList = $responseXmlObject->xpath("//d:response/d:href");
 		if (\is_array($elementList) && \count($elementList)) {
-			$elementListKeys = \array_keys($elementList);
-			\array_shift($elementListKeys);
+			\array_shift($elementList); //don't delete the folder itself
 			$davPrefix = "/" . $this->getFullDavFilesPath($user);
-			foreach ($elementListKeys as $element) {
-				if (\substr($element, 0, \strlen($davPrefix)) == $davPrefix) {
-					$element = \substr($element, \strlen($davPrefix));
-				}
+			foreach ($elementList as $element) {
+				$element = \substr($element, \strlen($davPrefix));
 				$this->userDeletesFile($user, $element);
 			}
 		}


### PR DESCRIPTION
## Description
make the `listFolder` method to use Guzzle and not Sabre

## Related Issue
part of #34000 & #33690

## Motivation and Context
finally be able to remove sabre from the acceptance tests infrastructure 

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
