### PR TITLE
Adjust CLI acceptance test to send email and specify password

### DIFF
--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -373,12 +373,19 @@ trait CommandLine {
 	/**
 	 * Reset user password
 	 *
+	 * If password is not supplied, then always send email.
+	 * If password is supplied, then only send email if sendEmail param is true
+	 *
 	 * @param string $username
 	 * @param string $password
+	 * @param bool $sendEmail
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	public function resetUserPassword($username, $password = null) {
+	public function resetUserPassword(
+		$username, $password = null, $sendEmail = false
+	) {
 		$actualUsername = $this->getActualUsername($username);
 		if ($password === null) {
 			$this->runOcc(
@@ -386,8 +393,13 @@ trait CommandLine {
 			);
 		} else {
 			$password = $this->getActualPassword($password);
+			if ($sendEmail) {
+				$sendEmailParam = "--send-email";
+			} else {
+				$sendEmailParam = "";
+			}
 			$this->runOccWithEnvVariables(
-				["user:resetpassword $actualUsername --password-from-env"],
+				["user:resetpassword $actualUsername $sendEmailParam --password-from-env"],
 				['OC_PASS' => $password]
 			);
 			if ($username === "%admin%") {

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -148,6 +148,18 @@ class OccUsersGroupsContext implements Context {
 	}
 
 	/**
+	 * @When the administrator resets the password of user :username to :password sending email using the occ command
+	 *
+	 * @param string $username
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function resetUserPasswordAndSendEmailUsingTheOccCommand($username, $password) {
+		$this->featureContext->resetUserPassword($username, $password, true);
+	}
+
+	/**
 	 * @When the administrator resets their own password to :newPassword using the occ command
 	 *
 	 * @param string $newPassword

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -14,7 +14,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  Scenario: user should get email when admin resets their password and sends email
+  Scenario: user should get email when admin does a "send email" password reset without specifying a password
     Given these users have been created:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
@@ -27,11 +27,11 @@ Feature: reset user password
       """
 
   @issue-33384
-  Scenario: user should not get email message when the administrator changes their email directly through occ command
+  Scenario: user should get email when the administrator changes their password and specifies to also send email
     Given these users have been created:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
-    When the administrator resets the password of user "brand-new-user" to "%alt1%" using the occ command
+    When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
     Then the command should have been successful
     And the command output should contain the text "Successfully reset password for brand-new-user"
     And the email address "brand.new.user@oc.com.np" should not have received an email


### PR DESCRIPTION
## Description
1) Enhance ``resetUserPassword`` so the caller can specify the password and also to send email.
2) Make a new test step that specifies a password and to send email
3) Adjust the test scenario to use the new step.

## Related Issue
#33384 

## Motivation and Context
The acceptance test added by PR #33686 does not actually specify a combination of ``--send-email`` and ``--password-from-env``, it seems to be testing only the ordinary case of a password reset using the ``occ`` command.

## How Has This Been Tested?
Local acceptance test runs to verify what commands are happening.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
