### PR TITLE
[stable10] Phan 7.3 and remove lint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -99,23 +99,14 @@ pipeline:
       matrix:
         TEST_SUITE: javascript
 
-  phplint:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make test-php-lint
-    when:
-      matrix:
-        TEST_SUITE: lint
-
-  php-cs-fixer:
+  owncloud-coding-standard:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
       - make test-php-style
     when:
       matrix:
-        TEST_SUITE: php-cs-fixer
+        TEST_SUITE: owncloud-coding-standard
 
   php-phan-70:
     image: owncloudci/php:7.0
@@ -137,6 +128,15 @@ pipeline:
 
   php-phan-72:
     image: owncloudci/php:7.2
+    pull: true
+    commands:
+      - make test-php-phan
+    when:
+      matrix:
+        TEST_SUITE: phan
+
+  php-phan-73:
+    image: owncloudci/php:7.3
     pull: true
     commands:
       - make test-php-phan
@@ -589,46 +589,19 @@ matrix:
       PHP_VERSION: 7.1
       COVERAGE: true
 
-    # linting
-    - TEST_SUITE: lint
-      PHP_VERSION: 5.6
-
-    - TEST_SUITE: lint
-      PHP_VERSION: 7.0
-
-    # PHP 5.6
-    #- PHP_VERSION: 5.6
-    #  DB_TYPE: sqlite
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-    #
-    #- PHP_VERSION: 5.6
-    #  DB_TYPE: mariadb
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-    #
-    #- PHP_VERSION: 5.6
-    #  DB_TYPE: mysql
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-
     - PHP_VERSION: 5.6
       DB_TYPE: postgres
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
 
-    # - PHP_VERSION: 5.6
-    #   DB_TYPE: oracle
-    #   TEST_SUITE: phpunit
-    #   INSTALL_SERVER: true
+  # owncloud-coding-standard
+  # Run with PHP 5.6 because that is not supported by phan.
+  # This gives us a syntax check for PHP 5.6
+    - PHP_VERSION: 5.6
+      TEST_SUITE: owncloud-coding-standard
 
-
-  # php-cs-fixer
-    - TEST_SUITE: php-cs-fixer
-      PHP_VERSION: 7.2
-
-  # phan
+  # phan (runs multiple PHP v7.* to provide syntax checks of each PHP version)
     - TEST_SUITE: phan
       PHP_VERSION: 7.1
 
@@ -652,11 +625,6 @@ matrix:
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
-
-#    - PHP_VERSION: 7.1
-#      DB_TYPE: mariadb
-#      TEST_SUITE: phpunit
-#      INSTALL_SERVER: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: postgres
@@ -685,52 +653,12 @@ matrix:
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
-    #- PHP_VERSION: 7.2
-    #  DB_TYPE: mariadb
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-    #
-    #- PHP_VERSION: 7.2
-    #  DB_TYPE: mysql
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-    #
-    #- PHP_VERSION: 7.2
-    #  DB_TYPE: postgres
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-    #
-    # - PHP_VERSION: 7.2
-    #   DB_TYPE: oracle
-    #   TEST_SUITE: phpunit
-    #   INSTALL_SERVER: true
-#
-#    # Integration
-#    - PHP_VERSION: 7.1
-#      DB_TYPE: sqlite
-#      TEST_SUITE: integration
-#      INSTALL_SERVER: true
 
     - PHP_VERSION: 7.2
       DB_TYPE: mariadb
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
-
-    #- PHP_VERSION: 7.2
-    #  DB_TYPE: mysql
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-    #
-    #- PHP_VERSION: 7.2
-    #  DB_TYPE: postgres
-    #  TEST_SUITE: phpunit
-    #  INSTALL_SERVER: true
-    #
-    # - PHP_VERSION: 7.2
-    #   DB_TYPE: oracle
-    #   TEST_SUITE: phpunit
-    #   INSTALL_SERVER: true
 
   # Files External
     - PHP_VERSION: 7.1

--- a/Makefile
+++ b/Makefile
@@ -197,10 +197,6 @@ test-acceptance-cli: $(composer_dev_deps)
 test-acceptance-webui: $(composer_dev_deps)
 	./tests/acceptance/run.sh --remote --type webUI
 
-.PHONY: test-php-lint
-test-php-lint: $(composer_dev_deps)
-	$(composer_deps)/bin/parallel-lint --exclude lib/composer --exclude build .
-
 .PHONY: test-php-style
 test-php-style: $(composer_dev_deps)
 	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --dry-run --allow-risky yes
@@ -215,7 +211,7 @@ test-php-phan: $(PHAN_BIN)
 	php $(PHAN_BIN) --config-file .phan/config.php --require-config-exists
 
 .PHONY: test
-test: test-php-lint test-php-style test-php test-js test-acceptance-api test-acceptance-cli test-acceptance-webui
+test: test-php-style test-php test-js test-acceptance-api test-acceptance-cli test-acceptance-webui
 
 .PHONY: clean-test-acceptance
 clean-test-acceptance:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         }
     },
     "require-dev": {
-        "jakub-onderka/php-parallel-lint": "^1.0.0",
         "jakub-onderka/php-console-highlighter": "^0.4",
         "phpunit/phpunit": "^5.7",
         "mikey179/vfsStream": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa954eff2f9fe1184a9cacddcd3d274c",
+    "content-hash": "ba60e966520e72fad7b8d744cc02138d",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -4287,54 +4287,6 @@
             ],
             "description": "Highlight PHP code in terminal",
             "time": "2018-09-29T18:48:56+00:00"
-        },
-        {
-            "name": "jakub-onderka/php-parallel-lint",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JakubOnderka/PHP-Parallel-Lint.git",
-                "reference": "04fbd3f5fb1c83f08724aa58a23db90bd9086ee8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/04fbd3f5fb1c83f08724aa58a23db90bd9086ee8",
-                "reference": "04fbd3f5fb1c83f08724aa58a23db90bd9086ee8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "~0.3",
-                "nette/tester": "~1.3",
-                "squizlabs/php_codesniffer": "~2.7"
-            },
-            "suggest": {
-                "jakub-onderka/php-console-highlighter": "Highlight syntax in code snippet"
-            },
-            "bin": [
-                "parallel-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "./"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "ahoj@jakubonderka.cz"
-                }
-            ],
-            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
-            "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-            "time": "2018-02-24T15:31:20+00:00"
         },
         {
             "name": "jarnaiz/behat-junit-formatter",


### PR DESCRIPTION
Backport #34088 

This is a "similar" backport. ``stable10`` supports PHP 5.6, so we:

- run ``owncloud-codestyle`` with PHP 5.6
- ``phan`` with PHP 7.*

Each of these tools will report syntax errors. So we get a syntax ``lint`` check for each PHP version "for free".

- remove ``lint``
- cleaned up old commented-out ``phpunit`` possible matrix combinations. These were getting old anyway and had become out-of-order and in odd places in the list. (they are not in master)
