### PR TITLE
Adjust travis scripts so webUI tests can work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,8 @@ env:
   global:
     - TEST_DAV=$(tests/travis/changed_app.sh dav)
     - TC=carddav
-    - SRV_HOST_NAME=owncloud
-    - SRV_HOST_PORT=8889
-    - REMOTE_FED_SRV_HOST_NAME=owncloud
-    - REMOTE_FED_SRV_HOST_PORT=8989
+    - TEST_SERVER_URL=http://owncloud:8889
+    - TEST_SERVER_FED_URL=http://owncloud:8989
   matrix:
     - DB=sqlite
 
@@ -29,9 +27,9 @@ branches:
 addons:
   apt: &common_apt
     packages:
-    - realpath
-    - net-tools
-    - libxml2-utils
+      - realpath
+      - net-tools
+      - libxml2-utils
   hosts: &common_hosts
     - owncloud
 
@@ -42,6 +40,7 @@ before_install:
 install:
   - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TC' = 'selenium' ]; then bash tests/travis/install.sh $DB; fi"
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/ci/$TC/install.sh; fi"
+  - sh -c "if [ '$TC' = 'selenium' ]; then cd apps && git clone https://github.com/owncloud/testing.git && cd .. && php occ a:e testing; fi"
 
 before_script:
   - sh -c "if [ '$TC' = 'selenium' ]; then bash tests/travis/start_php_dev_server.sh; fi"

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -20,6 +20,14 @@ PHPUNIT=$(which phpunit)
 TRAVIS_ORACLE_HOME="/usr/lib/oracle/xe/app/oracle/product/10.2.0/server"
 [ -z "$ORACLE_HOME" ] && ORACLE_HOME=$TRAVIS_ORACLE_HOME
 
+# if SRV_HOST_NAME is not set then set it from TEST_SERVER_URL
+# TEST_SERVER_URL should look something like http://owncloud:8889
+if [ -z "$SRV_HOST_NAME" ] && [ ! -z "$TEST_SERVER_URL" ]
+then
+	SRV_HOST_NAME_PORT=$(echo $TEST_SERVER_URL | cut -d "/" -f 3)
+	SRV_HOST_NAME=$(echo $SRV_HOST_NAME_PORT | cut -d ":" -f 1)
+fi
+
 if [ $1 ]; then
 	FOUND=0
 	for DBCONFIG in $DBCONFIGS; do

--- a/tests/travis/start_php_dev_server.sh
+++ b/tests/travis/start_php_dev_server.sh
@@ -6,7 +6,7 @@
 # @copyright Copyright (c) 2017 Artur Neumann info@individual-it.net
 #
 
-# $1 hostname[:port] on which server will listen
+# $1 URL on which server will listen, e.g. http://owncloud:8889
 # $2 instance type being started (e.g. primary or IPv4 or IPv6)
 
 # After return, the following global vars are available:
@@ -14,7 +14,8 @@
 # ERROR_STARTING_SERVER set to true if there was an error
 
 function start_php_dev_server {
-	php -S $1 > /dev/null 2>&1 &
+	HOST_AND_PORT=$(echo $1 | cut -d "/" -f 3)
+	php -S $HOST_AND_PORT > /dev/null 2>&1 &
 	serverPID=$!
 	sleep 1
 
@@ -31,15 +32,9 @@ function start_php_dev_server {
 ENV_PARAM_MISSING=false
 ERROR_STARTING_SERVER=false
 
-if [ -z "$SRV_HOST_NAME" ]
+if [ -z "$TEST_SERVER_URL" ]
 then
-	echo "environment variable SRV_HOST_NAME is not defined"
-	ENV_PARAM_MISSING=true
-fi
-
-if [ -z "$SRV_HOST_PORT" ]
-then
-	echo "environment variable SRV_HOST_PORT is not defined"
+	echo "environment variable TEST_SERVER_URL is not defined"
 	ENV_PARAM_MISSING=true
 fi
 
@@ -49,21 +44,11 @@ then
 	exit 1
 fi
 
-start_php_dev_server $SRV_HOST_NAME:$SRV_HOST_PORT primary
+start_php_dev_server $TEST_SERVER_URL primary
 
-if [ ! -z "$REMOTE_FED_SRV_HOST_NAME" ] && [ ! -z "$REMOTE_FED_SRV_HOST_PORT" ]
+if [ ! -z "$TEST_SERVER_FED_URL" ]
 then
-	start_php_dev_server $REMOTE_FED_SRV_HOST_NAME:$REMOTE_FED_SRV_HOST_PORT REMOTE_FEDERATION
-fi
-
-if [ ! -z "$IPV4_HOST_NAME" ] && [ "$SRV_HOST_NAME" != "$IPV4_HOST_NAME" ]
-then
-	start_php_dev_server $IPV4_HOST_NAME:$SRV_HOST_PORT IPv4
-fi
-
-if [ ! -z "$IPV6_HOST_NAME" ] && [ "$SRV_HOST_NAME" != "$IPV6_HOST_NAME" ]
-then
-	start_php_dev_server $IPV6_HOST_NAME:$SRV_HOST_PORT IPv6
+	start_php_dev_server $TEST_SERVER_FED_URL REMOTE_FEDERATION
 fi
 
 if [ "$ERROR_STARTING_SERVER" = true ]


### PR DESCRIPTION
## Description
1) Adjust scripts in ``tests/travis`` to use ``TEST_SERVER_URL`` and ``TEST_SERVER_FED_URL``
2) Adjust ``.travis.yml`` to clone and enable the testing app
3) Adjust ``.travis.yml`` to set ``TEST_SERVER_URL`` and ``TEST_SERVER_FED_URL``

## Motivation and Context
Scripts for running webUI tests on travis got out-of-date recently because the ``run.sh`` script (that is used for running tests locally, on drone, and on travis) was refactored to use ``TEST_SERVER_URL`` env var rather than ``SRV_HOST_NAME`` and ``SRV_HOST_PORT``

Also the testing app was put in a separate repo, so it needs to be cloned and enabled.

It is useful to still be able to enable some webUI test suites in travis. This allows us to try the tests with Edge and IE11 browsers, and also to be able to see the UI test video on SauceLabs (if we have a test scenario that is "doing weird stuff")

## How Has This Been Tested?
Run 2 webUI test suites in Travis in my fork.
See demonstration PR https://github.com/phil-davis/core/pull/140
And Travis result https://travis-ci.org/phil-davis/core/builds/474805358

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
