### PR TITLE
Skip preview expiry when owner cannot be determined

### DIFF
--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -1238,7 +1238,11 @@ class Preview {
 		$path = Files\Filesystem::normalizePath($args['path']);
 		$user = isset($args['user']) ? $args['user'] : \OC_User::getUser();
 		if ($user === false) {
-			$user = Filesystem::getOwner($path);
+			try {
+				$user = Filesystem::getOwner($path);
+			} catch (NotFoundException $e) {
+				return;
+			}
 		}
 
 		$userFolder = \OC::$server->getUserFolder($user);
@@ -1308,7 +1312,11 @@ class Preview {
 		if (!isset(self::$deleteFileMapper[$path])) {
 			$user = isset($args['user']) ? $args['user'] : \OC_User::getUser();
 			if ($user === false) {
-				$user = Filesystem::getOwner($path);
+				try {
+					$user = Filesystem::getOwner($path);
+				} catch (NotFoundException $e) {
+					return;
+				}
 			}
 
 			$userFolder = \OC::$server->getUserFolder($user);


### PR DESCRIPTION
## Description
In some scenarios, the owner of trashed files or versions cannot be determined, instead of failing hard, just skip expiration.
This is just a mitigation as we need a proper solution for trash/version
preview expiry.

Please note that this is just a mitigation and actual issue isn't fixed yet (see below) as we need to bigger changes in the preview code to accomodate for versions, see https://github.com/owncloud/core/pull/33188

## Related Issue
Mitigation for https://github.com/owncloud/core/issues/32346 (version expiry) and https://github.com/owncloud/enterprise/issues/3067 (trash expiry).

## Motivation and Context
Mitigate the issue and avoid stopping the process or crashing whenever expiry did not work.

## How Has This Been Tested?
- [x] manual test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
