### PR TITLE
[stable10]  Refactor infoparser

### DIFF
--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -124,7 +124,7 @@ class CheckCode extends Command {
 		if (!$input->getOption('skip-validate-info')) {
 			$infoChecker = new InfoChecker($this->infoParser, $this->appManager);
 
-			$infoChecker->listen('InfoChecker', 'invalidAppInfo', function($appId) use ($output) {
+			$infoChecker->listen('InfoChecker', 'invalidAppInfo', function ($appId) use ($output) {
 				$output->writeln("<error>$appId has invalid XML in appinfo.xml</error>");
 			});
 

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -35,9 +35,11 @@
 /** @var $application Symfony\Component\Console\Application */
 $application->add(new OC\Core\Command\Status);
 $application->add(new OC\Core\Command\Check(\OC::$server->getConfig()));
-$infoParser = new \OC\App\InfoParser();
-$application->add(new OC\Core\Command\App\CheckCode($infoParser));
 $application->add(new OC\Core\Command\L10n\CreateJs());
+$application->add(new OC\Core\Command\App\CheckCode(
+	new \OC\App\InfoParser(),
+	\OC::$server->getAppManager()
+));
 $application->add(new \OC\Core\Command\Integrity\SignApp(
 		\OC::$server->getIntegrityCodeChecker(),
 		new \OC\IntegrityCheck\Helpers\FileAccessHelper(),

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -576,7 +576,11 @@ class AppManager implements IAppManager {
 
 			$versionToLoad = [];
 			foreach ($possibleAppRoots as $possibleAppRoot) {
-				$version = $this->getAppVersionByPath($possibleAppRoot['path'] . '/' . $appId);
+				try {
+					$version = $this->getAppVersionByPath($possibleAppRoot['path'] . '/' . $appId);
+				} catch (\Exception $e) {
+					continue;
+				}
 				if (empty($versionToLoad) || \version_compare($version, $versionToLoad['version'], '>')) {
 					$versionToLoad = \array_merge($possibleAppRoot, ['version' => $version]);
 					$versionToLoad['path'] .= '/' . $appId;

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -25,15 +25,22 @@
 
 namespace OC\App;
 
+use InvalidArgumentException;
+use OCP\App\AppNotFoundException;
+
 class InfoParser {
 
 	/**
 	 * @param string $file the xml file to be loaded
-	 * @return null|array where null is an indicator for an error
+	 * @return array
+	 * @throws AppNotFoundException if file does not exist
+	 * @throws InvalidArgumentException on malformed XML
 	 */
 	public function parse($file) {
-		if (!\file_exists($file)) {
-			return null;
+		if (!\is_file($file)) {
+			throw new AppNotFoundException(
+				sprintf('%s does not exist', $file)
+			);
 		}
 
 		\libxml_use_internal_errors(true);
@@ -43,12 +50,12 @@ class InfoParser {
 		\libxml_disable_entity_loader($loadEntities);
 		if ($xml === false) {
 			\libxml_clear_errors();
-			return null;
+			throw new InvalidArgumentException('Invalid XML');
 		}
 		$array = $this->xmlToArray($xml);
 
-		if ($array === null) {
-			return null;
+		if (!\is_array($array)) {
+			throw new InvalidArgumentException('Could not convert XML to array');
 		}
 
 		if (!\array_key_exists('info', $array)) {
@@ -129,9 +136,9 @@ class InfoParser {
 
 	/**
 	 * @param \SimpleXMLElement $xml
-	 * @return array
+	 * @return array|string
 	 */
-	public function xmlToArray($xml) {
+	protected function xmlToArray($xml) {
 		if (!$xml->children()) {
 			return (string)$xml;
 		}

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -39,7 +39,7 @@ class InfoParser {
 	public function parse($file) {
 		if (!\is_file($file)) {
 			throw new AppNotFoundException(
-				sprintf('%s does not exist', $file)
+				\sprintf('%s does not exist', $file)
 			);
 		}
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -642,7 +642,12 @@ class OC_App {
 		}
 
 		$parser = new InfoParser();
-		$data = $parser->parse($file);
+		try {
+			$data = $parser->parse($file);
+		} catch (\Exception $e) {
+			\OC::$server->getLogger()->logException($e);
+			throw $e;
+		}
 
 		if (\is_array($data)) {
 			$data = OC_App::parseAppInfo($data);

--- a/tests/Core/Command/Apps/CheckCodeTest.php
+++ b/tests/Core/Command/Apps/CheckCodeTest.php
@@ -19,7 +19,6 @@
  *
  */
 
-
 namespace Tests\Core\Command\Config;
 
 use OCP\App\IAppManager;

--- a/tests/Core/Command/Apps/CheckCodeTest.php
+++ b/tests/Core/Command/Apps/CheckCodeTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace Tests\Core\Command\Config;
+
+use OCP\App\IAppManager;
+use OC\App\InfoParser;
+use OC\Core\Command\App\CheckCode;
+use OCP\App\AppNotFoundException;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class CheckCodeTest
+ *
+ * @group DB
+ */
+class CheckCodeTest extends TestCase {
+	/** @var CommandTester */
+	private $commandTester;
+
+	/**
+	 * @expectedException \RuntimeException
+	 */
+	public function testWrongAppId() {
+		$command = new CheckCode(new InfoParser, \OC::$server->getAppManager());
+		$this->commandTester = new CommandTester($command);
+		$this->commandTester->execute(['app-id' => 'hui-buh']);
+	}
+}

--- a/tests/data/app/invalid-info2.xml
+++ b/tests/data/app/invalid-info2.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<info>surprise</info>

--- a/tests/lib/App/CodeChecker/InfoCheckerTest.php
+++ b/tests/lib/App/CodeChecker/InfoCheckerTest.php
@@ -21,30 +21,33 @@
 
 namespace Test\App\CodeChecker;
 
+use OCP\App\AppNotFoundException;
+use OCP\App\IAppManager;
 use OC\App\CodeChecker\InfoChecker;
 use OC\App\InfoParser;
 use Test\TestCase;
 
 class InfoCheckerTest extends TestCase {
-	/** @var InfoChecker */
-	protected $infoChecker;
 
-	public static function setUpBeforeClass() {
-		\OC::$APPSROOTS[] = [
-			'path' => \OC::$SERVERROOT . '/tests/apps',
-			'url' => '/apps-test',
-			'writable' => false,
-		];
-	}
-
-	public static function tearDownAfterClass() {
-		// remove last element
-		\array_pop(\OC::$APPSROOTS);
-	}
+	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
+	protected $appManager;
 
 	protected function setUp() {
 		parent::setUp();
-		$this->infoChecker = new InfoChecker(new InfoParser());
+
+		$this->appManager = $this->getMockBuilder(IAppManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->will(
+				$this->returnCallback(
+					function ($appId){
+						return \OC::$SERVERROOT . '/tests/apps/' . $appId;
+					}
+				)
+			);
 	}
 
 	public function appInfoData() {
@@ -65,8 +68,27 @@ class InfoCheckerTest extends TestCase {
 	 * @param $expectedErrors
 	 */
 	public function testApps($appId, $expectedErrors) {
-		$errors = $this->infoChecker->analyse($appId);
+		$infoChecker = $this->getInfoChecker(new InfoParser());
+		$errors = $infoChecker->analyse($appId);
 
 		$this->assertEquals($expectedErrors, $errors);
+	}
+
+	public function testInvalidAppInfo() {
+		$infoParser = $this->getMockBuilder(InfoParser::class)
+			->getMock();
+		$infoParser->expects($this->any())
+			->method('parse')
+			->will($this->throwException(new AppNotFoundException()));
+
+		$infoChecker = $this->getInfoChecker($infoParser);
+		$errors = $infoChecker->analyse('testapp-infoxml');
+
+		$this->assertArrayHasKey('type', $errors[0]);
+		$this->assertEquals('invalidAppInfo', $errors[0]['type']);
+	}
+
+	private function getInfoChecker($infoParser) {
+		return new InfoChecker($infoParser, $this->appManager);
 	}
 }

--- a/tests/lib/App/CodeChecker/InfoCheckerTest.php
+++ b/tests/lib/App/CodeChecker/InfoCheckerTest.php
@@ -43,7 +43,7 @@ class InfoCheckerTest extends TestCase {
 			->method('getAppPath')
 			->will(
 				$this->returnCallback(
-					function ($appId){
+					function ($appId) {
 						return \OC::$SERVERROOT . '/tests/apps/' . $appId;
 					}
 				)

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -22,23 +22,34 @@ class InfoParserTest extends TestCase {
 		$this->parser = new InfoParser();
 	}
 
-	/**
-	 * @dataProvider providesInfoXml
-	 */
-	public function testParsingValidXml($expectedJson, $xmlFile) {
-		$expectedData = null;
-		if ($expectedJson !== null) {
-			$expectedData = \json_decode(\file_get_contents(OC::$SERVERROOT . "/tests/data/app/$expectedJson"), true);
-		}
-		$data = $this->parser->parse(OC::$SERVERROOT. "/tests/data/app/$xmlFile");
-
+	public function testParsingValidXml() {
+		$expectedData = json_decode(
+			file_get_contents(OC::$SERVERROOT . "/tests/data/app/expected-info.json"),
+			true
+		);
+		$data = $this->parser->parse(OC::$SERVERROOT. "/tests/data/app/valid-info.xml");
 		$this->assertEquals($expectedData, $data);
 	}
 
-	public function providesInfoXml() {
+	/**
+	 * @expectedException \OCP\App\AppNotFoundException
+	 */
+	public function testParsingMissingXml() {
+		$this->parser->parse('none');
+	}
+
+	/**
+	 * @dataProvider invalidXmlProvider
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testParsingInvalidXml($xmlFile) {
+		$this->parser->parse(OC::$SERVERROOT. '/tests/data/app/' . $xmlFile);
+	}
+
+	public function invalidXmlProvider() {
 		return [
-			['expected-info.json', 'valid-info.xml'],
-			[null, 'invalid-info.xml'],
+			['invalid-info.xml'],
+			['invalid-info2.xml']
 		];
 	}
 }

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -23,8 +23,8 @@ class InfoParserTest extends TestCase {
 	}
 
 	public function testParsingValidXml() {
-		$expectedData = json_decode(
-			file_get_contents(OC::$SERVERROOT . "/tests/data/app/expected-info.json"),
+		$expectedData = \json_decode(
+			\file_get_contents(OC::$SERVERROOT . "/tests/data/app/expected-info.json"),
 			true
 		);
 		$data = $this->parser->parse(OC::$SERVERROOT. "/tests/data/app/valid-info.xml");


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/30457

## Description
- Throw exception in `InfoParser` instead of returning `null` on error
- Log this exception in `OC_App` and rethrow it
- Minor code cleanup
- Some tests

## Related Issue
https://github.com/owncloud/core/issues/30190

## Motivation and Context
Control everything ;)

## How Has This Been Tested?
1. By putting garbage inside appinfo and opening OC from web
2. with `php occ occ app:check-code` for the  app broken in the same manner


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

