### PR TITLE
test propagation of etags when sharing between federated servers

### DIFF
--- a/tests/acceptance/features/apiFederation/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederation/etagPropagation.feature
@@ -1,5 +1,5 @@
 @api @federation-app-required @TestAlsoOnExternalUserBackend
-Feature: propagation of etags between federated an local server
+Feature: propagation of etags between federated and local server
 
   Background:
     Given using OCS API version "1"
@@ -17,6 +17,46 @@ Feature: propagation of etags between federated an local server
     When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
     Then the etag of element "/PARENT (2)" of user "user0" on server "REMOTE" should have changed
 
+  @issue-enterprise-2848
+  Scenario: Overwrite a federated shared folder as sharer propagates etag to root folder for recipient
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    And user "user0" has stored etag of element "/"
+    And using server "LOCAL"
+    When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
+    # After fixing issue-enterprise-2848, change the following step to "should have changed"
+    Then the etag of element "/" of user "user0" on server "REMOTE" should not have changed
+    #Then the etag of element "/" of user "user0" on server "REMOTE" should have changed
+
+  @issue-enterprise-2848
+  Scenario: Adding a file to a federated shared folder as sharer propagates etag to root folder for recipient
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    And user "user0" has stored etag of element "/"
+    And using server "LOCAL"
+    When user "user1" uploads file "filesForUpload/lorem.txt" to "/PARENT/new-textfile.txt" using the WebDAV API
+    # After fixing issue-enterprise-2848, change the following step to "should have changed"
+    Then the etag of element "/" of user "user0" on server "REMOTE" should not have changed
+    #Then the etag of element "/" of user "user0" on server "REMOTE" should have changed
+
+  Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    And user "user0" has stored etag of element "/PARENT (2)"
+    When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    Then the etag of element "/PARENT (2)" of user "user0" on server "REMOTE" should have changed
+
+  Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for recipient
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    And user "user0" has stored etag of element "/"
+    When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    Then the etag of element "/" of user "user0" on server "REMOTE" should have changed
+
   Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
     And user "user1" has stored etag of element "/PARENT"
@@ -24,3 +64,19 @@ Feature: propagation of etags between federated an local server
     And using server "REMOTE"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
     Then the etag of element "/PARENT" of user "user1" on server "LOCAL" should have changed
+
+  Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for sharer
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user1" has stored etag of element "/"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    Then the etag of element "/" of user "user1" on server "LOCAL" should have changed
+
+  Scenario: Adding a file to a federated shared folder as recipient propagates etag to root folder for sharer
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user1" has stored etag of element "/"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    When user "user0" uploads file "filesForUpload/lorem.txt" to "/PARENT (2)/new-textfile.txt" using the WebDAV API
+    Then the etag of element "/" of user "user1" on server "LOCAL" should have changed

--- a/tests/acceptance/features/apiFederation/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederation/etagPropagation.feature
@@ -1,0 +1,26 @@
+@api @federation-app-required @TestAlsoOnExternalUserBackend
+Feature: propagation of etags between federated an local server
+
+  Background:
+    Given using OCS API version "1"
+    And using server "REMOTE"
+    And user "user0" has been created with default attributes
+    And using server "LOCAL"
+    And user "user1" has been created with default attributes
+
+  Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    And user "user0" has stored etag of element "/PARENT (2)"
+    And using server "LOCAL"
+    When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
+    Then the etag of element "/PARENT (2)" of user "user0" on server "REMOTE" should have changed
+
+  Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
+    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
+    And user "user1" has stored etag of element "/PARENT"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using server "REMOTE"
+    When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    Then the etag of element "/PARENT" of user "user1" on server "LOCAL" should have changed

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -153,7 +153,7 @@ Feature: federated
     When user "UNAUTHORIZED_USER" requests shared secret using the federation API
     Then the HTTP status code should be "403"
 
-  Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
+  Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -153,23 +153,6 @@ Feature: federated
     When user "UNAUTHORIZED_USER" requests shared secret using the federation API
     Then the HTTP status code should be "403"
 
-  Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
-    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
-    And user "user0" from server "REMOTE" has accepted the last pending share
-    And using server "REMOTE"
-    And user "user0" has stored etag of element "/PARENT (2)"
-    And using server "LOCAL"
-    When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
-    Then the etag of element "/PARENT (2)" of user "user0" on server "REMOTE" should have changed
-
-  Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
-    Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
-    And user "user1" has stored etag of element "/PARENT"
-    And user "user0" from server "REMOTE" has accepted the last pending share
-    And using server "REMOTE"
-    When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-    Then the etag of element "/PARENT" of user "user1" on server "LOCAL" should have changed
-
   @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on home storage
     Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -518,6 +518,23 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @Then the etag of element :path of user :user on server :server should not have changed
+	 *
+	 * @param string $path
+	 * @param string $user
+	 * @param string $server
+	 *
+	 * @return void
+	 */
+	public function theEtagOfElementOfUserOnServerShouldNotHaveChanged(
+		$path, $user, $server
+	) {
+		$previousServer = $this->featureContext->usingServer($server);
+		$this->etagOfElementOfUserShouldNotHaveChanged($path, $user);
+		$this->featureContext->usingServer($previousServer);
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *


### PR DESCRIPTION
## Description
more test that check if etags are propagated correctly
multiple commits because there have been multiple logical steps, fixing existing tests, move tests, add more tests

please note: the tests are written in a way that they demonstrate the current behaviour, when the bug is fixed the developer will be forced to adjust the tests. The correct behaviour is mentioned in the comments

## Related Issue
tests for https://github.com/owncloud/enterprise/issues/2848
part of #34149

## Motivation and Context
demonstrate current issue

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
