### PR TITLE
Test to demonstrate lock owner name is not updated when user display …

### DIFF
--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -36,6 +36,22 @@ Feature: Locks
     And folder "simple-folder" should be marked as locked by user "My fancy name" in the locks tab of the details panel on the webUI
     And file "data.zip" should be marked as locked by user "My fancy name" in the locks tab of the details panel on the webUI
 
+  @issue-34315
+  Scenario: setting a lock shows the current display name of a user in the locking details
+    Given these users have been created:
+      |username              |displayname  |
+      |user-with-display-name|My fancy name|
+    Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
+      | lockscope | shared |
+    And user "user-with-display-name" has locked file "data.zip" setting following properties
+      | lockscope | exclusive |
+    And the administrator has changed the display name of user "user-with-display-name" to "An ordinary name"
+    When the user re-logs in with username "user-with-display-name" and password "%regular%" using the webUI
+    And folder "simple-folder" should be marked as locked by user "My fancy name" in the locks tab of the details panel on the webUI
+    And file "data.zip" should be marked as locked by user "My fancy name" in the locks tab of the details panel on the webUI
+    #And folder "simple-folder" should be marked as locked by user "An ordinary name" in the locks tab of the details panel on the webUI
+    #And file "data.zip" should be marked as locked by user "An ordinary name" in the locks tab of the details panel on the webUI
+
   Scenario: setting a lock shows the display name of a user in the locking details (user has set email address)
     Given these users have been created:
       |username              |displayname  |email      |
@@ -237,6 +253,19 @@ Feature: Locks
     Given user "brand-new-user" has locked folder "simple-folder" setting following properties
      | lockscope | shared |
     When user "brand-new-user" unlocks the last created lock of folder "simple-folder" using the WebDAV API
+    And the user browses to the files page
+    Then folder "simple-folder" should not be marked as locked on the webUI
+
+  Scenario: unlocking by webDAV after the display name has been changed deletes the lock symbols at the correct files/folders
+    Given these users have been created:
+      |username              |displayname  |
+      |user-with-display-name|My fancy name|
+    Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
+      | lockscope | shared |
+    And user "user-with-display-name" has locked file "data.zip" setting following properties
+      | lockscope | exclusive |
+    And the administrator has changed the display name of user "user-with-display-name" to "An ordinary name"
+    When user "user-with-display-name" unlocks the last created lock of folder "simple-folder" using the WebDAV API
     And the user browses to the files page
     Then folder "simple-folder" should not be marked as locked on the webUI
 


### PR DESCRIPTION
…name is changed

## Description
Test scenarios to demonstrate that:
1) the lock owner display string is not updated when the display name of the user changes.
2) locks can still be deleted even when the lock owner string is stale (lock deletes use the lock token to identify the lock) - so nothing is really badly broken

## Related Issue
#34315 

## Motivation and Context

## How Has This Been Tested?
Local acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
