### PR TITLE
show more information when occ command failed

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -79,7 +79,9 @@ class OccContext implements Context {
 		$exceptions = $this->featureContext->findExceptions();
 		$exitStatusCode = $this->featureContext->getExitStatusCodeOfOccCommand();
 		if ($exitStatusCode !== 0) {
-			$msg = "The command was not successful, exit code was $exitStatusCode.";
+			$msg = "The command was not successful, exit code was $this->lastCode.\n";
+			$msg .= "stdOut was: '$this->lastStdOut'\n";
+			$msg .= "stdErr was: '$this->lastStdErr'\n";
 			if (!empty($exceptions)) {
 				$msg .= ' Exceptions: ' . \implode(', ', $exceptions);
 			}


### PR DESCRIPTION
## Description
show the error and std output in case the command failed

## Related Issue
needed to track down errors in https://github.com/owncloud/ransomware_protection/issues/118

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
