### PR TITLE
Fix the share permissions evaluation

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -23,6 +23,7 @@ namespace OCA\Files_Sharing\Controller;
 
 use OC\OCS\Result;
 use OCP\AppFramework\OCSController;
+use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
@@ -531,6 +532,17 @@ class Share20OcsController extends OCSController {
 			if (($stateFilter === null || $share->getState() === $stateFilter) &&
 				$this->canAccessShare($share)) {
 				try {
+					/**
+					 * Check if the group to which the user belongs is not allowed
+					 * to reshare
+					 */
+					if ($this->shareManager->sharingDisabledForUser($this->currentUser->getUID())) {
+						/**
+						 * Now set the permission to 15. Which will allow not to reshare.
+						 */
+						$permissionEvaluated = $share->getPermissions() & ~Constants::PERMISSION_SHARE;
+						$share->setPermissions($permissionEvaluated);
+					}
 					$formatted[] = $this->formatShare($share, true);
 				} catch (NotFoundException $e) {
 					// Ignore this share

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -447,6 +447,7 @@ class ApiTest extends TestCase {
 	}
 
 	public function testGetAllSharesWithMe() {
+		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups_list', '[]');
 		$node1 = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
 		$share1->setNode($node1)
@@ -474,6 +475,7 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);
+		\OC::$server->getConfig()->deleteAppValue('core', 'shareapi_exclude_groups_list');
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -209,7 +209,6 @@ Feature: Sharing files and folders with internal users
     Then the user should see an error message on the share dialog saying "Sharing is not allowed"
     And the share-with field should not be visible in the details panel
 
-  @enterprise-issue-3037 # after the issue is fixed remove the comments on two lines and remove last line
   Scenario: user tries to re-share a file from a group which is blacklisted from sharing using webUI from shared with you page
     Given group "grp1" has been created
     And user "user1" has been added to group "grp1"
@@ -221,9 +220,8 @@ Feature: Sharing files and folders with internal users
     And the user re-logs in as "user1" using the webUI
     And the user browses to the shared-with-you page
     And the user opens the sharing tab from the file action menu of file "testimage (2).jpg" using the webUI
-    #Then the user should see an error message on the share dialog saying "Sharing is not allowed"
-    #And the share-with field should not be visible in the details panel
-    Then the share-with field should be visible in the details panel
+    Then the user should see an error message on the share dialog saying "Sharing is not allowed"
+    And the share-with field should not be visible in the details panel
     And user "user1" should not be able to share file "testimage (2).jpg" with user "User Three" using the sharing API
 
   Scenario: user shares the file/folder with another internal user and delete the share with user


### PR DESCRIPTION
When user tries to access "Shared with you"
to know the list of files/folders shared with
the user, the share tab for the files or folder
are having an issue. When the group(s) to which
the user belong is excluded from sharing, the
share options appear in the tab. This change
tries to fix the issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Enable guest user,  block the guest group ( `guest_app`) by selecting the check box `Exclude groups from sharing` and add the guest group name. Now login as guest user and navigate to the `Shared with you` and then select the share tab. The share tab should not be visible `Sharing not allowed` message should be seen. This is seen when user navigates from `All files` and then selects the file/folder sharing section. Where as guest user is able to share the file or folder even though the guest group is blocked. This issue tries to address the resharing not working as expected. 

As per the investigation the `permission` which is set to `31` for the file/folder in this scenario. And hence in the parse method in shareitemmode.js, the permissions is not evaluated properly. Which was resulting in permissions set to `31`, and hence the guest user was able to reshare the file/folder. In this PR, the server does check if the current user falls under the group which is blocked or not. If so the assign permissions read only mode.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR tries to check if the user falls under the group which is blocked to reshare. If the user falls under the blocked user, then permissions are set to read only mode.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- As admin user enable the guest user.
- As admin user navigate to admin->Settings->Sharing and check `Exclude groups from sharing`. Add the guest group ( select it from the drop down )
- Now login as guest user.
- Navigate to `All files` and select the file/folder. The share tab should be invisible
- Navigate to `Shared with you` and select the file/folder. The share tab should be invisible.
- Create a user as admin
- As admin share a file/folder to the new user.
- Login as new user.
- The share tab should be visible in `All files` and `Shared with you`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
