### PR TITLE
Fix reset confirmation mail from occ stable10

### DIFF
--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -175,6 +175,20 @@ class ResetPassword extends Command {
 			return 1;
 		}
 
+		if ($emailLink) {
+			$userId = $user->getUID();
+			list(, $token) = $this->lostController->generateTokenAndLink($userId);
+			$this->config->setUserValue($userId, 'owncloud', 'lostpassword', $this->timeFactory->getTime() . ':' . $token);
+			$success = $this->lostController->setPassword($token, $userId, $password, false);
+			if (\is_array($success) && isset($success['status']) && $success['status'] === 'success') {
+				$output->writeln("<info>Successfully reset password for {$username}.</info>");
+				return 0;
+			} else {
+				$output->writeln("<error>Error while resetting password!</error>");
+				return 1;
+			}
+		}
+
 		$success = $user->setPassword($password);
 		if ($success) {
 			$output->writeln("<info>Successfully reset password for " . $username . "</info>");

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -240,4 +240,72 @@ class ResetPasswordTest extends TestCase {
 			->with('<error>Email address is not set for the user foo</error>');
 		$this->invokePrivate($this->resetPassword, 'execute', [$input, $output]);
 	}
+
+	public function providesStatusOfPasswordFromEnvWithEmailConfirmation() {
+		return [
+			[true],
+			[false]
+		];
+	}
+
+	/**
+	 * @dataProvider providesStatusOfPasswordFromEnvWithEmailConfirmation
+	 * @param $expectedResult
+	 */
+	public function testPasswordFromEnvAndPasswordConfirmationEmail($expectedResult) {
+		$input = $this->createMock(InputInterface::class);
+		$output = $this->createMock(OutputInterface::class);
+
+		$input->expects($this->once())
+			->method('getArgument')
+			->willReturn('foo');
+
+		$input->expects($this->exactly(3))
+			->method('getOption')
+			->willReturnMap([
+				['send-email', true],
+				['output-link', false],
+				['password-from-env', true]
+			]);
+
+		$user = $this->createMock(IUser::class);
+
+		$user->method('getUID')
+			->willReturn('foo');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+
+		$this->environmentHelper->expects($this->once())
+			->method('getEnvVar')
+			->willReturn('fooPass');
+
+		$this->lostController->method('generateTokenAndLink')
+			->with('foo')
+			->willReturn(['http://localhost/foo/bar/123AbcFooBar/foo', '123AbcFooBar']);
+
+		if ($expectedResult === true) {
+			$this->lostController->method('setPassword')
+				->willReturn(['status' => 'success']);
+
+			$output->expects($this->once())
+				->method('writeln')
+				->with("<info>Successfully reset password for foo.</info>");
+		} else {
+			$this->lostController->method('setPassword')
+				->willReturn("failed");
+
+			$output->expects($this->once())
+				->method('writeln')
+				->with("<error>Error while resetting password!</error>");
+		}
+
+		$result = $this->invokePrivate($this->resetPassword, 'execute', [$input, $output]);
+		if ($expectedResult === true) {
+			$this->assertEquals(0, $result);
+		} else {
+			$this->assertEquals(1, $result);
+		}
+	}
 }

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -281,19 +281,22 @@ class ResetPasswordTest extends TestCase {
 			->method('getEnvVar')
 			->willReturn('fooPass');
 
-		$this->lostController->method('generateTokenAndLink')
+		$this->lostController->expects($this->once())
+			->method('generateTokenAndLink')
 			->with('foo')
 			->willReturn(['http://localhost/foo/bar/123AbcFooBar/foo', '123AbcFooBar']);
 
 		if ($expectedResult === true) {
-			$this->lostController->method('setPassword')
+			$this->lostController->expects($this->once())
+				->method('setPassword')
 				->willReturn(['status' => 'success']);
 
 			$output->expects($this->once())
 				->method('writeln')
 				->with("<info>Successfully reset password for foo.</info>");
 		} else {
-			$this->lostController->method('setPassword')
+			$this->lostController->expects($this->once())
+				->method('setPassword')
 				->willReturn("failed");
 
 			$output->expects($this->once())

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -26,7 +26,6 @@ Feature: reset user password
       Use the following link to reset your password: <a href=
       """
 
-  @issue-33384
   Scenario: user should get email when the administrator changes their password and specifies to also send email
     Given these users have been created:
       | username       | password  | displayname | email                    |
@@ -34,11 +33,10 @@ Feature: reset user password
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
     Then the command should have been successful
     And the command output should contain the text "Successfully reset password for brand-new-user"
-    And the email address "brand.new.user@oc.com.np" should not have received an email
-    #And the email address "brand.new.user@oc.com.np" should have received an email with the body containing
-      #"""
-      #Password changed successfully
-      #"""
+    And the email address "brand.new.user@oc.com.np" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When password for user is set using command `user:resetpassword`, with options `--send-email --password-from-env` ( apart from username ) , the password successful email is not sent. This is a minor issue though. In this PR an extra condition is added, so that password setting logic is routed to LostController's `setPassword`, if `--send-email` is used along with the option `password-from-env`. Care has also been taken to evaluate the return from LostControllers `setPassword()` method.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/33384

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
An email will be triggered if the password change has been made for the user with the options ``--send-email --password-from-env` passed to command `user:resetpassword`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create `user1` user
- Execute the command below:
```
sujith@sujith-ownCloud  ~/test/owncloud2   fix-reset-confirmation-mail-from-occ-stable10 ●  export OC_PASS=foo
 sujith@sujith-ownCloud  ~/test/owncloud2   fix-reset-confirmation-mail-from-occ-stable10 ●  ./occ user:resetpassword user1 --send-email --password-from-env
Cannot load Xdebug - it was already loaded
Successfully reset password for user1.
 sujith@sujith-ownCloud  ~/test/owncloud2   fix-reset-confirmation-mail-from-occ-stable10 ● 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
