### PR TITLE
step to create a user explicitly on the database backend

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -225,6 +225,19 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Given /^user "([^"]*)" has been created with default attributes in the database user backend$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userHasBeenCreatedOnDatabaseBackend($user) {
+		$this->adminCreatesUserUsingTheProvisioningApi($user);
+		$this->userShouldExist($user);
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has been created with default attributes$/
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
the "normal" Given steps to create users decide automatically how to create the steps
- by "API", meaning the users will be Database Backend users
- by "LDAP", meaning the users are not created but expected to be there, imported by LDIF at the beginning of the test-run

this PR makes an explicit step to create Database Backend users

## Related Issue
needed for https://github.com/owncloud/user_ldap/issues/35

## Motivation and Context
To be able to write tests that mix LDAP and Database users we need steps to explicitly create database users

## How Has This Been Tested?
using the step in LDAP tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
