### PR TITLE
Create a separate acceptance test TrashbinContext

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -70,6 +70,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
+        - TrashbinContext:
 
     apiShareOperations:
       paths:
@@ -77,6 +78,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
+        - TrashbinContext:
 
     apiSharingNotifications:
       paths:
@@ -96,6 +98,7 @@ default:
         - '%paths.base%/../features/apiTrashbin'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - TrashbinContext:
 
     apiWebdavOperations:
       paths:
@@ -141,6 +144,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
+        - TrashbinContext:
 
     webUIAdminSettings:
       paths:
@@ -319,6 +323,7 @@ default:
         - '%paths.base%/../features/webUITrashbin'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - TrashbinContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -41,7 +41,6 @@ trait BasicStructure {
 	use Provisioning;
 	use Sharing;
 	use Tags;
-	use Trashbin;
 	use WebDav;
 	use CommandLine;
 


### PR DESCRIPTION
## Description
Change ``Trashbin`` trait to be a separate ``TrashbinContext``

## Motivation and Context
The current API acceptance tests include "almost everything" in ``BasicStructure`` trait which is included in ``FeatureContext``. Each of these traits that contain a logical subset of acceptance test steps, and can be their own context.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
