### PR TITLE
Fix public link path for persistent locks

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -138,6 +138,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
         - WebDavLockingContext:
+        - WebDavPropertiesContext:
 
     cliProvisioning:
       paths:

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1071,10 +1071,13 @@ trait WebDav {
 	 * @param string $path
 	 * @param int $folderDepth requires 1 to see elements without children
 	 * @param array|null $properties
+	 * @param string $type
 	 *
 	 * @return SimpleXMLElement
 	 */
-	public function listFolder($user, $path, $folderDepth, $properties = null) {
+	public function listFolder(
+		$user, $path, $folderDepth, $properties = null, $type = "files"
+	) {
 		if ($this->customDavPath !== null) {
 			$path = $this->customDavPath . $path;
 		}
@@ -1084,7 +1087,7 @@ trait WebDav {
 			$this->getActualUsername($user),
 			$this->getPasswordForUser($user),
 			$path, $folderDepth, $properties,
-			"files", ($this->usingOldDavPath) ? 1 : 2
+			$type, ($this->usingOldDavPath) ? 1 : 2
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -124,7 +124,28 @@ class WebDavPropertiesContext implements Context {
 			)
 		);
 	}
-	
+
+	/**
+	 * @When /^the public gets the following properties of (?:file|folder|entry) "([^"]*)" in the last created public link using the WebDAV API$/
+	 *
+	 * @param string $path
+	 * @param TableNode $propertiesTable
+	 *
+	 * @return void
+	 */
+	public function publicGetsThePropertiesOfFolder($path, TableNode $propertiesTable) {
+		$user = (string)$this->featureContext->getLastShareData()->data->token;
+		$properties = null;
+		if ($propertiesTable instanceof TableNode) {
+			foreach ($propertiesTable->getRows() as $row) {
+				$properties[] = $row[0];
+			}
+		}
+		$this->featureContext->setResponseXmlObject(
+			$this->featureContext->listFolder($user, $path, 0, $properties, "public-files")
+		);
+	}
+
 	/**
 	 * @When /^user "([^"]*)" sets property "([^"]*)"  with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has set property "([^"]*)" with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
@@ -258,6 +279,56 @@ class WebDavPropertiesContext implements Context {
 				"expected \"$expectedValue\" or \"$altExpectedValue\""
 			);
 		}
+	}
+
+	/**
+	 * @Then the value of the item :xpath in the response should be :value
+	 *
+	 * @param string $xpath
+	 * @param string $expectedValue
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function assertValueOfItemInResponseIs($xpath, $expectedValue) {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find item with xpath \"$xpath\""
+		);
+		$value = $xmlPart[0]->__toString();
+		$expectedValue = $this->featureContext->substituteInLineCodes(
+			$expectedValue
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedValue, $value,
+			"item \"$xpath\" found with value \"$value\", " .
+			"expected \"$expectedValue\""
+		);
+	}
+
+	/**
+	 * @Then the value of the item :xpath in the response should match :value
+	 *
+	 * @param string $xpath
+	 * @param string $pattern
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function assertValueOfItemInResponseRegExp($xpath, $pattern) {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
+		PHPUnit_Framework_Assert::assertTrue(
+			isset($xmlPart[0]), "Cannot find item with xpath \"$xpath\""
+		);
+		$value = $xmlPart[0]->__toString();
+		$pattern = $this->featureContext->substituteInLineCodes(
+			$pattern
+		);
+		PHPUnit_Framework_Assert::assertRegExp(
+			$pattern, $value,
+			"item \"$xpath\" found with value \"$value\", " .
+			"expected to match regex pattern: \"$pattern\""
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
When querying lock info on public links, always return a path relative
to the public webdav endpoint.

## Related Issue
Fixes https://github.com/owncloud/core/issues/34225

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] Unit tests
With "/public/share" being the link share:
- [x] TEST: set lock on "/public", query locks on "public.php/webdav/sub" returns lock root "public.php/webdav/"
- [x] TEST: set lock on "/public/share", query locks on "public.php/webdav/sub" returns lock root "public.php/webdav/"
- [x] TEST: set lock on "/public/share/sub", query locks on "public.php/webdav/sub" returns lock root "public.php/webdav/sub"
- [x] TEST: set lock on "/public", set another lock on "public.php/webdav/sub" returns empty lock root ""
- [x] TEST: set lock on "/public/share/sub", set another lock on "public.php/webdav/sub" returns lock root "/sub"

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
