### PR TITLE
[stable10] Remove duplicate ceph services entry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -446,21 +446,6 @@ pipeline:
 
 services:
 
-  ceph:
-    image: owncloudci/ceph
-    pull: true
-    environment:
-      - KEYSTONE_PUBLIC_PORT=5034
-      - KEYSTONE_ADMIN_USER=test
-      - KEYSTONE_ADMIN_PASS=testing
-      - KEYSTONE_ADMIN_TENANT=testtenant
-      - KEYSTONE_ENDPOINT_REGION=testregion
-      - KEYSTONE_SERVICE=testceph
-      - OSD_SIZE=500
-    when:
-      matrix:
-        OBJECTSTORE: swift
-
   mariadb:
     image: mariadb:10.2
     environment:
@@ -786,6 +771,7 @@ matrix:
       DB_TYPE: sqlite
       OBJECTSTORE: swift
       PRIMARY_OBJECTSTORE: swift
+      FILES_EXTERNAL_TYPE: swift
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
 
@@ -795,6 +781,7 @@ matrix:
       DB_TYPE: sqlite
       OBJECTSTORE: swift
       PRIMARY_OBJECTSTORE: swift
+      FILES_EXTERNAL_TYPE: swift
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
 


### PR DESCRIPTION
## Description
The ``ceph`` services section was added in different place in ``.drone.yml`` by https://github.com/owncloud/core/pull/30767 and https://github.com/owncloud/core/pull/30775 resulting in it being duplicated.

Remove the one that is not in ``master`` (to make ``.drone.yml`` look closer to ``master``) and adjust the matrix so that the 2nd ``ceph`` happens in the relevant cases.

## Related Issue
- Fixes #34050 

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
