### PR TITLE
Remove test that tries to open live doc links

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
+++ b/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
@@ -17,15 +17,3 @@ Feature: Help and tips page
       | Improving the config.php          |
       | Theming                           |
       | Hardening and security guidance   |
-
-  @skip @issue-33639 @skipOnOcV11 @issue-33634
-  Scenario Outline: Admin can open links in help and tips page
-    When the administrator opens the link for "<linkName>"
-    Then the user should be redirected to a webUI page with the title "<pageTitle>"
-    Examples:
-      | linkName                          | pageTitle                       |
-      | How to do backups                 | Backing up ownCloud             |
-      | Performance tuning                | ownCloud Server Tuning          |
-      | Improving the config.php          | Core Config.php Parameters      |
-      | Theming                           | Theming ownCloud                |
-      | Hardening and security guidance   | Hardening and Security Guidance |


### PR DESCRIPTION
## Description
Remove the test scenario that was skipped anyway because of issue #33639

The scenario above constructs the form that the help links should be in, and checks that the actual link on the page matches. So we already verify that the links are what is expected.

The removed scenario was verifying that the link actually works to the live documentation web site. That test can easily fail through no fault of the core software - e.g. the core version is new, no released yet, and so the live doc does not exist, or the live documentation site happens to be down, or the test is being run in an environment with restricted access to the real internet. Such a test is outside the responsibility of just core.

## Related Issue
- Fixes #33639
- also part of https://github.com/owncloud/QA/issues/601

## Motivation and Context
Cleanup or adjust skipped tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
