### PR TITLE
Fix features files for running test from user_ldap

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: capabilities
 
   Background:
@@ -466,10 +466,10 @@ Feature: capabilities
 
   Scenario: Changing exclude groups from sharing
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And group "grp1" has been created
+    And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
@@ -493,12 +493,12 @@ Feature: capabilities
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "user0" has been created with default attributes
-    And group "grp1" has been created
+    And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
     And group "ordinary-group" has been created
     And user "user0" has been added to group "hash#group"
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
     When user "user0" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
@@ -521,14 +521,14 @@ Feature: capabilities
 
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "user0" has been created with default attributes
-    And group "grp1" has been created
+    And user "user1" has been created with default attributes
+    And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
     And group "ordinary-group" has been created
-    And user "user0" has been added to group "ordinary-group"
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-    When user "user0" retrieves the capabilities using the capabilities API
+    And user "user1" has been added to group "ordinary-group"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
+    When user "user1" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |
@@ -550,15 +550,15 @@ Feature: capabilities
 
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "user0" has been created with default attributes
-    And group "grp1" has been created
+    And user "user2" has been created with default attributes
+    And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
     And group "ordinary-group" has been created
-    And user "user0" has been added to group "hash#group"
-    And user "user0" has been added to group "ordinary-group"
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-    When user "user0" retrieves the capabilities using the capabilities API
+    And user "user2" has been added to group "hash#group"
+    And user "user2" has been added to group "ordinary-group"
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
+    When user "user2" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
       | core          | pollinterval                          | 60                |

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: favorite
 
   Background:

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required
+@api @federation-app-required @TestAlsoOnExternalUserBackend
 Feature: federated
 
   Background:
@@ -170,6 +170,7 @@ Feature: federated
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
     Then the etag of element "/PARENT" of user "user1" on server "LOCAL" should have changed
 
+  @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on home storage
     Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
@@ -178,6 +179,7 @@ Feature: federated
     Then the HTTP status code of all upload responses should be "201"
     Then as user "user0" on server "REMOTE" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
 
+  @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives
     Given using server "LOCAL"
     And the quota of user "user1" has been set to "20 B"
@@ -187,6 +189,7 @@ Feature: federated
     When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
 
+  @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on remote storage - remote server shares - local server receives
     Given using server "REMOTE"
     And the quota of user "user0" has been set to "20 B"

--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required
+@api @systemtags-app-required @TestAlsoOnExternalUserBackend
 Feature: Assign tags to file/folder
   I want to assign tags to the file/folder
   So that I can organize the files/folders easily
@@ -42,9 +42,9 @@ Feature: Assign tags to file/folder
       | MyFirstTag | normal |
 
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user belongs to tag's groups should work
-    Given group "group1" has been created
-    And user "user1" has been added to group "group1"
-    And the administrator has created a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And the administrator has created a "not user-assignable" tag with name "JustARegularTagName" and groups "grp1"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     When user "user1" adds tag "JustARegularTagName" to file "/myFileToTag.txt" using the WebDAV API
@@ -53,9 +53,9 @@ Feature: Assign tags to file/folder
       | JustARegularTagName | not user-assignable |
 
   Scenario: Assigning a static tag to a file shared by someone else as regular user belongs to tag's groups should work
-    Given group "group1" has been created
-    And user "user1" has been added to group "group1"
-    And the administrator has created a "static" tag with name "StaticTagName" and groups "group1"
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And the administrator has created a "static" tag with name "StaticTagName" and groups "grp1"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     When user "user1" adds tag "StaticTagName" to file "/myFileToTag.txt" using the WebDAV API
@@ -75,10 +75,10 @@ Feature: Assign tags to file/folder
       | MyFirstTag | normal |
 
   Scenario: Assigning a static tag to a file shared by someone else as regular user does not belong to tag's group should fail
-    Given group "group1" has been created
-    And user "user0" has been added to group "group1"
+    Given group "hash#group" has been created
+    And user "user0" has been added to group "hash#group"
     And the administrator has created a "normal" tag with name "NormalTag"
