### PR TITLE
test if locks are applied correctly for public links

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -911,6 +911,16 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
+    - PHP_VERSION: 7.1
+      TEST_SUITE: api
+      BEHAT_SUITE: apiWebdavLocks
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
   # CLI Provisioning Acceptance tests
     - PHP_VERSION: 7.1
       TEST_SUITE: cli

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -131,6 +131,14 @@ default:
         - LoggingContext:
         - WebDavPropertiesContext:
 
+    apiWebdavLocks:
+      paths:
+        - '%paths.base%/../features/apiWebdavLocks'
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - PublicWebDavContext:
+        - WebDavLockingContext:
+
     cliProvisioning:
       paths:
         - '%paths.base%/../features/cliProvisioning'

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,0 +1,68 @@
+@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required
+Feature: persistent-locking in case of a public link
+
+  Background:
+    Given user "user0" has been created with default attributes
+
+  Scenario Outline: Uploading a file into a locked public folder
+    Given using <dav-path> DAV path
+    And user "user0" has created a public link share of folder "FOLDER" with change permission
+    When the user "user0" locks folder "FOLDER" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then publicly uploading a file should not work
+    And the HTTP status code should be "423"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+      
+  Scenario Outline: Uploading a file into a locked subfolder of a public folder
+    Given using <dav-path> DAV path
+    And user "user0" has created a public link share of folder "PARENT" with change permission
+    And the user "user0" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "test.txt" with content "test" using the public WebDAV API
+    And the public uploads file "CHILD/test.txt" with content "test" using the public WebDAV API
+    Then the HTTP status code should be "423"
+    And as "user0" file "/PARENT/CHILD/test.txt" should not exist
+    But the content of file "/PARENT/test.txt" for user "user0" should be "test"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  Scenario Outline: Overwrite a file inside a locked public folder
+    Given using <dav-path> DAV path
+    And user "user0" has created a public link share of folder "PARENT" with change permission
+    And the user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "parent.txt" with content "test" using the public WebDAV API
+    Then the HTTP status code should be "423"
+    And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
+    Given using <dav-path> DAV path
+    And user "user0" has created a public link share of folder "PARENT" with change permission
+    And the user "user0" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "parent.txt" with content "changed text" using the public WebDAV API
+    And the public uploads file "CHILD/child.txt" with content "test" using the public WebDAV API
+    Then the HTTP status code should be "423"
+    And the content of file "/PARENT/parent.txt" for user "user0" should be "changed text"
+    But the content of file "/PARENT/CHILD/child.txt" for user "user0" should be "ownCloud test text file child" plus end-of-line
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -264,7 +264,10 @@ class PublicWebDavContext implements Context {
 	) {
 		$password = $this->featureContext->getActualPassword($password);
 		$url = $this->featureContext->getBaseUrl() . "/public.php/webdav/";
-		$url .= \rawurlencode(\ltrim($filename, '/'));
+		$filename = \implode(
+			'/', \array_map('rawurlencode', \explode('/', $filename))
+		);
+		$url .= \ltrim($filename, '/');
 		$token = $this->featureContext->getLastShareToken();
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 		


### PR DESCRIPTION
## Description
test if the public is stopped from uploading files if the parent folder is locked

## Related Issue
https://github.com/owncloud/core/issues/33848#issuecomment-455537368

## Motivation and Context
this cases are not cover by litmus

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
