### PR TITLE
Enable tests skipped for issue 31015

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -56,12 +56,16 @@ default:
         - '%paths.base%/../features/apiProvisioning-v1'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - OccUsersGroupsContext:
 
     apiProvisioning-v2:
       paths:
         - '%paths.base%/../features/apiProvisioning-v2'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - OccUsersGroupsContext:
 
     apiSharees:
       paths:

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -43,14 +43,22 @@ Feature: add groups
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-	# Note: these groups do get created OK, but the "should exist" step fails
-	# because the API to check their existence does not work.
-  @skip @issue-31015
+    # Note: these groups do get created OK, but:
+    # 1) the "should exist" step fails because the API to check their existence does not work.
+    # 2) the ordinary group deletion in AfterScenario does not work, because the
+    #    that group-delete API does not work for groups with a slash in the name
+  @issue-31015
   Scenario Outline: admin creates a group with a forward-slash in the group name
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And group "<group_id>" should exist
+    # After fixing issue-31015, change the following step to "should exist"
+    And group "<group_id>" should not exist
+    #And group "<group_id>" should exist
+    #
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -60,13 +68,18 @@ Feature: add groups
 
 	# A group name must not end in "/subadmins" because that would create ambiguity
 	# with the endpoint for getting the subadmins of a group
-  @skip @issue-31015
+  @issue-31015
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-    Then the OCS status code should be "101"
+    # After fixing issue-31015, change the expected status to "101"
+    Then the OCS status code should be "100"
+    #Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And group "priv/subadmins" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "priv/subadmins" using the occ command
 
   Scenario: admin tries to create a group that already exists
     Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -45,13 +45,18 @@ Feature: add users to group
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-  @skip @issue-31015
+  @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-    And group "<group_id>" has been created
+    # After fixing issue-31015, change the following step to "has been created"
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -53,7 +53,8 @@ Feature: delete groups
     When the administrator deletes group "<group_id>" using the provisioning API
     # After fixing issue-31015, change the expected status to "100"
     #Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
+    And the HTTP status code should be "404"
+    #And the HTTP status code should be "200"
     And group "<group_id>" should not exist
     # The following step is needed so that the group does get cleaned up.
     # After fixing issue-31015, remove the following step:

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -52,7 +52,6 @@ Feature: delete groups
     #Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
     # After fixing issue-31015, change the expected status to "100"
-    Then the OCS status code should be "999"
     #Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And group "<group_id>" should not exist

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -45,13 +45,20 @@ Feature: delete groups
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-  @skip @issue-31015
+  @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
-    Given group "<group_id>" has been created
+    # After fixing issue-31015, change the following step to "has been created"
+    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
-    Then the OCS status code should be "100"
+    # After fixing issue-31015, change the expected status to "100"
+    Then the OCS status code should be "999"
+    #Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And group "<group_id>" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -32,7 +32,7 @@ Feature: get user groups
     And the HTTP status code should be "200"
 
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-  @skip @issue-31015
+  @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
     Given user "brand-new-user" has been created with default attributes
     And group "unused-group" has been created
@@ -41,9 +41,13 @@ Feature: get user groups
     And group "Admin & Finance (NP)" has been created
     And group "admin:Pokhara@Nepal" has been created
     And group "नेपाली" has been created
-    And group "Mgmt/Sydney" has been created
-    And group "var/../etc" has been created
-    And group "priv/subadmins/1" has been created
+    # After fixing issue-31015, change the following steps to "has been created"
+    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
+    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
+    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
+    #And group "Mgmt/Sydney" has been created
+    #And group "var/../etc" has been created
+    #And group "priv/subadmins/1" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been added to group "0"
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
@@ -64,6 +68,11 @@ Feature: get user groups
       | priv/subadmins/1     |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
+    # The following steps are needed so that the groups do get cleaned up.
+    # After fixing issue-31015, remove the following steps:
+    And the administrator deletes group "Mgmt/Sydney" using the occ command
+    And the administrator deletes group "var/../etc" using the occ command
+    And the administrator deletes group "priv/subadmins/1" using the occ command
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -49,15 +49,20 @@ Feature: remove a user from a group
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-  @skip @issue-31015
+  @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-    And group "<group_id>" has been created
+    # After fixing issue-31015, change the following step to "has been created"
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -43,14 +43,22 @@ Feature: add groups
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-	# Note: these groups do get created OK, but the "should exist" step fails
-	# because the API to check their existence does not work.
-  @skip @issue-31015
+    # Note: these groups do get created OK, but:
+    # 1) the "should exist" step fails because the API to check their existence does not work.
+    # 2) the ordinary group deletion in AfterScenario does not work, because the
+    #    that group-delete API does not work for groups with a slash in the name
+  @issue-31015
   Scenario Outline: admin creates a group with a forward-slash in the group name
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And group "<group_id>" should exist
+    # After fixing issue-31015, change the following step to "should exist"
+    And group "<group_id>" should not exist
+    #And group "<group_id>" should exist
+    #
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -60,13 +68,19 @@ Feature: add groups
 
 	# A group name must not end in "/subadmins" because that would create ambiguity
 	# with the endpoint for getting the subadmins of a group
