### PR TITLE
Send OCM requests as JSON

### DIFF
--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -337,11 +337,13 @@ class Notifications {
 			}
 
 			try {
-				$response = $client->post($endpoint, [
-					'body' => $fields,
+				$options = [
 					'timeout' => 10,
 					'connect_timeout' => 10,
-				]);
+				];
+				$sendAs = $useOcm === true ? 'json' : 'body';
+				$options[$sendAs] = $fields;
+				$response = $client->post($endpoint, $options);
 				$result['result'] = $response->getBody();
 				$result['statusCode'] = $response->getStatusCode();
 				$result['success'] = true;


### PR DESCRIPTION
## Description
OCM spec says that POST body should be JSON
https://rawgit.com/GEANT/OCM-API/v1/docs.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
By creating federated shares between this branch and stable10 and sniffing the traffic with Wireshark

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added


## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
