### PR TITLE
Adjust mergeShare.feature:82 scenario for issue-34235

### DIFF
--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -78,14 +78,20 @@ Feature: sharing
     And as "user1" folder "/merge-test-inside-twogroups-perms (2)" should not exist
     And as "user1" folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
-  @skipOnLDAP
+  @issue-34235 @skipOnLDAP
   Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
     Given user "user0" has created folder "/merge-test-outside-groups-renamebeforesecondshare"
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
-    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "oc:permissions" with value "SRDNVCK"
-    And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
+    # issue-34235 bug is that usually user1 continues to see the share with the correct renamed name,
+    # but sometimes reverts to seeing the share with the original name.
+    # when the bug is fixed, delete the following test step, and uncomment the test steps below it
+    Then as "user1" exactly one of these folders should exist
+      | /merge-test-outside-groups-renamebeforesecondshare         |
+      | /merge-test-outside-groups-renamebeforesecondshare-renamed |
+    #Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "oc:permissions" with value "SRDNVCK"
+    #And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
 
   @skipOnLDAP @user_ldap-issue-274
   Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1040,6 +1040,32 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^as "([^"]*)" exactly one of these (files|folders|entries) should exist$/
+	 *
+	 * @param string $user
+	 * @param string $entries
+	 * @param TableNode $table of file, folder or entry paths
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function asExactlyOneOfTheseFilesOrFoldersShouldExist($user, $entries, $table) {
+		$numEntriesThatExist = 0;
+		foreach ($table->getTable() as $row) {
+			$path = $this->substituteInLineCodes($row[0]);
+			$this->responseXmlObject = $this->listFolder($user, $path, 0);
+			if ($this->isEtagValid()) {
+				$numEntriesThatExist = $numEntriesThatExist + 1;
+			}
+		}
+		PHPUnit_Framework_Assert::assertEquals(
+			1,
+			$numEntriesThatExist,
+			"exactly one of these $entries should exist but found $numEntriesThatExist $entries"
+		);
+	}
+
+	/**
 	 *
 	 * @param string $user
 	 * @param string $path


### PR DESCRIPTION
## Description
The issue-34235 bug is that usually user1 continues to see the share with the correct renamed name, but sometimes reverts to seeing the share with the original name. So one of the folders does always exist, just not always the one we hope.

Add a test step that checks that exactly one of the folders exists.

This will at least ensure that there are not further accidental regressions/changes in behavior - e.g. if neither folder exists or both folders exist then the scenario will fail.

## Related Issue
#34235 

## Motivation and Context
Have test scenarios that pass reliable, while waiting for bug fixes.

## How Has This Been Tested?
Local acceptance test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
