### PR TITLE
Create acceptance test ChecksumContext

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -15,6 +15,7 @@ default:
         - AppManagementContext:
         - CalDavContext:
         - CardDavContext:
+        - ChecksumContext:
         - FilesVersionsContext:
         - TransferOwnershipContext:
 

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -7,7 +7,7 @@ Feature: checksums
   Scenario Outline: Uploading a file with checksum should work
     Given using <dav_version> DAV path
     When user "user0" uploads file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
-    Then the webdav response should have a status code "201"
+    Then the HTTP status code should be "201"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -36,7 +36,6 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 trait BasicStructure {
 	use AppConfiguration;
 	use Auth;
-	use Checksums;
 	use Comments;
 	use Provisioning;
 	use Sharing;

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -83,22 +83,6 @@ trait Checksums {
 	}
 
 	/**
-	 * @Then the webdav response should have a status code :statusCode
-	 *
-	 * @param int $statusCode
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theWebdavResponseShouldHaveAStatusCode($statusCode) {
-		if ((int)$statusCode !== $this->response->getStatusCode()) {
-			throw new \Exception(
-				"Expected $statusCode, got " . $this->response->getStatusCode()
-			);
-		}
-	}
-
-	/**
 	 * @When user :user requests the checksum of :path via propfind
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
1) Remove acceptance test step ``theWebdavResponseShouldHaveAStatusCode`` because it did nothing special.
2) Rename Checksums.php trait to ChecksumContext.php class

## Related Issue

## Motivation and Context
Separate the various logical groupings of acceptance test steps into their own context files to remove the tendency for traits to "accidentally" mess with each other's private variables etc.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
