### PR TITLE
Fixup preview issues with trashbin/versions

### DIFF
--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -52,12 +52,12 @@ try {
 	/** @var \OCP\Files\Folder $trashFolder */
 	$trashFolder = $userFolder->getParent()->get('files_trashbin/files');
 	/** @var \OCP\Files\File | \OCP\Files\IPreviewNode $file */
-	$file = $trashFolder->get($file);
+	$fileNode = $trashFolder->get($file);
 
-	if ($file->getType() === \OCP\Files\FileInfo::TYPE_FOLDER) {
+	if ($fileNode->getType() === \OCP\Files\FileInfo::TYPE_FOLDER) {
 		$mimetype = 'httpd/unix-directory';
 	} else {
-		$pathInfo = \pathinfo(\ltrim($file->getName(), '/'));
+		$pathInfo = \pathinfo(\ltrim($file, '/'));
 		$fileName = $pathInfo['basename'];
 		// if in root dir
 		if ($pathInfo['dirname'] === '.') {
@@ -70,7 +70,7 @@ try {
 		$mimetype = \OC::$server->getMimeTypeDetector()->detectPath($fileName);
 	}
 
-	$image = $file->getThumbnail([
+	$image = $fileNode->getThumbnail([
 		'x' => $maxX,
 		'y' => $maxY,
 		'scalingup' => $scalingUp,

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -595,7 +595,7 @@ class Trashbin {
 
 		// Single-File Hooks
 		foreach ($filePaths as $path) {
-			self::emitTrashbinPreDelete($path);
+			self::emitTrashbinPreDelete($user, $path);
 		}
 
 		// actual file deletion
@@ -608,7 +608,7 @@ class Trashbin {
 
 		// Single-File Hooks
 		foreach ($filePaths as $path) {
-			self::emitTrashbinPostDelete($path);
+			self::emitTrashbinPostDelete($user, $path);
 		}
 
 		$view->mkdir('files_trashbin');
@@ -619,18 +619,30 @@ class Trashbin {
 
 	/**
 	 * wrapper function to emit the 'preDelete' hook of \OCP\Trashbin before a file is deleted
+	 *
+	 * @param string $uid
 	 * @param string $path
 	 */
-	protected static function emitTrashbinPreDelete($path) {
-		\OC_Hook::emit('\OCP\Trashbin', 'preDelete', ['path' => $path]);
+	protected static function emitTrashbinPreDelete($uid, $path) {
+		\OC_Hook::emit(
+			'\OCP\Trashbin',
+			'preDelete',
+			['path' => $path, 'user'=> $uid]
+		);
 	}
 
 	/**
 	 * wrapper function to emit the 'delete' hook of \OCP\Trashbin after a file has been deleted
+	 *
+	 * @param string $uid
 	 * @param string $path
 	 */
-	protected static function emitTrashbinPostDelete($path) {
-		\OC_Hook::emit('\OCP\Trashbin', 'delete', ['path' => $path]);
+	protected static function emitTrashbinPostDelete($uid, $path) {
+		\OC_Hook::emit(
+			'\OCP\Trashbin',
+			'delete',
+			['path' => $path, 'user'=> $uid]
+		);
 	}
 
 	/**
@@ -661,9 +673,9 @@ class Trashbin {
 		} else {
 			$size += $view->filesize('/files_trashbin/files/' . $file);
 		}
-		self::emitTrashbinPreDelete('/files_trashbin/files/' . $file);
+		self::emitTrashbinPreDelete($user, "/files_trashbin/files/$file");
 		$view->unlink('/files_trashbin/files/' . $file);
-		self::emitTrashbinPostDelete('/files_trashbin/files/' . $file);
+		self::emitTrashbinPostDelete($user, "/files_trashbin/files/$file");
 
 		return $size;
 	}

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -2,7 +2,7 @@
 /**
  * @author Roeland Jago Douma <rullzer@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
- * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
@@ -24,6 +24,7 @@
 namespace OCA\Files_Versions\AppInfo;
 
 use OCA\Files_Versions\Expiration;
+use OCA\Files_Versions\FileHelper;
 use OCP\AppFramework\App;
 
 class Application extends App {
@@ -41,10 +42,20 @@ class Application extends App {
 		 * Register expiration
 		 */
 		$container->registerService('Expiration', function ($c) {
-			return  new Expiration(
+			return new Expiration(
 				$c->query('ServerContainer')->getConfig(),
 				$c->query('OCP\AppFramework\Utility\ITimeFactory')
 			);
 		});
+
+		/*
+		 * Register FileHelper
+		 */
+		$container->registerService(
+			'FileHelper',
+			function ($c) {
+				return new FileHelper();
+			}
+		);
 	}
 }

--- a/apps/files_versions/lib/FileHelper.php
+++ b/apps/files_versions/lib/FileHelper.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Versions;
+
+use OC\Files\Filesystem;
+use OC\Files\View;
+
+class FileHelper {
+	const VERSIONS_RELATIVE_PATH = '/files_versions';
+
+	/**
+	 * Create recursively missing directories inside of files_versions
+	 * that match the given path to a file.
+	 *
+	 * @param View $view view on data/user/
+	 * @param string $path to a file, relative to the user's "files" folder
+	 *
+	 * @return void
+	 */
+	public function createMissingDirectories(View $view, $path) {
+		$dirName = Filesystem::normalizePath(\dirname($path));
+		$dirParts = \explode('/', $dirName);
+		$dir = self::VERSIONS_RELATIVE_PATH;
+		foreach ($dirParts as $part) {
+			$dir = \rtrim($dir, '/') . '/' . $part;
+			if (!$view->file_exists($dir)) {
+				$view->mkdir($dir);
+			}
+		}
+	}
+
+	/**
+	 * Get current size of all versions for a given user
+	 *
+	 * @param string $uid user who owns the versions
+	 *
+	 * @return int
+	 */
+	public function getVersionsSize($uid) {
+		$view = $this->getUserView($uid);
+		$fileInfo = $view->getFileInfo(self::VERSIONS_RELATIVE_PATH);
+		return isset($fileInfo['size']) ? $fileInfo['size'] : 0;
+	}
+
+	/**
+	 * Returns all stored file versions from a given user
+	 *
+	 * @param string $uid id of the user
+	 *
+	 * @return string[][]
+	 * [
+	 *   'all' => all versions sorted by age,
+	 *    'by_file' => all versions sorted by filename
+	 * ]
+	 */
+	public function getAllVersions($uid) {
+		$view = $this->getUserView($uid);
+		$dirs = [self::VERSIONS_RELATIVE_PATH];
+		$versions = [];
+
+		while (!empty($dirs)) {
+			$dir = \array_pop($dirs);
+			$files = $view->getDirectoryContent($dir);
+			foreach ($files as $file) {
+				$filePath = $dir . '/' . $file->getName();
+				if ($file->getType() === 'dir') {
+					\array_push($dirs, $filePath);
+				} else {
+					$versionInfo = $this->getPathAndRevision($filePath);
+					$relPathStart = \strlen(Storage::VERSIONS_ROOT);
+					$relPath = \substr($versionInfo['path'], $relPathStart);
+					$key = $versionInfo['revision'] . '#' . $relPath;
+					$versions[$key] = [
+						'path' => $relPath,
+						'timestamp' => $versionInfo['revision']
+					];
+				}
+			}
+		}
+
+		// newest version first
+		\krsort($versions);
+
+		$result = [];
+		foreach ($versions as $key => $value) {
+			$size = $view->filesize(Storage::VERSIONS_ROOT . '/' . $value['path'] . '.v' . $value['timestamp']);
+			$filename = $value['path'];
+
+			$result['all'][$key]['version'] = $value['timestamp'];
+			$result['all'][$key]['path'] = $filename;
+			$result['all'][$key]['size'] = $size;
+
+			$result['by_file'][$filename][$key]['version'] = $value['timestamp'];
+			$result['by_file'][$filename][$key]['path'] = $filename;
+			$result['by_file'][$filename][$key]['size'] = $size;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Split /path/filename.ext.v1234567
+	 * into [ 'path' => '/path/filename.ext', 'revision' => '1234567' ]
+	 *
+	 * @param string $versionPath
+	 *
+	 * @return array
+	 */
+	public function getPathAndRevision($versionPath) {
+		\preg_match_all(
+			'#(?<path>.*)\.v(?<timestamp>\d+)$#',
+			$versionPath,
+			$versionInfo
+		);
+		return [
+			'path' => $versionInfo['path'][0],
+			'revision' => $versionInfo['timestamp'][0]
+		];
+	}
+
+	/**
+	 * @param string $uid
+	 *
+	 * @return View
+	 *
+	 * @throws \Exception
+	 */
+	public function getUserView($uid) {
+		return new View("/$uid");
+	}
+
+	/**
+	 * @param string $uid
+	 *
+	 * @return View
+	 *
+	 * @throws \Exception
+	 */
+	public function getFilesView($uid) {
+		return new View("/$uid/files");
+	}
+
+	/**
+	 * @param string $uid
+	 *
+	 * @return View
+	 *
+	 * @throws \Exception
+	 */
+	public function getVersionsView($uid) {
+		return new View("/$uid" . self::VERSIONS_RELATIVE_PATH);
+	}
+}

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -410,10 +410,10 @@ class Storage {
 	 * get a list of all available versions of a file in descending chronological order
 	 * @param string $uid user id from the owner of the file
 	 * @param string $filename file to find versions of, relative to the user files dir
-	 * @param string $userFullPath
+	 *
 	 * @return array versions newest version first
 	 */
-	public static function getVersions($uid, $filename, $userFullPath = '') {
+	public static function getVersions($uid, $filename) {
 		$versions = [];
 		if (empty($filename)) {
 			return $versions;
@@ -447,11 +447,7 @@ class Storage {
 						$key = $timestamp . '#' . $filename;
 						$versions[$key]['version'] = $timestamp;
 						$versions[$key]['humanReadableTimestamp'] = self::getHumanReadableTimestamp($timestamp);
-						if (empty($userFullPath)) {
-							$versions[$key]['preview'] = '';
-						} else {
-							$versions[$key]['preview'] = \OCP\Util::linkToRoute('core_ajax_versions_preview', ['file' => $userFullPath, 'version' => $timestamp]);
-						}
+						$versions[$key]['preview'] = '';
 						$versions[$key]['path'] = Filesystem::normalizePath($pathinfo['dirname'] . '/' . $filename);
 						$versions[$key]['name'] = $versionedFile;
 						$versions[$key]['size'] = $view->filesize($dir . '/' . $entryName);

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -236,25 +236,16 @@ class Storage {
 			$versions = self::getVersions($uid, $filename);
 			if (!empty($versions)) {
 				foreach ($versions as $v) {
-					\OC_Hook::emit(
-						'\OCP\Versions',
-						'preDelete',
-						[
-							'user' => $uid,
-							'path' => $path . $v['version'],
-							'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED
-						]
-					);
+					$hookData = 						[
+						'user' => $uid,
+						'path' => $path . $v['version'],
+						'original_path' => $path,
+						'deleted_revision' => $v['version'],
+						'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED
+					];
+					\OC_Hook::emit('\OCP\Versions', 'preDelete', $hookData);
 					self::deleteVersion($view, $filename . '.v' . $v['version']);
-					\OC_Hook::emit(
-						'\OCP\Versions',
-						'delete',
-						[
-							'user' => $uid,
-							'path' => $path . $v['version'],
-							'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED
-						]
-					);
+					\OC_Hook::emit('\OCP\Versions', 'delete', $hookData);
 				}
 			}
 		}
@@ -492,25 +483,16 @@ class Storage {
 		$view = new View('/' . $uid . '/files_versions');
 		if (!empty($toDelete)) {
 			foreach ($toDelete as $version) {
-				\OC_Hook::emit(
-					'\OCP\Versions',
-					'preDelete',
-					[
-						'user' => $uid,
-						'path' => $version['path'].'.v'.$version['version'],
-						'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT
-					]
-				);
+				$hookData = [
+					'user' => $uid,
+					'path' => $version['path'] . '.v' . $version['version'],
+					'original_path' => $version['path'],
+					'deleted_revision' => $version['version'],
+					'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT
+				];
+				\OC_Hook::emit('\OCP\Versions', 'preDelete', $hookData);
 				self::deleteVersion($view, $version['path'] . '.v' . $version['version']);
-				\OC_Hook::emit(
-					'\OCP\Versions',
-					'delete',
-					[
-						'user' => $uid,
-						'path' => $version['path'].'.v'.$version['version'],
-						'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT
-					]
-				);
+				\OC_Hook::emit('\OCP\Versions', 'delete', $hookData);
 			}
 		}
 	}
@@ -727,25 +709,17 @@ class Storage {
 			}
 
 			foreach ($toDelete as $key => $path) {
-				\OC_Hook::emit(
-					'\OCP\Versions',
-					'preDelete',
-					[
-						'user' => $uid,
-						'path' => $path,
-						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
-					]
-				);
+				$versionInfo = self::getFileHelper()->getPathAndRevision($path);
+				$hookData = [
+					'user' => $uid,
+					'path' => $path,
+					'original_path' => $versionInfo['path'],
+					'deleted_revision' => $versionInfo['revision'],
+					'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
+				];
+				\OC_Hook::emit('\OCP\Versions', 'preDelete', $hookData);
 				self::deleteVersion($versionsFileview, $path);
-				\OC_Hook::emit(
-					'\OCP\Versions',
-					'delete',
-					[
-						'user' => $uid,
-						'path' => $path,
-						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
-					]
-				);
+				\OC_Hook::emit('\OCP\Versions', 'delete', $hookData);
 				unset($allVersions[$key]); // update array with the versions we keep
 				\OCP\Util::writeLog('files_versions', "Expire: " . $path, \OCP\Util::INFO);
 			}
@@ -760,25 +734,16 @@ class Storage {
 			\reset($allVersions);
 			while ($availableSpace < 0 && $i < $numOfVersions) {
 				$version = \current($allVersions);
-				\OC_Hook::emit(
-					'\OCP\Versions',
-					'preDelete',
-					[
-						'user' => $uid,
-						'path' => $version['path'].'.v'.$version['version'],
-						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
-					]
-				);
+				$hookData = [
+					'user' => $uid,
+					'path' => $version['path'].'.v'.$version['version'],
+					'original_path' => $version['path'],
+					'deleted_revision' => $version['version'],
+					'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
+				];
+				\OC_Hook::emit('\OCP\Versions', 'preDelete', $hookData);
 				self::deleteVersion($versionsFileview, $version['path'] . '.v' . $version['version']);
-				\OC_Hook::emit(
-					'\OCP\Versions',
-					'delete',
-					[
-						'user' => $uid,
-						'path' => $version['path'].'.v'.$version['version'],
-						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
-					]
-				);
+				\OC_Hook::emit('\OCP\Versions', 'delete', $hookData);
 				\OCP\Util::writeLog('files_versions', 'running out of space! Delete oldest version: ' . $version['path'].'.v'.$version['version'], \OCP\Util::INFO);
 				$versionsSize -= $version['size'];
 				$availableSpace += $version['size'];

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -248,9 +248,25 @@ class Storage {
 			$versions = self::getVersions($uid, $filename);
 			if (!empty($versions)) {
 				foreach ($versions as $v) {
-					\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path . $v['version'], 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED]);
+					\OC_Hook::emit(
+						'\OCP\Versions',
+						'preDelete',
+						[
+							'user' => $uid,
+							'path' => $path . $v['version'],
+							'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED
+						]
+					);
 					self::deleteVersion($view, $filename . '.v' . $v['version']);
-					\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path . $v['version'], 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED]);
+					\OC_Hook::emit(
+						'\OCP\Versions',
+						'delete',
+						[
+							'user' => $uid,
+							'path' => $path . $v['version'],
+							'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED
+						]
+					);
 				}
 			}
 		}
@@ -492,9 +508,25 @@ class Storage {
 		$view = new View('/' . $uid . '/files_versions');
 		if (!empty($toDelete)) {
 			foreach ($toDelete as $version) {
-				\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $version['path'].'.v'.$version['version'], 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
+				\OC_Hook::emit(
+					'\OCP\Versions',
+					'preDelete',
+					[
+						'user' => $uid,
+						'path' => $version['path'].'.v'.$version['version'],
+						'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT
+					]
+				);
 				self::deleteVersion($view, $version['path'] . '.v' . $version['version']);
-				\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $version['path'].'.v'.$version['version'], 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
+				\OC_Hook::emit(
+					'\OCP\Versions',
+					'delete',
+					[
+						'user' => $uid,
+						'path' => $version['path'].'.v'.$version['version'],
+						'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT
+					]
+				);
 			}
 		}
 	}
@@ -762,9 +794,25 @@ class Storage {
 			}
 
 			foreach ($toDelete as $key => $path) {
-				\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path, 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+				\OC_Hook::emit(
+					'\OCP\Versions',
+					'preDelete',
+					[
+						'user' => $uid,
+						'path' => $path,
+						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
+					]
+				);
 				self::deleteVersion($versionsFileview, $path);
-				\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path, 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+				\OC_Hook::emit(
+					'\OCP\Versions',
+					'delete',
+					[
+						'user' => $uid,
+						'path' => $path,
+						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
+					]
+				);
 				unset($allVersions[$key]); // update array with the versions we keep
 				\OCP\Util::writeLog('files_versions', "Expire: " . $path, \OCP\Util::INFO);
 			}
@@ -779,9 +827,25 @@ class Storage {
 			\reset($allVersions);
 			while ($availableSpace < 0 && $i < $numOfVersions) {
 				$version = \current($allVersions);
-				\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $version['path'].'.v'.$version['version'], 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+				\OC_Hook::emit(
+					'\OCP\Versions',
+					'preDelete',
+					[
+						'user' => $uid,
+						'path' => $version['path'].'.v'.$version['version'],
+						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
+					]
+				);
 				self::deleteVersion($versionsFileview, $version['path'] . '.v' . $version['version']);
-				\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $version['path'].'.v'.$version['version'], 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+				\OC_Hook::emit(
+					'\OCP\Versions',
+					'delete',
+					[
+						'user' => $uid,
+						'path' => $version['path'].'.v'.$version['version'],
+						'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED
+					]
+				);
 				\OCP\Util::writeLog('files_versions', 'running out of space! Delete oldest version: ' . $version['path'].'.v'.$version['version'], \OCP\Util::INFO);
 				$versionsSize -= $version['size'];
 				$availableSpace += $version['size'];

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -236,7 +236,7 @@ class Storage {
 			$versions = self::getVersions($uid, $filename);
 			if (!empty($versions)) {
 				foreach ($versions as $v) {
-					$hookData = 						[
+					$hookData = [
 						'user' => $uid,
 						'path' => $path . $v['version'],
 						'original_path' => $path,

--- a/apps/files_versions/tests/FileHelperTest.php
+++ b/apps/files_versions/tests/FileHelperTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Versions\Tests;
+
+use OC\Files\View;
+use OCA\Files_Versions\FileHelper;
+use OCP\Files\FileInfo;
+
+class FileHelperTest extends \Test\TestCase {
+	public function testCreateMissingDirectories() {
+		$viewMock = $this->getMockBuilder(View::class)
+			->disableOriginalConstructor()
+			->setMethods(['file_exists', 'mkdir'])
+			->getMock();
+		$path = 'some/long/path/to/file.ext';
+		$fileHelper = new FileHelper();
+		$viewMock->method('file_exists')->willReturn(false);
+		$viewMock->method('mkdir')
+			->withConsecutive(
+				[$this->equalTo(FileHelper::VERSIONS_RELATIVE_PATH . '/')],
+				[$this->equalTo(FileHelper::VERSIONS_RELATIVE_PATH . '/some')],
+				[$this->equalTo(FileHelper::VERSIONS_RELATIVE_PATH . '/some/long')],
+				[$this->equalTo(FileHelper::VERSIONS_RELATIVE_PATH . '/some/long/path')],
+				[$this->equalTo(FileHelper::VERSIONS_RELATIVE_PATH . '/some/long/path/to')]
+			);
+		$fileHelper->createMissingDirectories($viewMock, $path);
+	}
+
+	/**
+	 * @dataProvider dataTestGetPathAndRevision
+	 * @param string $path
+	 * @param string[][] $expectedVersionInfo
+	 */
+	public function testGetPathAndRevision($path, $expectedVersionInfo) {
+		$fileHelper = new FileHelper();
+		$versionInfo = $fileHelper->getPathAndRevision($path);
+		$this->assertEquals($expectedVersionInfo['path'], $versionInfo['path']);
+		$this->assertEquals($expectedVersionInfo['revision'], $versionInfo['revision']);
+	}
+
+	public function dataTestGetPathAndRevision() {
+		return [
+			[
+				'files_versions/name.txt.v1548687210',
+				[
+					'path' => 'files_versions/name.txt',
+					'revision' => '1548687210'
+				],
+				'files_versions/somepath/name.txt.v1548687211',
+				[
+					'path' => 'files_versions/somepath/name.txt',
+					'revision' => '1548687211'
+				],
+				'files_versions/somepath.v1548687210/name.txt.v1548687214',
+				[
+					'path' => 'files_versions/somepath.v1548687210/name.txt',
+					'revision' => '1548687214'
+				],
+			]
+		];
+	}
+
+	public function testGetAllVersions() {
+		$directoryTree = [
+			'files_versions' => [
+				'type' => 'dir',
+				'children' => [
+					'file1.txt.v1548687214' => ['type' => 'file', 'size' => 5],
+					'file1.txt.v2548687214' => ['type' => 'file', 'size' => 15],
+					'file1.txt.v1508687214' => ['type' => 'file', 'size' => 25],
+					'docs' => [
+						'type' => 'dir',
+						'children' => [
+							'file1.txt.v1548687234' => ['type' => 'file', 'size' => 3],
+							'file1.txt.v2548687224' => ['type' => 'file', 'size' => 52],
+							'file1.txt.v1508687274' => ['type' => 'file', 'size' => 125],
+						]
+					]
+				]
+			]
+		];
+
+		$viewMock = $this->createMock(View::class);
+		$viewMock->method('getDirectoryContent')
+			->willReturnCallback(
+				function ($dirName) use ($directoryTree) {
+					$dir = $this->descendByPath($dirName, $directoryTree);
+					if (!isset($dir['children'])) {
+						return [];
+					}
+					$dirContent = [];
+					foreach ($dir['children'] as $name => $data) {
+						$fileInfo = $this->createMock(FileInfo::class);
+						$fileInfo->method('getType')
+							->willReturn($data['type']);
+						$fileInfo->method('getName')
+							->willReturn($name);
+						$dirContent[] = $fileInfo;
+					}
+					return $dirContent;
+				}
+			);
+
+		$fileHelperMock = $this->getMockBuilder(FileHelper::class)
+			->setMethods(['getUserView'])->getMock();
+		$fileHelperMock->method('getUserView')
+			->willReturn($viewMock);
+
+		$allVersions = $fileHelperMock->getAllVersions('foo');
+		$versionsByTime = $allVersions['all'];
+		$versionsByFile = $allVersions['by_file'];
+
+		$this->assertEquals(
+			[
+				'2548687224#/docs/file1.txt',
+				'2548687214#/file1.txt',
+				'1548687234#/docs/file1.txt',
+				'1548687214#/file1.txt',
+				'1508687274#/docs/file1.txt',
+				'1508687214#/file1.txt',
+			],
+			\array_keys($versionsByTime)
+		);
+
+		$this->assertEquals(
+			[
+				'/docs/file1.txt',
+				'/file1.txt',
+			],
+			\array_keys($versionsByFile)
+		);
+	}
+
+	protected function descendByPath($path, $tree) {
+		$dirName = \trim($path, '/');
+		$path = \explode('/', $dirName);
+		$item = \current($path);
+		$depth = 1;
+		$fsItem = [];
+		while (isset($tree[$item]) && \is_array($tree[$item])) {
+			if ($depth === \count($path)) {
+				$fsItem = $tree[$item];
+			}
+			$depth++;
+			if ($tree[$item]['type'] === 'dir') {
+				$tree = $tree[$item]['children'];
+				$item = \ltrim(\next($path), '/');
+			} else {
+				break;
+			}
+		}
+		return $fsItem;
+	}
+}

--- a/apps/files_versions/tests/FileHelperTest.php
+++ b/apps/files_versions/tests/FileHelperTest.php
@@ -149,6 +149,15 @@ class FileHelperTest extends \Test\TestCase {
 		);
 	}
 
+	/**
+	 * Traverse an array as if it is a directory tree
+	 * treating 'children' key as directory items
+	 *
+	 * @param string $path
+	 * @param string[][] $tree
+	 *
+	 * @return string[] an array that matches given path or an empty array
+	 */
 	protected function descendByPath($path, $tree) {
 		$dirName = \trim($path, '/');
 		$path = \explode('/', $dirName);

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -1256,7 +1256,12 @@ class Preview {
 		if ($userFolder === false) {
 			return;
 		}
-		$node = $userFolder->get($path);
+		if (\strpos($path, '/files_trashbin/') === 0) {
+			$node = $userFolder->getParent()->get($path);
+		} else {
+			$node = $userFolder->get($path);
+		}
+
 		self::addPathToDeleteFileMapper($path, $node);
 		if ($node->getType() === FileInfo::TYPE_FOLDER) {
 			$children = self::getAllChildren($node);
@@ -1324,7 +1329,11 @@ class Preview {
 			if ($userFolder === false) {
 				return;
 			}
-			$node = $userFolder->get($path);
+			if (\strpos($path, '/files_trashbin/') === 0) {
+				$node = $userFolder->getParent()->get($path);
+			} else {
+				$node = $userFolder->get($path);
+			}
 		} else {
 			/** @var FileInfo $node */
 			$node = self::$deleteFileMapper[$path];

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -33,7 +33,6 @@ namespace OC;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
-use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\Node;
@@ -62,7 +61,7 @@ class Preview {
 	private $userView = null;
 
 	//vars
-	/** @var File */
+	/** @var Node | null */
 	private $file;
 	private $maxX;
 	private $maxY;
@@ -152,9 +151,9 @@ class Preview {
 	}
 
 	/**
-	 * returns the path of the file you want a thumbnail from
+	 * returns the node you want a thumbnail from
 	 *
-	 * @return File
+	 * @return Node | null
 	 */
 	public function getFile() {
 		return $this->file;
@@ -221,15 +220,6 @@ class Preview {
 	 */
 	public function getConfigMaxY() {
 		return $this->configMaxHeight;
-	}
-
-	/**
-	 * Returns the FileInfo object associated with the file to preview
-	 *
-	 * @return false|Files\FileInfo|\OCP\Files\FileInfo
-	 */
-	protected function getFileInfo() {
-		return $this->file;
 	}
 
 	/**
@@ -367,7 +357,7 @@ class Preview {
 			return false;
 		}
 
-		if (!$this->getFileInfo() instanceof FileInfo) {
+		if (!$this->getFile() instanceof FileInfo) {
 			Util::writeLog('core', 'File:"' . $file->getPath() . '" not found', Util::DEBUG);
 
 			return false;
@@ -379,16 +369,28 @@ class Preview {
 	/**
 	 * Deletes the preview of a file with specific width and height
 	 *
-	 * This should never delete the max preview, use deleteAllPreviews() instead
+	 * This should never delete versions preview, use deleteAllPreviews() instead
+	 *
+	 * @param bool $keepMax - keep max size preview
 	 *
 	 * @return bool
 	 */
-	public function deletePreview() {
-		$fileInfo = $this->getFileInfo();
+	public function deletePreview($keepMax = true) {
+		$fileInfo = $this->getFile();
 		if ($fileInfo !== null && $fileInfo !== false) {
-			$previewPath = $this->buildCachePath();
-			if (!\strpos($previewPath, 'max')) {
-				return $this->userView->unlink($previewPath);
+			if ($keepMax === true) {
+				$previewPath = $this->buildCachePath();
+				if (!\strpos($previewPath, 'max')) {
+					return $this->userView->unlink($previewPath);
+				}
+			} else {
+				$previewPath = $this->getPreviewPath();
+				foreach ($this->userView->getDirectoryContent($previewPath) as $fileInfo) {
+					if ($fileInfo->getType() === FileInfo::TYPE_FILE) {
+						$this->userView->unlink("$previewPath/{$fileInfo->getName()}");
+					}
+				}
+				return true;
 			}
 		}
 
@@ -396,7 +398,7 @@ class Preview {
 	}
 
 	/**
-	 * Deletes all previews of a file
+	 * Deletes all previews of a file including version previews
 	 *
 	 * @param int|null $versionId (optional) - delete all previews of the specified versionId
 	 */
@@ -406,7 +408,7 @@ class Preview {
 		$propagator->beginBatch();
 
 		$toDelete = $this->getChildren();
-		$toDelete[] = $this->getFileInfo();
+		$toDelete[] = $this->getFile();
 
 		foreach ($toDelete as $delete) {
 			if ($delete instanceof FileInfo) {
@@ -441,7 +443,7 @@ class Preview {
 	 * @return string|false path to the cached preview if it exists or false
 	 */
 	public function isCached() {
-		$fileId = $this->getFileInfo()->getId();
+		$fileId = $this->getFile()->getId();
 		if ($fileId === null) {
 			return false;
 		}
@@ -752,7 +754,7 @@ class Preview {
 		}
 
 		$this->preview = null;
-		$fileInfo = $this->getFileInfo();
+		$fileInfo = $this->getFile();
 		if ($fileInfo === null || $fileInfo === false) {
 			return new \OC_Image();
 		}
@@ -1077,14 +1079,15 @@ class Preview {
 	/**
 	 * Returns the path to the folder where the previews are stored, identified by the fileId
 	 *
+	 * @param int $fileId (optional)
+	 *
 	 * @return string
 	 */
 	private function getPreviewPath($fileId = null) {
 		if ($fileId === null) {
-			$fileId = $this->getFileInfo()->getId();
+			$fileId = $this->getFile()->getId();
 			if ($this->versionId !== null) {
-				$fileId .= '/';
-				$fileId .= $this->versionId;
+				$fileId .= "/{$this->versionId}";
 			}
 		}
 		return $this->getThumbnailsFolder() . '/' . $fileId . '/';
@@ -1226,7 +1229,10 @@ class Preview {
 	 * @param array $args
 	 */
 	public static function post_write($args) {
-		self::post_delete($args, 'files/');
+		self::post_delete(
+			\array_merge($args, ['keep_versions' => true]),
+			'files/'
+		);
 	}
 
 	/**
@@ -1326,7 +1332,13 @@ class Preview {
 
 		$preview = new Preview($node->getOwner()->getUID(), $prefix, $node);
 		$versionId = isset($args['deleted_revision']) ? $args['deleted_revision'] : null;
-		$preview->deleteAllPreviews($versionId);
+		if (isset($args['keep_versions'])) {
+			// PostWrite hook - delete main preview keeping versions previews
+			$preview->deletePreview(false);
+		} else {
+			// "true" PostDelete
+			$preview->deleteAllPreviews($versionId);
+		}
 	}
 
 	/**

--- a/tests/lib/PreviewTest.php
+++ b/tests/lib/PreviewTest.php
@@ -232,6 +232,8 @@ class PreviewTest extends TestCase {
 			[
 				'user' => self::TEST_PREVIEW_USER1,
 				'path' => '/test.txt.v' . $timestamp2,
+				'original_path' => '/test.txt',
+				'deleted_revision' => $timestamp2
 			]
 		);
 


### PR DESCRIPTION
## Description
- `uid` is always known - pass it within the `version_delete` hook info
- pass `original_path` that contains a path to the versioned file 
and `deleted_revision` - versionId for the deleted version 
- pass an optional `versionId` to deleteAllPreviews when we need to remove previous for the specific version only
- bonus 1: fix preview generation for files in deleted directories
- bonus 2: cover some parts of files_versions with tests

## Related Issue
- Fixes #32346
https://github.com/owncloud/enterprise/issues/2904

## Motivation and Context
- Version previews are not deleted properly
- Previews don't show for files in deleted directories
- Versions and trash expiration is flooding the log file with exceptions related to the previews

## How Has This Been Tested?

### Case 1
1. Create a text file "test.txt"
2. Edit the file three times in the text editor and save each time, will create three versions
3. Open the versions panel to have it generate previews
4. Run cron.php and observe the logs

#### Expected result
version previews for cleaned up versions are deleted
No errors

#### Actual result
version previews for cleaned up versions are NOT deleted

```
{"reqId":"viyF6aTvAF41QBIxIu9B","level":3,"time":"2018-10-15T19:37:42+00:00","remoteAddr":"","user":"--","app":"no app in context","method":"--","url":"--","message":"Exception: {\"Exception\":\"OCP\\\\Files\\\\NotFoundException\",\"Message\":\"\\\/test.txt.v1539632201 not found while trying to get owner\",\"Code\":0,\"Trace\":\"#0 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Filesystem.php(961): OC\\\\Files\\\\View->getOwner('\\\/test.txt.v1539...')\\n#1 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Preview.php(1241): OC\\\\Files\\\\Filesystem::getOwner('\\\/test.txt.v1539...')\\n#2 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/legacy\\\/hook.php(105): OC\\\\Preview::prepare_delete(Array)\\n#3 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/apps\\\/files_versions\\\/lib\\\/Storage.php(765): OC_Hook::emit('\\\\\\\\OCP\\\\\\\\Versions', 'preDelete', Array)\\n#4 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/apps\\\/files_versions\\\/lib\\\/Command\\\/Expire.php(60): OCA\\\\Files_Versions\\\\Storage::expire('\\\/test.txt', 'admin')\\n#5 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Command\\\/CommandJob.php(34): OCA\\\\Files_Versions\\\\Command\\\\Expire->handle()\\n#6 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/BackgroundJob\\\/Job.php(57): OC\\\\Command\\\\CommandJob->run('O:33:\\\"OCA\\\\\\\\Files...')\\n#7 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/BackgroundJob\\\/QueuedJob.php(42): OC\\\\BackgroundJob\\\\Job->execute(Object(OC\\\\BackgroundJob\\\\JobList), Object(OC\\\\Log))\\n#8 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/cron.php(120): OC\\\\BackgroundJob\\\\QueuedJob->execute(Object(OC\\\\BackgroundJob\\\\JobList), Object(OC\\\\Log))\\n#9 {main}\",\"File\":\"\\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/View.php\",\"Line\":1717}"}
{"reqId":"viyF6aTvAF41QBIxIu9B","level":3,"time":"2018-10-15T19:37:42+00:00","remoteAddr":"","user":"--","app":"no app in context","method":"--","url":"--","message":"Exception: {\"Exception\":\"OCP\\\\Files\\\\NotFoundException\",\"Message\":\"\\\/test.txt.v1539632201 not found while trying to get owner\",\"Code\":0,\"Trace\":\"#0 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Filesystem.php(961): OC\\\\Files\\\\View->getOwner('\\\/test.txt.v1539...')\\n#1 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Preview.php(1311): OC\\\\Files\\\\Filesystem::getOwner('\\\/test.txt.v1539...')\\n#2 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Preview.php(1299): OC\\\\Preview::post_delete(Array, 'files\\\/')\\n#3 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/legacy\\\/hook.php(105): OC\\\\Preview::post_delete_versions(Array)\\n#4 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/apps\\\/files_versions\\\/lib\\\/Storage.php(767): OC_Hook::emit('\\\\\\\\OCP\\\\\\\\Versions', 'delete', Array)\\n#5 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/apps\\\/files_versions\\\/lib\\\/Command\\\/Expire.php(60): OCA\\\\Files_Versions\\\\Storage::expire('\\\/test.txt', 'admin')\\n#6 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Command\\\/CommandJob.php(34): OCA\\\\Files_Versions\\\\Command\\\\Expire->handle()\\n#7 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/BackgroundJob\\\/Job.php(57): OC\\\\Command\\\\CommandJob->run('O:33:\\\"OCA\\\\\\\\Files...')\\n#8 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/BackgroundJob\\\/QueuedJob.php(42): OC\\\\BackgroundJob\\\\Job->execute(Object(OC\\\\BackgroundJob\\\\JobList), Object(OC\\\\Log))\\n#9 \\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/cron.php(120): OC\\\\BackgroundJob\\\\QueuedJob->execute(Object(OC\\\\BackgroundJob\\\\JobList), Object(OC\\\\Log))\\n#10 {main}\",\"File\":\"\\\/srv\\\/www\\\/htdocs\\\/owncloud\\\/lib\\\/private\\\/Files\\\/View.php\",\"Line\":1717}"}
```

### Case 2
1. create a text files, edit it several times 
2. open versions to create a previews for versions
3. edit file one more time

#### Expected result
Only file previews are deleted

#### Actual result
File previews  and all versions previews are deleted

### Case 3
delete a directory with a file and browse to the file in the trashbin

#### Expected result
File in deleted directory has a prievew

#### Actual result
No file preview

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
