### PR TITLE
Remove unused user parameter in acceptance test propfind methods

### DIFF
--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -106,7 +106,7 @@ Feature: favorite
     And the user has favorited element "/textfile4.txt"
     When the user lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
     #Then the search result of "user0" should contain any "3" of these entries:
-    Then the search result of "user0" should contain any "0" of these entries:
+    Then the search result should contain any "0" of these entries:
       | /textfile0.txt |
       | /textfile1.txt |
       | /textfile2.txt |
@@ -135,7 +135,7 @@ Feature: favorite
     And the user has favorited element "/subfolder/textfile5.txt"
     When the user lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
     #Then the search result of "user0" should contain any "3" of these entries:
-    Then the search result of "user0" should contain any "0" of these entries:
+    Then the search result should contain any "0" of these entries:
       | /subfolder/textfile0.txt |
       | /subfolder/textfile1.txt |
       | /subfolder/textfile2.txt |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -23,13 +23,13 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of "user0" should contain these entries:
+    And the search result should contain these entries:
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |
       | /upload folder                |
       | /just-a-folder/uploadÜठिF.txt |
       | /फनी näme/upload.txt          |
-    But the search result of "user0" should not contain these entries:
+    But the search result should not contain these entries:
       | /a-image.png |
     Examples:
       | dav_version |
@@ -40,8 +40,8 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "ol" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of "user0" should contain "4" entries
-    And the search result of "user0" should contain these entries:
+    And the search result should contain "4" entries
+    And the search result should contain these entries:
       | /just-a-folder           |
       | /upload folder           |
       | /FOLDER                  |
@@ -55,11 +55,11 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "png" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of "user0" should contain these entries:
+    And the search result should contain these entries:
       | /a-image.png               |
       | /just-a-folder/a-image.png |
       | /फनी näme/a-image.png      |
-    But the search result of "user0" should not contain these entries:
+    But the search result should not contain these entries:
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |
       | /just-a-folder/uploadÜठिF.txt |
@@ -81,7 +81,7 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" and limits the results to "3" items using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of "user0" should contain any "3" of these entries:
+    And the search result should contain any "3" of these entries:
       | /just-a-folder/upload.txt     |
       | /just-a-folder/uploadÜठिF.txt |
       | /upload folder                |
@@ -96,8 +96,8 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" and limits the results to "1" items using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of "user0" should contain "1" entries
-    And the search result of "user0" should contain these entries:
+    And the search result should contain "1" entries
+    And the search result should contain these entries:
       | /upload folder |
     Examples:
       | dav_version |
@@ -108,8 +108,8 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" and limits the results to "100" items using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of "user0" should contain "5" entries
-    And the search result of "user0" should contain these entries:
+    And the search result should contain "5" entries
+    And the search result should contain these entries:
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |
       | /upload folder                |
@@ -133,7 +133,7 @@ Feature: Search
       | oc:owner-display-name |
       | oc:size               |
     Then the HTTP status code should be "207"
-    And file "/upload.txt" in the search result of "user0" should contain these properties:
+    And file "/upload.txt" in the search result should contain these properties:
       | name                                       | value                                                                                             |
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVW\|RMDNVW)$                                                                                 |
@@ -161,7 +161,7 @@ Feature: Search
       | oc:owner-display-name |
       | oc:size               |
     Then the HTTP status code should be "207"
-    And folder "/upload folder" in the search result of "user0" should contain these properties:
+    And folder "/upload folder" in the search result should contain these properties:
       | name                                       | value                                                                                             |
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVCK\|RMDNVCK)$                                                                               |

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -105,7 +105,7 @@ class FavoritesContext implements Context {
 	) {
 		$this->userListsFavoriteOfFolder($user, $folder, null);
 		$this->featureContext->propfindResultShouldContainEntries(
-			$user, $shouldOrNot, $expectedElements
+			$shouldOrNot, $expectedElements
 		);
 	}
 	

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -83,20 +83,19 @@ class SearchContext implements Context {
 	}
 
 	/**
-	 * @Then file/folder :path in the search result of :user should contain these properties:
+	 * @Then file/folder :path in the search result should contain these properties:
 	 *
 	 * @param string $path
-	 * @param string $user
 	 * @param TableNode $properties
 	 *
 	 * @return void
 	 */
 	public function fileOrFolderInTheSearchResultShouldContainProperties(
-		$path, $user, TableNode $properties
+		$path, TableNode $properties
 	) {
 		$properties = $properties->getHash();
 		$fileResult = $this->featureContext->findEntryFromPropfindResponse(
-			$user, $path
+			$path
 		);
 		PHPUnit_Framework_Assert::assertNotFalse(
 			$fileResult, "could not find file/folder '$path'"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2184,23 +2184,22 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the (?:propfind|search) result of "([^"]*)" should (not|)\s?contain these (?:files|entries):$/
+	 * @Then /^the (?:propfind|search) result should (not|)\s?contain these (?:files|entries):$/
 	 *