-    And the administrator has created a "static" tag with name "StaticTag" and groups "group1"
+    And the administrator has created a "static" tag with name "StaticTag" and groups "hash#group"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     When the user adds tag "NormalTag" to file "/myFileToTag.txt" using the WebDAV API

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -1,26 +1,26 @@
-@api @systemtags-app-required
+@api @systemtags-app-required @TestAlsoOnExternalUserBackend
 Feature: Title of your feature
   I want to use this template for my feature file
 
   Background:
-    Given user "user0" has been created with default attributes
-    And as user "user0"
+    Given user "user1" has been created with default attributes
+    And as user "user1"
 
   Scenario: User can assign tags when in the tag's groups
-    Given group "group1" has been created
-    And user "user0" has been added to group "group1"
-    When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "grp1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the user should be able to assign the "not user-assignable" tag with name "TagWithGroups"
 
   Scenario: User can assign static tags when in the tag's groups
-    Given group "group1" has been created
-    And user "user0" has been added to group "group1"
-    When the administrator creates a "static" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When the administrator creates a "static" tag with name "TagWithGroups" and groups "grp1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the user should be able to assign the "static" tag with name "TagWithGroups"
 
   Scenario: User cannot assign tags when not in the tag's groups
-    When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
+    When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "grp2|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the user should not be able to assign the "not user-assignable" tag with name "TagWithGroups"

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required
+@api @systemtags-app-required @TestAlsoOnExternalUserBackend
 Feature: Creation of tags
   As a user
   I should be able to create tags

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required
+@api @systemtags-app-required @TestAlsoOnExternalUserBackend
 Feature: Deletion of tags
   As a user
   I want to delete the tags that are already created

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required
+@api @systemtags-app-required @TestAlsoOnExternalUserBackend
 Feature: Editing the tags
   As a user
   I want to be able to change the tags I have created

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required
+@api @systemtags-app-required @TestAlsoOnExternalUserBackend
 Feature: tags
 
   Background:

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required
+@api @systemtags-app-required @TestAlsoOnExternalUserBackend
 Feature: Unassigning tags from file/folder
   As a user
   I want to be able to remove tags from file/folder

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -1,4 +1,4 @@
-@api @files_versions-app-required
+@api @files_versions-app-required @TestAlsoOnExternalUserBackend
 
 Feature: dav-versions
 
@@ -237,11 +237,11 @@ Feature: dav-versions
   Scenario: sharer can restore a file inside a group shared folder modified by sharee
     Given user "user1" has been created with default attributes
     And user "user2" has been created with default attributes
-    And group "newgroup" has been created
-    And user "user1" has been added to group "newgroup"
-    And user "user2" has been added to group "newgroup"
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
     And user "user0" has created folder "/sharingfolder"
-    And user "user0" has shared folder "/sharingfolder" with group "newgroup"
+    And user "user0" has shared folder "/sharingfolder" with group "grp1"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
     And user "user2" has uploaded file with content "user2 content" to "/sharingfolder/sharefile.txt"

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -1,4 +1,4 @@
-@cli
+@cli @TestAlsoOnExternalUserBackend
 Feature: add and delete app configs using occ command
 
   As an administrator

--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -1,4 +1,4 @@
-@cli @local_storage
+@cli @local_storage @TestAlsoOnExternalUserBackend
 Feature: Files Operations command
 
   Scenario: Adding a file to local storage and running scan should add files.
@@ -48,28 +48,28 @@ Feature: Files Operations command
     Given using new DAV path
     And these users have been created with default attributes:
       | username |
-      | user0    |
       | user1    |
-    And group "newgroup" has been created
-    And user "user0" has been added to group "newgroup"
-    And user "user1" has been added to group "newgroup"
-    And user "user0" has created folder "/local_storage/folder1"
+      | user2    |
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user1" has created folder "/local_storage/folder1"
     And the administrator has set the external storage "local_storage" to be never scanned automatically
