### PR TITLE
[stable10] Backport of Add regex for shared object file names

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -167,7 +167,7 @@ class Detection implements IMimeTypeDetector {
 		 * No extension after '.so' is considered to be shared object file
 		 */
 		return (\count($match) === 4) && ($match[2] === '.so')
-			&& ($match[3] === '' || ($match[3] !== '' && strpos($match[3], '.') === 0));
+			&& ($match[3] === '' || ($match[3] !== '' && \strpos($match[3], '.') === 0));
 	}
 
 	/**

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -181,5 +181,6 @@
 	"yml": ["application/yaml", "text/plain"],
 	"zip": ["application/zip"],
 	"so": ["application/x-sharedlib"],
-	"dll": ["application/x-msdos-program"]
+	"dll": ["application/x-msdos-program"],
+	"dylib": ["application/x-sharedlib"]
 }

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -78,7 +78,14 @@ class DetectionTest extends \Test\TestCase {
 		$this->assertEquals('image/png', $this->detection->detectPath('.hidden/foo.png'));
 		$this->assertEquals('image/png', $this->detection->detectPath('test.jpg/foo.png'));
 		$this->assertEquals('application/octet-stream', $this->detection->detectPath('.png'));
+		$this->assertEquals('application/x-sharedlib', $this->detection->detectPath('test.so'));
+		$this->assertEquals('application/x-sharedlib', $this->detection->detectPath('test.so.0.0.1'));
+		$this->assertEquals('application/x-sharedlib', $this->detection->detectPath('test.1.2.so.0.0.1'));
+		$this->assertEquals('application/x-sharedlib', $this->detection->detectPath('test.1.2.so.1'));
+		$this->assertEquals('application/x-sharedlib', $this->detection->detectPath('foo.so.'));
 		$this->assertEquals('application/octet-stream', $this->detection->detectPath('foo'));
+		$this->assertEquals('application/octet-stream', $this->detection->detectPath('foo.somany'));
+		$this->assertEquals('application/octet-stream', $this->detection->detectPath('foo.so*'));
 		$this->assertEquals('application/octet-stream', $this->detection->detectPath(''));
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The change in this PR adds regular expression which would consider shared object file with extension not just `.so`. We should also consider files with extension say `foo.so.1.2` or `foo.1.2.so` or `foo.so` or `foo.so.`. The regular expression change acheives this.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The extensions added to `resources/config/mimetypemapping.dist.json` would only help for files with single extension. But for the shared object files in GNU/Linux we may have `.so`, `.so.1.2`, `.1.2.so`. For this we need a regular expression in the Detection.php to fix the problem of multiple extension.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested with unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
