### PR TITLE
Reorder query parts and do not reuse query builder instance

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -576,15 +576,18 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares) {
 		$shares = [];
-		$qb = $this->dbConnection->getQueryBuilder();
 
 		$nodeIdsChunks = \array_chunk($nodeIDs, 100);
 		foreach ($nodeIdsChunks as $nodeIdsChunk) {
-			// In federates sharing currently we have only one share_type_remote
+			$qb = $this->dbConnection->getQueryBuilder();
 			$qb->select('*')
 				->from($this->shareTable);
 
+			// In federated sharing currently we have only one share_type_remote
 			$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_REMOTE)));
+
+			$qb->andWhere($qb->expr()->in('file_source', $qb->createParameter('file_source_ids')));
+			$qb->setParameter('file_source_ids', $nodeIdsChunk, IQueryBuilder::PARAM_INT_ARRAY);
 
 			/**
 			 * Reshares for this user are shares where they are the owner.
@@ -610,9 +613,6 @@ class FederatedShareProvider implements IShareProvider {
 					)
 				);
 			}
-
-			$qb->andWhere($qb->expr()->in('file_source', $qb->createParameter('file_source_ids')));
-			$qb->setParameter('file_source_ids', $nodeIdsChunk, IQueryBuilder::PARAM_INT_ARRAY);
 
 			$qb->orderBy('id');
 


### PR DESCRIPTION
## Description
1. Reusing query builder makes it to append additional conditions to the old query
2. Moving `file_source` closer to the WHERE should slightly improve performance as this field has a single index on it.

## Related Issue
https://github.com/owncloud/enterprise/issues/3111

## Motivation and Context
Improves DB performance for OCA\DAV\Connector\Sabre\SharesPlugin DAV plugin when there are many federated shares

## How Has This Been Tested?

I tried to run `getAllSharesBy` with 300+ fileIds:
### 1st iteration (no params has been bound yet):
$qb->getParameters()  []

### 2nd iteration
$qb->getParameters() = {array} [4]
 dcValue1 = 6
 dcValue2 = "D"
 dcValue3 = "D"
 file_source_ids = {array} [100]

### 3rd iteration
dcValue1 = 6
dcValue2 = "D"
dcValue3 = "D"
file_source_ids = {array} [100]
dcValue4 = 6
dcValue5 = "D"
dcValue6 = "D"

### 4th iteration
dcValue1 = 6
dcValue2 = "D"
dcValue3 = "D"
file_source_ids = {array} [100]
dcValue4 = 6
dcValue5 = "D"
dcValue6 = "D"
dcValue7 = 6
dcValue8 = "D"
dcValue9 = "D"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
