### PR TITLE
Fix theUserOpensTheFileOrFolderUsingTheWebUI so it opens a file

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1224,18 +1224,28 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$pageObject = $this->getCurrentPageObject();
 
 		if (\is_array($relativePath)) {
-			$relativePath = \implode($relativePath);
+			// Store the single full concatenated file or folder name.
+			$breadCrumbs[] = \implode($relativePath);
+			// The passed-in path is itself an array of pieces of a single file
+			// or folder name. That is done when the file or folder name contains
+			// both single and double quotes. The pieces of the file or folder
+			// name need to be passed through to openFile still in array form.
+			$breadCrumbsForOpenFile[] = $relativePath;
+		} else {
+			// The passed-in path is a single string representing the path to
+			// the item to be opened. Each folder along the way is delimited
+			// by "/". Explode it into an array of items to be opened.
+			$breadCrumbs = \explode('/', \ltrim($relativePath, '/'));
+			$breadCrumbsForOpenFile = $breadCrumbs;
 		}
 
-		$breadCrumbs = \explode('/', \ltrim($relativePath, '/'));
-
-		foreach ($breadCrumbs as $breadCrumb) {
+		foreach ($breadCrumbsForOpenFile as $breadCrumb) {
 			$pageObject->openFile($breadCrumb, $this->getSession());
 			$pageObject->waitTillPageIsLoaded($this->getSession());
 		}
 
 		if ($fileOrFolder !== "folder") {
-			// Pop the file name off the end of the breadcrumbs
+			// Pop the file name off the end of the array of breadcrumbs
 			\array_pop($breadCrumbs);
 		}
 


### PR DESCRIPTION
## Description
1) Adjust the PHPdoc and method name so future readers will realize easily that it can be used to open a file or a folder.
2) Refactor so that if you pass in a path and say it is to a file, it will first navigate into any folders in the path and then open the file.
3) Make sure to remember the correct folders that were navigated into.

## Related Issue
#34254

## Motivation and Context
``files_texteditor`` webUI acceptance tests are failing. Make them great again.

## How Has This Been Tested?
Local runs of ``files_texteditor`` webUI acceptance tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
