### PR TITLE
Unskip acceptance test for issue-23151

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -105,25 +105,40 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  @skip @issue-23151
+  @issue-23151
+  # This scenario deletes many files as close together in time as the test can run.
+  # On a very slow system, the file deletes might all happen in different seconds.
+  # But on "reasonable" systems, some of the files will be deleted in the same second,
+  # thus testing the required behavior.
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes
     And user "user0" has created folder "/folderA"
     And user "user0" has created folder "/folderB"
+    And user "user0" has created folder "/folderC"
+    And user "user0" has created folder "/folderD"
     And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
     And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-    When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
-    And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
-    And user "user0" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
-    And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+    And user "user0" has copied file "/textfile0.txt" to "/folderC/textfile0.txt"
+    And user "user0" has copied file "/textfile0.txt" to "/folderD/textfile0.txt"
+    When user "user0" deletes these files without delays using the WebDAV API
+      | /folderA/textfile0.txt |
+      | /folderB/textfile0.txt |
+      | /folderC/textfile0.txt |
+      | /folderD/textfile0.txt |
+      | /textfile0.txt         |
+    # When issue-23151 is fixed, uncomment these lines. They should pass reliably.
+    #Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+    #And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+    #And as "user0" the folder with original path "/folderC/textfile0.txt" should exist in trash
+    #And as "user0" the folder with original path "/folderD/textfile0.txt" should exist in trash
     And as "user0" the folder with original path "/textfile0.txt" should exist in trash
     Examples:
       | dav-path |
       | old      |
       | new      |
 
+  # Note: the underlying acceptance test code ensures that each delete step is separated by a least 1 second
   Scenario Outline: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1643,6 +1643,33 @@ trait WebDav {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" (?:deletes|unshares) these (?:files|folders|entries) without delays using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table of files or folders to delete
+	 *
+	 * @return void
+	 */
+	public function userDeletesFilesFoldersWithoutDelays($user, $table) {
+		foreach ($table->getTable() as $entry) {
+			$entryName = $entry[0];
+			$this->response = $this->makeDavRequest($user, 'DELETE', $entryName, []);
+		}
+		$this->lastUploadDeleteTime = \time();
+	}
+
+	/**
+	 * @When /^the user (?:deletes|unshares) these (?:files|folders|entries) without delays using the WebDAV API$/
+	 *
+	 * @param TableNode $table of files or folders to delete
+	 *
+	 * @return void
+	 */
+	public function theUserDeletesFilesFoldersWithoutDelays($table) {
+		$this->userDeletesFilesFoldersWithoutDelays($this->getCurrentUser(), $table);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" on "(LOCAL|REMOTE)" (?:deletes|unshares) (?:file|folder) "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" on "(LOCAL|REMOTE)" has (?:deleted|unshared) (?:file|folder) "([^"]*)"$/
 	 *


### PR DESCRIPTION
## Description
1) Modify the test scenario so it deletes more files (5) of the same name as close together in time as possible. Then, for example, each API request takes as much as 0.7 seconds, we could have files deleted at time like:
```
12:34:50.9
12:34:51.6
12:34:52.3
12:34:53.0
12:34:53.7
```
and there will be some files that have a delete time in the same second.
(If we make and delete more files, we could extend that to 0.8 or 0.9 seconds, but this seems enough for now)

2) Comment out the results that are (mostly) not working now.

3) Leave notes to try and help the person who fixes the bug.

## Related Issue
https://github.com/owncloud/core/issues/23151
Working towards the "new" way that way provide acceptance test scenarios for bugs.
https://github.com/owncloud/QA/issues/601

## How Has This Been Tested?
CI and multiple local acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
