### PR TITLE
get correct values for occ command returns in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -79,9 +79,12 @@ class OccContext implements Context {
 		$exceptions = $this->featureContext->findExceptions();
 		$exitStatusCode = $this->featureContext->getExitStatusCodeOfOccCommand();
 		if ($exitStatusCode !== 0) {
-			$msg = "The command was not successful, exit code was $this->lastCode.\n";
-			$msg .= "stdOut was: '$this->lastStdOut'\n";
-			$msg .= "stdErr was: '$this->lastStdErr'\n";
+			$msg = "The command was not successful, exit code was " .
+				   $exitStatusCode . ".\n" .
+				   "stdOut was: '" .
+				   $this->featureContext->getStdOutOfOccCommand() . "'\n" .
+				   "stdErr was: '" .
+				   $this->featureContext->getStdErrOfOccCommand() . "'\n";
 			if (!empty($exceptions)) {
 				$msg .= ' Exceptions: ' . \implode(', ', $exceptions);
 			}


### PR DESCRIPTION
## Description
after recent refactoring we cannot access `lastStdOut` and `lastStdErr` directly but need to pull it from the feature context
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
