### PR TITLE
Repair subshares earlier to avoid errors

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -141,6 +141,9 @@ class Repair implements IOutput {
 			new RemoveGetETagEntries(\OC::$server->getDatabaseConnection()),
 			new UpdateOutdatedOcsIds(\OC::$server->getConfig()),
 			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
+			new RepairSubShares(
+				\OC::$server->getDatabaseConnection()
+			),
 			new SharePropagation(\OC::$server->getConfig()),
 			new MoveAvatarOutsideHome(
 				\OC::$server->getConfig(),
@@ -162,9 +165,6 @@ class Repair implements IOutput {
 				\OC::$server->getAppManager(),
 				\OC::$server->getConfig(),
 				\OC::$server->getAppConfig()
-			),
-			new RepairSubShares(
-				\OC::$server->getDatabaseConnection()
 			),
 		];
 	}


### PR DESCRIPTION
## Description
On some environments, some of the other repair steps would setup the FS
and fail with errors due to duplicate shares.

## Related Issue
- Ref https://github.com/owncloud/enterprise/issues/2921

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on user's test environment where the failure occurred and confirmed working.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
