### PR TITLE
Hide lock token in public webdav responses

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -94,7 +94,7 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 	);
 
 	return new \OC\Files\View($ownerView->getAbsolutePath($path));
-});
+}, true);
 
 $server->addPlugin(new \OCA\DAV\Connector\Sabre\AutorenamePlugin());
 $server->addPlugin($linkCheckPlugin);

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -95,12 +95,14 @@ class ServerFactory {
 	 * @param string $requestUri
 	 * @param BackendInterface $authBackend
 	 * @param callable $viewCallBack callback that should return the view for the dav endpoint
+	 * @param bool $isPublicAccess whether DAV is accessed through a public link
 	 * @return Server
 	 */
 	public function createServer($baseUri,
 								 $requestUri,
 								 BackendInterface $authBackend,
-								 callable $viewCallBack) {
+								 callable $viewCallBack,
+								 $isPublicAccess = false) {
 		// Fire up server
 		$objectTree = new \OCA\DAV\Connector\Sabre\ObjectTree();
 		$server = new \OCA\DAV\Connector\Sabre\Server($objectTree);
@@ -118,7 +120,7 @@ class ServerFactory {
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
-		$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true, $this->timeFactory)));
+		$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess)));
 
 		if (BrowserErrorPagePlugin::isBrowserRequest($this->request)) {
 			$server->addPlugin(new BrowserErrorPagePlugin());

--- a/apps/dav/lib/Files/FileLocksBackend.php
+++ b/apps/dav/lib/Files/FileLocksBackend.php
@@ -39,11 +39,14 @@ class FileLocksBackend implements BackendInterface {
 	private $useV1;
 	/** @var ITimeFactory */
 	private $timeFactory;
+	/** @var bool */
+	private $hideLockTokenInList;
 
-	public function __construct($tree, $useV1, $timeFactory) {
+	public function __construct($tree, $useV1, $timeFactory, $hideLockTokenInList = false) {
 		$this->tree = $tree;
 		$this->useV1 = $useV1;
 		$this->timeFactory = $timeFactory;
+		$this->hideLockTokenInList = $hideLockTokenInList;
 	}
 
 	/**
@@ -130,7 +133,10 @@ class FileLocksBackend implements BackendInterface {
 					$lockInfo->uri = "files/$uid/$fileName";
 				}
 			}
-			$lockInfo->token = $lock->getToken();
+
+			if (!$this->hideLockTokenInList) {
+				$lockInfo->token = $lock->getToken();
+			}
 			$lockInfo->created = $lock->getCreatedAt();
 			$lockInfo->depth = $lock->getDepth();
 			$lockInfo->owner = $lock->getOwner();

--- a/apps/dav/tests/unit/Files/FileLocksBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileLocksBackendTest.php
@@ -253,14 +253,14 @@ class FileLocksBackendTest extends TestCase {
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$timeFactory->method('getTime')->willReturn(self::CURRENT_TIME);
 
-		$this->plugin = new FileLocksBackend($this->tree, true, $timeFactory);
+		$this->plugin = new FileLocksBackend($this->tree, true, $timeFactory, true);
 
 		// "/public/share" is a public share
 		// "/public" has the locks
 		// we query "public.php/webdav/sub" inside that share
 		$locks = $this->plugin->getLocks($lockPluginGetLockPath, true);
 		$lockInfo = new LockInfo();
-		$lockInfo->token = '123-456-7890';
+		$lockInfo->token = null; // hidden in public endpoint
 		$lockInfo->scope = LockInfo::EXCLUSIVE;
 		$lockInfo->uri = $responseLockRoot;
 		$lockInfo->owner = 'Alice Wonder';

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -59,3 +59,19 @@ Feature: lock folders
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
+
+  Scenario Outline: lockdiscovery of a locked folder
+    Given using <dav-path> DAV path
+    And user "user0" has created a public link share of folder "PARENT" with change permission
+    And user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+      | d:lockdiscovery |
+    Then the value of the item "//d:lockroot/d:href" in the response should match "<lock-root>"
+    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:[a-z0-9-]+$/"
+    Examples:
+      | dav-path | lock-scope | lock-root                                             |
+      | old      | shared     | /%base_path%\/remote.php\/webdav\/PARENT$/            |
+      | old      | exclusive  | /%base_path%\/remote.php\/webdav\/PARENT$/            |
+      | new      | shared     | /%base_path%\/remote.php\/dav\/files\/user0\/PARENT$/ |
+      | new      | exclusive  | /%base_path%\/remote.php\/dav\/files\/user0\/PARENT$/ |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -83,9 +83,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:lockroot/d:href" in the response should be ""
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -98,9 +96,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:lockroot/d:href" in the response should be ""
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -113,9 +109,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:lockroot/d:href" in the response should be ""
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -128,9 +122,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:lockroot/d:href" in the response should be ""
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -143,9 +135,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:lockroot/d:href" in the response should be ""
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -158,9 +148,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD\/child.txt$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:lockroot/d:href" in the response should be ""
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -173,9 +161,8 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:lockroot/d:href" in the response should be ""
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+
     Examples:
       | lock-scope |
       | shared     |
@@ -188,7 +175,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -201,7 +188,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -214,7 +201,7 @@ Feature: persistent-locking in case of a public link
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
-    And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
     Examples:
       | lock-scope |
       | shared     |
@@ -230,10 +217,8 @@ Feature: persistent-locking in case of a public link
       | d:lockdiscovery |
     Then the value of the item "//d:activelock[1]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the value of the item "//d:activelock[2]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be ""
-    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
 
   Scenario: lockdiscovery subfolder of public link when root is locked by user and subfolder is locked by public
     Given user "user0" has created a public link share of folder "PARENT" with change permission
@@ -245,10 +230,8 @@ Feature: persistent-locking in case of a public link
       | d:lockdiscovery |
     Then the value of the item "//d:activelock[1]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the value of the item "//d:activelock[2]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
-    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be ""
-    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
 
   Scenario: lockdiscovery root of public link when user has locked folder above public link and public has locked root of public link
     Given user "user0" has created a public link share of folder "PARENT/CHILD" with change permission
@@ -260,10 +243,8 @@ Feature: persistent-locking in case of a public link
       | d:lockdiscovery |
     Then the value of the item "//d:activelock[1]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the value of the item "//d:activelock[2]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be ""
-    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
 
   Scenario: lockdiscovery subfolder of public link when user has locked folder above public link and public has locked subfolder of public link
     Given user "user0" has created a public link share of folder "PARENT/CHILD" with change permission
@@ -276,10 +257,8 @@ Feature: persistent-locking in case of a public link
       | d:lockdiscovery |
     Then the value of the item "//d:activelock[1]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the value of the item "//d:activelock[2]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/GRANDCHILD$/"
-    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be ""
-    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
 
   Scenario: lockdiscovery file in public link when user has locked folder above public link and public has locked file inside of public link
     Given user "user0" has created a public link share of folder "PARENT/CHILD" with change permission
@@ -291,7 +270,5 @@ Feature: persistent-locking in case of a public link
       | d:lockdiscovery |
     Then the value of the item "//d:activelock[1]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the value of the item "//d:activelock[2]/d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/child.txt$/"
-    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
-    #see https://github.com/owncloud/core/pull/34229#issuecomment-457186641
-    #And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be ""
-    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should match "/^opaquelocktoken:/"
+    And the value of the item "//d:activelock[1]/d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the value of the item "//d:activelock[2]/d:locktoken/d:href" in the response should be "opaquelocktoken:"


### PR DESCRIPTION
## Description
See https://github.com/owncloud/core/pull/34229#issuecomment-457186641 and https://github.com/owncloud/core/pull/34229#issuecomment-457225278.

## Related Issue
- Fixes https://github.com/owncloud/core/pull/34229#issuecomment-457186641 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test, checking that lock discovery never contains a token when queried through public link.
Note that due to https://github.com/sabre-io/dav/pull/1130 not being available yet to OC, instead of having a missing "locktoken" element you'll see one with the value "opaquetoken:" followed by nothing.
This was deemed non-critical in a discussion with @DeepDiver1975 and will solve itself in the next Sabre DAV release + update.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
