### PR TITLE
allow custom substitutions in substituteInLineCodes method

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1979,10 +1979,24 @@ trait BasicStructure {
 	 *                         own array
 	 *                         the replacement itself will be used as first parameter
 	 *                         e.g. substituteInLineCodes($value, ['preg_quote' => ['/']])
+	 * @param array $additionalSubstitutions
+	 *                         array of additional substitution configurations
+	 *                           [
+	 *                             [
+	 *                               "code" => "%my_code%",
+	 *                               "function" => [
+	 *                                                $myClass,
+	 *                                                "myFunction"
+	 *                               ],
+	 *                               "parameter" => []
+	 *                             ],
+	 *                           ]
 	 *
 	 * @return string
 	 */
-	public function substituteInLineCodes($value, $functions = []) {
+	public function substituteInLineCodes(
+		$value, $functions = [], $additionalSubstitutions = []
+	) {
 		$substitutions = [
 			[
 				"code" => "%base_url%",
@@ -2081,6 +2095,10 @@ trait BasicStructure {
 				"parameter" => []
 			]
 		];
+
+		if (!empty($additionalSubstitutions)) {
+			$substitutions = \array_merge($substitutions, $additionalSubstitutions);
+		}
 
 		foreach ($substitutions as $substitution) {
 			$replacement = \call_user_func_array(


### PR DESCRIPTION
## Description
makes it possible to pass in a description of substitutions that are not defined in the 

## Related Issue
needed for LDAP testing

## Motivation and Context
when substituting codes from the feature files we might want to use special codes that are only used in apps

## How Has This Been Tested?
using it in LDAP tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
