### PR TITLE
Improve code occ files_external:list --short

### DIFF
--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -75,27 +75,27 @@ class ListCommand extends Base {
 			->addArgument(
 				'user_id',
 				InputArgument::OPTIONAL,
-				'user id to list the personal mounts for, if no user is provided admin mounts will be listed'
+				'User id to list the personal mounts for, if no user is provided admin mounts will be listed'
 			)->addOption(
 				'show-password',
 				null,
 				InputOption::VALUE_NONE,
-				'show passwords and secrets'
+				'Show passwords and secrets'
 			)->addOption(
 				'full',
 				null,
 				InputOption::VALUE_NONE,
-				'don\'t truncate long values in table output'
+				'Don\'t truncate long values in table output'
 			)->addOption(
 				'all',
 				'a',
 				InputOption::VALUE_NONE,
-				'show both system wide mounts and all personal mounts'
+				'Show mounts for all users. All has precedence over user_id'
 			)->addOption(
 				'short',
 				's',
 				InputOption::VALUE_NONE,
-				'show only a reduced mount info'
+				'Show only a reduced mount info'
 			);
 		parent::configure();
 	}
@@ -126,6 +126,7 @@ class ListCommand extends Base {
 		$outputType = $input->getOption('output');
 		$shortView = $input->getOption('short');
 
+		// check if there are any mounts present
 		if (\count($mounts) === 0) {
 			if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
 				$output->writeln('[]');
@@ -141,8 +142,14 @@ class ListCommand extends Base {
 			return;
 		}
 
+		// set minimum columns used based on options
 		if ($shortView) {
-			$headers = ['Mount ID', 'Mount Point', 'Type'];
+			$headers = ['Mount ID', 'Mount Point', 'Auth', 'Type'];
+			// if there is no userId or option --all is set, insert additional columns
+			if (!$userId || $userId === self::ALL) {
+				\array_splice($headers, 2, 0, 'Applicable Users');
+				\array_splice($headers, 3, 0, 'Applicable Groups');
+			}
 		} else {
 			$headers = ['Mount ID', 'Mount Point', 'Storage', 'Authentication Type', 'Configuration', 'Options'];
 
@@ -168,100 +175,63 @@ class ListCommand extends Base {
 			}
 		}
 
-		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
-			$keys = \array_map(function ($header) {
-				return \strtolower(\str_replace(' ', '_', $header));
-			}, $headers);
+		// default output style
+		$full = $input->getOption('full');
+		$defaultMountOptions = [
+			'encrypt' => true,
+			'previews' => true,
+			'filesystem_check_changes' => 1,
+			'enable_sharing' => false,
+			'encoding_compatibility' => false
+		];
+		$countInvalid = 0;
+		// In case adding array elements, add them only after the first two (Mount ID / Mount Point)
+		// and before the last one entry (Type). Necessary for option -s
+		$rows = \array_map(function (IStorageConfig $config) use ($shortView, $userId, $defaultMountOptions, $full, &$countInvalid) {
+			if ($config->getBackend() instanceof InvalidBackend || $config->getAuthMechanism() instanceof InvalidAuth) {
+				$countInvalid++;
+			}
+			$storageConfig = $config->getBackendOptions();
+			$keys = \array_keys($storageConfig);
+			$values = \array_values($storageConfig);
 
+			if (!$full) {
+				$values = \array_map(function ($value) {
+					if (\is_string($value) && \strlen($value) > 32) {
+						return \substr($value, 0, 6) . '...' . \substr($value, -6, 6);
+					} else {
+						return $value;
+					}
+				}, $values);
+			}
+
+			$configStrings = \array_map(function ($key, $value) {
+				return $key . ': ' . \json_encode($value);
+			}, $keys, $values);
+			$configString = \implode(', ', $configStrings);
+
+			$mountOptions = $config->getMountOptions();
+			// hide defaults
+			foreach ($mountOptions as $key => $value) {
+				if ($value === $defaultMountOptions[$key]) {
+					unset($mountOptions[$key]);
+				}
+			}
+			$keys = \array_keys($mountOptions);
+			$values = \array_values($mountOptions);
+
+			$optionsStrings = \array_map(function ($key, $value) {
+				return $key . ': ' . \json_encode($value);
+			}, $keys, $values);
+			$optionsString = \implode(', ', $optionsStrings);
+
+			// output dependent on option shortview
 			if ($shortView) {
-				$pairs = \array_map(function (IStorageConfig $config) use ($keys) {
-					$values = [
-							$config->getId(),
-							$config->getMountPoint(),
-							$config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'admin' : 'personal'
-						];
-
-					return \array_combine($keys, $values);
-				}, $mounts);
+				$values = [
+					$config->getId(),
+					$config->getMountPoint()
+				];
 			} else {
-				$pairs = \array_map(function (IStorageConfig $config) use ($keys, $userId) {
-					$values = [
-							$config->getId(),
-							$config->getMountPoint(),
-							$config->getBackend()->getStorageClass(),
-							$config->getAuthMechanism()->getIdentifier(),
-							$config->getBackendOptions(),
-							$config->getMountOptions()
-						];
-					if (!$userId || $userId === self::ALL) {
-						$values[] = $config->getApplicableUsers();
-						$values[] = $config->getApplicableGroups();
-					}
-					if ($userId === self::ALL) {
-						$values[] = $config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'admin' : 'personal';
-					}
-
-					return \array_combine($keys, $values);
-				}, $mounts);
-			}
-
-			if ($outputType === self::OUTPUT_FORMAT_JSON) {
-				$output->writeln(\json_encode(\array_values($pairs)));
-			} else {
-				$output->writeln(\json_encode(\array_values($pairs), JSON_PRETTY_PRINT));
-			}
-		} else {
-
-			// default output style
-			$full = $input->getOption('full');
-			$defaultMountOptions = [
-				'encrypt' => true,
-				'previews' => true,
-				'filesystem_check_changes' => 1,
-				'enable_sharing' => false,
-				'encoding_compatibility' => false
-			];
-			$countInvalid = 0;
-			// In case adding array elements, add them only after the first two (Mount ID / Mount Point)
-			// and before the last one entry (Type). Necessary for option -s
-			$rows = \array_map(function (IStorageConfig $config) use ($shortView, $userId, $defaultMountOptions, $full, &$countInvalid) {
-				if ($config->getBackend() instanceof InvalidBackend || $config->getAuthMechanism() instanceof InvalidAuth) {
-					$countInvalid++;
-				}
-				$storageConfig = $config->getBackendOptions();
-				$keys = \array_keys($storageConfig);
-				$values = \array_values($storageConfig);
-
-				if (!$full) {
-					$values = \array_map(function ($value) {
-						if (\is_string($value) && \strlen($value) > 32) {
-							return \substr($value, 0, 6) . '...' . \substr($value, -6, 6);
-						} else {
-							return $value;
-						}
-					}, $values);
-				}
-
-				$configStrings = \array_map(function ($key, $value) {
-					return $key . ': ' . \json_encode($value);
-				}, $keys, $values);
-				$configString = \implode(', ', $configStrings);
-
-				$mountOptions = $config->getMountOptions();
-				// hide defaults
-				foreach ($mountOptions as $key => $value) {
-					if ($value === $defaultMountOptions[$key]) {
-						unset($mountOptions[$key]);
-					}
-				}
-				$keys = \array_keys($mountOptions);
-				$values = \array_values($mountOptions);
-
-				$optionsStrings = \array_map(function ($key, $value) {
-					return $key . ': ' . \json_encode($value);
-				}, $keys, $values);
-				$optionsString = \implode(', ', $optionsStrings);
-
 				$values = [
 					$config->getId(),
 					$config->getMountPoint(),
@@ -270,65 +240,64 @@ class ListCommand extends Base {
 					$configString,
 					$optionsString
 				];
+			}
 
-				if (!$userId || $userId === self::ALL) {
-					$applicableUsers = \implode(', ', $config->getApplicableUsers());
-					$applicableGroups = \implode(', ', $config->getApplicableGroups());
-					if ($applicableUsers === '' && $applicableGroups === '') {
-						$applicableUsers = 'All';
-					}
-					$values[] = $applicableUsers;
-					$values[] = $applicableGroups;
+			// output independent on option shortview
+			if (!$userId || $userId === self::ALL) {
+				$applicableUsers = \implode(', ', $config->getApplicableUsers());
+				$applicableGroups = \implode(', ', $config->getApplicableGroups());
+				if ($applicableUsers === '' && $applicableGroups === '') {
+					$applicableUsers = 'All';
 				}
-				// This MUST stay the last entry
-				if ($shortView || $userId === self::ALL) {
-					$values[] = $config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'Admin' : 'Personal';
+				$values[] = $applicableUsers;
+				$values[] = $applicableGroups;
+			}
+			// This MUST stay the last entry
+			if ($shortView || $userId === self::ALL) {
+				// query the auth type
+				if (\stristr($config->getBackend()->getText(), 'session') === true) {
+					$values[] =  'Session';
+				} else {
+					$values[] = 'User';
 				}
+				// get the mount type
+				$values[] = $config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'Admin' : 'Personal';
+			}
 
-				return $values;
-			}, $mounts);
+			return $values;
+		}, $mounts);
 
+		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
+			$keys = \array_map(function ($header) {
+				return \strtolower(\str_replace(' ', '_', $header));
+			}, $headers);
+
+			$pairs = [];
+			foreach ($rows as $array_1) {
+				$pairs[] = \array_combine($keys, $array_1);
+			}
+
+			if ($outputType === self::OUTPUT_FORMAT_JSON) {
+				$output->writeln(\json_encode(\array_values($pairs)));
+			} else {
+				$output->writeln(\json_encode(\array_values($pairs), JSON_PRETTY_PRINT));
+			}
+		} else {
 			$table = new Table($output);
 			$table->setHeaders($headers);
-			$table->setRows($this->getColumns($shortView, $rows));
+			$table->setRows($rows);
 			$table->render();
+		}
 
-			if ($countInvalid > 0) {
-				$output->writeln(
-					"<error>Number of invalid storages found: $countInvalid.\n" .
-					"The listed configuration details are likely incomplete.\n" .
-					"Please make sure that all related apps that provide these storages are enabled or delete these.</error>"
-				);
-			}
+		if ($countInvalid > 0) {
+			$output->writeln(
+				"<error>Number of invalid storages found: $countInvalid.\n" .
+				"The listed configuration details are likely incomplete.\n" .
+				"Please make sure that all related apps that provide these storages are enabled or delete these.</error>"
+			);
 		}
 	}
 
-	// Removes all unused columns for option -s.
-	// Only the first two (Mount ID / Mount Point) and the last column (Mount Type) is kept.
-	protected function getColumns($shortView, $rows) {
-		if ($shortView) {
-			$newRows = [];
-			// $subArr is a copy of $rows anyways...
-			foreach ($rows as $subArr) {
-				$c = \count($subArr) - 1;
-				$u = false;
-				foreach ($subArr as $key => $val) {
-					if ((int)$key > 1 && (int)$key < $c) {
-						unset($subArr[$key]);
-						$u = true;
-					}
-				}
-				if ($u) {
-					$subArr = \array_values($subArr);
-				}
-				$newRows[] = $subArr;
-			}
-			return $newRows;
-		} else {
-			return $rows;
-		}
-	}
-	
 	protected function getStorageService($userId) {
 		if (!empty($userId)) {
 			$user = $this->userManager->get($userId);

--- a/apps/files_external/tests/Command/ListCommandTest.php
+++ b/apps/files_external/tests/Command/ListCommandTest.php
@@ -98,29 +98,29 @@ class ListCommandTest extends CommandTest {
 			[
 				['short' => true, 'output' => 'json'],
 				[
-					['mount_id' => 1, 'mount_point' => '/ownCloud', 'type' => 'admin'],
-					['mount_id' => 2, 'mount_point' => '/SFTP', 'type' => 'personal'],
+					['mount_id' => 1, 'mount_point' => '/ownCloud', 'auth' => 'User', 'type' => 'Admin'],
+					['mount_id' => 2, 'mount_point' => '/SFTP', 'auth' => 'User', 'type' => 'Personal'],
 				],
 				[
-					['mount_id' => 1, 'mount_point' => '/ownCloud', 'type' => StorageConfig::MOUNT_TYPE_ADMIN],
-					['mount_id' => 2, 'mount_point' => '/SFTP', 'type' => StorageConfig::MOUNT_TYPE_PERSONAl],
+					['mount_id' => 1, 'mount_point' => '/ownCloud', 'auth' => 'User', 'type' => StorageConfig::MOUNT_TYPE_ADMIN],
+					['mount_id' => 2, 'mount_point' => '/SFTP', 'auth' => 'User', 'type' => StorageConfig::MOUNT_TYPE_PERSONAl],
 				]
 			],
 			[
 				['short' => true],
 				<<<EOS
-+----------+-------------+----------+
-| Mount ID | Mount Point | Type     |
-+----------+-------------+----------+
-| 1        | /ownCloud   | Admin    |
-| 2        | /SFTP       | Personal |
-+----------+-------------+----------+
++----------+-------------+------+----------+
+| Mount ID | Mount Point | Auth | Type     |
++----------+-------------+------+----------+
+| 1        | /ownCloud   | User | Admin    |
+| 2        | /SFTP       | User | Personal |
++----------+-------------+------+----------+
 
 EOS
 				,
 				[
-					['mount_id' => 1, 'mount_point' => '/ownCloud', 'type' => StorageConfig::MOUNT_TYPE_ADMIN],
-					['mount_id' => 2, 'mount_point' => '/SFTP', 'type' => StorageConfig::MOUNT_TYPE_PERSONAl],
+					['mount_id' => 1, 'mount_point' => '/ownCloud', 'auth' => 'User', 'type' => StorageConfig::MOUNT_TYPE_ADMIN],
+					['mount_id' => 2, 'mount_point' => '/SFTP', 'auth' => 'User', 'type' => StorageConfig::MOUNT_TYPE_PERSONAl],
 				]
 			],
 		];
@@ -162,6 +162,7 @@ EOS
 			for ($i = 0; $i < $countResults; $i++) {
 				$this->assertEquals($expectedResult[$i]['mount_id'], $results[$i]['mount_id']);
 				$this->assertEquals($expectedResult[$i]['mount_point'], $results[$i]['mount_point']);
+				$this->assertContains($results[$i]['auth'], 'UserSession', true);
 				$this->assertEquals($expectedResult[$i]['type'], $results[$i]['type']);
 			}
 		} else {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR improves the code for the `--short` option in occ command `files_external:list`
- removing unnecessary double code paths - make one code stream for:
standard output and json output
- greatly improving the array handling by using if statemens instead looping thru arrays
- better output of `--all` and if a `user` is given 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/pull/32178#issuecomment-451386297

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better code, easier to handle and enhance. Better output

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
**Commands**
```
sudo -uwww-data ./occ files_external:list -s 
+----------+-------------+------------------+-------------------+------+-------+
| Mount ID | Mount Point | Applicable Users | Applicable Groups | Auth | Type  |
+----------+-------------+------------------+-------------------+------+-------+
| 2        | /test       | user_x           | admin, testg      | User | Admin |
+----------+-------------+------------------+-------------------+------+-------+

sudo -uwww-data ./occ files_external:list -s user_y
+----------+---------------+------+----------+
| Mount ID | Mount Point   | Auth | Type     |
+----------+---------------+------+----------+
| 1        | /martin@filer | User | Personal |
+----------+---------------+------+----------+

sudo -uwww-data ./occ files_external:list -s -a
+----------+---------------+------------------+-------------------+------+----------+
| Mount ID | Mount Point   | Applicable Users | Applicable Groups | Auth | Type     |
+----------+---------------+------------------+-------------------+------+----------+
| 1        | /martin@filer | user_y           |                   | User | Personal |
| 2        | /test         | user_x           | admin, testg      | User | Admin    |
+----------+---------------+------------------+-------------------+------+----------+
```

**Auth**
This new field shows if a mount is based on User/Pwd (User) or Session (Session).
This info is important when using files:scan as session based mounts cant be scanned by occ.

The output of json is tested and correct to the plain one

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
