### PR TITLE
[stable10] Move php-cs-fixer in drone to be like in master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -108,6 +108,15 @@ pipeline:
       matrix:
         TEST_SUITE: lint
 
+  php-cs-fixer:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - make test-php-style
+    when:
+      matrix:
+        TEST_SUITE: php-cs-fixer
+
   php-phan-70:
     image: owncloudci/php:7.0
     pull: true
@@ -196,15 +205,6 @@ pipeline:
     when:
       matrix:
         PRIMARY_OBJECTSTORE: files_primary_s3
-
-  php-cs-fixer:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make test-php-style
-    when:
-      matrix:
-        TEST_SUITE: php-cs-fixer
 
   phpunit:
     image: owncloudci/php:${PHP_VERSION}


### PR DESCRIPTION
## Description

## Related Issue
- #34050 

## Motivation and Context
Make ``.drone.yml`` in ``stable10`` more like ``master`` so that backports work nicely.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