-  @skip @issue-31015
+  @issue-31015
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-    Then the OCS status code should be "400"
-    And the HTTP status code should be "400"
+    # After fixing issue-31015, change the expected status to "400"
+    Then the OCS status code should be "200"
+    #Then the OCS status code should be "400"
+    And the HTTP status code should be "200"
+    #And the HTTP status code should be "400"
     And group "priv/subadmins" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "priv/subadmins" using the occ command
 
   Scenario: admin tries to create a group that already exists
     Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -45,13 +45,18 @@ Feature: add users to group
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-  @skip @issue-31015
+  @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-    And group "<group_id>" has been created
+    # After fixing issue-31015, change the following step to "has been created"
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -52,7 +52,6 @@ Feature: delete groups
     #Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
     # After fixing issue-31015, change the expected status to "200"
-    Then the OCS status code should be "500"
     #Then the OCS status code should be "200"
     And the HTTP status code should be "500"
     #And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -53,7 +53,7 @@ Feature: delete groups
     When the administrator deletes group "<group_id>" using the provisioning API
     # After fixing issue-31015, change the expected status to "200"
     #Then the OCS status code should be "200"
-    And the HTTP status code should be "500"
+    And the HTTP status code should be "404"
     #And the HTTP status code should be "200"
     And group "<group_id>" should not exist
     # The following step is needed so that the group does get cleaned up.

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -45,13 +45,21 @@ Feature: delete groups
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-  @skip @issue-31015
+  @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
-    Given group "<group_id>" has been created
+    # After fixing issue-31015, change the following step to "has been created"
+    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
+    # After fixing issue-31015, change the expected status to "200"
+    Then the OCS status code should be "500"
+    #Then the OCS status code should be "200"
+    And the HTTP status code should be "500"
+    #And the HTTP status code should be "200"
     And group "<group_id>" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -32,7 +32,7 @@ Feature: get user groups
     And the HTTP status code should be "200"
 
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-  @skip @issue-31015
+  @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
     Given user "brand-new-user" has been created with default attributes
     And group "unused-group" has been created
@@ -41,9 +41,13 @@ Feature: get user groups
     And group "Admin & Finance (NP)" has been created
     And group "admin:Pokhara@Nepal" has been created
     And group "नेपाली" has been created
-    And group "Mgmt/Sydney" has been created
-    And group "var/../etc" has been created
-    And group "priv/subadmins/1" has been created
+    # After fixing issue-31015, change the following steps to "has been created"
+    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
+    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
+    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
+    #And group "Mgmt/Sydney" has been created
+    #And group "var/../etc" has been created
+    #And group "priv/subadmins/1" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been added to group "0"
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
@@ -64,6 +68,11 @@ Feature: get user groups
       | priv/subadmins/1     |
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
+    # The following steps are needed so that the groups do get cleaned up.
+    # After fixing issue-31015, remove the following steps:
+    And the administrator deletes group "Mgmt/Sydney" using the occ command
+    And the administrator deletes group "var/../etc" using the occ command
+    And the administrator deletes group "priv/subadmins/1" using the occ command
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -49,15 +49,20 @@ Feature: remove a user from a group
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-  @skip @issue-31015
+  @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-    And group "<group_id>" has been created
+      # After fixing issue-31015, change the following step to "has been created"
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -357,6 +357,7 @@ class OccUsersGroupsContext implements Context {
 		$this->occContext->invokingTheCommand(
 			"group:delete $group"
 		);
+		$this->featureContext->rememberThatGroupIsNotExpectedToExist($group);
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) Unskip acceptance test scenarios for issue #31015
2) Adjust them so they pass now.
3) Leave commented-out test steps that suggest what should pass when the bug is fixed.
4) When deleting groups with occ command rememberThatGroupIsNotExpectedToExist - I noticed this was missing when I made use of the step for deleting groups using the occ command

## Related Issue
https://github.com/owncloud/QA/issues/601

## Motivation and Context
For acceptance test scenarios that demonstrate bugs, instead of just skipping them, we want to comment-out the failing test step(s) and write test step(s) that currently pass (i.e. demonstrate the wrong behavior). Then when a developer fixes the bug, the test will start failing (because the wrong behavior no longer happens). This will force the developer to notice the acceptance test and adjust it.

Otherwise we end up with acceptance tests that stay skipped after the bug is fixed.

## How Has This Been Tested?
Local acceptance test run

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
