### PR TITLE
Enable mergeShare scenario that was skipped for issue-29016

### DIFF
--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -78,7 +78,7 @@ Feature: sharing
     And as "user1" folder "/merge-test-inside-twogroups-perms (2)" should not exist
     And as "user1" folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
-  @skip @issue-29016 @skipOnLDAP
+  @skipOnLDAP
   Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
     Given user "user0" has created folder "/merge-test-outside-groups-renamebeforesecondshare"
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API


### PR DESCRIPTION
## Description
Issue #29016 was about intermittent acceptance test fails on Jenkins. Now we are running on drone.
Locally this scenario passes for me. It should also pass fine on drone, so enable it.

## Related Issue
#29016

## Motivation and Context
Enable acceptance test scenarios that work.

## How Has This Been Tested?
Local run of acceptance test scenario:
```
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiShareManagement/mergeShare.feature:82
php build/composer.phar install --dev
You are using the deprecated option "dev". Dev packages are installed by default now.
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Package guzzle/common is abandoned, you should avoid using it. Use guzzle/guzzle instead.
Package guzzle/http is abandoned, you should avoid using it. Use guzzle/guzzle instead.
Package guzzle/parser is abandoned, you should avoid using it. Use guzzle/guzzle instead.
Package guzzle/stream is abandoned, you should avoid using it. Use guzzle/guzzle instead.
Generating optimized autoload files
Composer cleaner: Removed 14 files or directories.
ocramius/package-versions:  Generating version class...
ocramius/package-versions: ...done generating version class
./tests/acceptance/run.sh --remote --type api
Script path: /home/phil/git/owncloud/core/tests/acceptance
Not using php inbuilt server for running scenario ...
Updating .htaccess for proper rewrites


Running apiShareManagement tests tagged ~@skipWhenTestingRemoteSystems&&~@skipOnOcV11&&~@skipOnOcV11.0&&~@skipOnOcV11.0.0&&@api&&~@skip 
@api @TestAlsoOnExternalUserBackend
Feature: sharing

  Background:                                                 # /home/phil/git/owncloud/core/tests/acceptance/features/apiShareManagement/mergeShare.feature:4
    Given using OCS API version "1"                           # FeatureContext::usingOcsApiVersion()
    And using old DAV path                                    # FeatureContext::usingOldOrNewDavPath()
    And user "user0" has been created with default attributes # FeatureContext::userHasBeenCreatedWithDefaultAttributes()
    And user "user1" has been created with default attributes # FeatureContext::userHasBeenCreatedWithDefaultAttributes()
    And group "grp1" has been created                         # FeatureContext::groupHasBeenCreated()
    And user "user1" has been added to group "grp1"           # FeatureContext::userHasBeenAddedToGroup()

  @skipOnLDAP
  Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between                                                     # /home/phil/git/owncloud/core/tests/acceptance/features/apiShareManagement/mergeShare.feature:82
    Given user "user0" has created folder "/merge-test-outside-groups-renamebeforesecondshare"                                                                              # FeatureContext::userCreatesFolder()
    When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API                                            # FeatureContext::userSharesFileWithGroupUsingTheSharingApi()
    And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API # FeatureContext::userMovesFileUsingTheAPI()
    And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API                                             # FeatureContext::userSharesFileWithUserUsingTheSharingApi()
    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "oc:permissions" with value "SRDNVCK"                # WebDavPropertiesContext::asUserFolderShouldContainAPropertyWithValue()
    And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist                                                                             # FeatureContext::asFileOrFolderShouldNotExist()

1 scenario (1 passed)
12 steps (12 passed)
0m9.73s (15.97Mb)
runsh: Exit code of main run: 0
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
