### PR TITLE
[stable10] Skip preview expiry when owner cannot be determined

### DIFF
--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -1238,7 +1238,11 @@ class Preview {
 		$path = Files\Filesystem::normalizePath($args['path']);
 		$user = isset($args['user']) ? $args['user'] : \OC_User::getUser();
 		if ($user === false) {
-			$user = Filesystem::getOwner($path);
+			try {
+				$user = Filesystem::getOwner($path);
+			} catch (NotFoundException $e) {
+				return;
+			}
 		}
 
 		$userFolder = \OC::$server->getUserFolder($user);
@@ -1308,7 +1312,11 @@ class Preview {
 		if (!isset(self::$deleteFileMapper[$path])) {
 			$user = isset($args['user']) ? $args['user'] : \OC_User::getUser();
 			if ($user === false) {
-				$user = Filesystem::getOwner($path);
+				try {
+					$user = Filesystem::getOwner($path);
+				} catch (NotFoundException $e) {
+					return;
+				}
 			}
 
 			$userFolder = \OC::$server->getUserFolder($user);


### PR DESCRIPTION
In some scenarios, the owner of trashed files or versions cannot be determined, instead of failing hard, just skip expiration.
This is just a mitigation as we need a proper solution for trash/version
preview expiry.

backport of #34118 