### PR TITLE
don't use sabre DAV in acceptance tests

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -26,7 +26,6 @@ use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Stream\StreamInterface;
 use InvalidArgumentException;
-use Sabre\DAV\Client as SClient;
 use SimpleXMLElement;
 
 /**
@@ -344,27 +343,6 @@ class WebDavHelper {
 				"DAV path version $davPathVersionToUse is unknown"
 			);
 		}
-	}
-
-	/**
-	 * returns a Sabre client
-	 *
-	 * @param string $baseUrl
-	 * @param string $user
-	 * @param string $password
-	 *
-	 * @return \Sabre\DAV\Client
-	 */
-	public static function getSabreClient($baseUrl, $user, $password) {
-		$settings = [
-				'baseUri' => $baseUrl . "/",
-				'userName' => $user,
-				'password' => $password,
-				'authType' => SClient::AUTH_BASIC
-		];
-		$client = new SClient($settings);
-		$client->addCurlSetting(CURLOPT_SSL_VERIFYPEER, false);
-		return $client;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -25,7 +25,6 @@ use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Ring\Exception\ConnectException;
 use GuzzleHttp\Stream\StreamInterface;
 use Guzzle\Http\Exception\BadResponseException;
-use Sabre\DAV\Client as SClient;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
@@ -1328,19 +1327,6 @@ trait WebDav {
 			$this->getPasswordForUser($user),
 			$path, $folderDepth, $properties,
 			"files", ($this->usingOldDavPath) ? 1 : 2
-		);
-	}
-
-	/**
-	 * @param string $user
-	 *
-	 * @return SClient
-	 */
-	public function getSabreClient($user) {
-		return WebDavHelper::getSabreClient(
-			$this->getBaseUrl(),
-			$user,
-			$this->getPasswordForUser($user)
 		);
 	}
 


### PR DESCRIPTION
## Description
deleting the rests of sabre from core acceptance tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #34000

## Motivation and Context
use only one HTTP/DAV lib

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
