### PR TITLE
Add ownCloud motto change password email

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -263,12 +263,15 @@ class LostController extends Controller {
 		if ($email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
 			$msg = $tmpl->fetchPage();
+			$tmplAlt = new \OC_Template('core', 'lostpassword/altnotify');
+			$msgAlt = $tmplAlt->fetchPage();
 
 			try {
 				$message = $this->mailer->createMessage();
 				$message->setTo([$email => $userId]);
 				$message->setSubject($this->l10n->t('%s password changed successfully', [$this->defaults->getName()]));
-				$message->setPlainBody($msg);
+				$message->setPlainBody($msgAlt);
+				$message->setHtmlBody($msg);
 				$message->setFrom([$this->from => $this->defaults->getName()]);
 				$this->mailer->send($message);
 			} catch (\Exception $e) {

--- a/core/templates/lostpassword/altnotify.php
+++ b/core/templates/lostpassword/altnotify.php
@@ -1,0 +1,5 @@
+<?php
+p($l->t('Password changed successfully'));
+
+print_unescaped("\n\n");
+print_unescaped($this->inc('plain.mail.footer'));

--- a/core/templates/lostpassword/notify.php
+++ b/core/templates/lostpassword/notify.php
@@ -1,2 +1,32 @@
-<?php
-echo $l->t('Password changed successfully');
+<table cellspacing="0" cellpadding="0" border="0" width="100%">
+	<tr><td>
+			<table cellspacing="0" cellpadding="0" border="0" width="600px">
+				<tr>
+					<td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
+					<td bgcolor="<?php p($theme->getMailHeaderColor());?>">
+						<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+					</td>
+				</tr>
+				<tr><td colspan="2">&nbsp;</td></tr>
+				<tr>
+					<td width="20px">&nbsp;</td>
+					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
+						<?php
+						p($l->t('Password changed successfully'));
+						?>
+					</td>
+				</tr>
+				<tr><td colspan="2">&nbsp;</td></tr>
+				<tr>
+					<td width="20px">&nbsp;</td>
+					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
+						<?php print_unescaped($this->inc('html.mail.footer')); ?>
+					</td>
+				</tr>
+				<tr>
+					<td colspan="2">&nbsp;</td>
+				</tr>
+			</table>
+		</td></tr>
+</table>
+

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -78,12 +78,15 @@ class Controller {
 		if ($email !== null && $email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
 			$msg = $tmpl->fetchPage();
+			$tmplAlt = new \OC_Template('core', 'lostpassword/altnotify');
+			$msgAlt = $tmplAlt->fetchPage();
 
 			try {
 				$message = $mailer->createMessage();
 				$message->setTo([$email => $username]);
 				$message->setSubject($l10n->t('%s password changed successfully', [$defaults->getName()]));
-				$message->setPlainBody($msg);
+				$message->setPlainBody($msgAlt);
+				$message->setHtmlBody($msg);
 				$message->setFrom([$from => $defaults->getName()]);
 				$mailer->send($message);
 			} catch (\Exception $e) {

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -517,9 +517,13 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(2))
 			->method('setPlainBody')
-			->with('Password changed successfully');
+			->with($this->stringContains('Password changed successfully'));
 		$message
 			->expects($this->at(3))
+			->method('setHtmlBody')
+			->with($this->stringContains('Password changed successfully'));
+		$message
+			->expects($this->at(4))
 			->method('setFrom')
 			->with(['lostpassword-noreply@localhost' => null]);
 		$this->mailer


### PR DESCRIPTION
Resend of rebased version of #32081 from @imujjwal96 
In addition to @imujjwal96's work:
- Unit tests are adapted.
- I also updated `settings/ChangePassword/Controller.php`. It is using the same mail template.

## Description
- Added the motto as footer
- Added alternative Plain text page for notify email
- Update notify email with html template.

## Related Issue

- Fixes #32042 

## How Has This Been Tested?
Unit tests. Also, tried manually in local.

## Screenshots (if appropriate):
<img width="752" alt="screen shot 2018-07-18 at 2 50 53 pm" src="https://user-images.githubusercontent.com/8245662/42872233-006fa7ca-8a9a-11e8-9aaf-910fcccacf09.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
