### PR TITLE
Enable tests skipped for issue-33840

### DIFF
--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -96,7 +96,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @skip @issue-33840
+  @issue-33840
   Scenario Outline: Get favorited elements and limit count of entries
     Given using <dav_version> DAV path
     And the user has favorited element "/textfile0.txt"
@@ -105,7 +105,8 @@ Feature: favorite
     And the user has favorited element "/textfile3.txt"
     And the user has favorited element "/textfile4.txt"
     When the user lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
-    Then the search result of "user0" shoud contain any "3" of these entries:
+    #Then the search result of "user0" shoud contain any "3" of these entries:
+    Then the search result of "user0" shoud contain any "0" of these entries:
       | /textfile0.txt |
       | /textfile1.txt |
       | /textfile2.txt |
@@ -116,7 +117,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @skip @issue-33840
+  @issue-33840
   Scenario Outline: Get favorited elements paginated in subfolder
     Given using <dav_version> DAV path
     And the user has created folder "/subfolder"
@@ -133,7 +134,8 @@ Feature: favorite
     And the user has favorited element "/subfolder/textfile4.txt"
     And the user has favorited element "/subfolder/textfile5.txt"
     When the user lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
-    Then the search result of "user0" shoud contain any "3" of these entries:
+    #Then the search result of "user0" shoud contain any "3" of these entries:
+    Then the search result of "user0" shoud contain any "0" of these entries:
       | /subfolder/textfile0.txt |
       | /subfolder/textfile1.txt |
       | /subfolder/textfile2.txt |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2197,7 +2197,7 @@ trait WebDav {
 		$elementRows = $expectedFiles->getRowsHash();
 		$resultEntrys = $this->findEntryFromPropfindResponse($user);
 		foreach ($resultEntrys as $resultEntry) {
-			PHPUnit_Framework_Assert::arrayHasKey($resultEntry, $elementRows);
+			PHPUnit_Framework_Assert::assertArrayHasKey($resultEntry, $elementRows);
 		}
 	}
 
@@ -2208,7 +2208,8 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $entryNameToSearch
 	 *
-	 * @return string if $entryNameToSearch is given and is found
+	 * @return string|array|boolean
+	 * string if $entryNameToSearch is given and is found
 	 * array if $entryNameToSearch is not given
 	 * boolean false if $entryNameToSearch is given and is not found
 	 */
@@ -2236,9 +2237,9 @@ trait WebDav {
 				}
 				\array_push($results, $entryName);
 			}
-			if ($entryNameToSearch === null) {
-				return $results;
-			}
+		}
+		if ($entryNameToSearch === null) {
+			return $results;
 		}
 		return false;
 	}


### PR DESCRIPTION
## Description
1) Unskip acceptance test scenarios for issue #33840 
2) Adjust them so they pass now.
3) Leave commented-out test steps that suggest what should pass when the bug is fixed.
4) 

## Related Issue
https://github.com/owncloud/QA/issues/601

## Motivation and Context
For acceptance test scenarios that demonstrate bugs, instead of just skipping them, we want to comment-out the failing test step(s) and write test step(s) that currently pass (i.e. demonstrate the wrong behavior). Then when a developer fixes the bug, the test will start failing (because the wrong behavior no longer happens). This will force the developer to notice the acceptance test and adjust it.

Otherwise we end up with acceptance tests that stay skipped after the bug is fixed.

## How Has This Been Tested?
Local acceptance test run

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
