### PR TITLE
Bump phpstan 0.10.7 to 0.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ $(PHAN_BIN):
 	cd build && curl -s -L https://github.com/phan/phan/releases/download/0.12.11/phan.phar -o phan.phar;
 
 $(PHPSTAN_BIN):
-	cd build && curl -s -L https://github.com/phpstan/phpstan/releases/download/0.10.7/phpstan.phar -o phpstan.phar;
+	cd build && curl -s -L https://github.com/phpstan/phpstan/releases/download/0.11/phpstan.phar -o phpstan.phar;
 #
 # ownCloud core PHP dependencies
 #

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,8 +38,6 @@ parameters:
     - '#Undefined variable: \$OC_[a-zA-Z0-9\\_]+#'
     - '#Undefined variable: \$vendor#'
     - '#Undefined variable: \$baseuri#'
-    - '#Function apc_delete_file not found.#'
-    - '#Function accelerator_reset not found.#'
     - '#Instantiated class OC_Theme not found.#'
     # errors below are to be addressed by own pull requests - non trivial changes required
     - '#OCA\\DAV\\Connector\\Sabre\\ObjectTree::__construct\(\) does not call parent constructor from Sabre\\DAV\\Tree.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,15 +22,9 @@ parameters:
     - %currentWorkingDirectory%/apps/*/appinfo/routes.php
     - %currentWorkingDirectory%/apps/*/composer/*
     - %currentWorkingDirectory%/apps/*/3rdparty/*
-    - %currentWorkingDirectory%/apps/files/appinfo/update.php
     - %currentWorkingDirectory%/apps/files_sharing/ajax/shareinfo.php
     - %currentWorkingDirectory%/settings/templates/*
     - %currentWorkingDirectory%/settings/routes.php
-    # below requires update of phpstan
-    - %currentWorkingDirectory%/core/Command/Maintenance/DataFingerprint.php
-    - %currentWorkingDirectory%/apps/dav/lib/Server.php
-    - %currentWorkingDirectory%/apps/dav/appinfo/v1/carddav.php
-    - %currentWorkingDirectory%/apps/dav/appinfo/v1/caldav.php
     # specific app excludes
     # eventually move into app directories and use neon includes for better separation
     - %currentWorkingDirectory%/apps/dav/bin


### PR DESCRIPTION
## Description
1) Use new ``phpstan`` version 0.11 https://github.com/phpstan/phpstan/releases/tag/0.11
2) Remove errors that do not happen from ``ignoreErrors`` section of the config. Otherwise ``phpstan`` reports:
```
 --------------------------------------------------------------------------------------------------- 
  Error                                                                                              
 --------------------------------------------------------------------------------------------------- 
  Ignored error pattern #Function apc_delete_file not found.# was not matched in reported errors.    
  Ignored error pattern #Function accelerator_reset not found.# was not matched in reported errors.  
 --------------------------------------------------------------------------------------------------- 

[ERROR] Found 2 errors 
```
Note: we could ignore this report about "Ignored error pattern was not matched" by by setting ``reportUnmatchedIgnoredErrors`` to ``false`` in the PHPStan configuration. But there seems no point in keeping these errors listed in the ``ignoreErrors`` section when they are not happening.

## Motivation and Context
Keep up-to-date with good stuff.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
