### PR TITLE
move properties related methods into own context

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -18,6 +18,7 @@ default:
         - ChecksumContext:
         - FilesVersionsContext:
         - TransferOwnershipContext:
+        - WebDavPropertiesContext:
 
     apiCapabilities:
       paths:
@@ -25,6 +26,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
+        - WebDavPropertiesContext:
 
     apiComments:
       paths:
@@ -32,6 +34,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - CommentsContext:
+        - WebDavPropertiesContext:
 
     apiFederation:
       paths:
@@ -39,6 +42,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - FederationContext:
+        - WebDavPropertiesContext:
 
     apiFavorites:
       paths:
@@ -46,18 +50,21 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - FavoritesContext:
+        - WebDavPropertiesContext:
 
     apiProvisioning-v1:
       paths:
         - '%paths.base%/../features/apiProvisioning-v1'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebDavPropertiesContext:
 
     apiProvisioning-v2:
       paths:
         - '%paths.base%/../features/apiProvisioning-v2'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebDavPropertiesContext:
 
     apiSharees:
       paths:
@@ -65,6 +72,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - ShareesContext:
+        - WebDavPropertiesContext:
 
     apiShareManagement:
       paths:
@@ -73,6 +81,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
         - TrashbinContext:
+        - WebDavPropertiesContext:
 
     apiShareOperations:
       paths:
@@ -81,6 +90,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
         - TrashbinContext:
+        - WebDavPropertiesContext:
 
     apiSharingNotifications:
       paths:
@@ -88,6 +98,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
+        - WebDavPropertiesContext:
 
     apiTags:
       paths:
@@ -95,6 +106,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - TagsContext:
+        - WebDavPropertiesContext:
 
     apiTrashbin:
       paths:
@@ -102,6 +114,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - TrashbinContext:
+        - WebDavPropertiesContext:
 
     apiWebdavOperations:
       paths:
@@ -111,6 +124,7 @@ default:
         - LoggingContext:
         - SearchContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     apiWebdavProperties:
       paths:
@@ -118,6 +132,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
+        - WebDavPropertiesContext:
 
     cliProvisioning:
       paths:
@@ -126,6 +141,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
         - OccContext:
+        - WebDavPropertiesContext:
 
     cliMain:
       paths:
@@ -133,6 +149,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
+        - WebDavPropertiesContext:
 
     cliBackground:
       paths:
@@ -140,6 +157,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
+        - WebDavPropertiesContext:
 
     cliTrashbin:
       paths:
@@ -148,6 +166,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - OccContext:
         - TrashbinContext:
+        - WebDavPropertiesContext:
 
     webUIAdminSettings:
       paths:
@@ -165,6 +184,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - OccContext:
+        - WebDavPropertiesContext:
 
     webUIComments:
       paths:
@@ -175,6 +195,7 @@ default:
         - WebUILoginContext:
         - WebUIFilesContext:
         - WebUISharingContext:
+        - WebDavPropertiesContext:
 
     webUIFavorites:
       paths:
@@ -184,6 +205,7 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - WebDavPropertiesContext:
 
     webUIFiles:
       paths:
@@ -198,6 +220,7 @@ default:
         - WebUISharingContext:
         - OccContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     webUILogin:
       paths:
@@ -209,6 +232,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIPersonalGeneralSettingsContext:
+        - WebDavPropertiesContext:
 
     webUIMoveFilesFolders:
       paths:
@@ -220,6 +244,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     webUIPersonalSettings:
       paths:
@@ -234,6 +259,7 @@ default:
         - WebUIPersonalSecuritySettingsContext:
         - WebUIUserContext:
         - OccContext:
+        - WebDavPropertiesContext:
 
     webUIRenameFiles:
       paths:
@@ -245,6 +271,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     webUIRenameFolders:
       paths:
@@ -254,6 +281,7 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - WebDavPropertiesContext:
 
     webUIRestrictSharing:
       paths:
