### PR TITLE
[stable10] Fix access to /ocm-provider when clean urls are active

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -451,6 +451,7 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/updater/";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs-provider/";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocm-provider/";
 			$content .= "\n  RewriteCond %{REQUEST_URI} !^/.well-known/(acme-challenge|pki-validation)/.*";
 			$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteBase " . $rewriteBase;


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/34105
## Description
Update apache2 rewrite rules to allow `/ocm-provider` endpoint discovery

## Motivation and Context
When the OC is set to strip 'index.php' from URLs it doesn't allow anonymous access to `/ocm-provider` endpoint

## How Has This Been Tested?
setup ownCloud to strip index.php from the URLs:
1. add 'htaccess.RewriteBase'` into the config.php
2. run occ maintenance:update:htaccess
3. open `/ocm-provider/` page

### Expected 
json response
```
{"enabled":true,"apiVersion":"1.0-proposal1","endPoint":"http:\/\/owncloud\/index.php\/apps\/federatedfilesharing","shareTypes":[{"name":"file","protocols":{"webdav":"\/public.php\/webdav\/"}}]}
```
### Actual 
Redirect to the login page

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

