### PR TITLE
Hide lock owner when querying on public link

### DIFF
--- a/apps/dav/lib/Files/FileLocksBackend.php
+++ b/apps/dav/lib/Files/FileLocksBackend.php
@@ -136,10 +136,10 @@ class FileLocksBackend implements BackendInterface {
 
 			if (!$this->hideLockTokenInList) {
 				$lockInfo->token = $lock->getToken();
+				$lockInfo->owner = $lock->getOwner();
 			}
 			$lockInfo->created = $lock->getCreatedAt();
 			$lockInfo->depth = $lock->getDepth();
-			$lockInfo->owner = $lock->getOwner();
 			if ($lock->getScope() === ILock::LOCK_SCOPE_EXCLUSIVE) {
 				$lockInfo->scope = Locks\LockInfo::EXCLUSIVE;
 			} else {

--- a/apps/dav/tests/unit/Files/FileLocksBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileLocksBackendTest.php
@@ -261,9 +261,9 @@ class FileLocksBackendTest extends TestCase {
 		$locks = $this->plugin->getLocks($lockPluginGetLockPath, true);
 		$lockInfo = new LockInfo();
 		$lockInfo->token = null; // hidden in public endpoint
+		$lockInfo->owner = null; // hidden in public endpoint
 		$lockInfo->scope = LockInfo::EXCLUSIVE;
 		$lockInfo->uri = $responseLockRoot;
-		$lockInfo->owner = 'Alice Wonder';
 		$lockInfo->timeout = 400;
 		$lockInfo->depth = -1;
 		$lockInfo->created = self::CREATION_TIME;


### PR DESCRIPTION
## Description
When querying lockdiscovery on a PROPFIND on public webdav endpoint,
hide the lock owner to avoid leaking information about local users.

## Related Issue
Fixes https://github.com/owncloud/core/issues/34342

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- manual test with lock as local user and propfind as public user: no owner appears
- unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
