### PR TITLE
[stable10] Store quota overrides in preferences table

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -461,6 +461,8 @@ class User implements IUser {
 			$quota = OC_Helper::humanFileSize($quota);
 		}
 		$this->account->setQuota($quota);
+		// Set the quota on the preferences table as an override
+		$this->config->setUserValue($this->getUID(), 'files', 'quota', $quota);
 		$this->mapper->update($this->account);
 		$this->triggerChange('quota', $quota);
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Currently the user management UI in stable10 uses this method, through `setquota.php` to update the quota of a user. However, if they are from another user backend, on sync the quota is just replaced. 

New version of https://github.com/owncloud/core/pull/32731

Setting the quota override should set it in the preferences table as well which is used as the manual override. On sync, the sync serivce checks this and uses this as an override instead. You can delete the key here to go back to the one supplied by the user backend.

## Related Issue
https://github.com/owncloud/core/pull/32731

## Motivation and Context
Quota is replaced on every sync if you override the quota in owncloud 10 and use an external user backend. 

## How Has This Been Tested?
Manually in the UI.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
