### PR TITLE
make sure there are not more groups in the result than expected

### DIFF
--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -478,7 +478,13 @@ class OccUsersGroupsContext implements Context {
 
 		foreach ($groupTableNode as $row) {
 			PHPUnit_Framework_Assert::assertContains($row['group'], $lastOutputGroups);
+			$lastOutputGroups = \array_diff($lastOutputGroups, [$row['group']]);
 		}
+		PHPUnit_Framework_Assert::assertEmpty(
+			$lastOutputGroups,
+			"more than the expected groups are returned\n" .
+			\print_r($lastOutputGroups, true)
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -133,6 +133,7 @@ class OccUsersGroupsContext implements Context {
 			$this->featureContext->getActualPassword($password)
 		);
 		$this->featureContext->addUserToCreatedUsersList($username, $password);
+		$this->featureContext->addGroupToCreatedGroupsList($group);
 	}
 
 	/**


### PR DESCRIPTION
## Description
be more stricter when comparing the result and the expectation

## Related Issue
- needed for https://github.com/owncloud/user_ldap/issues/35

## Motivation and Context
if more than the expected groups are listed the test should fail

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
