### PR TITLE
allow the upload into a subfolder of a public link

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -264,7 +264,10 @@ class PublicWebDavContext implements Context {
 	) {
 		$password = $this->featureContext->getActualPassword($password);
 		$url = $this->featureContext->getBaseUrl() . "/public.php/webdav/";
-		$url .= \rawurlencode(\ltrim($filename, '/'));
+		$filename = \implode(
+			'/', \array_map('rawurlencode', \explode('/', $filename))
+		);
+		$url .= \ltrim($filename, '/');
 		$token = $this->featureContext->getLastShareToken();
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 		


### PR DESCRIPTION
## Description
allow to upload into a subfolder of a public link
encode the file name except of `/ `

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
