### PR TITLE
Replace shoud with should in acceptance tests

### DIFF
--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -105,8 +105,8 @@ Feature: favorite
     And the user has favorited element "/textfile3.txt"
     And the user has favorited element "/textfile4.txt"
     When the user lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
-    #Then the search result of "user0" shoud contain any "3" of these entries:
-    Then the search result of "user0" shoud contain any "0" of these entries:
+    #Then the search result of "user0" should contain any "3" of these entries:
+    Then the search result of "user0" should contain any "0" of these entries:
       | /textfile0.txt |
       | /textfile1.txt |
       | /textfile2.txt |
@@ -134,8 +134,8 @@ Feature: favorite
     And the user has favorited element "/subfolder/textfile4.txt"
     And the user has favorited element "/subfolder/textfile5.txt"
     When the user lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
-    #Then the search result of "user0" shoud contain any "3" of these entries:
-    Then the search result of "user0" shoud contain any "0" of these entries:
+    #Then the search result of "user0" should contain any "3" of these entries:
+    Then the search result of "user0" should contain any "0" of these entries:
       | /subfolder/textfile0.txt |
       | /subfolder/textfile1.txt |
       | /subfolder/textfile2.txt |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -81,7 +81,7 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" and limits the results to "3" items using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of "user0" shoud contain any "3" of these entries:
+    And the search result of "user0" should contain any "3" of these entries:
       | /just-a-folder/upload.txt    |
       | /just-a-folder/uploadÜठिF.txt |
       | /upload folder               |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2238,7 +2238,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the propfind/search result of :user shoud contain any :expectedNumber of these files/entries:
+	 * @Then the propfind/search result of :user should contain any :expectedNumber of these files/entries:
 	 *
 	 * @param string $user
 	 * @param integer $expectedNumber
@@ -2246,7 +2246,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function theSearchResultOfShoudContainAnyOfTheseEntries(
+	public function theSearchResultOfShouldContainAnyOfTheseEntries(
 		$user, $expectedNumber, TableNode $expectedFiles
 	) {
 		$this->propfindResultShouldContainNumEntries($user, $expectedNumber);


### PR DESCRIPTION
## Description
Replace typo ``shoud`` with ``should`` in acceptance tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
