### PR TITLE
Move steps out of CommandLine

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -17,6 +17,7 @@ default:
         - CardDavContext:
         - ChecksumContext:
         - FilesVersionsContext:
+        - OccContext:
         - TransferOwnershipContext:
 
     apiCapabilities:
@@ -106,6 +107,7 @@ default:
         - '%paths.base%/../features/apiTrashbin'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - TrashbinContext:
 
     apiWebdavOperations:

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -41,24 +41,6 @@ trait CommandLine {
 	 */
 	private $lastStdErr;
 
-	private $lastTransferPath;
-
-	/**
-	 * @return string
-	 */
-	public function getLastTransferPath() {
-		return $this->lastTransferPath;
-	}
-
-	/**
-	 * @param string $lastTransferPath
-	 *
-	 * @return void
-	 */
-	public function setLastTransferPath($lastTransferPath) {
-		$this->lastTransferPath = $lastTransferPath;
-	}
-
 	/**
 	 * get the exit status of the last occ command
 	 * app acceptance tests that have their own step code may need to process this
@@ -309,38 +291,6 @@ trait CommandLine {
 	}
 
 	/**
-	 * @When /^the administrator invokes occ command "([^"]*)"$/
-	 * @Given /^the administrator has invoked occ command "([^"]*)"$/
-	 *
-	 * @param string $cmd
-	 *
-	 * @return void
-	 */
-	public function invokingTheCommand($cmd) {
-		$this->runOcc([$cmd]);
-	}
-
-	/**
-	 * @When /^the administrator invokes occ command "([^"]*)" with environment variable "([^"]*)" set to "([^"]*)"$/
-	 * @Given /^the administrator has invoked occ command "([^"]*)" with environment variable "([^"]*)" set to "([^"]*)"$/
-	 *
-	 * @param string $cmd
-	 * @param string $envVariableName
-	 * @param string $envVariableValue
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function invokingTheCommandWithEnvVariable(
-		$cmd, $envVariableName, $envVariableValue
-	) {
-		$args = [$cmd];
-		$this->runOccWithEnvVariables(
-			$args, [$envVariableName => $envVariableValue]
-		);
-	}
-
-	/**
 	 * Find exception texts in stderr
 	 *
 	 * @return array of exception texts
@@ -383,119 +333,6 @@ trait CommandLine {
 	}
 
 	/**
-	 * @Then /^the command should have been successful$/
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theCommandShouldHaveBeenSuccessful() {
-		$exceptions = $this->findExceptions();
-		if ($this->lastCode !== 0) {
-			$msg = "The command was not successful, exit code was $this->lastCode.";
-			if (!empty($exceptions)) {
-				$msg .= ' Exceptions: ' . \implode(', ', $exceptions);
-			}
-			throw new \Exception($msg);
-		} elseif (!empty($exceptions)) {
-			$msg = 'The command was successful but triggered exceptions: '
-				. \implode(', ', $exceptions);
-			throw new \Exception($msg);
-		}
-	}
-
-	/**
-	 * @Then /^the command should have failed with exit code ([0-9]+)$/
-	 *
-	 * @param int $exitCode
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theCommandFailedWithExitCode($exitCode) {
-		if ($this->lastCode !== (int)$exitCode) {
-			throw new \Exception(
-				"The command was expected to fail with exit code $exitCode but got "
-				. $this->lastCode
-			);
-		}
-	}
-
-	/**
-	 * @Then /^the command should have failed with exception text "([^"]*)"$/
-	 *
-	 * @param string $exceptionText
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theCommandFailedWithExceptionText($exceptionText) {
-		$exceptions = $this->findExceptions();
-		if (empty($exceptions)) {
-			throw new \Exception('The command did not throw any exceptions');
-		}
-
-		if (!\in_array($exceptionText, $exceptions)) {
-			throw new \Exception(
-				"The command did not throw any exception with the text '$exceptionText'"
-			);
-		}
-	}
-
-	/**
-	 * @Then /^the command output should contain the text ((?:'[^']*')|(?:"[^"]*"))$/
-	 *
-	 * @param string $text
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theCommandOutputContainsTheText($text) {
-		// The capturing group of the regex always includes the quotes at each
-		// end of the captured string, so trim them.
-		$text = \trim($text, $text[0]);
-		$lines = $this->findLines($this->lastStdOut, $text);
-		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
-			1,
-			\count($lines),
-			"The command output did not contain the expected text on stdout '$text'\n" .
-			"The command output on stdout was:\n" .
-			$this->lastStdOut
-		);
-	}
-
-	/**
-	 * @Then /^the command error output should contain the text ((?:'[^']*')|(?:"[^"]*"))$/
-	 *
-	 * @param string $text
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function theCommandErrorOutputContainsTheText($text) {
-		// The capturing group of the regex always includes the quotes at each
-		// end of the captured string, so trim them.
-		$text = \trim($text, $text[0]);
-		$lines = $this->findLines($this->lastStdErr, $text);
-		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
-			1,
-			\count($lines),
-			"The command output did not contain the expected text on stderr '$text'\n" .
-			"The command output on stderr was:\n" .
-			$this->lastStdErr
-		);
-	}
-
-	/**
-	 * @Then the occ command JSON output should be empty
-	 *
-	 * @return void
-	 */
-	public function theOccCommandJsonOutputShouldNotReturnAnyData() {
-		PHPUnit_Framework_Assert::assertEquals(\trim($this->lastStdOut), "[]");
-		PHPUnit_Framework_Assert::assertEmpty($this->lastStdErr);
-	}
-
-	/**
 	 * @param string $sourceUser
 	 * @param string $targetUser
 	 *
@@ -534,46 +371,6 @@ trait CommandLine {
 	}
 
 	/**
-	 * @When /^the administrator transfers ownership from "([^"]+)" to "([^"]+)" using the occ command$/
-	 * @Given /^the administrator has transferred ownership from "([^"]+)" to "([^"]+)"$/
-	 *
-	 * @param string $user1
-	 * @param string $user2
-	 *
-	 * @return void
-	 */
-	public function transferringOwnership($user1, $user2) {
-		if ($this->runOcc(['files:transfer-ownership', $user1, $user2]) === 0) {
-			$this->lastTransferPath
-				= $this->findLastTransferFolderForUser($user1, $user2);
-		} else {
-			// failure
-			$this->lastTransferPath = null;
-		}
-	}
-
-	/**
-	 * @When /^the administrator transfers ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)" using the occ command$/
-	 * @Given /^the administrator has transferred ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"$/
-	 *
-	 * @param string $path
-	 * @param string $user1
-	 * @param string $user2
-	 *
-	 * @return void
-	 */
-	public function transferringOwnershipPath($path, $user1, $user2) {
-		$path = "--path=$path";
-		if ($this->runOcc(['files:transfer-ownership', $path, $user1, $user2]) === 0) {
-			$this->lastTransferPath
-				= $this->findLastTransferFolderForUser($user1, $user2);
-		} else {
-			// failure
-			$this->lastTransferPath = null;
-		}
-	}
-
-	/**
 	 * Reset user password
 	 *
 	 * @param string $username
@@ -584,15 +381,14 @@ trait CommandLine {
 	public function resetUserPassword($username, $password = null) {
 		$actualUsername = $this->getActualUsername($username);
 		if ($password === null) {
-			$this->invokingTheCommand(
-				"user:resetpassword $actualUsername --send-email"
+			$this->runOcc(
+				["user:resetpassword $actualUsername --send-email"]
 			);
 		} else {
 			$password = $this->getActualPassword($password);
-			$this->invokingTheCommandWithEnvVariable(
-				"user:resetpassword $actualUsername --password-from-env",
-				'OC_PASS',
-				$password
+			$this->runOccWithEnvVariables(
+				["user:resetpassword $actualUsername --password-from-env"],
+				['OC_PASS' => $password]
 			);
 			if ($username === "%admin%") {
 				$this->rememberNewAdminPassword($password);

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -35,6 +35,64 @@ class TransferOwnershipContext implements Context {
 	 */
 	private $featureContext;
 
+	private $lastTransferPath;
+
+	/**
+	 * @return string
+	 */
+	public function getLastTransferPath() {
+		return $this->lastTransferPath;
+	}
+
+	/**
+	 * @param string $lastTransferPath
+	 *
+	 * @return void
+	 */
+	public function setLastTransferPath($lastTransferPath) {
+		$this->lastTransferPath = $lastTransferPath;
+	}
+
+	/**
+	 * @When /^the administrator transfers ownership from "([^"]+)" to "([^"]+)" using the occ command$/
+	 * @Given /^the administrator has transferred ownership from "([^"]+)" to "([^"]+)"$/
+	 *
+	 * @param string $user1
+	 * @param string $user2
+	 *
+	 * @return void
+	 */
+	public function transferringOwnership($user1, $user2) {
+		if ($this->featureContext->runOcc(['files:transfer-ownership', $user1, $user2]) === 0) {
+			$this->lastTransferPath
+				= $this->featureContext->findLastTransferFolderForUser($user1, $user2);
+		} else {
+			// failure
+			$this->lastTransferPath = null;
+		}
+	}
+
+	/**
+	 * @When /^the administrator transfers ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)" using the occ command$/
+	 * @Given /^the administrator has transferred ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"$/
+	 *
+	 * @param string $path
+	 * @param string $user1
+	 * @param string $user2
+	 *
+	 * @return void
+	 */
+	public function transferringOwnershipPath($path, $user1, $user2) {
+		$path = "--path=$path";
+		if ($this->featureContext->runOcc(['files:transfer-ownership', $path, $user1, $user2]) === 0) {
+			$this->lastTransferPath
+				= $this->featureContext->findLastTransferFolderForUser($user1, $user2);
+		} else {
+			// failure
+			$this->lastTransferPath = null;
+		}
+	}
+
 	/**
 	 * @Then /^the downloaded content when downloading file "([^"]*)" for user "([^"]*)" with range "([^"]*)" from the last received transfer folder should be "([^"]*)"$/
 	 *
@@ -48,7 +106,7 @@ class TransferOwnershipContext implements Context {
 	public function downloadedContentWhenDownloadingForUserWithRangeShouldBe(
 		$fileSource, $user, $range, $content
 	) {
-		$fileSource = $this->featureContext->getLastTransferPath() . $fileSource;
+		$fileSource = $this->getLastTransferPath() . $fileSource;
 		$this->featureContext->downloadedContentWhenDownloadingForUserWithRangeShouldBe(
 			$fileSource, $user, $range, $content
 		);
@@ -69,9 +127,9 @@ class TransferOwnershipContext implements Context {
 		//but the last received transfer folder itself should exist
 		//that would help against snakeoil tests if testing a non-existing folder
 		$this->featureContext->asFileOrFolderShouldExist(
-			$user, $entry, $this->featureContext->getLastTransferPath()
+			$user, $entry, $this->getLastTransferPath()
 		);
-		$path = $this->featureContext->getLastTransferPath() . $path;
+		$path = $this->getLastTransferPath() . $path;
 		return $this->featureContext->asFileOrFolderShouldNotExist(
 			$user, $entry, $path
 		);
@@ -84,12 +142,12 @@ class TransferOwnershipContext implements Context {
 	 * @param string $entry
 	 * @param string $path
 	 *
-	 * @return array
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function asFileOrFolderShouldExist($user, $entry, $path) {
-		$path = $this->featureContext->getLastTransferPath() . $path;
-		return $this->featureContext->asFileOrFolderShouldExist(
+		$path = $this->getLastTransferPath() . $path;
+		$this->featureContext->asFileOrFolderShouldExist(
 			$user, $entry, $path
 		);
 	}


### PR DESCRIPTION
## Description
1) Move ``occ`` command steps into ``OccContext``
2) Move transfer-ownership steps into ``TransferOwnershipContext``
3) Adjust calls and ``behat.yml`` as required.

## Related Issue

## Motivation and Context
Work towards moving steps that are in acceptance test trait files (which all get lumped into FeatureContext) into the relevant Context files.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
