### PR TITLE
Web UI test for multiple public link creation and removal of certain

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -726,6 +726,23 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user removes the public link at position :number of file :entryName using the webUI
+	 *
+	 * @param integer $number
+	 * @param string $entryName
+	 *
+	 * @return void
+	 */
+	public function removesPublicLinkAtCertainPosition($number, $entryName) {
+		$session = $this->getSession();
+		$this->sharingDialog = $this->filesPage->openSharingDialog(
+			$entryName, $session
+		);
+		$this->publicShareTab = $this->sharingDialog->openPublicShareTab($session);
+		$this->sharingDialog->removePublicLink($session, $number);
+	}
+
+	/**
 	 * @Then the public should not get access to the publicly shared file
 	 *
 	 * @return void
@@ -980,7 +997,29 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->sharedWithYouPage->waitForAjaxCallsToStartAndFinish($this->getSession());
 		$this->assertShareIsInStateOnWebUI($item, $state);
 	}
-	
+
+	/**
+	 * @Then the public link with name :entryName should not be in the public links list
+	 *
+	 * @param string $entryName
+	 *
+	 * @return void
+	 */
+	public function thePublicLinkWithNameShouldNotBeInPublicLinksList($entryName) {
+		$this->sharingDialog->checkThatNameIsNotInPublicLinkList($this->getSession(), $entryName);
+	}
+
+	/**
+	 * @Then the number of public links should be :count
+	 *
+	 * @param integer $count
+	 *
+	 * @return void
+	 */
+	public function theNumberOfPublicLinksShouldBe($count) {
+		$this->sharingDialog->checkPublicLinkCount($this->getSession(), $count);
+	}
+
 	/**
 	 * @Then /^it should not be possible to share (?:file|folder) "([^"]*)"(?: with "([^"]*)")? using the webUI$/
 	 *

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -294,3 +294,36 @@ Feature: Share by public link
     When the user tries to remove the public link of file "lorem.txt" but later cancels the remove dialog using webUI
     And the public accesses the last created public link using the webUI
     Then the content of the file shared by the last public link should be the same as "lorem.txt"
+
+  Scenario: user creates a multiple public link of a file and delete the first link
+    Given the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | first-link |
+    And the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | second-link |
+    And the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | third-link |
+    When the user removes the public link at position 1 of file "lorem.txt" using the webUI
+    Then the public link with name "first-link" should not be in the public links list
+    And the number of public links should be 2
+
+  Scenario: user creates a multiple public link of a file and delete the second link
+    Given the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | first-link |
+    And the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | second-link |
+    And the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | third-link |
+    When the user removes the public link at position 2 of file "lorem.txt" using the webUI
+    Then the public link with name "second-link" should not be in the public links list
+    And the number of public links should be 2
+
+  Scenario: user creates a multiple public link of a file and delete the third link
+    Given the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | first-link |
+    And the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | second-link |
+    And the user has created a new public link for file "lorem.txt" using the webUI with
+      | name | third-link |
+    When the user removes the public link at position 3 of file "lorem.txt" using the webUI
+    Then the public link with name "third-link" should not be in the public links list
+    And the number of public links should be 2


### PR DESCRIPTION
creates multiple public link and remove certain public link acceptance test

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## How Has This Been Tested?
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [X] Backport (if applicable set "backport-request" label and remove when the backport was done)
