### PR TITLE
Update PR template to include DB changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,9 +48,10 @@ Please set the following labels:
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
+- [ ] Database schema changes (next release will require increase of minor version instead of patch)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Technical debt
-- [ ] Tests
+- [ ] Tests only (no source changes)
 
 ## Checklist:
 <!-- Tick the checkboxes when done. -->


### PR DESCRIPTION
Since for [Semver](https://central.owncloud.org/t/owncloud-core-switching-to-semver-apps-need-re-release/17054) we will want to increase the minor version component instead of patch, I've added a checkbox in case there are database changes.

In a broader scope I wonder if we should remove those checkboxes and rely on labels instead, which would make it easier to sort or even script.
