### PR TITLE
WebDav Client missing proxy credentials

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -474,6 +474,11 @@ $CONFIG = array(
 /**
  * The optional authentication for the proxy to use to connect to the internet.
  * The format is: `username:password`.
+ *
+ * The username and the password need to be urlencoded to avoid breaking the
+ * delimiter syntax "username:password@hostname:port
+ *
+ * Example: "usern@me" needs to be encoded as "usern%40ame"
  */
 'proxyuserpwd' => '',
 

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -342,7 +342,14 @@ class DAV extends Common {
 							->newClient()
 							->get($this->createBaseUri() . $this->encodePath($path), [
 									'auth' => [$this->user, $this->password],
-									'stream' => true
+									'stream' => true,
+									'config' => [
+										'stream_context' => [
+											'http' => [
+												'request_fulluri' => true
+											]
+										],
+									],
 							]);
 				} catch (RequestException $e) {
 					if ($e->getResponse() instanceof ResponseInterface

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -132,9 +132,24 @@ class Client implements IClient {
 	 * @throws \Exception If the request could not get completed
 	 */
 	public function get($uri, array $options = []) {
-		$this->setDefaultOptions();
-		$response = $this->client->get($uri, $options);
 		$isStream = isset($options['stream']) && $options['stream'];
+		$this->setDefaultOptions();
+		if ($isStream) {
+			$proxyHost = $this->config->getSystemValue('proxy', null);
+			if ($proxyHost !== null) {
+				$this->client->setDefaultOption(
+					'proxy',
+					'tcp://' . $proxyHost
+				);
+			}
+
+			$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', null);
+			if ($proxyUserPwd !== null) {
+				$auth = \base64_encode(\urldecode($proxyUserPwd));
+				$this->client->setDefaultOption('headers/Proxy-Authorization', "Basic $auth");
+			}
+		}
+		$response = $this->client->get($uri, $options);
 		return new Response($response, $isStream);
 	}
 

--- a/lib/private/Http/Client/WebDavClientService.php
+++ b/lib/private/Http/Client/WebDavClientService.php
@@ -71,7 +71,7 @@ class WebDavClientService implements IWebDavClientService {
 	 */
 	public function newClient($settings) {
 		if (!isset($settings['proxy'])) {
-			$proxy = $this->config->getSystemValue('proxy', '');
+			$proxy = $this->getProxyUri();
 			if ($proxy !== '') {
 				$settings['proxy'] = $proxy;
 			}
@@ -92,5 +92,23 @@ class WebDavClientService implements IWebDavClientService {
 			$client->addCurlSetting(CURLOPT_CAINFO, $certPath);
 		}
 		return $client;
+	}
+
+	/**
+	 * Get the proxy URI
+	 *
+	 * @return string
+	 */
+	private function getProxyUri() {
+		$proxyHost = $this->config->getSystemValue('proxy', null);
+		$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', null);
+		$proxyUri = '';
+		if ($proxyUserPwd !== null) {
+			$proxyUri .= $proxyUserPwd . '@';
+		}
+		if ($proxyHost !== null) {
+			$proxyUri .= $proxyHost;
+		}
+		return $proxyUri;
 	}
 }

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -526,7 +526,14 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true
+					'stream' => true,
+					'config' => [
+						'stream_context' => [
+							'http' => [
+								'request_fulluri' => true
+							]
+						],
+					],
 				]
 			)
 			->willReturn($response);
@@ -544,7 +551,14 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true
+					'stream' => true,
+					'config' => [
+						'stream_context' => [
+							'http' => [
+								'request_fulluri' => true
+							]
+						],
+					],
 				]
 			)
 			->willThrowException($this->createGuzzleClientException(Http::STATUS_NOT_FOUND));
@@ -561,7 +575,14 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true
+					'stream' => true,
+					'config' => [
+						'stream_context' => [
+							'http' => [
+								'request_fulluri' => true
+							]
+						],
+					],
 				]
 			)
 			->willThrowException($this->createGuzzleClientException(Http::STATUS_FORBIDDEN));
@@ -582,7 +603,14 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true
+					'stream' => true,
+					'config' => [
+						'stream_context' => [
+							'http' => [
+								'request_fulluri' => true
+							]
+						],
+					],
 				]
 			)
 			->willReturn($response);

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -67,15 +67,13 @@ class ClientTest extends \Test\TestCase {
 
 	public function testGetProxyUriProxyHostWithPassword() {
 		$this->config
-			->expects($this->at(0))
 			->method('getSystemValue')
-			->with('proxy', null)
-			->willReturn('foo');
-		$this->config
-			->expects($this->at(1))
-			->method('getSystemValue')
-			->with('proxyuserpwd', null)
-			->willReturn('username:password');
+			->willReturnMap(
+				[
+					['proxy', null, 'foo'],
+					['proxyuserpwd', null, 'username:password']
+				]
+			);
 		$this->assertSame('username:password@foo', self::invokePrivate($this->client, 'getProxyUri'));
 	}
 
@@ -83,6 +81,32 @@ class ClientTest extends \Test\TestCase {
 		$this->guzzleClient->method('get')
 			->willReturn(new Response(1337));
 		$this->assertEquals(1337, $this->client->get('http://localhost/', [])->getStatusCode());
+	}
+
+	public function testGetStream() {
+		$this->config
+			->method('getSystemValue')
+			->willReturnMap(
+				[
+					['proxy', null, 'foo'],
+					['proxyuserpwd', null, 'username:password']
+				]
+			);
+		$this->guzzleClient->method('get')
+			->willReturn(new Response(1337));
+		$this->assertEquals(1337, $this->client->get(
+			'http://localhost/',
+			[
+				'stream' => true,
+				'config' => [
+					'stream_context' => [
+						'http' => [
+							'request_fulluri' => true
+						]
+					],
+				],
+			]
+		)->getStatusCode());
 	}
 
 	public function testPost() {


### PR DESCRIPTION
## Description
Adds the proxy user and passwords to the Curl Options.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/3078

## Motivation and Context
Federation behind a Proxy is not possible without this patch.

## How Has This Been Tested?
- will be tested manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
