### PR TITLE
don't use sabre for tags tests

### DIFF
--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -22,6 +22,9 @@
 namespace TestHelpers;
 
 use GuzzleHttp\Message\ResponseInterface;
+use Exception;
+use PHPUnit_Framework_Assert;
+use SimpleXMLElement;
 
 /**
  * Helper to administer Tags
@@ -41,6 +44,8 @@ class TagsHelper {
 	 * @param string|null $fileOwner
 	 * @param string|null $fileOwnerPassword
 	 * @param int $davPathVersionToUse (1|2)
+	 * @param string $adminUsername
+	 * @param string $adminPassword
 	 *
 	 * @return ResponseInterface
 	 * @throws \Exception
@@ -53,7 +58,9 @@ class TagsHelper {
 		$fileName,
 		$fileOwner = null,
 		$fileOwnerPassword = null,
-		$davPathVersionToUse = 1
+		$davPathVersionToUse = 2,
+		$adminUsername = null,
+		$adminPassword = null
 	) {
 		if ($fileOwner === null) {
 			$fileOwner = $taggingUser;
@@ -67,10 +74,22 @@ class TagsHelper {
 			$baseUrl, $fileOwner, $fileOwnerPassword, $fileName
 		);
 
-		$tag = self::requestTagByDisplayName(
-			$baseUrl, $taggingUser, $password, $tagName
-		);
-		$tagID = (int) $tag['{http://owncloud.org/ns}id'];
+		try {
+			$tag = self::requestTagByDisplayName(
+				$baseUrl, $taggingUser, $password, $tagName
+			);
+		} catch (Exception $e) {
+			//the tag might be not accessible by the user
+			//if we still want to find it, we need to try as admin
+			if ($adminUsername !== null && $adminPassword !== null) {
+				$tag = self::requestTagByDisplayName(
+					$baseUrl, $adminUsername, $adminPassword, $tagName
+				);
+			} else {
+				throw $e;
+			}
+		}
+		$tagID = self::getTagIdFromTagData($tag);
 		$path = '/systemtags-relations/files/' . $fileID . '/' . $tagID;
 		$response = WebDavHelper::makeDavRequest(
 			$baseUrl, $taggingUser, $password, "PUT",
@@ -80,6 +99,20 @@ class TagsHelper {
 	}
 
 	/**
+	 * @param \SimpleXMLElement $tagData
+	 *
+	 * @return int
+	 */
+	public static function getTagIdFromTagData($tagData) {
+		$tagID = $tagData->xpath(".//oc:id");
+		\PHPUnit_Framework_Assert::assertArrayHasKey(
+			0, $tagID, "cannot find id of tag"
+		);
+		
+		return (int) $tagID[0]->__toString();
+	}
+	
+	/**
 	 * get all tags of a user
 	 *
 	 * @param string $baseUrl
@@ -87,7 +120,7 @@ class TagsHelper {
 	 * @param string $password
 	 * @param bool $withGroups
 	 *
-	 * @return array
+	 * @return SimpleXMLElement
 	 */
 	public static function requestTagsForUser(
 		$baseUrl,
@@ -95,24 +128,20 @@ class TagsHelper {
 		$password,
 		$withGroups = false
 	) {
-		$baseUrl = WebDavHelper::sanitizeUrl($baseUrl, true);
-		$client = WebDavHelper::getSabreClient($baseUrl, $user, $password);
 		$properties = [
-			'{http://owncloud.org/ns}id',
-			'{http://owncloud.org/ns}display-name',
-			'{http://owncloud.org/ns}user-visible',
-			'{http://owncloud.org/ns}user-assignable',
-			'{http://owncloud.org/ns}can-assign'
+			'oc:id',
+			'oc:display-name',
+			'oc:user-visible',
+			'oc:user-assignable',
+			'oc:can-assign'
 		];
 		if ($withGroups) {
-			\array_push($properties, '{http://owncloud.org/ns}groups');
+			\array_push($properties, 'oc:groups');
 		}
-		$appPath = '/systemtags/';
-		$fullUrl = $baseUrl
-			. WebDavHelper::getDavPath($user, 2, "systemtags")
-			. $appPath;
-		$response = $client->propfind($fullUrl, $properties, 1);
-		return $response;
+		$response = WebDavHelper::propfind(
+			$baseUrl, $user, $password, '/systemtags/', $properties, 1, "systemtags"
+		);
+		return HttpRequestHelper::getResponseXml($response);
 	}
 
 	/**
@@ -124,7 +153,7 @@ class TagsHelper {
 	 * @param string $tagDisplayName
 	 * @param bool $withGroups
 	 *
-	 * @return array
+	 * @return SimpleXMLElement
 	 */
 	public static function requestTagByDisplayName(
 		$baseUrl,
@@ -134,13 +163,14 @@ class TagsHelper {
 		$withGroups = false
 	) {
 		$tagList = self::requestTagsForUser($baseUrl, $user, $password, $withGroups);
-		foreach ($tagList as $path => $tagData) {
-			if (!empty($tagData)
-				&& $tagData['{http://owncloud.org/ns}display-name'] === $tagDisplayName
-			) {
-				return $tagData;
-			}
-		}
+		$tagData = $tagList->xpath(
+			"//d:prop//oc:display-name[text() ='$tagDisplayName']/.."
+		);
+		PHPUnit_Framework_Assert::assertArrayHasKey(
+			0, $tagData,
+			"cannot find 'oc:display-name' property with text '$tagDisplayName'"
+		);
+		return $tagData[0];
 	}
 
 	/**

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -154,6 +154,7 @@ class WebDavHelper {
 	 * @param string $namespaceString string containing prefix and namespace
 	 *                                e.g "x1='http://whatever.org/ns'"
 	 * @param number $davPathVersionToUse
+	 * @param string $type
 	 *
 	 * @return ResponseInterface
 	 */
@@ -164,8 +165,9 @@ class WebDavHelper {
 		$path,
 		$propertyName,
 		$propertyValue,
-		$namespaceString,
-		$davPathVersionToUse = 2
+		$namespaceString = "oc='http://owncloud.org/ns'",
+		$davPathVersionToUse = 2,
+		$type="files"
 	) {
 		$matches = [];
 		\preg_match("/^(.*)='(.*)'$/", $namespaceString, $matches);
@@ -185,7 +187,7 @@ class WebDavHelper {
 
 		return self::makeDavRequest(
 			$baseUrl, $user, $password, "PROPPATCH", $path, [], $body,
-			null, $davPathVersionToUse
+			null, $davPathVersionToUse, $type
 		);
 	}
 

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -17,7 +17,7 @@ Feature: Deletion of tags
   Scenario: Deleting a normal tag that has already been assigned to a file should work
     Given the user has created a "normal" tag with name "JustARegularTagName"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
-    And the user has added tag "MyFirstTag" to file "/myFileToTag.txt"
+    And the user has added tag "JustARegularTagName" to file "/myFileToTag.txt"
     When the user deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for the administrator


### PR DESCRIPTION
## Description
remove sabre usage from tags acceptance tests

## Related Issue
part of #34000

## Motivation and Context
see issue

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
