### PR TITLE
Add webUI tests for federationSharing sub-folder operations

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1214,19 +1214,24 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		if ($typeOfFilesPage === "trashbin") {
 			$this->theUserBrowsesToTheTrashbinPage();
 		}
+		$pageObject = $this->getCurrentPageObject();
 		if ($fileOrFolder === "folder") {
 			if (\is_array($name)) {
 				$this->currentFolder .= "/" . \implode($name);
+				$pageObject->openFile($name, $this->getSession());
+				$pageObject->waitTillPageIsLoaded($this->getSession());
 			} else {
+				$name = \ltrim($name, '/');
 				$this->currentFolder .= "/$name";
+				$folderBreadCrumbs = \explode('/', $name);
+				foreach ($folderBreadCrumbs as $folder) {
+					$pageObject->openFile($folder, $this->getSession());
+					$pageObject->waitTillPageIsLoaded($this->getSession());
+				}
 			}
 		}
-		$pageObject = $this->getCurrentPageObject();
-		$pageObject->waitTillPageIsLoaded($this->getSession());
-		$pageObject->openFile($name, $this->getSession());
-		$pageObject->waitTillPageIsLoaded($this->getSession());
 	}
-	
+
 	/**
 	 * @Then /^the folder should (not|)\s?be empty on the webUI$/
 	 *

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -257,3 +257,45 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user accepts the offered remote shares using the webUI
     And using server "REMOTE"
     Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
+
+  Scenario: sharee should be able to access the files/folders inside other folder
+    Given user "user1" has created folder "simple-folder/simple-empty-folder/finalfolder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    And user "user1" re-logs in to "%remote_server%" using the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    Then file "textfile.txt" should be listed on the webUI
+    And folder "finalfolder" should be listed on the webUI
+
+  Scenario: sharee uploads a file inside a folder of a folder
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    When user "user1" re-logs in to "%remote_server%" using the webUI
+    And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
+    And the user uploads file "lorem.txt" using the webUI
+    And using server "LOCAL"
+    Then as "user1" file "simple-folder/simple-empty-folder/lorem.txt" should exist
+
+  Scenario: rename a file in a folder inside a shared folder
+    Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    And user "user1" re-logs in to "%remote_server%" using the webUI
+    And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
+    When the user renames file "textfile.txt" to "new-lorem.txt" using the webUI
+    And using server "LOCAL"
+    Then as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
+    But as "user1" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
+
+  Scenario: delete a file in a folder inside a shared folder
+    Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    And user "user1" re-logs in to "%remote_server%" using the webUI
+    And the user opens folder "/simple-folder (2)/simple-empty-folder" using the webUI
+    When the user deletes file "textfile.txt" using the webUI
+    And using server "LOCAL"
+    Then as "user1" file "/simple-folder/simple-empty-folder/textfile.txt" should not exist


### PR DESCRIPTION
## Description
Add webUI tests for federationSharing sub-folder operations

## Related Issue
#34150

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

