### PR TITLE
[acceptance tests] get password for user if not set when initializing it

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1000,9 +1000,14 @@ trait Provisioning {
 	 */
 	public function theseUsersHaveBeenInitialized(TableNode $table) {
 		foreach ($table as $row) {
+			if (!isset($row ['password'])) {
+				$password = $this->getPasswordForUser($row ['username']);
+			} else {
+				$password = $row ['password'];
+			}
 			$this->initializeUser(
 				$row ['username'],
-				$row ['password']
+				$password
 			);
 		}
 	}


### PR DESCRIPTION
## Description
if the password is not set for the initialisation step then find it yourself

## Related Issue
needed for https://github.com/owncloud/user_ldap/pull/352

## Motivation and Context
see https://github.com/owncloud/user_ldap/pull/352#discussion_r249702204

## How Has This Been Tested?
made LDAP test using the new step

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
