### PR TITLE
Provide convenience test method getPathFromCoreToAppAcceptanceTests

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -308,6 +308,39 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @param string $appTestCodeFullPath
+	 *
+	 * @return string the relative path from the core tests/acceptance dir
+	 *                to the equivalent dir in the app
+	 */
+	public function getPathFromCoreToAppAcceptanceTests(
+		$appTestCodeFullPath
+	) {
+		// $appTestCodeFullPath is something like:
+		// '/somedir/anotherdir/core/apps/guests/tests/acceptance/features/bootstrap'
+		// and we want to know the 'apps/guests/tests/acceptance' part
+
+		// Sadly we have to support PHP 5.6 still.
+		// From PHP 7.0 we can go up 2 levels more directly:
+		// $path = dirname(__DIR__, 2);
+		$path = \dirname(\dirname($appTestCodeFullPath));
+		$acceptanceDir = \basename($path);
+		$path = \dirname($path);
+		$testsDir = \basename($path);
+		$path = \dirname($path);
+		$appNameDir = \basename($path);
+		$path = \dirname($path);
+		// We specially are not sure about the name of the directory 'apps'
+		// Sometimes the app could be installed in some alternate apps directory
+		// like, for example, `apps-external`. So this really does need to be
+		// resolved here at run-time.
+		$appsDir = \basename($path);
+		// To get from core tests/acceptance we go up 2 levels then down through
+		// the above app dirs.
+		return "../../$appsDir/$appNameDir/$testsDir/$acceptanceDir";
+	}
+
+	/**
 	 * Get the externally-defined admin username, if any
 	 *
 	 * @return string|false


### PR DESCRIPTION
## Description
Provide core acceptance test convenience method ``getPathFromCoreToAppAcceptanceTests`` 
Once this is available overnight in the QA tarballs, then apps can be adjusted to call it where needed.

## Issue
#34367 

## Motivation and Context
In some apps we have to know the relative path from the core ``tests/acceptance`` folder across to the app ``tests/acceptance`` folder (and then be able to navigate from there into app-specific test folders that might contain test data files etc.)

Currently ``files_antivirus``, ``files_classifier`` and ``guests`` all have a fixed private constant ``relativePathToTestDataFolder`` that specifies a path like ``../../apps/guests/tests/acceptance/data/``

In particular, ``apps`` dir is hard-coded. So it does not work if the app is installed in some alternate apps dir like ``apps-external``

Rather than fix this with the same code in each app that needs it, provide a convenience method in core test code.

## How Has This Been Tested?
Running ``files_classifier`` acceptance tests from a local development environment where the app is installed in ``apps-external``` folder.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
