### PR TITLE
[stable10] add before-after share link auth events

### DIFF
--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -182,6 +182,8 @@ class ShareController extends Controller {
 	 * @return bool
 	 */
 	private function linkShareAuth(\OCP\Share\IShare $share, $password = null) {
+		$beforeEvent = new GenericEvent(null, ['shareObject' => $share]);
+		$this->eventDispatcher->dispatch('share.beforelinkauth', $beforeEvent);
 		if ($password !== null) {
 			if ($this->shareManager->checkPassword($share, $password)) {
 				$this->session->set('public_link_authenticated', (string)$share->getId());
@@ -196,6 +198,8 @@ class ShareController extends Controller {
 				return false;
 			}
 		}
+		$afterEvent = new GenericEvent(null, ['shareObject' => $share]);
+		$this->eventDispatcher->dispatch('share.afterlinkauth', $afterEvent);
 		return true;
 	}
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/34158

## Description
Adds before and after events for public share link auths.

## Related Issue
The first step for:
#33542, [owncloud/brute_force_protection#57](https://github.com/owncloud/brute_force_protection/issues/57)

## Motivation and Context
To be able to detect and interrupt public link share auth attempts.

## How Has This Been Tested?
Manually and unit test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
