### PR TITLE
Clarify checksum error message on interrupted upload

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -208,7 +208,7 @@ class File extends Node implements IFile, IFileNode {
 			}
 
 			if (!self::isChecksumValid($partStorage, $internalPartPath)) {
-				throw new BadRequest('The computed checksum does not match the one received from the client.');
+				throw new BadRequest('The computed checksum does not match the one received from the client. Upload has been interrupted or got corrupted, and requires re-upload.');
 			}
 
 			if ($result === false) {
@@ -535,7 +535,7 @@ class File extends Node implements IFile, IFileNode {
 					$chunk_handler->file_assemble($partStorage, $partInternalPath);
 
 					if (!self::isChecksumValid($partStorage, $partInternalPath)) {
-						throw new BadRequest('The computed checksum does not match the one received from the client.');
+						throw new BadRequest('The computed checksum does not match the one received from the client for this chunked file.');
 					}
 
 					// here is the final atomic rename


### PR DESCRIPTION
1.- Prepare A file big enough (<10MB) to give the time to shut down the sync-client
2.- Add the file in the sync-folder and waint until the syncing icon appears
3.- Turn off the sync client.

This will interupt the upload of the file, and log exception about checksum, which might be misleading. 

Actually it is expected exception as bytes sent are not matching the expected bytes on the server, as stream has been closed gracefully by the client, and server thinks the upload finished and continues adding the file.