-    And user "user0" has shared folder "/local_storage/folder1" with group "newgroup"
+    And user "user1" has shared folder "/local_storage/folder1" with group "grp1"
     And the administrator has scanned the filesystem for all users
-    And the administrator has scanned the filesystem for group "newgroup"
+    And the administrator has scanned the filesystem for group "grp1"
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
-    And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
+    And user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
       | /hello1.txt |
-    When user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
+    When user "user2" requests "/remote.php/dav/files/user2/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
       | /hello1.txt |
-    When the administrator scans the filesystem for group "newgroup" using the occ command
-    And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
+    When the administrator scans the filesystem for group "grp1" using the occ command
+    And user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
       | /hello1.txt |
-    When user "user1" requests "/remote.php/dav/files/user1/folder1" with "PROPFIND" using basic auth
+    When user "user2" requests "/remote.php/dav/files/user2/folder1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
       | /hello1.txt |
 
@@ -137,40 +137,40 @@ Feature: Files Operations command
     Given using new DAV path
     And these users have been created with default attributes:
       | username |
-      | user0    |
       | user1    |
       | user2    |
-    And group "newgroup" has been created
-    And group "newgroup2" has been created
-    And user "user0" has been added to group "newgroup"
-    And user "user1" has been added to group "newgroup"
-    And user "user2" has been added to group "newgroup2"
+      | user3    |
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user3" has been added to group "grp2"
     And the administrator has created the local storage mount "local_storage1"
-    And the administrator has added group "newgroup" as the applicable group for the last local storage mount
+    And the administrator has added group "grp1" as the applicable group for the last local storage mount
     And the administrator has created the local storage mount "local_storage2"
-    And the administrator has added group "newgroup2" as the applicable group for the last local storage mount
+    And the administrator has added group "grp2" as the applicable group for the last local storage mount
     And the administrator has set the external storage "local_storage1" to be never scanned automatically
     And the administrator has set the external storage "local_storage2" to be never scanned automatically
     And the administrator has scanned the filesystem for all users
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage1" using the testing API
     And the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
-    And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
+    And user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
       | /hello1.txt |
-    When user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
+    When user "user2" requests "/remote.php/dav/files/user2/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
       | /hello1.txt |
-    When user "user2" requests "/remote.php/dav/files/user2/local_storage2" with "PROPFIND" using basic auth
+    When user "user3" requests "/remote.php/dav/files/user3/local_storage2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
       | /hello1.txt |
-    When the administrator scans the filesystem for group "newgroup" using the occ command
-    And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
+    When the administrator scans the filesystem for group "grp1" using the occ command
+    And user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
       | /hello1.txt |
-    When user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
+    When user "user2" requests "/remote.php/dav/files/user2/local_storage1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
       | /hello1.txt |
-    When user "user2" requests "/remote.php/dav/files/user2/local_storage2" with "PROPFIND" using basic auth
+    When user "user3" requests "/remote.php/dav/files/user3/local_storage2" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
       | /hello1.txt |
 
@@ -217,46 +217,46 @@ Feature: Files Operations command
     Given using new DAV path
     And these users have been created with default attributes:
       | username |
-      | user0    |
       | user1    |
-    And group "newgroup" has been created
-    And user "user0" has been added to group "newgroup"
+      | user2    |
+    And group "grp4" has been created
+    And user "user1" has been added to group "grp4"
     And the administrator has created the local storage mount "local_storage2"
-    When the administrator adds group "newgroup" as the applicable group for the last local storage mount using the occ command
-    Then as "user0" folder "/local_storage2" should exist
-    And as "user1" folder "/local_storage2" should not exist
+    When the administrator adds group "grp4" as the applicable group for the last local storage mount using the occ command
+    Then as "user1" folder "/local_storage2" should exist
+    And as "user2" folder "/local_storage2" should not exist
 
   Scenario: administrator should be able to create a local mount for more than one group
     Given using new DAV path
     And these users have been created with default attributes:
       | username |
-      | user0    |
       | user1    |
       | user2    |
