### PR TITLE
Create acceptance test TagsContext

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -31,6 +31,7 @@ default:
         - '%paths.base%/../features/apiComments'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - CommentsContext:
 
     apiFederation:
       paths:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -94,6 +94,7 @@ default:
         - '%paths.base%/../features/apiTags'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - TagsContext:
 
     apiTrashbin:
       paths:
@@ -189,6 +190,7 @@ default:
         - '%paths.base%/../features/webUIFiles'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - TagsContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
@@ -315,10 +317,12 @@ default:
         - '%paths.base%/../features/webUITags'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - TagsContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
         - WebUISharingContext:
+        - WebUITagsContext:
 
     webUITrashbin:
       paths:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -15,6 +15,7 @@ default:
         - AppManagementContext:
         - CalDavContext:
         - CardDavContext:
+        - ChecksumContext:
         - FilesVersionsContext:
         - TransferOwnershipContext:
 

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -7,7 +7,7 @@ Feature: checksums
   Scenario Outline: Uploading a file with checksum should work
     Given using <dav_version> DAV path
     When user "user0" uploads file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
-    Then the webdav response should have a status code "201"
+    Then the HTTP status code should be "201"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -36,7 +36,6 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 trait BasicStructure {
 	use AppConfiguration;
 	use Auth;
-	use Checksums;
 	use Comments;
 	use Provisioning;
 	use Sharing;

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -38,7 +38,6 @@ trait BasicStructure {
 	use Auth;
 	use Provisioning;
 	use Sharing;
-	use Tags;
 	use WebDav;
 	use CommandLine;
 

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -36,7 +36,6 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 trait BasicStructure {
 	use AppConfiguration;
 	use Auth;
-	use Comments;
 	use Provisioning;
 	use Sharing;
 	use Tags;

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -83,22 +83,6 @@ trait Checksums {
 	}
 
 	/**
-	 * @Then the webdav response should have a status code :statusCode
-	 *
-	 * @param int $statusCode
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theWebdavResponseShouldHaveAStatusCode($statusCode) {
-		if ((int)$statusCode !== $this->response->getStatusCode()) {
-			throw new \Exception(
-				"Expected $statusCode, got " . $this->response->getStatusCode()
-			);
-		}
-	}
-
-	/**
 	 * @When user :user requests the checksum of :path via propfind
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1764,102 +1764,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the user has added a tag :tagName to the file using the webUI
-	 * @Given the user has toggled a tag :tagName on the file using the webUI
-	 * @When the user adds a tag :tagName to the file using the webUI
-	 * @When the user toggles a tag :tagName on the file using the webUI
-	 *
-	 * @param string $tagName
-	 *
-	 * @return void
-	 */
-	public function theUserAddsATagToTheFileUsingTheWebUI($tagName) {
-		$this->filesPage->getDetailsDialog()->addTag($tagName);
-
-		// For tags to be created, OC checks (|for the permission) if the tag could be created
-		// and if it can, then only it creates a tag. So, in the webUI, it does two
-		// requests before the tags are created.
-		// If we use a single wait, it returns after it has checked for the permission.
-		// Locally that passes but sometimes fail on the ci. So, we need two waits for each requests.
-		// FIXME: Find a better way to wait for these calls
-		$this->filesPage->waitForAjaxCallsToStartAndFinish($this->getSession());
-		$this->filesPage->waitForAjaxCallsToStartAndFinish($this->getSession());
-
-		$this->featureContext->addToTheListOfCreatedTagsByDisplayName($tagName);
-	}
-
-	/**
-	 * @When the user types :value in the collaborative tags field using the webUI
-	 *
-	 * @param string $value
-	 *
-	 * @return void
-	 */
-	public function theUserTypesAValueInTheCollaborativeTagsFieldUsingTheWebUI($value) {
-		$this->filesPage->getDetailsDialog()->insertTagNameInTheTagsField($value);
-	}
-
-	/**
-	 * @Then all the tags starting with :value in their name should be listed in the dropdown list on the webUI
-	 *
-	 * @param string $value
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function allTheTagsStartingWithInTheirNameShouldBeListedInTheDropdownListOnTheWebUI($value) {
-		$results = $this->filesPage->getDetailsDialog()->getDropDownTagsSuggestionResults();
-		foreach ($results as $tagResult) {
-			PHPUnit_Framework_Assert::assertStringStartsWith($value, $tagResult->getText());
-		}
-
-		// check also that all tags that have been created and starts with $value
-		// are also shown in the dropdown
-		$createdTags = $this->featureContext->getListOfCreatedTags();
-		foreach ($createdTags as $tag) {
-			$tagName = $tag['name'];
-			if (\substr($tagName, 0, \strlen($value)) === $value && !empty($tag['userAssignable'])) {
-				$this->theTagShouldBeListedInTheDropdownListOnTheWebUI($tagName);
-			}
-		}
-	}
-
-	/**
-	 * @Then the tag :tagName should be listed in the dropdown list on the webUI
-	 *
-	 * @param string $tagName
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theTagShouldBeListedInTheDropdownListOnTheWebUI($tagName) {
-		$results = $this->filesPage->getDetailsDialog()->getDropDownTagsSuggestionResults();
-		foreach ($results as $tagResult) {
-			if ($tagResult->getText() === $tagName) {
-				return;
-			}
-		}
-		throw new \Exception("No tags could be found with $tagName.");
-	}
-
-	/**
-	 * @Then tag :tagName should not be listed in the dropdown list on the webUI
-	 *
-	 * @param string $tagName
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function tagShouldNotBeListedInTheDropdownListOnTheWebui($tagName) {
-		try {
-			$this->theTagShouldBeListedInTheDropdownListOnTheWebUI($tagName);
-		} catch (\Exception $e) {
-			return;
-		}
-		throw new \Exception("Tag $tagName should not be on the dropdown.");
-	}
-
-	/**
 	 * Asserts that the content of a remote and a local file is the same
 	 * or is different
 	 * uses the current user to download the remote file
@@ -2081,17 +1985,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theUserClosesTheDetailsDialog() {
 		$this->filesPage->closeDetailsDialog();
-	}
-
-	/**
-	 * @When the user deletes tag with name :name using the webUI
-	 *
-	 * @param string $name
-	 *
-	 * @return void
-	 */
-	public function theUserDeletesTagWithNameUsingTheWebui($name) {
-		$this->filesPage->getDetailsDialog()->deleteTag($name);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUITagsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUITagsContext.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ * @copyright Copyright (c) 2019 Phil Davis phil@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\FilesPage;
+use Page\TagsPage;
+
+require_once 'bootstrap.php';
+
+/**
+ * WebUI Tags context.
+ */
+class WebUITagsContext extends RawMinkContext implements Context {
+
+	/**
+	 *
+	 * @var FilesPage
+	 */
+	private $filesPage;
+
+	/**
+	 *
+	 * @var TagsPage
+	 */
+	private $tagsPage;
+
+	/**
+	 *
+	 * @var TagsContext
+	 */
+	private $tagsContext;
+
+	/**
+	 * WebUITagsContext constructor.
+	 *
+	 * @param FilesPage $filesPage
+	 * @param TagsPage $tagsPage
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		FilesPage $filesPage,
+		TagsPage $tagsPage
+	) {
+		$this->filesPage = $filesPage;
+		$this->tagsPage = $tagsPage;
+	}
+
+	/**
+	 * @Given the user has added a tag :tagName to the file using the webUI
+	 * @Given the user has toggled a tag :tagName on the file using the webUI
+	 * @When the user adds a tag :tagName to the file using the webUI
+	 * @When the user toggles a tag :tagName on the file using the webUI
+	 *
+	 * @param string $tagName
+	 *
+	 * @return void
+	 */
+	public function theUserAddsATagToTheFileUsingTheWebUI($tagName) {
+		$this->filesPage->getDetailsDialog()->addTag($tagName);
+
+		// For tags to be created, OC checks (|for the permission) if the tag could be created
+		// and if it can, then only it creates a tag. So, in the webUI, it does two
+		// requests before the tags are created.
+		// If we use a single wait, it returns after it has checked for the permission.
+		// Locally that passes but sometimes fail on the ci. So, we need two waits for each requests.
+		// FIXME: Find a better way to wait for these calls
+		$this->filesPage->waitForAjaxCallsToStartAndFinish($this->getSession());
+		$this->filesPage->waitForAjaxCallsToStartAndFinish($this->getSession());
+
+		$this->tagsContext->addToTheListOfCreatedTagsByDisplayName($tagName);
+	}
+
+	/**
+	 * @When the user types :value in the collaborative tags field using the webUI
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 */
+	public function theUserTypesAValueInTheCollaborativeTagsFieldUsingTheWebUI($value) {
+		$this->filesPage->getDetailsDialog()->insertTagNameInTheTagsField($value);
+	}
+
+	/**
+	 * @Then all the tags starting with :value in their name should be listed in the dropdown list on the webUI
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function allTheTagsStartingWithInTheirNameShouldBeListedInTheDropdownListOnTheWebUI($value) {
+		$results = $this->filesPage->getDetailsDialog()->getDropDownTagsSuggestionResults();
+		foreach ($results as $tagResult) {
+			PHPUnit_Framework_Assert::assertStringStartsWith($value, $tagResult->getText());
+		}
+
+		// check also that all tags that have been created and starts with $value
+		// are also shown in the dropdown
+		$createdTags = $this->tagsContext->getListOfCreatedTags();
+		foreach ($createdTags as $tag) {
+			$tagName = $tag['name'];
+			if (\substr($tagName, 0, \strlen($value)) === $value && !empty($tag['userAssignable'])) {
+				$this->theTagShouldBeListedInTheDropdownListOnTheWebUI($tagName);
+			}
+		}
+	}
+
+	/**
+	 * @Then the tag :tagName should be listed in the dropdown list on the webUI
+	 *
+	 * @param string $tagName
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theTagShouldBeListedInTheDropdownListOnTheWebUI($tagName) {
+		$results = $this->filesPage->getDetailsDialog()->getDropDownTagsSuggestionResults();
+		foreach ($results as $tagResult) {
+			if ($tagResult->getText() === $tagName) {
+				return;
+			}
+		}
+		throw new \Exception("No tags could be found with $tagName.");
+	}
+
+	/**
+	 * @Then tag :tagName should not be listed in the dropdown list on the webUI
+	 *
+	 * @param string $tagName
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function tagShouldNotBeListedInTheDropdownListOnTheWebui($tagName) {
+		try {
+			$this->theTagShouldBeListedInTheDropdownListOnTheWebUI($tagName);
+		} catch (\Exception $e) {
+			return;
+		}
+		throw new \Exception("Tag $tagName should not be on the dropdown.");
+	}
+
+	/**
+	 * @When the user deletes tag with name :name using the webUI
+	 *
+	 * @param string $name
+	 *
+	 * @return void
+	 */
+	public function theUserDeletesTagWithNameUsingTheWebui($name) {
+		$this->filesPage->getDetailsDialog()->deleteTag($name);
+	}
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario @webUI
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->tagsContext = $environment->getContext('TagsContext');
+	}
+}


### PR DESCRIPTION
## Description
- Rename Tags.php trait to TagsContext.php class and adjust calls that need ``FeatureContext``
- Move tag-related test steps out of ``WebUIFilesContext`` to ``WebUITagsContext``. This allows ``WebUIFilesContext`` to not need to know about ``TagsContext`` (If ``WebUIFilesContext`` has to ``getContext('TagsContext')`` then every suite that makes use of ``WebUIFilesContext`` would have to also include ``TagsContext`` even though it did not ever execute any tags-related steps.


## Motivation and Context
Separate the various logical groupings of acceptance test steps into their own context files to remove the tendency for traits to "accidentally" mess with each other's private variables etc.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
