### PR TITLE
Correct throw statement in EmailContext

### DIFF
--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -96,7 +96,7 @@ class EmailContext implements Context {
 			PHPUnit_Framework_Assert::assertTrue(true);
 			return;
 		}
-		throw \Exception("Email exists with email address: {$address}.");
+		throw new \Exception("Email exists with email address: {$address}.");
 	}
 
 	/**


### PR DESCRIPTION
## Description
Change an erroneous ``throw \Exception`` to ``throw new \Exception``

## Motivation and Context
I was testing various combinations of password setting without and without ``--send-email`` and came across this error in a ``throw`` statement. It's a pity some parser does not find this crud.

## How Has This Been Tested?
Local acceptance test runs of password changing and inducing email errors.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
