### PR TITLE
public link expiration date change acceptance test using webUI

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -323,6 +323,23 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user changes the expiration of the public link named :linkName of file/folder :name to :date
+	 *
+	 * @param string $linkName
+	 * @param string $name
+	 * @param string $date
+	 *
+	 * @return void
+	 */
+	public function theUserChangeTheExpirationOfThePublicLinkNamedForTo($linkName, $name, $date) {
+		$session = $this->getSession();
+		$this->theUserOpensTheShareDialogForFileFolder($name);
+		$this->theUserHasOpenedThePublicLinkShareTab();
+		$this->publicShareTab->editLink($session, $linkName, null, null, null, $date);
+		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
 	 * @When the user opens the create public link share popup
 	 *
 	 * @return void

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -224,6 +224,9 @@ class PublicLinkTab extends OwncloudPage {
 		if ($permissions !== null) {
 			$this->editPublicLinkPopupPageObject->setLinkPermissions($permissions);
 		}
+		if ($expirationDate !== null) {
+			$this->editPublicLinkPopupPageObject->setLinkExpirationDate($expirationDate);
+		}
 
 		if ($save === true) {
 			$this->editPublicLinkPopupPageObject->save();
@@ -312,7 +315,7 @@ class PublicLinkTab extends OwncloudPage {
 	}
 
 	/**
-	 * @return void
+	 * @return string
 	 */
 	public function getWarningMessage() {
 		$warningMessageField = $this->find("xpath", $this->publicLinkWarningMessageXpath);

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -275,6 +275,29 @@ Feature: Share by public link
     Then the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
+  Scenario: user changes the expiration date of an already existing public link using webUI
+    Given user "user1" has created a share with settings
+      | path       | lorem.txt   |
+      | name       | Public link |
+      | expireDate | 14-10-2038  |
+      | shareType  | 3           |
+    When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "21-07-2038"
+    And the user gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | expiration        | 21-07-2038              |
+
+  Scenario: user tries to change the expiration date of the public link to past date using webUI
+    Given user "user1" has created a share with settings
+      | path       | lorem.txt   |
+      | name       | Public link |
+      | expireDate | 14-10-2038  |
+      | shareType  | 3           |
+    When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "14-09-2017"
+    And the user gets the info of the last share using the sharing API
+    Then the user should see an error message on the public link share dialog saying "Expiration date is in the past"
+    And the fields of the last response should include
+      | expiration        | 14-10-2038              |
+
   Scenario: share two file with same name but different paths by public link
     When the user creates a new public link for file "lorem.txt" using the webUI
     And the user closes the details dialog


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
test expiration date change of the public link using webUI

## How Has This Been Tested?
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [X] Backport (if applicable set "backport-request" label and remove when the backport was done)
