### PR TITLE
Add pause of one second before delete in acceptance test steps

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -131,9 +131,9 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has created folder "/folderB"
     And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
     And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-    When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
-    And user "user0" waits and deletes file "/folderB/textfile0.txt" using the WebDAV API
-    And user "user0" waits and deletes file "/textfile0.txt" using the WebDAV API
+    When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
+    And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
+    And user "user0" deletes file "/textfile0.txt" using the WebDAV API
     Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
     And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
     And as "user0" the folder with original path "/textfile0.txt" should exist in trash


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
In Upload function of acceptance test, there was a pause of one second before upload to make sure that the files created don't have same "stime"
Added same kind of delay for delete to make sure that the entries in trashbin don't have same timesamp.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to ransomware_protection/issues/116

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
