### PR TITLE
The great CORS fix .....

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -118,9 +118,14 @@ class CorsPlugin extends ServerPlugin {
 	 * @return void
 	 */
 	public function setCorsHeaders(RequestInterface $request, ResponseInterface $response) {
-		if ($request->getHeader('origin') !== null && $this->userSession->getUser() !== null) {
+		if ($request->getHeader('origin') !== null) {
 			$requesterDomain = $request->getHeader('origin');
-			$userId = $this->userSession->getUser()->getUID();
+			// unauthenticated request shall add cors headers as well
+			$userId = null;
+			if ($this->userSession->getUser() !== null) {
+				$userId = $this->userSession->getUser()->getUID();
+			}
+
 			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, null, $this->getExtraHeaders($request));
 			foreach ($headers as $key => $value) {
 				$response->addHeader($key, \implode(',', $value));

--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -60,8 +60,6 @@ class CorsPlugin extends ServerPlugin {
 
 	private function getExtraHeaders(RequestInterface $request) {
 		if ($this->extraHeaders === null) {
-			// TODO: design a way to have plugins provide these
-			$this->extraHeaders['Access-Control-Allow-Headers'] = ['X-OC-Mtime', 'OC-Checksum', 'OC-Total-Length', 'Depth', 'Destination', 'Overwrite'];
 			if ($this->userSession->getUser() === null) {
 				$this->extraHeaders['Access-Control-Allow-Methods'] = [
 					'OPTIONS',

--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -88,8 +88,8 @@ class CorsPluginTest extends TestCase {
 		$allowedDomains = '["https://requesterdomain.tld", "http://anotherdomain.tld"]';
 
 		$allowedHeaders = [
-			'X-OC-Mtime', 'OC-Checksum', 'OC-Total-Length', 'OCS-APIREQUEST', 'Accept',
-			'Authorization', 'Brief', 'Content-Length', 'Content-Range', 'Content-type',
+			'OC-Checksum', 'OC-Total-Length', 'OCS-APIREQUEST', 'X-OC-Mtime', 'Accept',
+			'Authorization', 'Brief', 'Content-Length', 'Content-Range',
 			'Content-Type', 'Date', 'Depth', 'Destination', 'Host', 'If', 'If-Match',
 			'If-Modified-Since', 'If-None-Match', 'If-Range', 'If-Unmodified-Since',
 			'Location', 'Lock-Token', 'Overwrite', 'Prefer', 'Range', 'Schedule-Reply',
@@ -327,7 +327,7 @@ class CorsPluginTest extends TestCase {
 		];
 	}
 
-	public function testAdditionalAllowedHeaders() {
+	public function testAuthenticatedAdditionalAllowedHeaders() : void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('someuser');
 
@@ -347,7 +347,27 @@ class CorsPluginTest extends TestCase {
 		$this->server->addPlugin($this->plugin);
 
 		$this->plugin->setCorsHeaders($this->server->httpRequest, $this->server->httpResponse);
-		self::assertEquals('X-Additional-Configured-Header,authorization,X-OC-Mtime,OC-Checksum,OC-Total-Length,OCS-APIREQUEST,Accept,Authorization,Brief,Content-Length,Content-Range,Content-type,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With',
+		self::assertEquals('X-Additional-Configured-Header,authorization,OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With',
+			$this->server->httpResponse->getHeader('Access-Control-Allow-Headers'));
+	}
+
+	public function testUnauthenticatedAdditionalAllowedHeaders() : void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->server->httpRequest->setHeader('Origin', 'https://requesterdomain.tld');
+
+		$this->config->method('getSystemValue')->withConsecutive(
+			['cors.allowed-domains', []],
+			['cors.allowed-headers', []]
+		)
+			->willReturnMap([
+				['cors.allowed-domains', [], ['https://requesterdomain.tld']],
+				['cors.allowed-headers', [], ['X-Additional-Configured-Header', 'authorization']]
+			]);
+
+		$this->server->addPlugin($this->plugin);
+
+		$this->plugin->setCorsHeaders($this->server->httpRequest, $this->server->httpResponse);
+		self::assertEquals('X-Additional-Configured-Header,authorization,OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With',
 			$this->server->httpResponse->getHeader('Access-Control-Allow-Headers'));
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -26,6 +26,8 @@ use OCP\IUser;
 use OCP\IConfig;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\Request;
+use Sabre\HTTP\Response;
 use Test\TestCase;
 
 class CorsPluginTest extends TestCase {
@@ -86,19 +88,15 @@ class CorsPluginTest extends TestCase {
 		$allowedDomains = '["https://requesterdomain.tld", "http://anotherdomain.tld"]';
 
 		$allowedHeaders = [
-			'authorization',
-			'OCS-APIREQUEST',
-			'Origin',
-			'X-Requested-With',
-			'Content-Type',
-			'Access-Control-Allow-Origin',
-			'X-Request-ID',
-			'X-OC-Mtime',
-			'OC-Checksum',
-			'OC-Total-Length',
-			'Depth',
-			'Destination',
-			'Overwrite',
+			'X-OC-Mtime', 'OC-Checksum', 'OC-Total-Length', 'OCS-APIREQUEST', 'Accept',
+			'Authorization', 'Brief', 'Content-Length', 'Content-Range', 'Content-type',
+			'Content-Type', 'Date', 'Depth', 'Destination', 'Host', 'If', 'If-Match',
+			'If-Modified-Since', 'If-None-Match', 'If-Range', 'If-Unmodified-Since',
+			'Location', 'Lock-Token', 'Overwrite', 'Prefer', 'Range', 'Schedule-Reply',
+			'Timeout', 'User-Agent', 'X-Expected-Entity-Length', 'Accept-Language',
+			'Access-Control-Request-Method', 'Access-Control-Allow-Origin', 'ETag',
+			'OC-Autorename', 'OC-CalDav-Import', 'OC-Chunked', 'OC-Etag', 'OC-FileId',
+			'OC-LazyOps', 'OC-Total-File-Length', 'Origin', 'X-Request-ID', 'X-Requested-With'
 		];
 		$allowedMethods = [
 			'GET',
@@ -281,6 +279,7 @@ class CorsPluginTest extends TestCase {
 			$this->userSession->method('getUser')->willReturn(null);
 		}
 
+		$this->config->method('getSystemValue')->willReturn([]);
 		$this->config->method('getUserValue')
 			->with('someuser', 'core', 'domains')
 			->willReturn($allowedDomains);
@@ -326,5 +325,29 @@ class CorsPluginTest extends TestCase {
 			'Null Origin' => [true, null],
 			'plain http' => [false, 'http://example.net/'],
 		];
+	}
+
+	public function testAdditionalAllowedHeaders() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('someuser');
+
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->server->httpRequest->setHeader('Origin', 'https://requesterdomain.tld');
+
+		$this->config->method('getSystemValue')->withConsecutive(
+			['cors.allowed-domains', []],
+			['cors.allowed-headers', []]
+		)
+			->willReturnMap([
+				['cors.allowed-domains', [], []],
+				['cors.allowed-headers', [], ['X-Additional-Configured-Header', 'authorization']]
+			]);
+		$this->config->method('getUserValue')->willReturn('["https://requesterdomain.tld"]');
+
+		$this->server->addPlugin($this->plugin);
+
+		$this->plugin->setCorsHeaders($this->server->httpRequest, $this->server->httpResponse);
+		self::assertEquals('X-Additional-Configured-Header,authorization,X-OC-Mtime,OC-Checksum,OC-Total-Length,OCS-APIREQUEST,Accept,Authorization,Brief,Content-Length,Content-Range,Content-type,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With',
+			$this->server->httpResponse->getHeader('Access-Control-Allow-Headers'));
 	}
 }

--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
+use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\IConfig;
@@ -98,10 +99,15 @@ class CORSMiddleware extends Middleware {
 			$userId = $this->session->getUser()->getUID();
 		}
 
-		if ($this->request->getHeader('Origin') !== null &&
-			$this->reflector->hasAnnotation('CORS')) {
-			$requesterDomain = $this->request->getHeader('Origin');
+		$requesterDomain = $this->request->getHeader('Origin');
+		if ($requesterDomain === null) {
+			return $response;
+		}
 
+		// controller methods with the annotation @CORS will add CORS headers
+		// same for all methods in a OCSController - all OCS requests are allowed via CORS by default
+		if ($controller instanceof OCSController ||
+			$this->reflector->hasAnnotation('CORS')) {
 			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, $this->config);
 			foreach ($headers as $key => $value) {
 				$response->addHeader($key, \implode(',', $value));

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -153,10 +153,14 @@ class OC_API {
 
 		// If CORS is set to active for some method, try to add CORS headers
 		if (self::$actions[$name][0]['cors'] &&
-			\OC::$server->getUserSession()->getUser() !== null &&
 			\OC::$server->getRequest()->getHeader('Origin') !== null) {
 			$requesterDomain = \OC::$server->getRequest()->getHeader('Origin');
-			$userId = \OC::$server->getUserSession()->getUser()->getUID();
+
+			// unauthenticated request shall add cors headers as well
+			$userId = null;
+			if (\OC::$server->getUserSession()->getUser() !== null) {
+				$userId = \OC::$server->getUserSession()->getUser()->getUID();
+			}
 			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain);
 			foreach ($headers as $key => $value) {
 				$response->addHeader($key, \implode(',', $value));

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -298,7 +298,7 @@ class OC_Response {
 		}
 		if ($isCorsRequest) {
 			// TODO: infer allowed verbs from existing known routes
-			$allHeaders['Access-Control-Allow-Headers'] = ['authorization', 'OCS-APIREQUEST', 'Origin', 'X-Requested-With', 'Content-Type', 'Access-Control-Allow-Origin', 'X-Request-ID'];
+			$allHeaders['Access-Control-Allow-Headers'] = self::getAllowedCorsHeaders($config);
 			$allHeaders['Access-Control-Allow-Origin'] = [$domain];
 			$allHeaders['Access-Control-Allow-Methods'] =['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE', 'MKCOL', 'PROPFIND', 'PATCH', 'PROPPATCH', 'REPORT'];
 
@@ -326,11 +326,12 @@ class OC_Response {
 	 *     "Access-Control-Allow-Methods": ["a", "b", "c"]
 	 * ]
 	 *
+	 * @param \OCP\IConfig|null $config
 	 * @return Sabre\HTTP\ResponseInterface $response
 	 */
-	public static function setOptionsRequestHeaders($response, $headers = []) {
+	public static function setOptionsRequestHeaders($response, $headers = [], \OCP\IConfig $config = null) {
 		// TODO: infer allowed verbs from existing known routes
-		$allHeaders['Access-Control-Allow-Headers'] = ['authorization', 'OCS-APIREQUEST', 'Origin', 'X-Requested-With', 'Content-Type', 'Access-Control-Allow-Origin', 'X-Request-ID'];
+		$allHeaders['Access-Control-Allow-Headers'] = self::getAllowedCorsHeaders($config);
 		$allHeaders['Access-Control-Allow-Origin'] = ['*'];
 		$allHeaders['Access-Control-Allow-Methods'] =['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE', 'MKCOL', 'PROPFIND', 'PATCH', 'PROPPATCH', 'REPORT'];
 
@@ -345,5 +346,66 @@ class OC_Response {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * @param \OCP\IConfig $config
+	 * @return array|mixed
+	 */
+	private static function getAllowedCorsHeaders(\OCP\IConfig $config = null) {
+		if ($config === null) {
+			$config = \OC::$server->getConfig();
+		}
+		$allowedDefaultHeaders = [
+			// own headers
+			'X-OC-Mtime', 'OC-Checksum', 'OC-Total-Length', 'OCS-APIREQUEST',
+			// as used in sabre
+			'Accept',
+			'Authorization',
+			'Brief',
+			'Content-Length',
+			'Content-Range',
+			'Content-type',
+			'Content-Type',
+			'Date',
+			'Depth',
+			'Destination',
+			'Host',
+			'If',
+			'If-Match',
+			'If-Modified-Since',
+			'If-None-Match',
+			'If-Range',
+			'If-Unmodified-Since',
+			'Location',
+			'Lock-Token',
+			'Overwrite',
+			'Prefer',
+			'Range',
+			'Schedule-Reply',
+			'Timeout',
+			'User-Agent',
+			'X-Expected-Entity-Length',
+			// generally used headers in core
+			'Accept-Language',
+			'Access-Control-Request-Method',
+			'Access-Control-Allow-Origin',
+			'ETag',
+			'OC-Autorename',
+			'OC-CalDav-Import',
+			'OC-Chunked',
+			'OC-Etag',
+			'OC-FileId',
+			'OC-LazyOps',
+			'OC-Total-File-Length',
+			'OC-Total-Length',
+			'Origin',
+			'X-Request-ID',
+			'X-Requested-With'
+		];
+		$corsAllowedHeaders = $config->getSystemValue('cors.allowed-headers', []);
+		$corsAllowedHeaders = \array_merge($corsAllowedHeaders, $allowedDefaultHeaders);
+		$corsAllowedHeaders = \array_unique(\array_values($corsAllowedHeaders));
+		return $corsAllowedHeaders;
 	}
 }

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -349,20 +349,34 @@ class OC_Response {
 		return $response;
 	}
 
+	/**
+	 * These are the header which a browser can access from javascript code.
+	 * Simple headers are always accessible.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+	 *
+	 * @return array
+	 */
 	private static function getExposeCorsHeaders() {
 		return [
-			'X-Sabre-Status',
+			'Content-Location',
+			'DAV',
 			'ETag',
+			'Link',
+			'Lock-Token',
 			'OC-ETag',
+			'OC-Checksum',
 			'OC-FileId',
 			'OC-JobStatus-Location',
 			'Vary',
-			'DAV',
-			'Lock-Token'
+			'Webdav-Location',
+			'X-Sabre-Status',
 		];
 	}
 
 	/**
+	 * These are the headers the browser is allowed to ask for in a CORS request.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+	 *
 	 * @param \OCP\IConfig $config
 	 * @return array|mixed
 	 */
@@ -372,14 +386,16 @@ class OC_Response {
 		}
 		$allowedDefaultHeaders = [
 			// own headers
-			'X-OC-Mtime', 'OC-Checksum', 'OC-Total-Length', 'OCS-APIREQUEST',
+			'OC-Checksum',
+			'OC-Total-Length',
+			'OCS-APIREQUEST',
+			'X-OC-Mtime',
 			// as used in sabre
 			'Accept',
 			'Authorization',
 			'Brief',
 			'Content-Length',
 			'Content-Range',
-			'Content-type',
 			'Content-Type',
 			'Date',
 			'Depth',

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -299,6 +299,7 @@ class OC_Response {
 		if ($isCorsRequest) {
 			// TODO: infer allowed verbs from existing known routes
 			$allHeaders['Access-Control-Allow-Headers'] = self::getAllowedCorsHeaders($config);
+			$allHeaders['Access-Control-Expose-Headers'] = self::getExposeCorsHeaders();
 			$allHeaders['Access-Control-Allow-Origin'] = [$domain];
 			$allHeaders['Access-Control-Allow-Methods'] =['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE', 'MKCOL', 'PROPFIND', 'PATCH', 'PROPPATCH', 'REPORT'];
 
@@ -346,6 +347,19 @@ class OC_Response {
 		}
 
 		return $response;
+	}
+
+	private static function getExposeCorsHeaders() {
+		return [
+			'X-Sabre-Status',
+			'ETag',
+			'OC-ETag',
+			'OC-FileId',
+			'OC-JobStatus-Location',
+			'Vary',
+			'DAV',
+			'Lock-Token'
+		];
 	}
 
 	/**

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -30,7 +30,7 @@ use OCP\API;
 API::register(
 	'get',
 	'/config',
-	['OC_OCS_Config', 'apiConfig'],
+	['\OC\OCS\Config', 'apiConfig'],
 	'core',
 	API::GUEST_AUTH
 	);
@@ -38,7 +38,7 @@ API::register(
 API::register(
 	'post',
 	'/person/check',
-	['OC_OCS_Person', 'check'],
+	['\OC\OCS\Person', 'check'],
 	'core',
 	API::GUEST_AUTH
 	);
@@ -46,7 +46,7 @@ API::register(
 API::register(
 	'get',
 	'/privatedata/getattribute',
-	['OC_OCS_Privatedata', 'get'],
+	['\OC\OCS\PrivateData', 'get'],
 	'core',
 	API::USER_AUTH,
 	['app' => '', 'key' => '']
@@ -54,7 +54,7 @@ API::register(
 API::register(
 	'get',
 	'/privatedata/getattribute/{app}',
-	['OC_OCS_Privatedata', 'get'],
+	['\OC\OCS\PrivateData', 'get'],
 	'core',
 	API::USER_AUTH,
 	['key' => '']
@@ -62,21 +62,21 @@ API::register(
 API::register(
 	'get',
 	'/privatedata/getattribute/{app}/{key}',
-	['OC_OCS_Privatedata', 'get'],
+	['\OC\OCS\PrivateData', 'get'],
 	'core',
 	API::USER_AUTH
 	);
 API::register(
 	'post',
 	'/privatedata/setattribute/{app}/{key}',
-	['OC_OCS_Privatedata', 'set'],
+	['\OC\OCS\PrivateData', 'set'],
 	'core',
 	API::USER_AUTH
 	);
 API::register(
 	'post',
 	'/privatedata/deleteattribute/{app}/{key}',
-	['OC_OCS_Privatedata', 'delete'],
+	['\OC\OCS\PrivateData', 'delete'],
 	'core',
 	API::USER_AUTH
 	);

--- a/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
@@ -31,7 +31,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	private $reflector;
 	/** @var Session */
 	private $session;
-	/** @var IConfig */
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject*/
 	private $config;
 	/** @var IUserSession */
 	private $fakeSession;
@@ -68,6 +68,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	 * @CORS
 	 */
 	public function testSetCORSAPIHeader() {
+		$this->config->method('getSystemValue')->willReturn([]);
 		$request = new Request(
 			[
 				'server' => [
@@ -179,6 +180,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	 * @expectedException \OC\AppFramework\Middleware\Security\Exceptions\SecurityException
 	 */
 	public function testCorsIgnoredIfWithCredentialsHeaderPresent() {
+		$this->config->method('getSystemValue')->willReturn([]);
 		$request = new Request(
 			[
 				'server' => [


### PR DESCRIPTION
## Description
- All known headers which are read from requests are being added to the Access-Control-Allowed-Headers
- All known header which are sent back to the client and which shall be processed by clients are added to the Access-Control-Expose-Headers
- Additional Allowed-headers can be read from the config file
- Bugfix for unauthenticated requests to OCS and DAV

## Related Issue
- https://github.com/owncloud/phoenix/issues/476

## How Has This Been Tested?
- unit tests
- integration tests as per https://github.com/owncloud/js-owncloud-client/pull/159

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
