### PR TITLE
Fix persistent locking handling in public links

### DIFF
--- a/apps/dav/lib/Files/FileLocksBackend.php
+++ b/apps/dav/lib/Files/FileLocksBackend.php
@@ -74,11 +74,13 @@ class FileLocksBackend implements BackendInterface {
 			/** @var IPersistentLockingStorage $storage */
 			$locks = $storage->getLocks($node->getFileInfo()->getInternalPath(), $returnChildLocks);
 		} catch (NotFound $e) {
-			// get parent storage and check for locks on the target path
-			list($parentPath, $childPath) = \Sabre\Uri\split($uri);
-			if ($parentPath === '') {
+			if ($uri === '') {
+				// no more parents
 				return [];
 			}
+
+			// get parent storage and check for locks on the target path
+			list($parentPath, $childPath) = \Sabre\Uri\split($uri);
 
 			try {
 				$node = $this->tree->getNodeForPath($parentPath);

--- a/apps/dav/tests/unit/Files/FileLocksBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileLocksBackendTest.php
@@ -34,6 +34,7 @@ use Sabre\DAV\IFile;
 use Sabre\DAV\Locks\LockInfo;
 use Sabre\DAV\Tree;
 use Test\TestCase;
+use OCA\DAV\Connector\Sabre\Directory;
 
 class FileLocksBackendTest extends TestCase {
 	const CREATION_TIME = 164419200;
@@ -56,6 +57,17 @@ class FileLocksBackendTest extends TestCase {
 
 		$this->tree = $this->createMock(Tree::class);
 		$this->tree->method('getNodeForPath')->willReturnCallback(function ($uri) {
+			// root node
+			if ($uri === '') {
+				$storage = $this->createMock([IPersistentLockingStorage::class, IStorage::class]);
+				$storage->method('instanceOfStorage')->willReturn(true);
+				$storage->method('getLocks')->willReturn([]);
+				$fileInfo = $this->createMock(FileInfo::class);
+				$fileInfo->method('getStorage')->willReturn($storage);
+				$file = $this->createMock(Directory::class);
+				$file->method('getFileInfo')->willReturn($fileInfo);
+				return $file;
+			}
 			if ($uri === 'unknown-file.txt') {
 				throw new NotFound();
 			}

--- a/apps/files/js/filelockplugin.js
+++ b/apps/files/js/filelockplugin.js
@@ -23,16 +23,24 @@
 	 * @return {Object} parsed values in associative array
 	 */
 	function parseLockNode(xmlvalue) {
-		return {
+		var lockInfo = {
 			lockscope: getChildNodeLocalName(xmlvalue.getElementsByTagNameNS(NS_DAV, 'lockscope')[0]),
 			locktype: getChildNodeLocalName(xmlvalue.getElementsByTagNameNS(NS_DAV, 'locktype')[0]),
 			lockroot: getHrefNodeContents(xmlvalue.getElementsByTagNameNS(NS_DAV, 'lockroot')[0]),
 			// string, as it can also be "infinite"
 			depth: xmlvalue.getElementsByTagNameNS(NS_DAV, 'depth')[0].textContent,
 			timeout: xmlvalue.getElementsByTagNameNS(NS_DAV, 'timeout')[0].textContent,
-			locktoken: getHrefNodeContents(xmlvalue.getElementsByTagNameNS(NS_DAV, 'locktoken')[0]),
-			owner: xmlvalue.getElementsByTagNameNS(NS_DAV, 'owner')[0].textContent
+			locktoken: getHrefNodeContents(xmlvalue.getElementsByTagNameNS(NS_DAV, 'locktoken')[0])
 		};
+
+		var owner = null;
+		var ownerEl = xmlvalue.getElementsByTagNameNS(NS_DAV, 'owner');
+		if (ownerEl && ownerEl.length) {
+			owner = ownerEl[0].textContent;
+		}
+
+		lockInfo.owner = owner || t('files', 'Unknown user');
+		return lockInfo;
 	}
 
 	function getHrefNodeContents(node) {

--- a/apps/files/js/locktabview.js
+++ b/apps/files/js/locktabview.js
@@ -28,7 +28,12 @@
 		var client = OC.Files.getClient();
 
 		return _.map(locks, function(lock, index) {
-			var path = client.getRelativePath(lock.lockroot) || lock.lockroot;
+			var path = client.getRelativePath(lock.lockroot);
+			if (path === null) {
+				path = lock.lockroot;
+			} else if (path === '') {
+				path = '/';
+			}
 
 			// TODO: what if user in root doesn't match ?
 

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -330,6 +330,9 @@ class WebDavHelper {
 	public static function getDavPath(
 		$user, $davPathVersionToUse = 1, $type = "files"
 	) {
+		if ($type === "public-files") {
+			return "public.php/webdav/";
+		}
 		if ($davPathVersionToUse === 1) {
 			return "remote.php/webdav/";
 		} elseif ($davPathVersionToUse === 2) {

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -60,6 +60,40 @@ Feature: Locks
     And folder "simple-folder" should be marked as locked by user "user-with-email (mail@oc.org)" in the locks tab of the details panel on the webUI
     And file "data.zip" should be marked as locked by user "user-with-email (mail@oc.org)" in the locks tab of the details panel on the webUI
 
+  Scenario: setting a lock on a publicly shared file shows the lock symbols at the correct file
+    Given user "brand-new-user" has created a public link share of file "data.zip"
+    When the public locks the last public shared file using the WebDAV API setting following properties
+      | lockscope | shared |
+    And the user browses to the files page
+    Then file "data.zip" should be marked as locked on the webUI
+    And file "data.zip" should be marked as locked by user "Unknown user" in the locks tab of the details panel on the webUI
+    But file "data.tar.gz" should not be marked as locked on the webUI
+
+  Scenario: setting a lock on a publicly shared folder shows the lock symbols at the correct files/folder
+    Given user "brand-new-user" has created a public link share of folder "simple-folder"
+    When the public locks the last public shared folder using the WebDAV API setting following properties
+      | lockscope | shared |
+    And the user browses to the files page
+    Then folder "simple-folder" should be marked as locked on the webUI
+    And folder "simple-folder" should be marked as locked by user "Unknown user" in the locks tab of the details panel on the webUI
+    But folder "simple-empty-folder" should not be marked as locked on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then file "data.zip" should be marked as locked on the webUI
+    And file "data.zip" should be marked as locked by user "Unknown user" in the locks tab of the details panel on the webUI
+    And file "data.tar.gz" should be marked as locked on the webUI
+
+  Scenario: setting a lock on a file in a publicly shared folder shows the lock symbols at the correct files
+    Given user "brand-new-user" has created a public link share of folder "simple-folder"
+    When the public locks "data.zip" in the last public shared folder using the WebDAV API setting following properties
+      | lockscope | shared |
+    And the user browses to the files page
+    Then folder "simple-folder" should not be marked as locked on the webUI
+    And folder "simple-empty-folder" should not be marked as locked on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then file "data.zip" should be marked as locked on the webUI
+    And file "data.zip" should be marked as locked by user "Unknown user" in the locks tab of the details panel on the webUI
+    And file "data.tar.gz" should not be marked as locked on the webUI
+
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the favorites page
     Given the user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | shared |


### PR DESCRIPTION
## Description
- Display "unknown user" in UI when locked through public link and owner
info is null
- Properly check parent lock for Webdav calls on the public Webdav
endpoint

## Related Issue
Fixes public link part of https://github.com/owncloud/core/issues/33848

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] public webdav write access to locked resource: https://github.com/owncloud/core/issues/33848#issuecomment-455537368
- [x] lock a folder through public webdav then view the lock as regular user: owner field missing, now appears as "unknown user"

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