-	 * @param string $user
 	 * @param string $shouldOrNot (not|)
 	 * @param TableNode $expectedFiles
 	 *
 	 * @return void
 	 */
 	public function propfindResultShouldContainEntries(
-		$user, $shouldOrNot, TableNode $expectedFiles
+		$shouldOrNot, TableNode $expectedFiles
 	) {
 		$elementRows = $expectedFiles->getRows();
 		$should = ($shouldOrNot !== "not");
 		
 		foreach ($elementRows as $expectedFile) {
 			$fileFound = $this->findEntryFromPropfindResponse(
-				$user, $expectedFile[0]
+				$expectedFile[0]
 			);
 			if ($should) {
 				PHPUnit_Framework_Assert::assertNotEmpty(
@@ -2217,14 +2216,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the propfind/search result of :user should contain :numFiles files/entries
+	 * @Then the propfind/search result should contain :numFiles files/entries
 	 *
-	 * @param string $user
 	 * @param int $numFiles
 	 *
 	 * @return void
 	 */
-	public function propfindResultShouldContainNumEntries($user, $numFiles) {
+	public function propfindResultShouldContainNumEntries($numFiles) {
 		//if we are using that step the second time in a scenario e.g. 'But ... should not'
 		//then don't parse the result again, because the result in a ResponseInterface
 		if (empty($this->responseXml)) {
@@ -2240,20 +2238,19 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the propfind/search result of :user should contain any :expectedNumber of these files/entries:
+	 * @Then the propfind/search result should contain any :expectedNumber of these files/entries:
 	 *
-	 * @param string $user
 	 * @param integer $expectedNumber
 	 * @param TableNode $expectedFiles
 	 *
 	 * @return void
 	 */
 	public function theSearchResultOfShouldContainAnyOfTheseEntries(
-		$user, $expectedNumber, TableNode $expectedFiles
+		$expectedNumber, TableNode $expectedFiles
 	) {
-		$this->propfindResultShouldContainNumEntries($user, $expectedNumber);
+		$this->propfindResultShouldContainNumEntries($expectedNumber);
 		$elementRows = $expectedFiles->getRowsHash();
-		$resultEntries = $this->findEntryFromPropfindResponse($user);
+		$resultEntries = $this->findEntryFromPropfindResponse();
 		foreach ($resultEntries as $resultEntry) {
 			PHPUnit_Framework_Assert::assertArrayHasKey($resultEntry, $elementRows);
 		}
@@ -2263,7 +2260,6 @@ trait WebDav {
 	 * parses a PROPFIND response from $this->response into xml
 	 * and returns found search results if found else returns false
 	 *
-	 * @param string $user
 	 * @param string $entryNameToSearch
 	 *
 	 * @return string|array|boolean
@@ -2271,7 +2267,7 @@ trait WebDav {
 	 * array if $entryNameToSearch is not given
 	 * boolean false if $entryNameToSearch is given and is not found
 	 */
-	public function findEntryFromPropfindResponse($user, $entryNameToSearch = null) {
+	public function findEntryFromPropfindResponse($entryNameToSearch = null) {
 		//if we are using that step the second time in a scenario e.g. 'But ... should not'
 		//then don't parse the result again, because the result in a ResponseInterface
 		if (empty($this->responseXml)) {
@@ -2279,15 +2275,15 @@ trait WebDav {
 				HttpRequestHelper::parseResponseAsXml($this->response)
 			);
 		}
+		$fullWebDavPath = \ltrim(
+			\parse_url($this->response->getEffectiveUrl(), PHP_URL_PATH) . "/",
+			"/"
+		);
 		$multistatusResults = $this->responseXml["value"];
 		$results = [];
 		if ($multistatusResults !== null) {
 			foreach ($multistatusResults as $multistatusResult) {
 				$entryPath = $multistatusResult['value'][0]['value'];
-				$fullWebDavPath = \ltrim(
-					$this->getBasePath() . "/" . $this->getDavFilesPath($user) . "/",
-					"/"
-				);
 				$entryName = \str_replace($fullWebDavPath, "", $entryPath);
 				$entryName = \rawurldecode($entryName);
 				if ($entryNameToSearch === $entryName) {

--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -9,14 +9,14 @@ Feature: Files Operations command
     And the administrator has scanned the filesystem for all users
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage/hello1.txt |
     When the administrator scans the filesystem for all users using the occ command
     And the administrator creates file "hello2.txt" with content "<? php :(" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage/hello1.txt |
-    But the propfind result of "user0" should not contain these entries:
+    But the propfind result should not contain these entries:
       | /local_storage/hello2.txt |
 
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
@@ -31,17 +31,17 @@ Feature: Files Operations command
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
     And the administrator creates file "folder2/hello2.txt" with content "<? php :(" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage/folder1/hello1.txt |
     When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage/folder2/hello2.txt |
     When the administrator scans the filesystem in path "/user0/files/local_storage/folder1" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage/folder1/hello1.txt |
     When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage/folder2/hello2.txt |
 
   Scenario: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
@@ -60,17 +60,17 @@ Feature: Files Operations command
     And the administrator has scanned the filesystem for group "newgroup"
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage/folder1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage/folder1/hello1.txt |
     When the administrator scans the filesystem for group "newgroup" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage/folder1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/folder1" with "PROPFIND" using basic auth
-    Then the propfind result of "user1" should contain these entries:
+    Then the propfind result should contain these entries:
       | /folder1/hello1.txt |
 
   Scenario: administrator should be able to create a local mount for a specific user
@@ -93,15 +93,15 @@ Feature: Files Operations command
     And user "user0" has been created with default attributes
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/hello1.txt"
     When user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage/hello1.txt |
     When the administrator deletes file "hello1.txt" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage/hello1.txt |
     When the administrator scans the filesystem for all users using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage/hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific user should add file for only that user
@@ -120,17 +120,17 @@ Feature: Files Operations command
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage1" using the testing API
     And the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result of "user1" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage2/hello1.txt |
     When the administrator scans the filesystem for user "user0" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result of "user1" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage2/hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific group should add file for only the users of that group
@@ -155,23 +155,23 @@ Feature: Files Operations command
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage1" using the testing API
     And the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result of "user1" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage1/hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result of "user2" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage2/hello1.txt |
     When the administrator scans the filesystem for group "newgroup" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result of "user0" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result of "user1" should contain these entries:
+    Then the propfind result should contain these entries:
       | /local_storage1/hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result of "user2" should not contain these entries:
+    Then the propfind result should not contain these entries:
       | /local_storage2/hello1.txt |
 
   Scenario: administrator should be able to add more than one user as the applicable user for a local mount

--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -10,14 +10,14 @@ Feature: Files Operations command
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage/hello1.txt |
+      | /hello1.txt |
     When the administrator scans the filesystem for all users using the occ command
     And the administrator creates file "hello2.txt" with content "<? php :(" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage/hello1.txt |
+      | /hello1.txt |
     But the propfind result should not contain these entries:
-      | /local_storage/hello2.txt |
+      | /hello2.txt |
 
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
     Given using new DAV path
@@ -32,17 +32,17 @@ Feature: Files Operations command
     And the administrator creates file "folder2/hello2.txt" with content "<? php :(" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage/folder1/hello1.txt |
+      | /hello1.txt |
     When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage/folder2/hello2.txt |
+      | /hello2.txt |
     When the administrator scans the filesystem in path "/user0/files/local_storage/folder1" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage/folder1/hello1.txt |
+      | /hello1.txt |
     When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage/folder2/hello2.txt |
+      | /hello2.txt |
 
   Scenario: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
     Given using new DAV path
@@ -61,17 +61,17 @@ Feature: Files Operations command
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage/folder1/hello1.txt |
+      | /hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage/folder1/hello1.txt |
+      | /hello1.txt |
     When the administrator scans the filesystem for group "newgroup" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage/folder1/hello1.txt |
+      | /hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/folder1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /folder1/hello1.txt |
+      | /hello1.txt |
 
   Scenario: administrator should be able to create a local mount for a specific user
     Given using new DAV path
@@ -94,15 +94,15 @@ Feature: Files Operations command
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/hello1.txt"
     When user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage/hello1.txt |
+      | /hello1.txt |
     When the administrator deletes file "hello1.txt" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage/hello1.txt |
+      | /hello1.txt |
     When the administrator scans the filesystem for all users using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage/hello1.txt |
+      | /hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific user should add file for only that user
     Given using new DAV path
@@ -121,17 +121,17 @@ Feature: Files Operations command
     And the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage1/hello1.txt |
+      | /hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage2/hello1.txt |
+      | /hello1.txt |
     When the administrator scans the filesystem for user "user0" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage1/hello1.txt |
+      | /hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage2/hello1.txt |
+      | /hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific group should add file for only the users of that group
     Given using new DAV path
@@ -156,23 +156,23 @@ Feature: Files Operations command
     And the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage1/hello1.txt |
+      | /hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage1/hello1.txt |
+      | /hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage2/hello1.txt |
+      | /hello1.txt |
     When the administrator scans the filesystem for group "newgroup" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage1/hello1.txt |
+      | /hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
-      | /local_storage1/hello1.txt |
+      | /hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
-      | /local_storage2/hello1.txt |
+      | /hello1.txt |
 
   Scenario: administrator should be able to add more than one user as the applicable user for a local mount
     Given using new DAV path


### PR DESCRIPTION
## Description
1) Remove unused ``$user`` parameter from ``propfindResultShouldContainNumEntries`` - see comment https://github.com/owncloud/core/pull/34334/files#r252529339
2) Modify ``findEntryFromPropfindResponse`` so that it looks in the response itself to find the WebDav path that was used in the request, rather than having to pass in the username and construct the path based on the username.
3) Adjust all callers and Gherkin step text so that these ``Then`` steps do not need to redundantly specify the username.

## Motivation and Context
Cleaner acceptance test code.

## How Has This Been Tested?
Local acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
