### PR TITLE
tests to check webdav requests with locktoken in header

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -1,0 +1,86 @@
+@api
+Feature: actions on a locked item are possible if the token is sent with the request
+
+  Background:
+    Given user "user0" has been created with default attributes
+
+  Scenario Outline: rename a file in a locked folder
+    Given using <dav-path> DAV path
+    And user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" moves file "/PARENT/parent.txt" to "/PARENT/renamed-file.txt" sending the locktoken of folder "PARENT" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "/PARENT/parent.txt" should not exist
+    But as "user0" file "/PARENT/renamed-file.txt" should exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  Scenario Outline: move a file into a locked folder
+    Given using <dav-path> DAV path
+    And user "user0" has locked folder "FOLDER" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" moves file "/PARENT/parent.txt" to "/FOLDER/moved-file.txt" sending the locktoken of folder "FOLDER" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "/PARENT/parent.txt" should not exist
+    But as "user0" file "/FOLDER/moved-file.txt" should exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  Scenario Outline: move a file into a locked folder is impossible when using the wrong token
+    Given using <dav-path> DAV path
+    And user "user0" has locked folder "FOLDER" setting following properties
+      | lockscope | <lock-scope> |
+    And user "user0" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user0" moves file "/PARENT/parent.txt" to "/FOLDER/moved-file.txt" sending the locktoken of folder "PARENT/CHILD" using the WebDAV API
+    Then the HTTP status code should be "423"
+    And as "user0" file "/PARENT/parent.txt" should exist
+    But as "user0" file "/FOLDER/moved-file.txt" should not exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  @issue-34338
+  Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
+    Given using <dav-path> DAV path
+    And user "user1" has been created with default attributes
+    And user "user0" has shared folder "PARENT" with user "user1"
+    And user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When user "user1" moves file "PARENT (2)/parent.txt" to "PARENT (2)/renamed-file.txt" sending the locktoken of file "PARENT" of user "user0" using the WebDAV API
+    #When the issue is fixed, remove the following steps and replace with the commented-out steps
+    Then the HTTP status code should be "403"
+    And as "user0" file "/PARENT/parent.txt" should not exist
+    But as "user0" file "/PARENT/renamed-file.txt" should exist
+    #Then the HTTP status code should be "423"
+    #And as "user0" file "/PARENT/parent.txt" should exist
+    #But as "user0" file "/PARENT/renamed-file.txt" should not exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+  Scenario Outline: public cannot overwrite a file in a folder locked by the owner even when sending the locktoken
+    Given user "user0" has created a public link share of folder "PARENT" with change permission
+    And user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "user0" using the public WebDAV API
+    Then the HTTP status code should be "423"
+    And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
+    Examples:
+      | lock-scope |
+      | shared     |
+      | exclusive  |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -254,6 +254,7 @@ class PublicWebDavContext implements Context {
 	 * @param string $password
 	 * @param string $body
 	 * @param bool $autorename
+	 * @param array $additionalHeaders
 	 *
 	 * @return void
 	 */
@@ -261,7 +262,8 @@ class PublicWebDavContext implements Context {
 		$filename,
 		$password = '',
 		$body = 'test',
-		$autorename = false
+		$autorename = false,
+		$additionalHeaders = []
 	) {
 		$password = $this->featureContext->getActualPassword($password);
 		$url = $this->featureContext->getBaseUrl() . "/public.php/webdav/";
@@ -275,6 +277,7 @@ class PublicWebDavContext implements Context {
 		if ($autorename) {
 			$headers['OC-Autorename'] = 1;
 		}
+		$headers = \array_merge($headers, $additionalHeaders);
 		$response = HttpRequestHelper::put(
 			$url, $token, $password, $headers, $body
 		);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -417,7 +417,7 @@ trait WebDav {
 	 *
 	 * @return string
 	 */
-	private function destinationHeaderValue($user, $fileDestination) {
+	public function destinationHeaderValue($user, $fileDestination) {
 		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
 		return $fullUrl . '/' . \ltrim($fileDestination, '/');
 	}


### PR DESCRIPTION
## Description
locked resources can be used by the owner when the locktoken is send in the header, test if that works correctly

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #34336 

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
