### PR TITLE
[stable10] [acceptance tests] get password for user if not set when initializing it

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1000,9 +1000,14 @@ trait Provisioning {
 	 */
 	public function theseUsersHaveBeenInitialized(TableNode $table) {
 		foreach ($table as $row) {
+			if (!isset($row ['password'])) {
+				$password = $this->getPasswordForUser($row ['username']);
+			} else {
+				$password = $row ['password'];
+			}
 			$this->initializeUser(
 				$row ['username'],
-				$row ['password']
+				$password
 			);
 		}
 	}


### PR DESCRIPTION
backport of  #34213