### PR TITLE
[stable10] Backport of Fixing email sent to recipient using recipient…

### DIFF
--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -164,8 +164,16 @@ class MailNotifications {
 			$filename = $filter->getFile();
 			$link = $filter->getLink();
 
-			$subject = (string) $this->l->t('%s shared »%s« with you', [$this->senderDisplayName, $unescapedFilename]);
-			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, null, 'internal');
+			$recipientLanguageCode = $this->config->getUserValue($recipient->getUID(), 'core', 'lang', 'en');
+			$recipientL10N = \OC::$server->getL10N('core');
+			if ($this->l->getLanguageCode() !== $recipientLanguageCode) {
+				$recipientL10N = \OC::$server->getL10N('core', $recipientLanguageCode);
+				$subject = (string)$recipientL10N->t('%s shared »%s« with you', [$this->senderDisplayName, $unescapedFilename]);
+			} else {
+				$subject = (string)$this->l->t('%s shared »%s« with you', [$this->senderDisplayName, $unescapedFilename]);
+			}
+
+			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, null, 'internal', $recipientL10N);
 
 			// send it out now
 			try {


### PR DESCRIPTION
…s language code

The recipient, internal to owncloud instance should
recieve the email from the sender ( internal to owncloud )
in the language chosen by the recipient.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
While sharing the file/folders to internal user(s), the notification mail sent should be based on the language configured for recipient(s). Currently that is not the case. ownCloud instance is aware of the internal users. Hence this change tries to grab the recipients language stored in the preferences table. And then tries to compare with the senders setting. If they are different, then recipients language is used.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/33397

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Try to use recipients language while sending notification mails. At least this should be for the internal users of oC instance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- As admin user create another user `user1`
- Configure oC instance to send emails ( smtp email settings configuration )
- Now change the language setting of `user1` to `Castellano`
- In the settings page of `admin` set the option `Allow users to send mail notification for shared files`
- Create a new folder `foo` and share to `user1`
- the admin user would see `notify by email` button. Click it.
- An email would arrive in the language opted by `user1`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
