### PR TITLE
[CalDAV] In case of a cancel message the status has to be set inside …

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -113,6 +113,7 @@ class IMipPlugin extends SabreIMipPlugin {
 				break;
 			case 'CANCEL':
 				$subject = 'Cancelled: ' . $summary;
+				$iTipMessage->message->VEVENT->STATUS = 'CANCELLED';
 				break;
 		}
 

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -125,4 +125,36 @@ class IMipPluginTest extends TestCase {
 		$this->assertEquals(['gandalf@wiz.ard' => null], $mailMessage->getReplyTo());
 		$this->assertEquals('text/calendar; charset=UTF-8; method=REQUEST', $mailMessage->getSwiftMessage()->getContentType());
 	}
+
+	public function testDeliveryOfCancel(): void {
+		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
+		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
+		$mailer = $this->createMock(Mailer::class);
+		$mailer->method('createMessage')->willReturn($mailMessage);
+		$mailer->expects($this->once())->method('send');
+		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+		$logger = $this->createMock(Log::class);
+		/** @var IRequest| \PHPUnit_Framework_MockObject_MockObject $request */
+		$request = $this->createMock(IRequest::class);
+
+		$plugin = new IMipPlugin($mailer, $logger, $request);
+		$message = new Message();
+		$message->method = 'CANCEL';
+		$message->message = new VCalendar();
+		$message->message->add('VEVENT', [
+			'UID' => $message->uid,
+			'SEQUENCE' => $message->sequence,
+			'SUMMARY' => 'Fellowship meeting',
+		]);
+		$message->sender = 'mailto:gandalf@wiz.ard';
+		$message->recipient = 'mailto:frodo@hobb.it';
+
+		$plugin->schedule($message);
+		$this->assertEquals('1.1', $message->getScheduleStatus());
+		$this->assertEquals('Cancelled: Fellowship meeting', $mailMessage->getSubject());
+		$this->assertEquals(['frodo@hobb.it' => null], $mailMessage->getTo());
+		$this->assertEquals(['gandalf@wiz.ard' => null], $mailMessage->getReplyTo());
+		$this->assertEquals('text/calendar; charset=UTF-8; method=CANCEL', $mailMessage->getSwiftMessage()->getContentType());
+		$this->assertEquals('CANCELLED', $message->message->VEVENT->STATUS->getValue());
+	}
 }


### PR DESCRIPTION
…the VEVENT

## Description
In case a cancel message is sent to an invites attendee the status within the VEVENT has to be set to CANCELLED.
If not some clients(e.g. Exchange) are having issues with this.

## Motivation and Context
- be compatible ...

## How Has This Been Tested?
- manually by comparing the email attachment
- needs to be tested in a exchange environment

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
