### PR TITLE
add before-after share link auth events

### DIFF
--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -180,6 +180,8 @@ class ShareController extends Controller {
 	 * @return bool
 	 */
 	private function linkShareAuth(\OCP\Share\IShare $share, $password = null) {
+		$beforeEvent = new GenericEvent(null, ['shareObject' => $share]);
+		$this->eventDispatcher->dispatch('share.beforelinkauth', $beforeEvent);
 		if ($password !== null) {
 			if ($this->shareManager->checkPassword($share, $password)) {
 				$this->session->set('public_link_authenticated', (string)$share->getId());
@@ -194,6 +196,8 @@ class ShareController extends Controller {
 				return false;
 			}
 		}
+		$afterEvent = new GenericEvent(null, ['shareObject' => $share]);
+		$this->eventDispatcher->dispatch('share.afterlinkauth', $afterEvent);
 		return true;
 	}
 


### PR DESCRIPTION
## Description
Adds before and after events for public share link auths.

## Related Issue
The first step for:
#33542, https://github.com/owncloud/brute_force_protection/issues/57

## Motivation and Context
To be able to detect and interrupt public link share auth attempts.

## How Has This Been Tested?
Unit test and manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

I am not sure about the location of the events. As far as I see, adding events in `linkShareAuth` function is enough. But, if you see any missing place, please let me know. 

When this pr merged, I will update here: https://github.com/owncloud/docs/issues/311#issuecomment-419377043 