### PR TITLE
[stable10] Enable PreviewPlugin on public webdav

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -49,7 +49,8 @@ $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getMountManager(),
 	\OC::$server->getTagManager(),
 	\OC::$server->getRequest(),
-	\OC::$server->getTimeFactory()
+	\OC::$server->getTimeFactory(),
+	\OC::$server->getPreviewManager()
 );
 
 $requestUri = \OC::$server->getRequest()->getRequestUri();

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -38,7 +38,8 @@ $serverFactory = new \OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getMountManager(),
 	\OC::$server->getTagManager(),
 	\OC::$server->getRequest(),
-	\OC::$server->getTimeFactory()
+	\OC::$server->getTimeFactory(),
+	\OC::$server->getPreviewManager()
 );
 
 // Backends

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -41,6 +41,8 @@ use OCP\ITagManager;
 use OCP\IUserSession;
 use Sabre\DAV\Auth\Backend\BackendInterface;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IPreview;
+use OCA\DAV\Files\PreviewPlugin;
 
 class ServerFactory {
 	/** @var IConfig */
@@ -59,6 +61,8 @@ class ServerFactory {
 	private $request;
 	/** @var ITimeFactory */
 	private $timeFactory;
+	/** @var IPreview */
+	private $previewManager;
 
 	/**
 	 * @param IConfig $config
@@ -78,7 +82,8 @@ class ServerFactory {
 		IMountManager $mountManager,
 		ITagManager $tagManager,
 		IRequest $request,
-		ITimeFactory $timeFactory
+		ITimeFactory $timeFactory,
+		IPreview $previewManager
 	) {
 		$this->config = $config;
 		$this->logger = $logger;
@@ -88,6 +93,7 @@ class ServerFactory {
 		$this->tagManager = $tagManager;
 		$this->request = $request;
 		$this->timeFactory = $timeFactory;
+		$this->previewManager = $previewManager;
 	}
 
 	/**
@@ -125,6 +131,8 @@ class ServerFactory {
 		if (BrowserErrorPagePlugin::isBrowserRequest($this->request)) {
 			$server->addPlugin(new BrowserErrorPagePlugin());
 		}
+
+		$server->addPlugin(new PreviewPlugin($this->timeFactory, $this->previewManager));
 
 		// wait with registering these until auth is handled and the filesystem is setup
 		$server->on('beforeMethod', function () use ($server, $objectTree, $viewCallBack) {

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTest.php
@@ -31,6 +31,7 @@ use Sabre\HTTP\Request;
 use Test\TestCase;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
+use OCP\IPreview;
 
 abstract class RequestTest extends TestCase {
 	use UserTrait;
@@ -61,7 +62,8 @@ abstract class RequestTest extends TestCase {
 			\OC::$server->getMountManager(),
 			\OC::$server->getTagManager(),
 			$this->createMock('\OCP\IRequest'),
-			\OC::$server->getTimeFactory()
+			\OC::$server->getTimeFactory(),
+			$this->createMock(IPreview::class)
 		);
 	}
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1723,15 +1723,7 @@
 			return OC.linkToRemoteBase('dav') + '/files/' + uid + encodedPath;
 		},
 
-		/**
-		 * Generates a preview URL based on the URL space.
-		 * @param urlSpec attributes for the URL
-		 * @param {int} urlSpec.x width
-		 * @param {int} urlSpec.y height
-		 * @param {String} urlSpec.file path to the file
-		 * @return {String} preview URL
-		 */
-		generatePreviewUrl: function(urlSpec) {
+		_generatePreviewParams: function(urlSpec) {
 			urlSpec = urlSpec || {};
 			if (!urlSpec.x) {
 				urlSpec.x = this.$table.data('preview-x') || 32;
@@ -1744,15 +1736,24 @@
 			urlSpec.x = Math.ceil(urlSpec.x);
 			urlSpec.y = Math.ceil(urlSpec.y);
 			urlSpec.forceIcon = 0;
-			var parts = urlSpec.file.split('/');
-			var encoded = [];
-			for (var i = 0; i < parts.length; i++) {
-				encoded.push(encodeURIComponent(parts[i]));
-			}
-			var file = encoded.join('/');
-			delete urlSpec.file;
 			urlSpec.preview = 1;
 
+			return urlSpec;
+		},
+
+		/**
+		 * Generates a preview URL based on the URL space.
+		 * @param urlSpec attributes for the URL
+		 * @param {int} urlSpec.x width
+		 * @param {int} urlSpec.y height
+		 * @param {String} urlSpec.file path to the file
+		 * @return {String} preview URL
+		 */
+		generatePreviewUrl: function(urlSpec) {
+			urlSpec = this._generatePreviewParams(urlSpec);
+
+			var file = OC.encodePath(urlSpec.file);
+			delete urlSpec.file;
 			return OC.linkToRemoteBase('dav') + '/files/' + OC.getCurrentUser().uid + file + '?' + $.param(urlSpec);
 		},
 

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -206,19 +206,11 @@ OCA.Sharing.PublicApp = {
 			};
 
 			this.fileList.generatePreviewUrl = function (urlSpec) {
-				urlSpec = urlSpec || {};
-				if (!urlSpec.x) {
-					urlSpec.x = 32;
-				}
-				if (!urlSpec.y) {
-					urlSpec.y = 32;
-				}
-				urlSpec.x *= window.devicePixelRatio;
-				urlSpec.y *= window.devicePixelRatio;
-				urlSpec.x = Math.ceil(urlSpec.x);
-				urlSpec.y = Math.ceil(urlSpec.y);
-				urlSpec.t = $('#dirToken').val();
-				return OC.generateUrl('/apps/files_sharing/ajax/publicpreview.php?') + $.param(urlSpec);
+				urlSpec = this._generatePreviewParams(urlSpec);
+
+				var file = OC.encodePath(urlSpec.file);
+				delete urlSpec.file;
+				return OC.getRootPath() + '/public.php/webdav' + file + '?' + $.param(urlSpec);
 			};
 
 			this.fileList.updateEmptyContent = function() {


### PR DESCRIPTION
## Description
Also provide Webdav-style URLs with extra args for requesting previews on the public webdav endpoint. We already have this on non-public webdav endpoint.

## Related Issue
None raised but follow up of https://github.com/owncloud/core/pull/31050 which brought Webdav previews.

## Motivation and Context
While working on the [media viewer app](https://github.com/owncloud/files_mediaviewer) came the question about how to retrieve the previews on the public endpont after realizing that the magic Webdav URLs did not work there.

## How Has This Been Tested?
:warning: doesn't work :warning: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Port to master