### PR TITLE
Bump phan 0.12.11 phpstan 0.10.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,10 @@ $(COMPOSER_BIN):
 	cd build && ./getcomposer.sh
 
 $(PHAN_BIN):
-	cd build && curl -s -L https://github.com/phan/phan/releases/download/0.12.10/phan.phar -o phan.phar;
+	cd build && curl -s -L https://github.com/phan/phan/releases/download/0.12.11/phan.phar -o phan.phar;
 
 $(PHPSTAN_BIN):
-	cd build && curl -s -L https://github.com/phpstan/phpstan/releases/download/0.10.6/phpstan.phar -o phpstan.phar;
+	cd build && curl -s -L https://github.com/phpstan/phpstan/releases/download/0.10.7/phpstan.phar -o phpstan.phar;
 #
 # ownCloud core PHP dependencies
 #


### PR DESCRIPTION
## Description
- Bump phan ``0.12.10`` to ``0.12.11`` Note: higher versions of phan are reporting new stuff, so we need to investigate the new reported stuff before moving to the latest phan ``1.1.*`` https://github.com/phan/phan/releases
- Bump phpstan ``0.10.6`` to ``0.10.7`` https://github.com/phpstan/phpstan/releases/tag/0.10.7

## Motivation and Context
Keep up-to-date with code analysis tools.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
