### PR TITLE
Fix persistent lock timeout behavior

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -48,7 +48,8 @@ $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getUserSession(),
 	\OC::$server->getMountManager(),
 	\OC::$server->getTagManager(),
-	\OC::$server->getRequest()
+	\OC::$server->getRequest(),
+	\OC::$server->getTimeFactory()
 );
 
 $requestUri = \OC::$server->getRequest()->getRequestUri();

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -37,7 +37,8 @@ $serverFactory = new \OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getUserSession(),
 	\OC::$server->getMountManager(),
 	\OC::$server->getTagManager(),
-	\OC::$server->getRequest()
+	\OC::$server->getRequest(),
+	\OC::$server->getTimeFactory()
 );
 
 // Backends

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -40,6 +40,7 @@ use OCP\IRequest;
 use OCP\ITagManager;
 use OCP\IUserSession;
 use Sabre\DAV\Auth\Backend\BackendInterface;
+use OCP\AppFramework\Utility\ITimeFactory;
 
 class ServerFactory {
 	/** @var IConfig */
@@ -56,6 +57,8 @@ class ServerFactory {
 	private $tagManager;
 	/** @var IRequest */
 	private $request;
+	/** @var ITimeFactory */
+	private $timeFactory;
 
 	/**
 	 * @param IConfig $config
@@ -65,6 +68,7 @@ class ServerFactory {
 	 * @param IMountManager $mountManager
 	 * @param ITagManager $tagManager
 	 * @param IRequest $request
+	 * @param ITimeFactory $timeFactory
 	 */
 	public function __construct(
 		IConfig $config,
@@ -73,7 +77,8 @@ class ServerFactory {
 		IUserSession $userSession,
 		IMountManager $mountManager,
 		ITagManager $tagManager,
-		IRequest $request
+		IRequest $request,
+		ITimeFactory $timeFactory
 	) {
 		$this->config = $config;
 		$this->logger = $logger;
@@ -82,6 +87,7 @@ class ServerFactory {
 		$this->mountManager = $mountManager;
 		$this->tagManager = $tagManager;
 		$this->request = $request;
+		$this->timeFactory = $timeFactory;
 	}
 
 	/**
@@ -112,7 +118,7 @@ class ServerFactory {
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
-		$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true)));
+		$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true, $this->timeFactory)));
 
 		if (BrowserErrorPagePlugin::isBrowserRequest($this->request)) {
 			$server->addPlugin(new BrowserErrorPagePlugin());

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -139,7 +139,7 @@ class Server {
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $logger));
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
-		$this->server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($this->server->tree, false)));
+		$this->server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($this->server->tree, false, \OC::$server->getTimeFactory())));
 
 		// ACL plugin not used in files subtree, also it causes issues
 		// with performance and locking issues because it will query

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTest.php
@@ -62,7 +62,8 @@ abstract class RequestTest extends TestCase {
 			\OC::$server->getUserSession(),
 			\OC::$server->getMountManager(),
 			\OC::$server->getTagManager(),
-			$this->createMock(IRequest::class)
+			$this->createMock(IRequest::class),
+			\OC::$server->getTimeFactory()
 		);
 	}
 

--- a/apps/dav/tests/unit/Files/FileLocksBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileLocksBackendTest.php
@@ -36,7 +36,6 @@ use Sabre\DAV\Tree;
 use Test\TestCase;
 
 class FileLocksBackendTest extends TestCase {
-
 	const CREATION_TIME = 164419200;
 	const CURRENT_TIME = 164419800;
 

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -469,7 +469,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		}, $locks);
 	}
 
-	public function lockNodePersistent(string $internalPath, array $lockInfo) : bool {
+	public function lockNodePersistent(string $internalPath, array $lockInfo) : ILock {
 		return parent::lockNodePersistent($this->getSourcePath($internalPath), $lockInfo);
 	}
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -56,6 +56,7 @@ use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\IPersistentLockingStorage;
 use OCP\Files\Storage\IVersionedStorage;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\Persistent\ILock;
 
 /**
  * Storage backend class for providing common filesystem operation methods
@@ -757,7 +758,7 @@ abstract class Common implements Storage, ILockingStorage, IVersionedStorage, IP
 		return false;
 	}
 
-	public function lockNodePersistent(string $internalPath, array $lockInfo) : bool {
+	public function lockNodePersistent(string $internalPath, array $lockInfo) : ILock {
 		/** @var LockManager $locksManager */
 		$locksManager = \OC::$server->query(LockManager::class);
 		$storageId = $this->getCache()->getNumericStorageId();

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -30,6 +30,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\IPersistentLockingStorage;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\Persistent\ILock;
 
 class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistentLockingStorage {
 	/**
@@ -615,7 +616,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistent
 		}
 	}
 
-	public function lockNodePersistent(string $internalPath, array $lockInfo) : bool {
+	public function lockNodePersistent(string $internalPath, array $lockInfo) : ILock {
 		$storage = $this->getWrapperStorage();
 		if ($storage->instanceOfStorage(IPersistentLockingStorage::class)) {
 			return $storage->lockNodePersistent($internalPath, $lockInfo);

--- a/lib/private/Lock/Persistent/Lock.php
+++ b/lib/private/Lock/Persistent/Lock.php
@@ -86,7 +86,7 @@ class Lock extends Entity implements ILock {
 	 * Return the owner of the lock - plain text field as transmitted by clients
 	 *
 	 * @return string
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getOwner(): ?string {
 		return $this->owner;
@@ -96,7 +96,7 @@ class Lock extends Entity implements ILock {
 	 * Foreign key to oc_filecache.fileid
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getFileId(): int {
 		return $this->fileId;
@@ -106,7 +106,7 @@ class Lock extends Entity implements ILock {
 	 * Seconds of lock life time
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getTimeout(): int {
 		return $this->timeout;
@@ -116,7 +116,7 @@ class Lock extends Entity implements ILock {
 	 * Unix timestamp when lock was created
 	 *
 	 * @return mixed
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getCreatedAt(): int {
 		return $this->createdAt;
@@ -126,7 +126,7 @@ class Lock extends Entity implements ILock {
 	 * Token to identify the lock - uuid usually
 	 *
 	 * @return string
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getToken(): string {
 		return $this->token;
@@ -136,7 +136,7 @@ class Lock extends Entity implements ILock {
 	 * Either shared lock or exclusive lock
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getScope(): int {
 		return $this->scope;
@@ -146,7 +146,7 @@ class Lock extends Entity implements ILock {
 	 * Depth as used in WebDAV: 0, 1 or infinite
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getDepth(): int {
 		return $this->depth;
@@ -156,7 +156,7 @@ class Lock extends Entity implements ILock {
 	 * Absolute path to the file/folder on webdav
 	 *
 	 * @return string
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getAbsoluteDavPath(): string {
 		return $this->absoluteDavPath;
@@ -166,7 +166,7 @@ class Lock extends Entity implements ILock {
 	 * User id on webdav URI
 	 *
 	 * @return string
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getDavUserId(): string {
 		return $this->davUserId;
@@ -177,7 +177,7 @@ class Lock extends Entity implements ILock {
 	 *
 	 * @param string $owner
 	 * @return mixed
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function setOwner(?string $owner) : void {
 		$this->setter('owner', [$owner]);

--- a/lib/public/Files/Storage/IPersistentLockingStorage.php
+++ b/lib/public/Files/Storage/IPersistentLockingStorage.php
@@ -26,30 +26,41 @@ use OCP\Lock\Persistent\ILock;
  * Interface IPersistentLockingStorage
  *
  * @package OCP\Files\Storage
- * @since 11.0.0
+ * @since 10.1.0
  */
 interface IPersistentLockingStorage {
 	/**
+	 * Acquire or refresh a persistent lock on the given internal path.
+	 *
+	 * If lockinfo is passed with an existing token, the matching lock will be refreshed.
+	 *
+	 * Note: it is the responsibility of the caller to enforce lock uniqueness in case
+	 * of exclusive locks.
+	 *
 	 * @param string $internalPath
 	 * @param array $lockInfo
-	 * @return mixed
-	 * @since 11.0.0
+	 * @return ILock newly created lock
+	 * @since 10.1.0
 	 */
 	public function lockNodePersistent(string $internalPath, array $lockInfo);
 
 	/**
-	 * @param string $internalPath
+	 * @param string $internalPath storage internal path to query
 	 * @param array $lockInfo
-	 * @return mixed
-	 * @since 11.0.0
+	 * @return bool true if the lock was deleted, false if no such lock existed
+	 * @since 10.1.0
 	 */
 	public function unlockNodePersistent(string $internalPath, array $lockInfo);
 
 	/**
-	 * @param string $internalPath
-	 * @param bool $returnChildLocks
+	 * Returns the direct locks from the given internal path and also indirect locks
+	 * that exist on any parents.
+	 *
+	 * @param string $internalPath storage internal path to query
+	 * @param bool $returnChildLocks whether to also return locks that exist on any
+	 * child paths
 	 * @return ILock[]
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getLocks(string $internalPath, bool $returnChildLocks = false) : array;
 }

--- a/lib/public/Lock/Persistent/ILock.php
+++ b/lib/public/Lock/Persistent/ILock.php
@@ -24,7 +24,7 @@ namespace OCP\Lock\Persistent;
  * Interface ILock
  *
  * @package OCP\Lock\Persistent
- * @since 11.0.0
+ * @since 10.1.0
  */
 interface ILock {
 	// these values are in sync with \Sabre\DAV\Locks\LockInfo
@@ -37,7 +37,7 @@ interface ILock {
 	 * Return the owner of the lock - plain text field as transmitted by clients
 	 *
 	 * @return string | null
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getOwner() : ?string;
 
@@ -45,7 +45,7 @@ interface ILock {
 	 * Foreign key to oc_filecache.fileid
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getFileId() : int;
 
@@ -53,7 +53,7 @@ interface ILock {
 	 * Seconds of lock life time
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getTimeout() : int;
 
@@ -61,7 +61,7 @@ interface ILock {
 	 * Unix timestamp when lock was created
 	 *
 	 * @return mixed
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getCreatedAt() : int;
 
@@ -69,7 +69,7 @@ interface ILock {
 	 * Token to identify the lock - uuid usually
 	 *
 	 * @return string
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getToken() : string;
 
@@ -77,7 +77,7 @@ interface ILock {
 	 * Either shared lock or exclusive lock
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 
 	public function getScope() : int;
@@ -86,21 +86,21 @@ interface ILock {
 	 * Depth as used in WebDAV: 0, 1 or infinite
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getDepth() : int;
 
 	/**
 	 * Absolute path to the file/folder on webdav
 	 * @return string
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getAbsoluteDavPath() : string;
 
 	/**
 	 * User id on webdav URI
 	 * @return string
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function getDavUserId() : string;
 
@@ -109,7 +109,7 @@ interface ILock {
 	 *
 	 * @param string $owner
 	 * @return void
-	 * @since 11.0.0
+	 * @since 10.1.0
 	 */
 	public function setOwner(?string $owner) : void;
 }

--- a/tests/lib/Files/Storage/LockingTests.php
+++ b/tests/lib/Files/Storage/LockingTests.php
@@ -78,9 +78,11 @@ class LockingTests extends TestCase {
 		self::assertEquals([], $locks);
 
 		// locking the file
-		self::assertEquals(true, $this->storage->lockNodePersistent('files/foo/bar.txt', [
+		$lock = $this->storage->lockNodePersistent('files/foo/bar.txt', [
 			'token' => '123-456-789'
-		]));
+		]);
+		self::assertNotNull($lock);
+		self::assertEquals('123-456-789', $lock->getToken());
 
 		// lock shall exist
 		$locks = $this->storage->getLocks('files/foo/bar.txt');


### PR DESCRIPTION
## Description
Set timeout from header when specified.
Timeout value returned in lock discovery must be the remaining time.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/33846

## Motivation and Context
Timeout has bugs

## How Has This Been Tested?
Manual tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
