### PR TITLE
fixes occ doesn't support enabling/disabling multiple apps at once

### DIFF
--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -31,8 +31,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Enable extends Command
-{
+class Enable extends Command {
 
 	/** @var IAppManager */
 	protected $manager;
@@ -40,14 +39,12 @@ class Enable extends Command
 	/**
 	 * @param IAppManager $manager
 	 */
-	public function __construct(IAppManager $manager)
-	{
+	public function __construct(IAppManager $manager) {
 		parent::__construct();
 		$this->manager = $manager;
 	}
 
-	protected function configure()
-	{
+	protected function configure() {
 		$this
 			->setName('app:enable')
 			->setDescription('Enable an app.')
@@ -64,8 +61,7 @@ class Enable extends Command
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output)
-	{
+	protected function execute(InputInterface $input, OutputInterface $output) {
 		$appIds = $input->getArgument('app-id');
 		$groups = $input->getOption('groups');
 
@@ -80,8 +76,7 @@ class Enable extends Command
 	 * @return int 1 when one or more apps not found, 0 when everything went successfully
 	 * @throws \Exception
 	 */
-	private function enableApps(array $appIds, array $groups, OutputInterface $output): int
-	{
+	private function enableApps(array $appIds, array $groups, OutputInterface $output): int {
 		$errorFlag = 0;
 		foreach ($appIds as $appId) {
 			if (!\OC_App::getAppPath($appId)) {
@@ -98,8 +93,6 @@ class Enable extends Command
 				$output->writeln($appId . ' enabled for groups: ' . \implode(', ', $groups));
 			}
 		}
-
 		return $errorFlag;
 	}
-
 }

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -34,73 +34,72 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Enable extends Command
 {
 
-    /** @var IAppManager */
-    protected $manager;
+	/** @var IAppManager */
+	protected $manager;
 
-    /**
-     * @param IAppManager $manager
-     */
-    public function __construct(IAppManager $manager)
-    {
-        parent::__construct();
-        $this->manager = $manager;
-    }
+	/**
+	 * @param IAppManager $manager
+	 */
+	public function __construct(IAppManager $manager)
+	{
+		parent::__construct();
+		$this->manager = $manager;
+	}
 
-    protected function configure()
-    {
-        $this
-            ->setName('app:enable')
-            ->setDescription('Enable an app.')
-            ->addArgument(
-                'app-id',
-                InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-                'Enable the specified app.'
-            )
-            ->addOption(
-                'groups',
-                'g',
-                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                'Enable the app only for a specific list of groups.'
-            );
-    }
+	protected function configure()
+	{
+		$this
+			->setName('app:enable')
+			->setDescription('Enable an app.')
+			->addArgument(
+				'app-id',
+				InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+				'Enable the specified app.'
+			)
+			->addOption(
+				'groups',
+				'g',
+				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+				'Enable the app only for a specific list of groups.'
+			);
+	}
 
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        $appIds = $input->getArgument('app-id');
-        $groups = $input->getOption('groups');
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$appIds = $input->getArgument('app-id');
+		$groups = $input->getOption('groups');
 
-        return $this->enableApps($appIds, $groups, $output);
-    }
+		return $this->enableApps($appIds, $groups, $output);
+	}
 
-    /**
-     * Enable a list of apps
-     * @param array $appIds
-     * @param array $groups
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return int 1 when one or more apps not found, 0 when everything went successfully
-     * @throws \Exception
-     */
-    private function enableApps(array $appIds, array $groups, OutputInterface $output): int
-    {
-        $errorFlag = 0;
-        foreach ($appIds as $appId) {
-            if (!\OC_App::getAppPath($appId)) {
-                $output->writeln($appId . ' not found');
-                $errorFlag = 1;
-                continue;
-            }
+	/**
+	 * Enable a list of apps
+	 * @param array $appIds
+	 * @param array $groups
+	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 * @return int 1 when one or more apps not found, 0 when everything went successfully
+	 * @throws \Exception
+	 */
+	private function enableApps(array $appIds, array $groups, OutputInterface $output): int
+	{
+		$errorFlag = 0;
+		foreach ($appIds as $appId) {
+			if (!\OC_App::getAppPath($appId)) {
+				$output->writeln($appId . ' not found');
+				$errorFlag = 1;
+				continue;
+			}
 
-            if (empty($groups)) {
-                \OC_App::enable($appId);
-                $output->writeln($appId . ' enabled');
-            } else {
-                \OC_App::enable($appId, $groups);
-                $output->writeln($appId . ' enabled for groups: ' . \implode(', ', $groups));
-            }
+			if (empty($groups)) {
+				\OC_App::enable($appId);
+				$output->writeln($appId . ' enabled');
+			} else {
+				\OC_App::enable($appId, $groups);
+				$output->writeln($appId . ' enabled for groups: ' . \implode(', ', $groups));
+			}
+		}
 
-        }
-
-        return $errorFlag;
-    }
+		return $errorFlag;
+	}
 
 }

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -30,19 +30,16 @@ use Test\TestCase;
  *
  * @group DB
  */
-class AppsEnableTest extends TestCase
-{
+class AppsEnableTest extends TestCase {
 
 	/** @var CommandTester */
 	private $commandTester;
 
-	public function setUp()
-	{
+	public function setUp() {
 		parent::setUp();
 
 		$command = new Enable(\OC::$server->getAppManager());
 		$this->commandTester = new CommandTester($command);
-
 	}
 
 	/**
@@ -51,8 +48,7 @@ class AppsEnableTest extends TestCase
 	 * @param $expectedOutput
 	 * @param string|null $group
 	 */
-	public function testCommandInput($appId, $expectedOutput, $group = null)
-	{
+	public function testCommandInput($appId, $expectedOutput, $group = null) {
 		$input = ['app-id' => $appId];
 		if ($group !== null) {
 			$input['--groups'] = [$group];
@@ -63,8 +59,7 @@ class AppsEnableTest extends TestCase
 		$this->assertContains($expectedOutput, $output);
 	}
 
-	public function providesAppIds()
-	{
+	public function providesAppIds() {
 		return [
 			[["comments", "files"], "comments enabled\nfiles enabled"],
 			[["comments", "kukki"], "comments enabled\nkukki not found"],

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -30,40 +30,50 @@ use Test\TestCase;
  *
  * @group DB
  */
-class AppsEnableTest extends TestCase {
+class AppsEnableTest extends TestCase
+{
 
-	/** @var CommandTester */
-	private $commandTester;
+    /** @var CommandTester */
+    private $commandTester;
 
-	public function setUp() {
-		parent::setUp();
+    public function setUp()
+    {
+        parent::setUp();
 
-		$command = new Enable(\OC::$server->getAppManager());
-		$this->commandTester = new CommandTester($command);
-	}
+        $command = new Enable(\OC::$server->getAppManager());
+        $this->commandTester = new CommandTester($command);
 
-	/**
-	 * @dataProvider providesAppIds
-	 * @param $appId
-	 * @param $expectedOutput
-	 * @param string|null $group
-	 */
-	public function testCommandInput($appId, $expectedOutput, $group = null) {
-		$input = ['app-id' => $appId];
-		if ($group !== null) {
-			$input['--groups'] = [$group];
-		}
-		$this->commandTester->execute($input);
-		$output = $this->commandTester->getDisplay();
-		$this->assertContains($expectedOutput, $output);
-	}
+    }
 
-	public function providesAppIds() {
-		return [
-			['testing', 'testing enabled'],
-			['hui-buh', 'hui-buh not found'],
-			['updatenotification', 'updatenotification enabled for groups: admin', 'admin'],
-			['hui-buh', 'hui-buh not found', 'admin'],
-		];
-	}
+    /**
+     * @dataProvider providesAppIds
+     * @param $appId
+     * @param $expectedOutput
+     * @param string|null $group
+     */
+    public function testCommandInput($appId, $expectedOutput, $group = null)
+    {
+        $input = ['app-id' => $appId];
+        if ($group !== null) {
+            $input['--groups'] = [$group];
+        }
+        $this->commandTester->execute($input);
+        $output = $this->commandTester->getDisplay();
+
+        $this->assertContains($expectedOutput, $output);
+    }
+
+    public function providesAppIds()
+    {
+        return [
+            [["comments", "files"], "comments enabled\nfiles enabled"],
+            [["comments", "kukki"], "comments enabled\nkukki not found"],
+            [["hui-buh"], "hui-buh not found"],
+            [['updatenotification'], "updatenotification enabled for groups: admin", "admin"],
+            [
+                ["hui-buh", "hebele-hubele", "updatenotification"],
+                "hui-buh not found\nhebele-hubele not found\nupdatenotification enabled",
+            ],
+        ];
+    }
 }

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -33,47 +33,47 @@ use Test\TestCase;
 class AppsEnableTest extends TestCase
 {
 
-    /** @var CommandTester */
-    private $commandTester;
+	/** @var CommandTester */
+	private $commandTester;
 
-    public function setUp()
-    {
-        parent::setUp();
+	public function setUp()
+	{
+		parent::setUp();
 
-        $command = new Enable(\OC::$server->getAppManager());
-        $this->commandTester = new CommandTester($command);
+		$command = new Enable(\OC::$server->getAppManager());
+		$this->commandTester = new CommandTester($command);
 
-    }
+	}
 
-    /**
-     * @dataProvider providesAppIds
-     * @param $appId
-     * @param $expectedOutput
-     * @param string|null $group
-     */
-    public function testCommandInput($appId, $expectedOutput, $group = null)
-    {
-        $input = ['app-id' => $appId];
-        if ($group !== null) {
-            $input['--groups'] = [$group];
-        }
-        $this->commandTester->execute($input);
-        $output = $this->commandTester->getDisplay();
+	/**
+	 * @dataProvider providesAppIds
+	 * @param $appId
+	 * @param $expectedOutput
+	 * @param string|null $group
+	 */
+	public function testCommandInput($appId, $expectedOutput, $group = null)
+	{
+		$input = ['app-id' => $appId];
+		if ($group !== null) {
+			$input['--groups'] = [$group];
+		}
+		$this->commandTester->execute($input);
+		$output = $this->commandTester->getDisplay();
 
-        $this->assertContains($expectedOutput, $output);
-    }
+		$this->assertContains($expectedOutput, $output);
+	}
 
-    public function providesAppIds()
-    {
-        return [
-            [["comments", "files"], "comments enabled\nfiles enabled"],
-            [["comments", "kukki"], "comments enabled\nkukki not found"],
-            [["hui-buh"], "hui-buh not found"],
-            [['updatenotification'], "updatenotification enabled for groups: admin", "admin"],
-            [
-                ["hui-buh", "hebele-hubele", "updatenotification"],
-                "hui-buh not found\nhebele-hubele not found\nupdatenotification enabled",
-            ],
-        ];
-    }
+	public function providesAppIds()
+	{
+		return [
+			[["comments", "files"], "comments enabled\nfiles enabled"],
+			[["comments", "kukki"], "comments enabled\nkukki not found"],
+			[["hui-buh"], "hui-buh not found"],
+			[['updatenotification'], "updatenotification enabled for groups: admin", "admin"],
+			[
+				["hui-buh", "hebele-hubele", "updatenotification"],
+				"hui-buh not found\nhebele-hubele not found\nupdatenotification enabled",
+			],
+		];
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Allows users to enable multiple apps at once
./occ app:enable app1, app2
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>
https://github.com/owncloud/core/issues/32751
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ x] Code changes
- [ x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