-    And group "newgroup" has been created
-    And group "newgroup2" has been created
-    And user "user0" has been added to group "newgroup"
-    And user "user1" has been added to group "newgroup2"
+      | user3    |
+    And group "grp1" has been created
+    And group "grp4" has been created
+    And user "user1" has been added to group "grp4"
+    And user "user2" has been added to group "grp1"
     And the administrator has created the local storage mount "local_storage2"
-    When the administrator adds group "newgroup" as the applicable group for the last local storage mount using the occ command
-    And the administrator adds group "newgroup2" as the applicable group for the last local storage mount using the occ command
-    Then as "user0" folder "/local_storage2" should exist
-    And as "user1" folder "/local_storage2" should exist
-    And as "user2" folder "/local_storage2" should not exist
+    When the administrator adds group "grp1" as the applicable group for the last local storage mount using the occ command
+    And the administrator adds group "grp4" as the applicable group for the last local storage mount using the occ command
+    Then as "user1" folder "/local_storage2" should exist
+    And as "user2" folder "/local_storage2" should exist
+    And as "user3" folder "/local_storage2" should not exist
 
   Scenario: administrator should be able to create a local mount for a specific group and user
     Given using new DAV path
     And these users have been created with default attributes:
       | username |
-      | user0    |
       | user1    |
-    And group "newgroup" has been created
-    And user "user0" has been added to group "newgroup"
+      | user3    |
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
     And the administrator has created the local storage mount "local_storage2"
-    When the administrator adds group "newgroup" as the applicable group for the last local storage mount using the occ command
-    And the administrator adds user "user1" as the applicable user for the last local storage mount using the occ command
-    Then as "user0" folder "/local_storage2" should exist
-    And as "user1" folder "/local_storage2" should exist
+    When the administrator adds group "grp1" as the applicable group for the last local storage mount using the occ command
+    And the administrator adds user "user3" as the applicable user for the last local storage mount using the occ command
+    Then as "user1" folder "/local_storage2" should exist
+    And as "user3" folder "/local_storage2" should exist
 
   Scenario: removing group from applicable group of a local mount
     Given using new DAV path
@@ -290,17 +290,17 @@ Feature: Files Operations command
     Given using new DAV path
     And these users have been created with default attributes:
       | username |
-      | user0    |
       | user1    |
-      | user2    |
-    And group "newgroup" has been created
-    And group "newgroup2" has been created
-    And user "user0" has been added to group "newgroup"
-    And user "user1" has been added to group "newgroup2"
+      | user3    |
+      | user4    |
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user3" has been added to group "grp2"
     And the administrator has created the local storage mount "local_storage2"
-    And the administrator has added group "newgroup" as the applicable group for the last local storage mount
-    And the administrator has added group "newgroup2" as the applicable group for the last local storage mount
-    When the administrator removes group "newgroup" from the applicable group for the last local storage mount using the occ command
-    Then as "user0" folder "/local_storage2" should not exist
-    And as "user1" folder "/local_storage2" should exist
-    And as "user2" folder "/local_storage2" should not exist
+    And the administrator has added group "grp1" as the applicable group for the last local storage mount
+    And the administrator has added group "grp2" as the applicable group for the last local storage mount
+    When the administrator removes group "grp1" from the applicable group for the last local storage mount using the occ command
+    Then as "user1" folder "/local_storage2" should not exist
+    And as "user3" folder "/local_storage2" should exist
+    And as "user4" folder "/local_storage2" should not exist


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Currently LDAP users cannot be created during test. Even if we try to create regular users from tests through user_ldap app, it assumes that we want to create ldap users and does not create any users.
Because of this we cannot test some basic features for LDAP users.
But while running tests through user_ldap app some ldap users are created by default and added to some default groups. So fixed the feature files to use those users and groups so that we can run these tests from user_ldap.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related issue https://github.com/owncloud/user_ldap/issues/354

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently user_ldap requires more test coverate, but we cannot run these basic tests on ldap. By this fix we can add these core suites in user_ldap.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
