### PR TITLE
test create folder/file in a locked folder

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -1,0 +1,61 @@
+@api
+Feature: lock folders
+
+  Background:
+    Given user "user0" has been created with default attributes
+
+  Scenario Outline: upload to a locked folder
+    Given using <dav-path> DAV path
+    And user "user0" has locked folder "FOLDER" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "/FOLDER/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "423"
+    And as "user0" file "/FOLDER/textfile.txt" should not exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  Scenario Outline: upload to a subfolder of a locked folder
+    Given using <dav-path> DAV path
+    And user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "/PARENT/CHILD/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "423"
+    And as "user0" file "/PARENT/CHILD/textfile.txt" should not exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+      
+  Scenario Outline: create folder in a locked folder
+    Given using <dav-path> DAV path
+    And user "user0" has locked folder "FOLDER" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" creates folder "/FOLDER/new-folder" using the WebDAV API
+    Then the HTTP status code should be "423"
+    And as "user0" folder "/FOLDER/new-folder" should not exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  Scenario Outline: create folder in a subfolder of a locked folder
+    Given using <dav-path> DAV path
+    And user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" creates folder "/PARENT/CHILD/new-folder" using the WebDAV API
+    Then the HTTP status code should be "423"
+    And as "user0" folder "/PARENT/CHILD/new-folder" should not exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |


### PR DESCRIPTION
## Description
some basic tests for operations inside a locked folder that litmus did not catch

## Related Issue
https://github.com/owncloud/core/issues/34239

## Motivation and Context
see https://github.com/owncloud/core/issues/33848 and https://github.com/owncloud/core/pull/34171

## How Has This Been Tested?
without the fix in #34171 the test fail, now they are passing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
