### PR TITLE
Expand test scenarios for emojis and Unicode in comments

### DIFF
--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -8,12 +8,17 @@ Feature: Comments
     And as user "user0"
 
   @smokeTest
-  Scenario: Deleting my own comments on a file belonging to myself
+  Scenario Outline: Deleting my own comments on a file belonging to myself
     Given the user has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
-    And the user has commented with content "My first comment" on file "/myFileToComment.txt"
+    And the user has commented with content "<comment>" on file "/myFileToComment.txt"
     When the user deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
     And user "user0" should have 0 comments on file "/myFileToComment.txt"
+    Examples:
+      | comment          |
+      | My first comment |
+      | 😀 🤖            |
+      | नेपालि           |
 
   Scenario: Deleting a comment on a file belonging to myself having several comments
     Given the user has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -8,13 +8,18 @@ Feature: Comments
     And as user "user0"
 
   @smokeTest
-  Scenario: Edit my own comments on a file belonging to myself
+  Scenario Outline: Edit my own comments on a file belonging to myself
     Given the user has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And the user has commented with content "File owner comment" on file "/myFileToComment.txt"
-    When the user edits the last created comment with content "My edited comment" using the WebDAV API
+    When the user edits the last created comment with content "<comment>" using the WebDAV API
     Then the HTTP status code should be "207"
     And the user should have the following comments on file "/myFileToComment.txt"
-      | user0 | My edited comment |
+      | user0 | <comment> |
+    Examples:
+      | comment           |
+      | My edited comment |
+      | 😀 🤖             |
+      | नेपालि            |
 
   Scenario: Edit my own comments on a file shared by someone with me
     Given the user has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"

--- a/tests/acceptance/features/apiWebdavProperties/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/createFolder.feature
@@ -20,12 +20,15 @@ Feature: create folder
       | old         | /नेपाली         |
       | old         | /folder #2      |
       | old         | /folder ?2      |
+      | old         | /😀 🤖          |
       | new         | /upload         |
       | new         | /strängé folder |
       | new         | /C++ folder.cpp |
       | new         | /नेपाली         |
       | new         | /folder #2      |
       | new         | /folder ?2      |
+      | new         | /folder ?2      |
+      | new         | /😀 🤖          |
 
   @smokeTest
   Scenario Outline: Creating a folder

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1948,7 +1948,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theUserCommentsWithContentUsingTheWebui($content) {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
-		$detailsDialog->addComment($content);
+		$detailsDialog->addComment($this->getSession(), $content);
 		$this->filesPage->waitForAjaxCallsToStartAndFinish($this->getSession());
 	}
 

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -256,11 +256,12 @@ class DetailsDialog extends OwncloudPage {
 	/**
 	 * add a comment in a file whose details dialog is shown in the webUI
 	 *
+	 * @param Session $session
 	 * @param string $content
 	 *
 	 * @return void
 	 */
-	public function addComment($content) {
+	public function addComment(Session $session, $content) {
 		$commentInput = $this->detailsDialogElement->find(
 			"xpath", $this->commentInputXpath
 		);
@@ -270,7 +271,10 @@ class DetailsDialog extends OwncloudPage {
 			" xpath: $this->commentInputXpath" .
 			"could not find comment input field"
 		);
-		$commentInput->setValue($content);
+		$this->fillFieldWithCharacters(
+			$session, $this->commentInputXpath, $content
+		);
+
 		$postButton = $this->detailsDialogElement->find(
 			"xpath", $this->commentPostXpath
 		);

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -766,6 +766,29 @@ class OwncloudPage extends Page {
 	}
 
 	/**
+	 * Fill the field at the specified xpath with the given string
+	 *
+	 * If you want to put non-BMP characters, like emoji, into a text field in
+	 * the browser using "ordinary" methods like setValue or fillField,
+	 * then chromedriver complains:
+	 * "ChromeDriver only supports characters in the BMP"
+	 * This method provides a way to set the text field value via JavaScript.
+	 *
+	 * @param Session $session
+	 * @param string $xpath
+	 * @param string $string
+	 *
+	 * @return void
+	 */
+	public function fillFieldWithCharacters(
+		Session $session, $xpath, $string
+	) {
+		$session->executeScript(
+			"document.evaluate(`" . $xpath . "`, document).iterateNext().value = \"" . $string . "\";"
+		);
+	}
+
+	/**
 	 * Edge often returns whitespace before or after element text.
 	 * This is a convenient wrapper to ensure that text is trimmed
 	 * before using it in tests.

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -13,18 +13,28 @@ Feature: Add, delete and edit comments in files and folders
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  Scenario: user adds and deletes comment for a file/folder
+  Scenario Outline: user adds and deletes comment for a file/folder
     When the user browses directly to display the "comments" details of file "lorem.txt" in folder "/"
-    And the user comments with content "lorem ipsum" using the webUI
-    Then the comment "lorem ipsum" should be listed in the comments tab in details dialog
-    When the user deletes the comment "lorem ipsum" using the webUI
-    Then the comment "lorem ipsum" should not be listed in the comments tab in details dialog
+    And the user comments with content "<comment>" using the webUI
+    Then the comment "<comment>" should be listed in the comments tab in details dialog
+    When the user deletes the comment "<comment>" using the webUI
+    Then the comment "<comment>" should not be listed in the comments tab in details dialog
+    Examples:
+      | comment     |
+      | lorem ipsum |
+      | 😀 🤖       |
+      | नेपालि      |
 
-  Scenario: Add comment on a shared file and check it is shown in other user's UI
+  Scenario Outline: Add comment on a shared file and check it is shown in other user's UI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
-    And the user comments with content "lorem ipsum" using the webUI
+    And the user comments with content "<comment>" using the webUI
     And the user shares file "new-lorem.txt" with user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
-    Then the comment "lorem ipsum" should be listed in the comments tab in details dialog
+    Then the comment "<comment>" should be listed in the comments tab in details dialog
+    Examples:
+      | comment     |
+      | lorem ipsum |
+      | 😀 🤖       |
+      | नेपालि      |

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -9,6 +9,16 @@ Feature: create folders
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
+  Scenario Outline: Create a folder
+    When the user creates a folder with the name "<folder-name>" using the webUI
+    Then folder "<folder-name>" should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then folder "<folder-name>" should be listed on the webUI
+    Examples:
+      | folder-name       |
+      | folder-!@#$%^&* ! |
+      | नेपालि            |
+
   @smokeTest
   Scenario: Create a folder inside another folder
     When the user creates a folder with the name "top-folder" using the webUI


### PR DESCRIPTION
## Description
Add acceptance test scenarios for:
- API delete and edit comments that contain emojis and Unicode
- API create a folder that contains emojis in the name (Unicode scenarios already exist)
- webUI create, delete, edit comments that contain emojis and Unicode
- webUI create folders with punctuation characters and Unicode characters

See the comments in ``fillFieldWithCharacters`` for information about what I had to do to get emojis into a text box on the webUI.

Note: I have not added a test scenario for creating a folder with emojis in its name on the webUI. ``fillFieldWithCharacters`` happily puts the emojis into the "folder name" field. But then we need to somehow get focus into the field and send the enter key, while keeping the emojis in the field. That is a challenge for another day.

## Related Issue
- Fixes #34419 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
