### PR TITLE
[stable10] Backport of Use loadFromFile instead of loadFromFileHandle

### DIFF
--- a/lib/private/Preview/Image.php
+++ b/lib/private/Preview/Image.php
@@ -44,11 +44,12 @@ abstract class Image implements IProvider2 {
 		}
 
 		$image = new \OC_Image();
-		$stream = $file->fopen('r');
 
-		$image->loadFromFileHandle($stream);
+		$internalPath = $file->getInternalPath();
+		$localPath = $file->getStorage()->getLocalFile($internalPath);
+		$image->loadFromFile($localPath);
 		$image->fixOrientation();
-		\fclose($stream);
+
 		if ($image->valid()) {
 			$image->scaleDownToFit($maxX, $maxY);
 


### PR DESCRIPTION
Use loadFromFile instead of loadFromFileHandle
while generating the thumbnail.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When `loadFromFileHandle` is used for generating thumbnail of images, the problem found is that it doesn't fix the orientation of images with exif. While `loadFromFile` handles this. It uses `exif_imagetype` before checking the mimetype of the image file. There is a word of caution noted in the https://github.com/owncloud/core/blob/master/lib/private/legacy/image.php#L496 ( reference: http://php.net/manual/en/function.exif-imagetype.php#79283 ). With the changeset the orientation issue while generating preview is resolved.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/18645

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This changeset fixes the orientation issue of images while generating preview.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Done basic test with a jpeg image with exif orientation. And the thumbnail was working. properly
- The image used for testing was taken from the issue mentioned in the PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
