### PR TITLE
add public link remove acceptance test

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -28,6 +28,7 @@ use Behat\Mink\Session;
 use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use Page\OwncloudPageElement\OCDialog;
 
 /**
  * The Sharing Dialog
@@ -55,8 +56,10 @@ class SharingDialog extends OwncloudPage {
 	private $publicLinksShareTabXpath = ".//li[contains(@class,'subtab-publicshare')]";
 	private $publicLinksTabContentXpath = "//div[@id='shareDialogLinkList']";
 	private $noSharingMessageXpath = "//div[@class='noSharingPlaceholder']";
+	private $publicLinkRemoveBtnXpath = "//div[contains(@class, 'removeLink')]";
 	
 	private $sharedWithGroupAndSharerName = null;
+	private $publicLinkRemoveDeclineMsg = "No";
 
 	/**
 	 *
@@ -470,6 +473,56 @@ class SharingDialog extends OwncloudPage {
 			$this->publicLinksTabContentXpath
 		);
 		return $publicLinkTab;
+	}
+
+	/**
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function removePublicLink(Session $session) {
+		$this->clickRemoveBtn($session);
+		$ocDialog = $this->getLastOcDialog($session);
+		$ocDialog->accept($session);
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function cancelRemovePublicLinkOperation(Session $session) {
+		$this->clickRemoveBtn($session);
+		$ocDialog = $this->getLastOcDialog($session);
+		$ocDialog->clickButton($session, $this->publicLinkRemoveDeclineMsg);
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	private function clickRemoveBtn(Session $session) {
+		$publicLinkRemoveBtn = $this->find("xpath", $this->publicLinkRemoveBtnXpath);
+		$this->assertElementNotNull(
+			$publicLinkRemoveBtn,
+			__METHOD__ .
+			" xpath $this->publicLinkRemoveBtnXpath " .
+			"could not find public link remove button"
+		);
+		$publicLinkRemoveBtn->click();
+	}
+
+	/**
+	 * @param Session $session
+	 *
+	 * @return OCDialog
+	 */
+	private function getLastOcDialog(Session $session) {
+		$ocDialogs = $this->getOcDialogs();
+		return \end($ocDialogs);
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -283,3 +283,14 @@ Feature: Share by public link
     And the user browses to the shared-by-link page
     Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
+
+  Scenario: user removes the public link of a file
+    Given the user has created a new public link for file "lorem.txt" using the webUI
+    When the user removes the public link of file "lorem.txt" using the webUI
+    Then the public should see an error message "File not found" while accessing last created public link using the webUI
+
+  Scenario: user cancel removes operation for the public link of a file
+    Given the user has created a new public link for file "lorem.txt" using the webUI
+    When the user tries to remove the public link of file "lorem.txt" but later cancels the remove dialog using webUI
+    And the public accesses the last created public link using the webUI
+    Then the content of the file shared by the last public link should be the same as "lorem.txt"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
this PR adds webUI test for removing public link of shared file

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [X] Backport (if applicable set "backport-request" label and remove when the backport was done)
