### PR TITLE
Check parent locks when creating node in DAV collection

### DIFF
--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -469,10 +469,13 @@ Feature: Locks
        | lockscope | <lockscope> |
     And the user has browsed to the files page
     When the user moves file "lorem.txt" into folder "simple-empty-folder" using the webUI
-    And as "brand-new-user" file "/simple-empty-folder/lorem.txt" should exist
-    And as "brand-new-user" file "lorem.txt" should not exist
-    And file "lorem.txt" should not be listed on the webUI
-    And 1 locks should be reported for file "/simple-empty-folder/lorem.txt" of user "brand-new-user" by the WebDAV API
+    Then notifications should be displayed on the webUI with the text
+        | Could not move "lorem.txt" because either the file or the target are locked. |
+    And as "brand-new-user" file "/simple-empty-folder/lorem.txt" should not exist
+    And as "brand-new-user" file "lorem.txt" should exist
+    And file "lorem.txt" should be listed on the webUI
+    And 0 locks should be reported for file "/simple-empty-folder/lorem.txt" of user "brand-new-user" by the WebDAV API
+    And 0 locks should be reported for file "/lorem.txt" of user "brand-new-user" by the WebDAV API
     Examples:
       | lockscope |
       | exclusive |
@@ -532,9 +535,10 @@ Feature: Locks
        | lockscope | <lockscope> |
     And the user has opened folder "simple-folder" using the webUI
     When the user uploads file "new-lorem.txt" using the webUI
-    Then file "new-lorem.txt" should be marked as locked on the webUI
-    And file "new-lorem.txt" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
-    And 1 locks should be reported for file "simple-folder/new-lorem.txt" of user "brand-new-user" by the WebDAV API
+    Then notifications should be displayed on the webUI with the text
+      | The file new-lorem.txt is currently locked, please try again later |
+    And file "new-lorem.txt" should not be listed on the webUI
+    And 0 locks should be reported for file "simple-folder/new-lorem.txt" of user "brand-new-user" by the WebDAV API
     Examples:
       | lockscope |
       | exclusive |


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
When checking locks on a URI for a non-existing node, check for parent
locks instead of assuming no locks at all.

This makes it possible to prevent creation of new collection members in
case of a lock on the parent collections


## Related Issue
- Fixes https://github.com/owncloud/core/issues/33848 but only for depth: infinite

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test + unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
