### PR TITLE
Adjust phan in drone to be more like stable10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -108,6 +108,33 @@ pipeline:
       matrix:
         TEST_SUITE: owncloud-coding-standard
 
+  php-phan-71:
+    image: owncloudci/php:7.1
+    pull: true
+    commands:
+      - make test-php-phan
+    when:
+      matrix:
+        TEST_SUITE: phan
+
+  php-phan-72:
+    image: owncloudci/php:7.2
+    pull: true
+    commands:
+      - make test-php-phan
+    when:
+      matrix:
+        TEST_SUITE: phan
+
+  php-phan-73:
+    image: owncloudci/php:7.3
+    pull: true
+    commands:
+      - make test-php-phan
+    when:
+      matrix:
+        TEST_SUITE: phan
+
   install-server:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -153,15 +180,6 @@ pipeline:
     when:
       matrix:
         TEST_OBJECTSTORAGE: true
-
-  php-phan:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make test-php-phan
-    when:
-      matrix:
-        TEST_SUITE: phan
 
   phpstan:
     image: owncloudci/php:${PHP_VERSION}
@@ -570,15 +588,9 @@ matrix:
     - PHP_VERSION: 7.3
       TEST_SUITE: owncloud-coding-standard
 
-  # phan
+  # phan (runs multiple PHP v7.* to provide syntax checks of each PHP version)
     - TEST_SUITE: phan
       PHP_VERSION: 7.1
-
-    - TEST_SUITE: phan
-      PHP_VERSION: 7.2
-
-    - TEST_SUITE: phan
-      PHP_VERSION: 7.3
 
   # phpstan
     - TEST_SUITE: phpstan
@@ -660,8 +672,7 @@ matrix:
       INSTALL_SERVER: true
       INSTALL_TESTING-APP: true
 
-
-    # PHP 7.2
+  # PHP 7.2
     - PHP_VERSION: 7.2
       DB_TYPE: sqlite
       TEST_SUITE: phpunit


### PR DESCRIPTION
## Description
``phan`` in ``stable10`` is run with multiple PHP versions one-after-another in a single matrix entry. That works. So make it the same way in ``master`` to be consistent.

Note: the actual PHP versions in ``master`` are different - 7.1 7.2 7.3 - because ``master`` does not support PHP 5.6 or 7.0

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
