### PR TITLE
Pass remote user to activity for dav1 anon requests

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -85,6 +85,13 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 	$fileInfo = $ownerView->getFileInfo($path);
 	$linkCheckPlugin->setFileInfo($fileInfo);
 
+	\OC::$server->getEventDispatcher()->addListener(
+		'public.user.resolve',
+		function ($event) use ($share) {
+			$event->setArgument('user', $share->getSharedWith());
+		}
+	);
+
 	return new \OC\Files\View($ownerView->getAbsolutePath($path));
 });
 


### PR DESCRIPTION
## Description
Allows cleaner solution for https://github.com/owncloud/activity/pull/672

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/2444

## Motivation and Context
Prints "user@host" instead of  "remote user" in activity feed

## How Has This Been Tested?
1. create a text file 
2. share it via federation
3. accept and change as a recipient
4. Look into activity feed


## Screenshots (if appropriate):
![activity](https://user-images.githubusercontent.com/991300/49961389-a3180a00-ff23-11e8-8d1a-34a010f62bf0.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
