### PR TITLE
[stable10] Add ocm-provider directory to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ core_vendor=core/vendor
 
 core_doc_files=AUTHORS COPYING README.md CHANGELOG.md
 core_src_files=$(wildcard *.php) index.html db_structure.xml .htaccess .user.ini robots.txt
-core_src_dirs=apps core l10n lib occ ocs ocs-provider resources settings
+core_src_dirs=apps core l10n lib occ ocs ocs-provider ocm-provider resources settings
 core_test_dirs=tests
 core_all_src=$(core_src_files) $(core_src_dirs) $(core_doc_files)
 core_config_files=config/config.sample.php config/config.apps.sample.php


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/34251

## Description
add **ocm-provider** directory to the build

## Motivation and Context
New ocm will be unused otherwise

## How Has This Been Tested?
```
> make dist

> unzip -vl build/dist/owncloud-core.zip | grep ocm-provider
       0  Stored        0   0% 2019-01-24 18:26 00000000  owncloud/ocm-provider/
    1316  Defl:X      744  44% 2019-01-24 18:26 078654e2  owncloud/ocm-provider/index.php

> tar -jtvf build/dist/owncloud-core.tar.bz2 | grep ocm-provider
drwxr-xr-x deo/users         0 2019-01-24 18:26 owncloud/ocm-provider/
-rw-r--r-- deo/users      1316 2019-01-24 18:26 owncloud/ocm-provider/index.php

> make dist-qa

> tar -jtvf build/dist/qa/owncloud-qa-core.tar.bz2 | grep ocm-provider
drwxr-xr-x deo/users         0 2019-01-24 18:47 owncloud/ocm-provider/
-rw-r--r-- deo/users      1316 2019-01-24 18:47 owncloud/ocm-provider/index.php
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

