### PR TITLE
Phan 7.2 and 7.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -99,15 +99,6 @@ pipeline:
       matrix:
         TEST_SUITE: javascript
 
-  phplint:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make test-php-lint
-    when:
-      matrix:
-        TEST_SUITE: lint
-
   owncloud-coding-standard:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -574,16 +565,6 @@ matrix:
     - TEST_SUITE: javascript
       PHP_VERSION: 7.1
       COVERAGE: true
-
-  # linting
-    - TEST_SUITE: lint
-      PHP_VERSION: 7.1
-
-    - TEST_SUITE: lint
-      PHP_VERSION: 7.2
-
-    - TEST_SUITE: lint
-      PHP_VERSION: 7.3
 
   # owncloud-coding-standard
     - PHP_VERSION: 7.3

--- a/.drone.yml
+++ b/.drone.yml
@@ -108,14 +108,14 @@ pipeline:
       matrix:
         TEST_SUITE: lint
 
-  php-cs-fixer:
+  owncloud-coding-standard:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
       - make test-php-style
     when:
       matrix:
-        TEST_SUITE: php-cs-fixer
+        TEST_SUITE: owncloud-coding-standard
 
   install-server:
     image: owncloudci/php:${PHP_VERSION}
@@ -164,7 +164,7 @@ pipeline:
         TEST_OBJECTSTORAGE: true
 
   php-phan:
-    image: owncloudci/php:7.1
+    image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
       - make test-php-phan
@@ -585,13 +585,19 @@ matrix:
     - TEST_SUITE: lint
       PHP_VERSION: 7.3
 
-  # php-cs-fixer
-    - TEST_SUITE: php-cs-fixer
-      PHP_VERSION: 7.2
+  # owncloud-coding-standard
+    - PHP_VERSION: 7.3
+      TEST_SUITE: owncloud-coding-standard
 
   # phan
     - TEST_SUITE: phan
       PHP_VERSION: 7.1
+
+    - TEST_SUITE: phan
+      PHP_VERSION: 7.2
+
+    - TEST_SUITE: phan
+      PHP_VERSION: 7.3
 
   # phpstan
     - TEST_SUITE: phpstan

--- a/Makefile
+++ b/Makefile
@@ -198,10 +198,6 @@ test-acceptance-cli: $(composer_dev_deps)
 test-acceptance-webui: $(composer_dev_deps)
 	./tests/acceptance/run.sh --remote --type webUI
 
-.PHONY: test-php-lint
-test-php-lint: $(composer_dev_deps)
-	$(composer_deps)/bin/parallel-lint --exclude lib/composer --exclude build .
-
 .PHONY: test-php-style
 test-php-style: $(composer_dev_deps)
 	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --dry-run --allow-risky yes
@@ -221,7 +217,7 @@ test-php-phpstan: $(PHPSTAN_BIN)
 	php $(PHPSTAN_BIN) analyse --memory-limit=2G --configuration=./phpstan.neon --level=0 apps core settings lib/private lib/public ocs ocs-provider
 
 .PHONY: test
-test: test-php-lint test-php-style test-php test-js test-acceptance-api test-acceptance-cli test-acceptance-webui
+test: test-php-style test-php test-js test-acceptance-api test-acceptance-cli test-acceptance-webui
 
 .PHONY: clean-test-acceptance
 clean-test-acceptance:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "dev-master",
         "jakub-onderka/php-console-highlighter": "^0.4",
-        "jakub-onderka/php-parallel-lint": "^1.0.0",
         "jarnaiz/behat-junit-formatter": "^1.3",
         "mikey179/vfsStream": "^1.6",
         "owncloud/coding-standard": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d77e8283446db682923afb8c3d3e85c",
+    "content-hash": "25b3fc0c4066430b685d8b658917791a",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -4285,54 +4285,6 @@
             ],
             "description": "Highlight PHP code in terminal",
             "time": "2018-09-29T18:48:56+00:00"
-        },
-        {
-            "name": "jakub-onderka/php-parallel-lint",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JakubOnderka/PHP-Parallel-Lint.git",
-                "reference": "04fbd3f5fb1c83f08724aa58a23db90bd9086ee8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/04fbd3f5fb1c83f08724aa58a23db90bd9086ee8",
-                "reference": "04fbd3f5fb1c83f08724aa58a23db90bd9086ee8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "~0.3",
-                "nette/tester": "~1.3",
-                "squizlabs/php_codesniffer": "~2.7"
-            },
-            "suggest": {
-                "jakub-onderka/php-console-highlighter": "Highlight syntax in code snippet"
-            },
-            "bin": [
-                "parallel-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "./"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "ahoj@jakubonderka.cz"
-                }
-            ],
-            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
-            "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-            "time": "2018-02-24T15:31:20+00:00"
         },
         {
             "name": "jarnaiz/behat-junit-formatter",


### PR DESCRIPTION
## Description
1) rename ``php-cs-fixer`` to ``owncloud-coding-standard`` in drone to be like all the apps
2) run ``owncloud-coding-standard`` on PHP 7.3 (just to prove that it works)
3) run ``phan`` on each supported PHP 7.1 7.2 7.3 
4) Remove ``lint`` (covered by point 3)

## Motivation and Context
- partly related to #33902 
- ``phan`` now works in PHP 7.3
- ``phan`` and ``owncloud-codestyle`` complain if they find syntax errors, so they provide ``lint``

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
