### PR TITLE
move eTag steps to WebDavPropertiesContext

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -18,7 +18,6 @@ default:
         - ChecksumContext:
         - FilesVersionsContext:
         - TransferOwnershipContext:
-        - WebDavPropertiesContext:
 
     apiCapabilities:
       paths:
@@ -26,7 +25,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
-        - WebDavPropertiesContext:
 
     apiComments:
       paths:
@@ -57,14 +55,12 @@ default:
         - '%paths.base%/../features/apiProvisioning-v1'
       contexts:
         - FeatureContext: *common_feature_context_params
-        - WebDavPropertiesContext:
 
     apiProvisioning-v2:
       paths:
         - '%paths.base%/../features/apiProvisioning-v2'
       contexts:
         - FeatureContext: *common_feature_context_params
-        - WebDavPropertiesContext:
 
     apiSharees:
       paths:
@@ -72,7 +68,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - ShareesContext:
-        - WebDavPropertiesContext:
 
     apiShareManagement:
       paths:
@@ -98,7 +93,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
-        - WebDavPropertiesContext:
 
     apiTags:
       paths:
@@ -106,7 +100,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - TagsContext:
-        - WebDavPropertiesContext:
 
     apiTrashbin:
       paths:
@@ -114,7 +107,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - TrashbinContext:
-        - WebDavPropertiesContext:
 
     apiWebdavOperations:
       paths:
@@ -124,7 +116,6 @@ default:
         - LoggingContext:
         - SearchContext:
         - PublicWebDavContext:
-        - WebDavPropertiesContext:
 
     apiWebdavProperties:
       paths:
@@ -141,7 +132,6 @@ default:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
         - OccContext:
-        - WebDavPropertiesContext:
 
     cliMain:
       paths:
@@ -149,7 +139,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
-        - WebDavPropertiesContext:
 
     cliBackground:
       paths:
@@ -157,7 +146,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
-        - WebDavPropertiesContext:
 
     cliTrashbin:
       paths:
@@ -166,7 +154,6 @@ default:
         - FeatureContext: *common_feature_context_params
         - OccContext:
         - TrashbinContext:
-        - WebDavPropertiesContext:
 
     webUIAdminSettings:
       paths:
@@ -184,7 +171,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - OccContext:
-        - WebDavPropertiesContext:
 
     webUIComments:
       paths:
@@ -195,7 +181,6 @@ default:
         - WebUILoginContext:
         - WebUIFilesContext:
         - WebUISharingContext:
-        - WebDavPropertiesContext:
 
     webUIFavorites:
       paths:
@@ -205,7 +190,6 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebDavPropertiesContext:
 
     webUIFiles:
       paths:
@@ -220,7 +204,6 @@ default:
         - WebUISharingContext:
         - OccContext:
         - PublicWebDavContext:
-        - WebDavPropertiesContext:
 
     webUILogin:
       paths:
@@ -232,7 +215,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIPersonalGeneralSettingsContext:
-        - WebDavPropertiesContext:
 
     webUIMoveFilesFolders:
       paths:
@@ -244,7 +226,6 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
-        - WebDavPropertiesContext:
 
     webUIPersonalSettings:
       paths:
@@ -259,7 +240,6 @@ default:
         - WebUIPersonalSecuritySettingsContext:
         - WebUIUserContext:
         - OccContext:
-        - WebDavPropertiesContext:
 
     webUIRenameFiles:
       paths:
@@ -271,7 +251,6 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
-        - WebDavPropertiesContext:
 
     webUIRenameFolders:
       paths:
@@ -281,7 +260,6 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebDavPropertiesContext:
 
     webUIRestrictSharing:
       paths:
@@ -292,7 +270,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUISharingContext:
-        - WebDavPropertiesContext:
 
     webUISharingExternal:
       paths:
@@ -306,7 +283,6 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
-        - WebDavPropertiesContext:
 
     webUISharingInternalGroups:
       paths:
@@ -318,7 +294,6 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - WebUIAdminSharingSettingsContext:
-        - WebDavPropertiesContext:
 
     webUISharingInternalUsers:
       paths:
@@ -330,7 +305,6 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - WebUIAdminSharingSettingsContext:
-        - WebDavPropertiesContext:
 
     webUISharingNotifications:
       paths:
@@ -343,7 +317,6 @@ default:
         - WebUILoginContext:
         - WebUINotificationsContext:
         - WebUISharingContext:
-        - WebDavPropertiesContext:
 
     webUITags:
       paths:
@@ -356,7 +329,6 @@ default:
         - WebUIFilesContext:
         - WebUISharingContext:
         - WebUITagsContext:
-        - WebDavPropertiesContext:
 
     webUITrashbin:
       paths:
@@ -367,7 +339,6 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebDavPropertiesContext:
 
     webUIUpload:
       paths:
@@ -379,7 +350,6 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
-        - WebDavPropertiesContext:
 
     webUIWebdavLocks:
       paths:
@@ -393,7 +363,6 @@ default:
         - WebUIWebDavLockingContext:
         - WebUISharingContext:
         - PublicWebDavContext:
-        - WebDavPropertiesContext:
 
   extensions:
     jarnaiz\JUnitFormatter\JUnitFormatterExtension:


### PR DESCRIPTION
## Description
1) Move acceptance test steps about etags from ``FeatureContext`` to ``WebDavPropertiesContext`` - these steps had calls into ``WebDavPropertiesContext`` anyway, and etags are a property. So it fits.

2) ``FeatureContext`` keeps the ``responseXmlObject`` (which potentially has an etag property inside it). Add methods to ``FeatureContext`` to extract the etag, and to determine if the etag is valid. This allows other code to get at this information without having to call into ``WebDavPropertiesContext``

3) Move ``storedETAG`` into ``WebDavPropertiesContext`` because that is now the context that has the steps related to remembering an etag and then later comparing it.

4) Adjust ``behat.yml`` so that not so many suites need to know about ``WebDavPropertiesContext``

## Related Issue
part of issue #33690 
further refactor after #34115 added ``WebDavPropertiesContext``

## Motivation and Context
The new ``WebDavPropertiesContext`` calls to ``FeatureContext`` but also  ``FeatureContext`` calls to ``WebDavPropertiesContext``. This 2-way dependency means that every suite (in every app) has to mention (include) ``WebDavPropertiesContext``, even though it may not use any of the acceptance test steps defined there.

Sort this out so that ``WebDavPropertiesContext`` only needs to be included by suites that really use its acceptance test steps.

## How Has This Been Tested?
Local acceptance test runs and CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
