### PR TITLE
Bump README.md doc links to 10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/10.0/developer_manual/app/index.html
+https://doc.owncloud.org/server/10.1/developer_manual/app/index.html
 
 ## Contribution Guidelines
 https://owncloud.org/contribute/
@@ -39,4 +39,4 @@ Please submit translations via Transifex:
 https://www.transifex.com/projects/p/owncloud/
 
 For detailed information about translations:
-https://doc.owncloud.org/server/10.0/developer_manual/core/translation.html
+https://doc.owncloud.org/server/10.1/developer_manual/core/translation.html


### PR DESCRIPTION
## Description
Make the doc links in the GitHub README point to what will be the new release.

**Only merge this after the 10.1 docs have been published.**

## Motivation and Context
Use the most current doc links for people clicking from GitHub.

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
