### PR TITLE
[stable10] Backpot of Fix visibility of static tags in the tags page

### DIFF
--- a/apps/systemtags/js/systemtagsfilelist.js
+++ b/apps/systemtags/js/systemtagsfilelist.js
@@ -122,18 +122,50 @@
 		},
 
 		/**
+		 * Get the fetched tags from the filter query
+		 *
+		 * @param {Object} query select2 query object
+		 */
+		fetchedResult: function(query) {
+			var results = OC.SystemTags.collection.filterByName(query.term);
+			/**
+			 * Check if static tags are visible for this user.
+			 * If so show it, else don't.
+			 */
+			var indexToSplice = [];
+			for(var i=0; i < results.length; i++) {
+				var tagAttribute = results[i].attributes;
+				//Check if the tag is static tag
+				if (tagAttribute.userEditable === false && tagAttribute.userAssignable === true) {
+					if (!OC.isUserAdmin() && tagAttribute.editableInGroup === false) {
+						var index = i;
+						if (indexToSplice.length > 0) {
+							index -= indexToSplice.length;
+						}
+						indexToSplice.push(index);
+					}
+				}
+			}
+
+			indexToSplice.forEach(function (index) {
+				results.splice(index, 1);
+			});
+
+			query.callback({
+				results: _.invoke(results, 'toJSON')
+			});
+		},
+
+		/**
 		 * Autocomplete function for dropdown results
 		 *
 		 * @param {Object} query select2 query object
 		 */
 		_queryTagsAutocomplete: function(query) {
+			var self = this;
 			OC.SystemTags.collection.fetch({
-				success: function() {
-					var results = OC.SystemTags.collection.filterByName(query.term);
-
-					query.callback({
-						results: _.invoke(results, 'toJSON')
-					});
+				success: function () {
+					self.fetchedResult(query)
 				}
 			});
 		},

--- a/apps/systemtags/tests/js/systemtagsfilelistSpec.js
+++ b/apps/systemtags/tests/js/systemtagsfilelistSpec.js
@@ -46,7 +46,7 @@ describe('OCA.SystemTags.FileList tests', function() {
 	});
 
 	describe('filter field', function() {
-		var select2Stub, oldCollection, fetchTagsStub;
+		var select2Stub, oldCollection, fetchTagsStub, isAdminStub;
 		var $tagsField;
 
 		beforeEach(function() {
@@ -61,6 +61,15 @@ describe('OCA.SystemTags.FileList tests', function() {
 				{
 					id: '456',
 					name: 'def'
+				},
+				{
+					id: '789',
+					name: 'staticTag',
+					userAssignable: true,
+					userEditable: false,
+					userVisible: true,
+					canAssign: true,
+					editableInGroup: false
 				}
 			]);
 
@@ -70,10 +79,12 @@ describe('OCA.SystemTags.FileList tests', function() {
 				}
 			);
 			$tagsField = fileList.$el.find('[name=tags]');
+			isAdminStub = sinon.stub(OC, 'isUserAdmin').returns(false);
 		});
 		afterEach(function() {
 			select2Stub.restore();
 			fetchTagsStub.restore();
+			isAdminStub.restore();
 			OC.SystemTags.collection = oldCollection;
 		});
 		it('inits select2 on filter field', function() {
@@ -115,6 +126,29 @@ describe('OCA.SystemTags.FileList tests', function() {
 			expect(callback.calledOnce).toEqual(true);
 			expect(callback.lastCall.args[0]).toEqual({
 				results: [
+					OC.SystemTags.collection.get('456').toJSON()
+				]
+			});
+		});
+		it('fetches tag list from the global collection and removes static tag', function () {
+			var callback = sinon.stub();
+			var opts = select2Stub.firstCall.args[0];
+
+			opts.query({
+				term: "",
+				callback: callback
+			});
+
+
+			//expect(callback.notCalled).toEqual(true);
+			OCA.SystemTags.FileList.prototype.fetchedResult({
+				term: "",
+				callback: callback
+			});
+
+			expect(callback.lastCall.args[0]).toEqual({
+				results: [
+					OC.SystemTags.collection.get('123').toJSON(),
 					OC.SystemTags.collection.get('456').toJSON()
 				]
 			});


### PR DESCRIPTION
Fix the visibility of static tags in the tags
page. The static tags should not be visible
for all users.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Static tags should not be visible for all users. Excluding admin users, the users of the group which are whitelisted can see the tag. In this case, when user navigates to the tags page in the systemtags filter page, user is able to see the static tags. Expected behaviour is not all users should see it. This PR tries to address this problem.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/34002

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Static tags should not be visible for all users. Only users which are whitelisted in the groups for static tags can see the tag. This PR tries to fix the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create users `user1`, `user2`, `user3` and `user4`
- Create groups `group1` and add `user1` and `user2` to it.
- Create groups `group2` and add `user3` to it.
- Add `user4` to both `group1` and `group2`.
- Create restricted tag for `group1`. Create static tag for `group2`. Create visible tag.
- Now login as `user1` or `user2`.
- User should be able to see restricted tag and visible tag ( same case with `user2` )

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
