### PR TITLE
Adjust test for issue 32889

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -249,16 +249,32 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @param string $errorMessage
 	 * @param int $numEmails which number of multiple emails to read (first email is 1)
 	 *
-	 * @return void
+	 * @return string
 	 */
-	public function followLinkFromEmail($emailAddress, $regexSearch, $errorMessage, $numEmails = 1) {
+	public function getLinkFromEmail($emailAddress, $regexSearch, $errorMessage, $numEmails = 1) {
 		$content = EmailHelper::getBodyOfEmail(
 			EmailHelper::getLocalMailhogUrl(), $emailAddress, $numEmails
 		);
 		$matches = [];
 		\preg_match($regexSearch, $content, $matches);
 		PHPUnit_Framework_Assert::assertArrayHasKey(1, $matches, $errorMessage);
-		$this->visitPath($matches[1]);
+		return $matches[1];
+	}
+
+	/**
+	 *
+	 * @param string $emailAddress
+	 * @param string $regexSearch
+	 * @param string $errorMessage
+	 * @param int $numEmails which number of multiple emails to read (first email is 1)
+	 *
+	 * @return void
+	 */
+	public function followLinkFromEmail($emailAddress, $regexSearch, $errorMessage, $numEmails = 1) {
+		$link = $this->getLinkFromEmail(
+			$emailAddress, $regexSearch, $errorMessage, $numEmails
+		);
+		$this->visitPath($link);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -491,6 +491,60 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user follows the password reset link from email address :emailAddress but supplying invalid user name :username
+	 *
+	 * @param string $emailAddress
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function theUserFollowsThePasswordResetLinkFromTheirEmailUsingInvalidUsername(
+		$emailAddress, $username
+	) {
+		$link = $this->webUIGeneralContext->getLinkFromEmail(
+			$emailAddress,
+			"/Use the following link to reset your password: (http.*)/",
+			"Couldn't find password reset link in the email"
+		);
+		// The link has a form like:
+		// http://172.17.0.1:8080/index.php/lostpassword/reset/form/ossdSL1Q95s4e0seCwsTb/user1
+		// pop off the last part and replace it with the invalid username
+		$linkParts = \explode('/', $link);
+		\array_pop($linkParts);
+		\array_push($linkParts, $username);
+		$adjustedLink = \implode('/', $linkParts);
+		$this->visitPath($adjustedLink);
+	}
+
+	/**
+	 * @When the user follows the password reset link from email address :emailAddress but supplying an invalid token
+	 *
+	 * @param string $emailAddress
+	 *
+	 * @return void
+	 */
+	public function theUserFollowsThePasswordResetLinkFromTheirEmailUsingInvalidToken(
+		$emailAddress
+	) {
+		$link = $this->webUIGeneralContext->getLinkFromEmail(
+			$emailAddress,
+			"/Use the following link to reset your password: (http.*)/",
+			"Couldn't find password reset link in the email"
+		);
+		// The link has a form like:
+		// http://172.17.0.1:8080/index.php/lostpassword/reset/form/ossdSL1Q95s4e0seCwsTb/user1
+		$linkParts = \explode('/', $link);
+		$username = \array_pop($linkParts);
+		$goodToken = \array_pop($linkParts);
+		// reverse the token string, an easy way to make the token invalid
+		$invalidToken = \strrev($goodToken);
+		\array_push($linkParts, $invalidToken);
+		\array_push($linkParts, $username);
+		$adjustedLink = \implode('/', $linkParts);
+		$this->visitPath($adjustedLink);
+	}
+
+	/**
 	 * @When the user resets/sets the password to :newPassword using the webUI
 	 * @Given the user has reset/set the password to :newPassword using the webUI
 	 *

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -416,11 +416,30 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function aSetPasswordErrorMessageWithTheTextShouldBeDisplayed(PyStringNode $string) {
+	public function aSetPasswordErrorMessageWithTheTextShouldBeDisplayed(
+		PyStringNode $string
+	) {
 		$expectedString = $string->getRaw();
 		$setPasswordErrorMessage = $this->loginPage->getSetPasswordErrorMessage();
 		PHPUnit_Framework_Assert::assertEquals(
 			$expectedString, $setPasswordErrorMessage
+		);
+	}
+
+	/**
+	 * @Then a lost password reset error message with this text should be displayed on the webUI:
+	 *
+	 * @param PyStringNode $string
+	 *
+	 * @return void
+	 */
+	public function aLostPasswordResetErrorMessageWithTheTextShouldBeDisplayed(
+		PyStringNode $string
+	) {
+		$expectedString = $string->getRaw();
+		$resetPasswordErrorMessage = $this->loginPage->getLostPasswordResetErrorMessage();
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedString, $resetPasswordErrorMessage
 		);
 	}
 

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -150,7 +150,8 @@ class LoginPage extends OwncloudPage {
 		$this->assertElementNotNull(
 			$lostPasswordResetErrorMessageField,
 			__METHOD__ .
-			" id $this->lostPasswordResetErrorXpath could not find lost password reset error message field"
+			" id $this->lostPasswordResetErrorXpath" .
+			" could not find lost password reset error message field"
 		);
 		return $lostPasswordResetErrorMessageField;
 	}

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -22,6 +22,7 @@
 
 namespace Page;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
@@ -41,6 +42,7 @@ class LoginPage extends OwncloudPage {
 	protected $lostPasswordId = "lost-password";
 	protected $setPasswordErrorMessageId = "error-message";
 
+	protected $lostPasswordResetErrorXpath = "//li[contains(@class,'error')]";
 	protected $imprintUrlXpath = "//a[contains(text(),'Imprint')]";
 	protected $privacyPolicyXpath = "//a[contains(text(),'Privacy Policy')]";
 
@@ -123,7 +125,7 @@ class LoginPage extends OwncloudPage {
 	 *
 	 * @throws ElementNotFoundException
 	 *
-	 * @return Page
+	 * @return NodeElement
 	 */
 	private function getSetPasswordErrorMessageField() {
 		$setPasswordErrorMessageField = $this->findById($this->setPasswordErrorMessageId);
@@ -133,6 +135,24 @@ class LoginPage extends OwncloudPage {
 			" id $this->setPasswordErrorMessageId could not find set password error message field"
 		);
 		return $setPasswordErrorMessageField;
+	}
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 *
+	 * @return NodeElement
+	 */
+	private function getLostPasswordResetErrorMessageField() {
+		$lostPasswordResetErrorMessageField = $this->find(
+			"xpath", $this->lostPasswordResetErrorXpath
+		);
+		$this->assertElementNotNull(
+			$lostPasswordResetErrorMessageField,
+			__METHOD__ .
+			" id $this->lostPasswordResetErrorXpath could not find lost password reset error message field"
+		);
+		return $lostPasswordResetErrorMessageField;
 	}
 
 	/**
@@ -161,6 +181,15 @@ class LoginPage extends OwncloudPage {
 	public function getSetPasswordErrorMessage() {
 		$setPasswordErrorMessage = $this->getSetPasswordErrorMessageField()->getText();
 		return $setPasswordErrorMessage;
+	}
+
+	/**
+	 *
+	 * @return string
+	 */
+	public function getLostPasswordResetErrorMessage() {
+		$generalErrorMessage = $this->getLostPasswordResetErrorMessageField()->getText();
+		return $generalErrorMessage;
 	}
 
 	/**

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -49,3 +49,23 @@ Feature: reset the password
       Password changed successfully
       """
     And the reset email to "user1@example.org" should be from "owncloud@foobar.com"
+
+  @skipOnEncryption
+  Scenario: using the password reset token plus invalid username does not work
+    When the user requests the password reset link using the webUI
+    And the user follows the password reset link from email address "user1@example.org" but supplying invalid user name "qwerty"
+    Then the user should be redirected to a webUI page with the title "%productname%"
+    And a lost password reset error message with this text should be displayed on the webUI:
+      """
+      Could not reset password because the token is invalid
+      """
+
+  @skipOnEncryption
+  Scenario: using an invalid password reset token with valid username does not work
+    When the user requests the password reset link using the webUI
+    And the user follows the password reset link from email address "user1@example.org" but supplying an invalid token
+    Then the user should be redirected to a webUI page with the title "%productname%"
+    And a lost password reset error message with this text should be displayed on the webUI:
+      """
+      Could not reset password because the token does not match
+      """

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -25,16 +25,21 @@ Feature: reset the password using an email address
 			"""
 
   @skipOnEncryption
-  @smokeTest
-  @skip @issue-32889
+  # consider adding this to the smoke tests when the issue is fixed @smokeTest
+  @issue-32889
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" using the webUI
-    Then the email address "user1@example.org" should have received an email with the body containing
+    # The issue is that the system thinks the link token is invalid
+    And a lost password reset error message with this text should be displayed on the webUI:
 			"""
-			Password changed successfully
+			Could not reset password because the token is invalid
 			"""
-    When the user logs in with username "user1" and password "%alt3%" using the webUI
-    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+    #When the user resets the password to "%alt3%" using the webUI
+    #Then the email address "user1@example.org" should have received an email with the body containing
+	#		"""
+	#		Password changed successfully
+	#		"""
+    #When the user logs in with username "user1" and password "%alt3%" using the webUI
+    #Then the user should be redirected to a webUI page with the title "Files - %productname%"


### PR DESCRIPTION
## Description
1) Adjust the test scenario for a user trying to login with their email address and requesting password reset. Make it run and "test" that the (wrong) error is displayed. Comment out the test steps that should happen when the bug is fixed.

2) Add test scenarios that purposely provide invalid token-username combinations to confirm that such unauthorized password reset attempts will fail.

## Related Issue
#32889 
https://github.com/owncloud/QA/issues/601

## Motivation and Context
Adjust test scenarios that have been skipped

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
