### PR TITLE
[stable10] Remove duplicate ceph from drone services

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -108,6 +108,15 @@ pipeline:
       matrix:
         TEST_SUITE: lint
 
+  php-cs-fixer:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - make test-php-style
+    when:
+      matrix:
+        TEST_SUITE: php-cs-fixer
+
   php-phan-70:
     image: owncloudci/php:7.0
     pull: true
@@ -180,14 +189,12 @@ pipeline:
   prepare-objectstore:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
-    environment:
-      - OBJECTSTORE=$OBJECTSTORE
     commands:
       - cd /drone/src/apps
       - git clone https://github.com/owncloud/files_primary_s3.git
       - cd files_primary_s3
       - composer install
-      - cp tests/drone/$${OBJECTSTORE}.config.php /drone/src/config
+      - cp tests/drone/scality.config.php /drone/src/config
       - cd /drone/src
       - php occ a:l
       - php occ a:e files_primary_s3
@@ -195,25 +202,16 @@ pipeline:
       - php ./occ s3:create-bucket owncloud --accept-warning
     when:
       matrix:
-        PRIMARY_OBJECTSTORE: files_primary_s3
-
-  php-cs-fixer:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make test-php-style
-    when:
-      matrix:
-        TEST_SUITE: php-cs-fixer
+        TEST_OBJECTSTORAGE: true
 
   phpunit:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     group: test
     environment:
+      - DB_TYPE=${DB_TYPE}
       - FILES_EXTERNAL_TYPE=${FILES_EXTERNAL_TYPE}
       - COVERAGE=${COVERAGE}
-      - PRIMARY_OBJECTSTORE=${PRIMARY_OBJECTSTORE}
     commands:
       - ./tests/drone/test-phpunit.sh
     when:
@@ -445,22 +443,6 @@ pipeline:
       event: [ push, tag ]
 
 services:
-
-  ceph:
-    image: owncloudci/ceph
-    pull: true
-    environment:
-      - KEYSTONE_PUBLIC_PORT=5034
-      - KEYSTONE_ADMIN_USER=test
-      - KEYSTONE_ADMIN_PASS=testing
-      - KEYSTONE_ADMIN_TENANT=testtenant
-      - KEYSTONE_ENDPOINT_REGION=testregion
-      - KEYSTONE_SERVICE=testceph
-      - OSD_SIZE=500
-    when:
-      matrix:
-        OBJECTSTORE: swift
-
   mariadb:
     image: mariadb:10.2
     environment:
@@ -587,7 +569,7 @@ services:
       - HOST_NAME=scality
     when:
       matrix:
-        OBJECTSTORE: scality
+        TEST_OBJECTSTORAGE: true
 
   email:
     image: mailhog/mailhog
@@ -747,67 +729,65 @@ matrix:
     #   TEST_SUITE: phpunit
     #   INSTALL_SERVER: true
 
+  # test on objectstore
+    - PHP_VERSION: 7.1
+      DB_TYPE: sqlite
+      TEST_SUITE: phpunit
+      COVERAGE: true
+      TEST_OBJECTSTORAGE: true
+      INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
+
   # Files External
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
+      INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
       FILES_EXTERNAL_TYPE: webdav_apache
-      INSTALL_SERVER: true
-      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
+      INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
       FILES_EXTERNAL_TYPE: smb_samba
-      INSTALL_SERVER: true
-      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
+      INSTALL_SERVER: true
+      INSTALL_TESTING-APP: true
       FILES_EXTERNAL_TYPE: smb_windows
-      INSTALL_SERVER: true
-      INSTALL_TESTING-APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
-      FILES_EXTERNAL_TYPE: swift
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
+      FILES_EXTERNAL_TYPE: swift
 
   # Primary Objectstorage
     - PHP_VERSION: 5.6
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
-      OBJECTSTORE: swift
-      PRIMARY_OBJECTSTORE: swift
+      TEST_OBJECTSTORAGE: true
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
+      FILES_EXTERNAL_TYPE: swift
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
-      OBJECTSTORE: swift
-      PRIMARY_OBJECTSTORE: swift
+      TEST_OBJECTSTORAGE: true
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
-
-  # files_primary_s3
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: phpunit
-      COVERAGE: true
-      DB_TYPE: sqlite
-      OBJECTSTORE: scality
-      PRIMARY_OBJECTSTORE: files_primary_s3
-      INSTALL_SERVER: true
-      INSTALL_TESTING-APP: true
+      FILES_EXTERNAL_TYPE: swift
 
   # API Acceptance tests
     - PHP_VERSION: 7.1


### PR DESCRIPTION
## Description
1) Moved ``php-cs-fixer`` up higher to match where it is in ``master``
2) Added ``DB_TYPE`` to ``phpunit`` environment to be the same as master
3) Removed duplicate ``ceph`` services entry
4) Adjust matrix entries for objectstore-related ``phpunit``

## Related Issue
- Fixes #34050

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
