### PR TITLE
allow to specify sharing permissions as text

### DIFF
--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -100,42 +100,7 @@ class SharingHelper {
 			throw new \InvalidArgumentException("invalid share type");
 		}
 		if ($permissions !== null) {
-			if (\is_numeric($permissions)) {
-				$permissionSum = (int) $permissions;
-			} else {
-				if (!\is_array($permissions)) {
-					$permissions = [$permissions];
-				}
-				$validPermissionTypes
-					= [
-						'read' => 1,
-						'update' => 2,
-						'create' => 4,
-						'delete' => 8,
-						'change' => 15,
-						'share' => 16,
-						'all' => 31
-					];
-				$permissionSum = 0;
-				foreach ($permissions as $permission) {
-					if (isset($validPermissionTypes[$permission])) {
-						$permissionSum += $validPermissionTypes[$permission];
-					} elseif (\in_array($permission, $validPermissionTypes)) {
-						$permissionSum += (int) $permission;
-					} else {
-						throw new \InvalidArgumentException(
-							"invalid permission type ($permission)"
-						);
-					}
-				}
-			}
-
-			if ($permissionSum < 1 || $permissionSum > 31) {
-				throw new \InvalidArgumentException(
-					"invalid permission total ($permissionSum)"
-				);
-			}
-			$fd['permissions'] = $permissionSum;
+			$fd['permissions'] = self::getPermissionSum($permissions);
 		}
 
 		if (!\in_array($ocsApiVersion, [1, 2], true)) {
@@ -143,7 +108,6 @@ class SharingHelper {
 				"invalid ocsApiVersion ($ocsApiVersion)"
 			);
 		}
-
 		if (!\in_array($sharingApiVersion, [1, 2], true)) {
 			throw new \InvalidArgumentException(
 				"invalid sharingApiVersion ($sharingApiVersion)"
@@ -175,5 +139,60 @@ class SharingHelper {
 		}
 
 		return HttpRequestHelper::post($fullUrl, $user, $password, null, $fd);
+	}
+	
+	/**
+	 * calculates the permission sum (int) from given permissions
+	 * permissions can be passed in as int, string or array of int or string
+	 * 'read' => 1
+	 * 'update' => 2
+	 * 'create' => 4
+	 * 'delete' => 8
+	 * 'change' => 15
+	 * 'share' => 16
+	 * 'all' => 31
+	 *
+	 * @param string[]|string|int|int[] $permissions
+	 *
+	 * @throws \InvalidArgumentException
+	 *
+	 * @return int
+	 */
+	public static function getPermissionSum($permissions) {
+		if (\is_numeric($permissions)) {
+			$permissionSum = (int) $permissions;
+		} else {
+			if (!\is_array($permissions)) {
+				$permissions = [$permissions];
+			}
+			$validPermissionTypes
+				= [
+					'read' => 1,
+					'update' => 2,
+					'create' => 4,
+					'delete' => 8,
+					'change' => 15,
+					'share' => 16,
+					'all' => 31
+				];
+			$permissionSum = 0;
+			foreach ($permissions as $permission) {
+				if (isset($validPermissionTypes[$permission])) {
+					$permissionSum += $validPermissionTypes[$permission];
+				} elseif (\in_array($permission, $validPermissionTypes)) {
+					$permissionSum += (int) $permission;
+				} else {
+					throw new \InvalidArgumentException(
+						"invalid permission type ($permission)"
+					);
+				}
+			}
+		}
+		if ($permissionSum < 1 || $permissionSum > 31) {
+			throw new \InvalidArgumentException(
+				"invalid permission total ($permissionSum)"
+			);
+		}
+		return $permissionSum;
 	}
 }

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -822,15 +822,20 @@ trait Sharing {
 
 	/**
 	 * @param string $userOrGroup
-	 * @param int $permissions
+	 * @param int|int[]|string|string[] $permissions
 	 *
 	 * @return bool
 	 */
 	public function isUserOrGroupInSharedData($userOrGroup, $permissions = null) {
+		if ($permissions !== null) {
+			$permissionSum = SharingHelper::getPermissionSum($permissions);
+		}
+		
 		$data = $this->getResponseXml()->data[0];
 		foreach ($data as $element) {
-			if ($element->share_with == $userOrGroup
-				&& ($permissions === null || $permissions == $element->permissions)
+			if ($element->share_with->__toString() === $userOrGroup
+				&& ($permissions === null
+				|| $permissionSum === (int)$element->permissions->__toString())
 			) {
 				return true;
 			}
@@ -839,7 +844,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
+	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $user1
 	 * @param string $filepath
@@ -872,7 +877,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))?$/
+	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (.*))?$/
 	 *
 	 * @param string $user1
 	 * @param string $filepath
@@ -894,7 +899,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with the administrator(?: with permissions ([\d]*))?$/
+	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with the administrator(?: with permissions (.*))?$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -912,7 +917,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
+	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $filepath
 	 * @param string $user2
@@ -929,7 +934,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))?$/
+	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (.*))?$/
 	 *
 	 * @param string $filepath
 	 * @param string $user2
@@ -946,7 +951,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
+	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $filepath
 	 * @param string $group
@@ -963,7 +968,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
+	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions (.*))?$/
 	 *
 	 * @param string $filepath
 	 * @param string $group
@@ -980,7 +985,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
+	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $filepath
@@ -1010,7 +1015,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
+	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions (.*))?$/
 	 *
 	 * @param string $user
 	 * @param string $filepath
@@ -1045,7 +1050,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
+	 * @Then /^user "([^"]*)" should not be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -1068,7 +1073,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
+	 * @Then /^user "([^"]*)" should be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath


### PR DESCRIPTION
## Description
make it possible to write the permissions in words and not magic numbers in the test steps

## Related Issue
makes it nicer for https://github.com/owncloud/user_ldap/issues/35

## Motivation and Context
the main share creation method in the helper already had all logic to do human readable permissions, so moved that logic to an own method and adjusted the test steps

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
