### PR TITLE
[Stable10] Return only creatable part of the shareFolder path

### DIFF
--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -283,13 +283,23 @@ class Helper {
 		$shareFolder = Filesystem::normalizePath($shareFolder);
 
 		if (!$view->file_exists($shareFolder)) {
-			$dir = '';
-			$subdirs = \explode('/', $shareFolder);
-			foreach ($subdirs as $subdir) {
-				$dir = $dir . '/' . $subdir;
-				if (!$view->is_dir($dir)) {
-					$view->mkdir($dir);
+			$currentDir = $shareFolder;
+			$dirsToCreate = [$shareFolder];
+			while (($currentDir = \dirname($currentDir)) !== '/') {
+				// FIXME: check if there is such file as well?
+				if ($view->is_dir($currentDir)) {
+					break;
 				}
+				$dirsToCreate[] = $currentDir;
+			}
+
+			$dirsToCreate = \array_reverse($dirsToCreate);
+			$shareFolder = '/';
+			foreach ($dirsToCreate as $dirToCreate) {
+				if ($view->mkdir($dirToCreate) === false) {
+					break;
+				}
+				$shareFolder = $dirToCreate;
 			}
 		}
 

--- a/apps/files_sharing/tests/HelperTest.php
+++ b/apps/files_sharing/tests/HelperTest.php
@@ -24,6 +24,8 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\View;
+
 /**
  * Class HelperTest
  *
@@ -42,6 +44,25 @@ class HelperTest extends TestCase {
 		$sharedFolder = \OCA\Files_Sharing\Helper::getShareFolder();
 		$this->assertSame('/Shared/Folder', \OCA\Files_Sharing\Helper::getShareFolder());
 		$this->assertTrue(\OC\Files\Filesystem::is_dir($sharedFolder));
+
+		// cleanup
+		\OC::$server->getConfig()->deleteSystemValue('share_folder');
+	}
+
+	/**
+	 * test get share folder on a read only storage
+	 */
+	public function testGetShareFolderOnReadOnlyStorage() {
+		\OCA\Files_Sharing\Helper::setShareFolder('/Share/Folder');
+
+		// Simulate when it is possible to create path /Share but not /Share/Folder
+		$viewMock = $this->createMock(View::class);
+		$viewMock->method('is_dir')
+			->willReturnOnConsecutiveCalls(false, false);
+		$viewMock->method('mkdir')
+			->willReturnOnConsecutiveCalls(true, false);
+		$sharedFolder = \OCA\Files_Sharing\Helper::getShareFolder($viewMock);
+		$this->assertSame('/Share', $sharedFolder);
 
 		// cleanup
 		\OC::$server->getConfig()->deleteSystemValue('share_folder');


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/34388

## Description
Check if  `shareFolder` is creatable and return it only if it exists or can be created

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3122

## Motivation and Context
Missing shares for guest users when shareFolder is non-default

## How Has This Been Tested?
1. Install and enable guests app.
2. add `	'share_folder' => '/omg/share',` to config.php
3. create a guest user by sharing any file via email
4. login as a guest user
#### Expected
guest user can see the shared file

#### Actual
guest user see no files

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
