### PR TITLE
step to create a group explicitly on the database backend

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1623,6 +1623,19 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Given /^group "([^"]*)" has been created in the database user backend$/
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function groupHasBeenCreatedOnDatabaseBackend($group) {
+		$this->adminCreatesGroupUsingTheProvisioningApi($group);
+		$this->groupShouldExist($group);
+	}
+
+	/**
 	 * @Given these groups have been created:
 	 * expects a table of groups with the heading "groupname"
 	 *


### PR DESCRIPTION
## Description
similar to #34169 a step to create groups explicitly on the database backend

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