@@ -264,6 +292,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUISharingContext:
+        - WebDavPropertiesContext:
 
     webUISharingExternal:
       paths:
@@ -277,6 +306,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     webUISharingInternalGroups:
       paths:
@@ -288,6 +318,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - WebUIAdminSharingSettingsContext:
+        - WebDavPropertiesContext:
 
     webUISharingInternalUsers:
       paths:
@@ -299,6 +330,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - WebUIAdminSharingSettingsContext:
+        - WebDavPropertiesContext:
 
     webUISharingNotifications:
       paths:
@@ -311,6 +343,7 @@ default:
         - WebUILoginContext:
         - WebUINotificationsContext:
         - WebUISharingContext:
+        - WebDavPropertiesContext:
 
     webUITags:
       paths:
@@ -323,6 +356,7 @@ default:
         - WebUIFilesContext:
         - WebUISharingContext:
         - WebUITagsContext:
+        - WebDavPropertiesContext:
 
     webUITrashbin:
       paths:
@@ -333,6 +367,7 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - WebDavPropertiesContext:
 
     webUIUpload:
       paths:
@@ -344,6 +379,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     webUIWebdavLocks:
       paths:
@@ -357,6 +393,7 @@ default:
         - WebUIWebDavLockingContext:
         - WebUISharingContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
   extensions:
     jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -40,6 +40,12 @@ class FavoritesContext implements Context {
 	private $featureContext;
 
 	/**
+	 *
+	 * @var WebDavPropertiesContext
+	 */
+	private $webDavPropertiesContext;
+
+	/**
 	 * @When user :user favorites element :path using the WebDAV API
 	 * @Given user :user has favorited element :path
 	 *
@@ -193,7 +199,7 @@ class FavoritesContext implements Context {
 	 */
 	public function asUserTheFileOrFolderShouldBeFavorited($user, $path, $expectedValue = 1) {
 		$property = "oc:favorite";
-		$this->featureContext->asUserFolderShouldContainAPropertyWithValue(
+		$this->webDavPropertiesContext->asUserFolderShouldContainAPropertyWithValue(
 			$user, $path, $property, $expectedValue
 		);
 	}
@@ -272,5 +278,8 @@ class FavoritesContext implements Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
+		$this->webDavPropertiesContext = $environment->getContext(
+			'WebDavPropertiesContext'
+		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -19,6 +19,7 @@
  *
  */
 
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
@@ -95,6 +96,28 @@ trait WebDav {
 	private $httpRequestTimeout = 0;
 
 	private $chunkingToUse = null;
+
+	/**
+	 *
+	 * @var WebDavPropertiesContext
+	 */
+	private $webDavPropertiesContext;
+
+	/**
+	 * @return SimpleXMLElement
+	 */
+	public function getResponseXmlObject() {
+		return $this->responseXmlObject;
+	}
+
+	/**
+	 * @param SimpleXMLElement $responseXmlObject
+	 *
+	 * @return void
+	 */
+	public function setResponseXmlObject($responseXmlObject) {
+		$this->responseXmlObject = $responseXmlObject;
+	}
 
 	/**
 	 * @param array $responseXml
@@ -949,136 +972,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $user
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function userGetsThePropertiesOfFolder(
-		$user, $path
-	) {
-		$this->responseXmlObject = $this->listFolder($user, $path, 0);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $user
-	 * @param string $path
-	 * @param TableNode|null $propertiesTable
-	 *
-	 * @return void
-	 */
-	public function userGetsPropertiesOfFolder(
-		$user, $path, $propertiesTable
-	) {
-		$properties = null;
-		if ($propertiesTable instanceof TableNode) {
-			foreach ($propertiesTable->getRows() as $row) {
-				$properties[] = $row[0];
-			}
-		}
-		$this->responseXmlObject = $this->listFolder($user, $path, 0, $properties);
-	}
-
-	/**
-	 * @When /^the user gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $path
-	 * @param TableNode|null $propertiesTable
-	 *
-	 * @return void
-	 */
-	public function theUserGetsPropertiesOfFolder($path, $propertiesTable) {
-		$this->userGetsPropertiesOfFolder($this->getCurrentUser(), $path, $propertiesTable);
-	}
-
-	/**
-	 * @When user :user gets a custom property :propertyName with namespace :namespace of file :path
-	 *
-	 * @param string $user
-	 * @param string $propertyName
-	 * @param string $namespace namespace in form of "x1='http://whatever.org/ns'"
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function userGetsPropertiesOfFile($user, $propertyName, $namespace, $path) {
-		$properties = [
-			$namespace => $propertyName
-		];
-		$this->response = WebDavHelper::propfind(
-			$this->getBaseUrl(),
-			$this->getActualUsername($user),
-			$this->getUserPassword($user), $path,
-			$properties
-		);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" sets property "([^"]*)"  with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
-	 * @Given /^user "([^"]*)" has set property "([^"]*)" with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
-	 *
-	 * @param string $user user id who sets the property
-	 * @param string $propertyName name of property in Clark notation
-	 * @param string $namespace namespace in form of "x1='http://whatever.org/ns'"
-	 * @param string $path path on which to set properties to
-	 * @param string $propertyValue property value
-	 *
-	 * @return void
-	 */
-	public function userHasSetPropertyWithNamespaceOfEntryTo(
-		$user, $propertyName, $namespace, $path, $propertyValue
-	) {
-		WebDavHelper::proppatch(
-			$this->getBaseUrl(),
-			$this->getActualUsername($user),
-			$this->getUserPassword($user), $path,
-			$propertyName, $propertyValue, $namespace,
-			$this->getDavPathVersion()
-		);
-	}
-
-	/**
-	 * @Then /^the response should contain a custom "([^"]*)" property with namespace "([^"]*)" and value "([^"]*)"$/
-	 *
-	 * @param string $propertyName
-	 * @param string $namespaceString
-	 * @param string $propertyValue
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theResponseShouldContainACustomPropertyWithValue(
-		$propertyName, $namespaceString, $propertyValue
-	) {
-		$this->responseXmlObject = HttpRequestHelper::getResponseXml(
-			$this->response
-		);
-		//calculate the namespace prefix and namespace
-		$matches = [];
-		\preg_match("/^(.*)='(.*)'$/", $namespaceString, $matches);
-		$nameSpace = $matches[2];
-		$nameSpacePrefix = $matches[1];
-		$this->responseXmlObject->registerXPathNamespace(
-			$nameSpacePrefix, $nameSpace
-		);
-		$xmlPart = $this->responseXmlObject->xpath(
-			"//d:prop/" . "$nameSpacePrefix:$propertyName"
-		);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
-			0, $xmlPart, "Cannot find property \"$propertyName\""
-		);
-		PHPUnit_Framework_Assert::assertEquals(
-			$propertyValue, $xmlPart[0]->__toString(),
-			"\"$propertyName\" has a value \"" .
-			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected"
-		);
-	}
-
-	/**
 	 * @Then /^as "([^"]*)" (file|folder|entry) "([^"]*)" should not exist$/
 	 *
 	 * @param string $user
@@ -1118,193 +1011,12 @@ trait WebDav {
 		$path = $this->substituteInLineCodes($path);
 		$this->responseXmlObject = $this->listFolder($user, $path, 0);
 		try {
-			$this->thePropertiesResponseShouldContainAnEtag();
+			$this->webDavPropertiesContext->thePropertiesResponseShouldContainAnEtag();
 		} catch (\Exception $e) {
 			throw new \Exception(
 				"$entry '$path' expected to exist but not found"
 			);
 		}
-	}
-
-	/**
-	 * @Then /^the properties response should contain an etag$/
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function thePropertiesResponseShouldContainAnEtag() {
-		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
-		if (!\is_array($xmlPart)
-			|| !\preg_match("/^\"[a-f0-9]{1,32}\"$/", $xmlPart[0]->__toString())
-		) {
-			throw new \Exception(
-				"getetag not found in response"
-			);
-		}
-	}
-
-	/**
-	 * @Then the single response should contain a property :key with value :value
-	 *
-	 * @param string $key
-	 * @param string $expectedValue
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theSingleResponseShouldContainAPropertyWithValue(
-		$key, $expectedValue
-	) {
-		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
-			$key, $expectedValue, $expectedValue
-		);
-	}
-
-	/**
-	 * @Then the single response should contain a property :key with value :value or with value :altValue
-	 *
-	 * @param string $key
-	 * @param string $expectedValue
-	 * @param string $altExpectedValue
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theSingleResponseShouldContainAPropertyWithValueAndAlternative(
-		$key, $expectedValue, $altExpectedValue
-	) {
-		$xmlPart = $this->responseXmlObject->xpath("//d:prop/$key");
-		PHPUnit_Framework_Assert::assertTrue(
-			isset($xmlPart[0]), "Cannot find property \"$key\""
-		);
-		$value = $xmlPart[0]->__toString();
-
-		if ($expectedValue === "a_comment_url") {
-			$basePath = \ltrim($this->getBasePath() . "/", "/");
-			$expected = "#^/{$basePath}remote.php/dav/comments/files/([0-9]+)$#";
-			PHPUnit_Framework_Assert::assertRegExp(
-				$expected, $value,
-				"Property \"$key\" found with value \"$value\", expected \"$expectedValue\""
-			);
-		} elseif ($value != $expectedValue && $value != $altExpectedValue) {
-			throw new \Exception(
-				"Property \"$key\" found with value \"$value\", expected \"$expectedValue\""
-			);
-		}
-	}
-	
-	/**
-	 * @Then the single response should contain a property :property with a child property :childProperty
-	 *
-	 * @param string $property
-	 * @param string $childProperty
-	 *
-	 * @return void
-	 *
-	 * @throws \Exception
-	 */
-	public function theSingleResponseShouldContainAPropertyWithChildProperty(
-		$property, $childProperty
-	) {
-		$xmlPart = $this->responseXmlObject->xpath(
-			"//d:prop/$property/$childProperty"
-		);
-		PHPUnit_Framework_Assert::assertTrue(
-			isset($xmlPart[0]), "Cannot find property \"$property/$childProperty\""
-		);
-	}
-
-	/**
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)" or with value "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $path
-	 * @param string $property
-	 * @param string $expectedValue
-	 * @param string $altExpectedValue
-	 *
-	 * @return void
-	 */
-	public function asUserFolderShouldContainAPropertyWithValueOrWithValue(
-		$user, $path, $property, $expectedValue, $altExpectedValue
-	) {
-		$this->responseXmlObject = $this->listFolder($user, $path, 0, [$property]);
-		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
-			$property, $expectedValue, $altExpectedValue
-		);
-	}
-
-	/**
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $path
-	 * @param string $property
-	 * @param string $value
-	 *
-	 * @return void
-	 */
-	public function asUserFolderShouldContainAPropertyWithValue(
-		$user, $path, $property, $value
-	) {
-		$this->asUserFolderShouldContainAPropertyWithValueOrWithValue(
-			$user, $path, $property, $value, $value
-		);
-	}
-
-	/**
-	 * @Then the single response should contain a property :key with value like :regex
-	 *
-	 * @param string $key
-	 * @param string $regex
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theSingleResponseShouldContainAPropertyWithValueLike(
-		$key, $regex
-	) {
-		$xmlPart = $this->responseXmlObject->xpath("//d:prop/$key");
-		PHPUnit_Framework_Assert::assertTrue(
-			isset($xmlPart[0]), "Cannot find property \"$key\""
-		);
-		$value = $xmlPart[0]->__toString();
-		PHPUnit_Framework_Assert::assertRegExp(
-			$regex, $value,
-			"Property \"$key\" found with value \"$value\", expected \"$regex\""
-		);
-	}
-
-	/**
-	 * @Then the response should contain a share-types property with
-	 *
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theResponseShouldContainAShareTypesPropertyWith($table) {
-		WebDavAssert::assertResponseContainsShareTypes(
-			$this->responseXmlObject, $table
-		);
-	}
-
-	/**
-	 * @Then the response should contain an empty property :property
-	 *
-	 * @param string $property
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theResponseShouldContainAnEmptyProperty($property) {
-		$xmlPart = $this->responseXmlObject->xpath("//d:prop/$property");
-		PHPUnit_Framework_Assert::assertCount(
-			1, $xmlPart, "Cannot find property \"$property\""
-		);
-		PHPUnit_Framework_Assert::assertEmpty(
-			$xmlPart[0], "Property \"$property\" is not empty"
-		);
 	}
 
 	/**
@@ -2248,7 +1960,7 @@ trait WebDav {
 	 */
 	public function userStoresEtagOfElement($user, $path) {
 		$propertiesTable = new TableNode([['getetag']]);
-		$this->userGetsPropertiesOfFolder(
+		$this->webDavPropertiesContext->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
 		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
@@ -2265,7 +1977,7 @@ trait WebDav {
 	 */
 	public function etagOfElementOfUserShouldNotHaveChanged($path, $user) {
 		$propertiesTable = new TableNode([['getetag']]);
-		$this->userGetsPropertiesOfFolder(
+		$this->webDavPropertiesContext->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
 		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
@@ -2284,7 +1996,7 @@ trait WebDav {
 	 */
 	public function etagOfElementOfUserShouldHaveChanged($path, $user) {
 		$propertiesTable = new TableNode([['getetag']]);
-		$this->userGetsPropertiesOfFolder(
+		$this->webDavPropertiesContext->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
 		$xmlPart = $this->responseXmlObject->xpath("//d:prop/d:getetag");
@@ -2595,6 +2307,25 @@ trait WebDav {
 		if ($this->lastUploadDeleteTime !== null && $time - $this->lastUploadDeleteTime < 1) {
 			\sleep(1);
 		}
+	}
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->webDavPropertiesContext = $environment->getContext(
+			'WebDavPropertiesContext'
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use TestHelpers\Asserts\WebDav as WebDavTest;
+use TestHelpers\HttpRequestHelper;
+use TestHelpers\WebDavHelper;
+
+require_once 'bootstrap.php';
+
+/**
+ * Steps that relate to files_versions app
+ */
+class WebDavPropertiesContext implements Context {
+
+	/**
+	 *
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+	/**
+	 * @When /^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function userGetsThePropertiesOfFolder(
+		$user, $path
+	) {
+		$this->featureContext->setResponseXmlObject(
+			$this->featureContext->listFolder($user, $path, 0)
+		);
+	}
+	
+	/**
+	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param TableNode|null $propertiesTable
+	 *
+	 * @return void
+	 */
+	public function userGetsPropertiesOfFolder(
+		$user, $path, $propertiesTable
+	) {
+		$properties = null;
+		if ($propertiesTable instanceof TableNode) {
+			foreach ($propertiesTable->getRows() as $row) {
+				$properties[] = $row[0];
+			}
+		}
+		$this->featureContext->setResponseXmlObject(
+			$this->featureContext->listFolder($user, $path, 0, $properties)
+		);
+	}
+	
+	/**
+	 * @When /^the user gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
+	 *
+	 * @param string $path
+	 * @param TableNode|null $propertiesTable
+	 *
+	 * @return void
+	 */
+	public function theUserGetsPropertiesOfFolder($path, $propertiesTable) {
+		$this->userGetsPropertiesOfFolder(
+			$this->featureContext->getCurrentUser(), $path, $propertiesTable
+		);
+	}
+	
+	/**
+	 * @When user :user gets a custom property :propertyName with namespace :namespace of file :path
+	 *
+	 * @param string $user
+	 * @param string $propertyName
+	 * @param string $namespace namespace in form of "x1='http://whatever.org/ns'"
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function userGetsPropertiesOfFile(
+		$user, $propertyName, $namespace, $path
+	) {
+		$properties = [
+			$namespace => $propertyName
+		];
+		$this->featureContext->setResponse(
+			WebDavHelper::propfind(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getActualUsername($user),
+				$this->featureContext->getUserPassword($user), $path,
+				$properties
+			)
+		);
+	}
+	
+	/**
+	 * @When /^user "([^"]*)" sets property "([^"]*)"  with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
+	 * @Given /^user "([^"]*)" has set property "([^"]*)" with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user user id who sets the property
+	 * @param string $propertyName name of property in Clark notation
+	 * @param string $namespace namespace in form of "x1='http://whatever.org/ns'"
+	 * @param string $path path on which to set properties to
+	 * @param string $propertyValue property value
+	 *
+	 * @return void
+	 */
+	public function userHasSetPropertyWithNamespaceOfEntryTo(
+		$user, $propertyName, $namespace, $path, $propertyValue
+	) {
+		WebDavHelper::proppatch(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getActualUsername($user),
+			$this->featureContext->getUserPassword($user), $path,
+			$propertyName, $propertyValue, $namespace,
+			$this->featureContext->getDavPathVersion()
+		);
+	}
+	
+	/**
+	 * @Then /^the response should contain a custom "([^"]*)" property with namespace "([^"]*)" and value "([^"]*)"$/
+	 *
+	 * @param string $propertyName
+	 * @param string $namespaceString
+	 * @param string $propertyValue
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theResponseShouldContainACustomPropertyWithValue(
+		$propertyName, $namespaceString, $propertyValue
+	) {
+		$this->featureContext->setResponseXmlObject(
+			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())
+		);
+		$responseXmlObject = $this->featureContext->getResponseXmlObject();
+		//calculate the namespace prefix and namespace
+		$matches = [];
+		\preg_match("/^(.*)='(.*)'$/", $namespaceString, $matches);
+		$nameSpace = $matches[2];
+		$nameSpacePrefix = $matches[1];
+		$responseXmlObject->registerXPathNamespace(
+			$nameSpacePrefix, $nameSpace
+		);
+		$xmlPart = $responseXmlObject->xpath(
+			"//d:prop/" . "$nameSpacePrefix:$propertyName"
+		);
+		PHPUnit_Framework_Assert::assertArrayHasKey(
+			0, $xmlPart, "Cannot find property \"$propertyName\""
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			$propertyValue, $xmlPart[0]->__toString(),
+			"\"$propertyName\" has a value \"" .
+			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected"
+		);
+	}
+
+	/**
+	 * @Then the single response should contain a property :property with a child property :childProperty
+	 *
+	 * @param string $property
+	 * @param string $childProperty
+	 *
+	 * @return void
+	 *
+	 * @throws \Exception
+	 */
+	public function theSingleResponseShouldContainAPropertyWithChildProperty(
+		$property, $childProperty
+	) {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
+			"//d:prop/$property/$childProperty"
+		);
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find property \"$property/$childProperty\""
+		);
+	}
+
+	/**
+	 * @Then the single response should contain a property :key with value :value
+	 *
+	 * @param string $key
+	 * @param string $expectedValue
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theSingleResponseShouldContainAPropertyWithValue(
+		$key, $expectedValue
+	) {
+		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
+			$key, $expectedValue, $expectedValue
+		);
+	}
+
+	/**
+	 * @Then the single response should contain a property :key with value :value or with value :altValue
+	 *
+	 * @param string $key
+	 * @param string $expectedValue
+	 * @param string $altExpectedValue
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theSingleResponseShouldContainAPropertyWithValueAndAlternative(
+		$key, $expectedValue, $altExpectedValue
+	) {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
+			"//d:prop/$key"
+		);
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find property \"$key\""
+		);
+		$value = $xmlPart[0]->__toString();
+		
+		if ($expectedValue === "a_comment_url") {
+			$basePath = \ltrim($this->featureContext->getBasePath() . "/", "/");
+			$expected = "#^/{$basePath}remote.php/dav/comments/files/([0-9]+)$#";
+			PHPUnit_Framework_Assert::assertRegExp(
+				$expected, $value,
+				"Property \"$key\" found with value \"$value\", " .
+				"expected \"$expectedValue\""
+			);
+		} elseif ($value != $expectedValue && $value != $altExpectedValue) {
+			throw new \Exception(
+				"Property \"$key\" found with value \"$value\", " .
+				"expected \"$expectedValue\""
+			);
+		}
+	}
+
+	/**
+	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)" or with value "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $property
+	 * @param string $expectedValue
+	 * @param string $altExpectedValue
+	 *
+	 * @return void
+	 */
+	public function asUserFolderShouldContainAPropertyWithValueOrWithValue(
+		$user, $path, $property, $expectedValue, $altExpectedValue
+	) {
+		$this->featureContext->setResponseXmlObject(
+			$this->featureContext->listFolder($user, $path, 0, [$property])
+		);
+		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
+			$property, $expectedValue, $altExpectedValue
+		);
+	}
+
+	/**
+	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $property
+	 * @param string $value
+	 *
+	 * @return void
+	 */
+	public function asUserFolderShouldContainAPropertyWithValue(
+		$user, $path, $property, $value
+	) {
+		$this->asUserFolderShouldContainAPropertyWithValueOrWithValue(
+			$user, $path, $property, $value, $value
+		);
+	}
+	
+	/**
+	 * @Then the single response should contain a property :key with value like :regex
+	 *
+	 * @param string $key
+	 * @param string $regex
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theSingleResponseShouldContainAPropertyWithValueLike(
+		$key, $regex
+	) {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
+			"//d:prop/$key"
+		);
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find property \"$key\""
+		);
+		$value = $xmlPart[0]->__toString();
+		PHPUnit_Framework_Assert::assertRegExp(
+			$regex, $value,
+			"Property \"$key\" found with value \"$value\", expected \"$regex\""
+		);
+	}
+	
+	/**
+	 * @Then the response should contain a share-types property with
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theResponseShouldContainAShareTypesPropertyWith($table) {
+		WebdavTest::assertResponseContainsShareTypes(
+			$this->featureContext->getResponseXmlObject(), $table
+		);
+	}
+	
+	/**
+	 * @Then the response should contain an empty property :property
+	 *
+	 * @param string $property
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theResponseShouldContainAnEmptyProperty($property) {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
+			"//d:prop/$property"
+		);
+		PHPUnit_Framework_Assert::assertCount(
+			1, $xmlPart, "Cannot find property \"$property\""
+		);
+		PHPUnit_Framework_Assert::assertEmpty(
+			$xmlPart[0], "Property \"$property\" is not empty"
+		);
+	}
+
+	/**
+	 * @Then /^the properties response should contain an etag$/
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function thePropertiesResponseShouldContainAnEtag() {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
+			"//d:prop/d:getetag"
+		);
+		if (!\is_array($xmlPart)
+			|| !\preg_match("/^\"[a-f0-9]{1,32}\"$/", $xmlPart[0]->__toString())
+		) {
+			throw new \Exception(
+				"getetag not found in response"
+			);
+		}
+	}
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+	}
+}


### PR DESCRIPTION
## Description
move methods into own context

## Related Issue
part of #33690

## Motivation and Context
make the WebDav.php shorter and easier to use

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
