### PR TITLE
[OCM] Make webdav URL absolute according to spec

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/OcmController.php
+++ b/apps/federatedfilesharing/lib/Controller/OcmController.php
@@ -423,7 +423,7 @@ class OcmController extends Controller {
 	 */
 	protected function getProtocols() {
 		return [
-			'webdav' => '/public.php/webdav/'
+			'webdav' => $this->urlGenerator->getAbsoluteURL('/public.php/webdav/')
 		];
 	}
 


### PR DESCRIPTION
## Description
Return an absolute URL for OCM WebDav discovery endpoint and change the storage to work with absolute discovery URLs

Note: It makes OCM-based sharing in 10.1 incompatible with 10.2+ without patching apps/files_sharing/lib/External/Storage.php

## Related Issue
- Fixes https://github.com/owncloud/core/issues/34631

## Motivation and Context
To comply with OCM 1.0.0-proposal1 spec

## How Has This Been Tested?
open URL owncloud.tld/ocm-provider/
#### expected 
```
{"enabled":true,"apiVersion":"1.0-proposal1",
"endPoint":"http:\/\/owncloud.tld\/index.php\/apps\/federatedfilesharing",
"shareTypes":[{"name":"file",
"protocols":{"webdav":"http:\/\/owncloud.tld\/public.php\/webdav\/"}}]}
```

#### actual
```
{"enabled":true,"apiVersion":"1.0-proposal1",
"endPoint":"http:\/\/owncloud.tld\/index.php\/apps\/federatedfilesharing",
"shareTypes":[{"name":"file",
"protocols":{"webdav":"\/public.php\/webdav\/"}}]}
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:

- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
