### PR TITLE
[stable10] Backport of Add lock to the static tag in the input field …

### DIFF
--- a/apps/systemtags/js/systemtagsinfoview.js
+++ b/apps/systemtags/js/systemtagsinfoview.js
@@ -12,10 +12,20 @@
 
 	function modelToSelection(model) {
 		var data = model.toJSON();
-		if (!OC.isUserAdmin() && !data.canAssign) {
-			data.locked = true;
+		if (!OC.isUserAdmin()) {
+			/**
+			 * If tag cannot be assigned just lock it.
+			 * Static tags need to be locked if they do not belong to the groups
+			 */
+			if (!data.canAssign || (isStaticTag(data) && !data.editableInGroup)) {
+				data.locked = true;
+			}
 		}
 		return data;
+	}
+
+	function isStaticTag(data) {
+		return data.userEditable === false && data.userAssignable === true;
 	}
 
 	/**

--- a/apps/systemtags/tests/js/systemtagsinfoviewSpec.js
+++ b/apps/systemtags/tests/js/systemtagsinfoviewSpec.js
@@ -118,6 +118,33 @@ describe('OCA.SystemTags.SystemTagsInfoView tests', function() {
 
 			inputViewSpy.restore();
 		});
+		it('sets locked flag on static tags when user is not an admin and tag not part of the group', function () {
+			isAdminStub.returns(false);
+
+			var inputViewSpy = sinon.spy(OC.SystemTags, 'SystemTagsInputField');
+			var element = $('<input type="hidden" val="1,3"/>');
+			view.remove();
+			view = new OCA.SystemTags.SystemTagsInfoView();
+			view.selectedTagsCollection.add([
+				{id: '1', name: 'test1'},
+				{id: '3', name: 'test3', userAssignable: false, canAssign: false},
+				{id: '4', name: 'statictag', userAssignable: true, userEditable: false, userVisible: true, canAssign: false, editableInGroup: false}
+			]);
+
+			var callback = sinon.stub();
+			inputViewSpy.getCall(0).args[0].initSelection(element, callback);
+
+			expect(callback.calledOnce).toEqual(true);
+			expect(callback.getCall(0).args[0]).toEqual([{
+				id: '1', name: 'test1', userVisible: true, userAssignable: true, canAssign: true
+			}, {
+				id: '3', name: 'test3', userVisible: true, userAssignable: false, canAssign: false, locked: true
+			}, {
+				id: '4', name: 'statictag', userAssignable: true, userEditable: false, userVisible: true, canAssign: false, editableInGroup: false, locked: true
+			}]);
+
+			inputViewSpy.restore();
+		});
 		it('does not set locked flag on non-assignable tags when canAssign overrides it with true', function() {
 			isAdminStub.returns(false);
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This change tries to fix the problem:
- When a file is tagged with static tag which is not part of the group whitelisted ( in the static tag or say while creating static tag), the user is able to delete the tag using keyboard `Backspace`. Though technically its a fake delete. Because after refreshing the page, the static tag appears again for the file.

This is caused because of missing `select2-locked` class in the html element. This change tries to add the same. It tries to see if the tag is static tag or not and if the tag could be edited by the user. Based on these conditions the code would add `select2-locked` to the element.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding `select2-locked` to static tags when the user cannot edit the tags. This would prevent fake deletion of the tags by using `Backspace` key of keyboard.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create 2 groups, group1 and group2.
- Create 2 users user1 and user2. `user1` belongs to `group1`. `user2` belongs to `group2`.
- Add static tag `statictag` to the `group1`.
- As `user2` create file `test.txt` and share to `group1`.
- As `user1` assign static tag to `test.txt`.
- As `user2` try to check the fake delete using the keyboard.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
