### PR TITLE
[stable10] Backport of Fix the share permissions evaluation

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\Files_Sharing\API;
 
+use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
@@ -535,6 +536,17 @@ class Share20OCS {
 			if (($stateFilter === null || $share->getState() === $stateFilter) &&
 					$this->canAccessShare($share)) {
 				try {
+					/**
+					 * Check if the group to which the user belongs is not allowed
+					 * to reshare
+					 */
+					if ($this->shareManager->sharingDisabledForUser($this->currentUser->getUID())) {
+						/**
+						 * Now set the permission to 15. Which will allow not to reshare.
+						 */
+						$permissionEvaluated = $share->getPermissions() & ~Constants::PERMISSION_SHARE;
+						$share->setPermissions($permissionEvaluated);
+					}
 					$formatted[] = $this->formatShare($share, true);
 				} catch (NotFoundException $e) {
 					// Ignore this share

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -3112,6 +3112,72 @@ class Share20OCSTest extends TestCase {
 		}
 	}
 
+	public function testGetSharesSharedWithMeAndBlockGroup() {
+		$requestedPath = "/requested/path";
+		$stateFilter = "all";
+		$testStateFilter = $stateFilter;
+		if ($testStateFilter === '' || $testStateFilter === 'all') {
+			$testStateFilter = \OCP\Share::STATE_ACCEPTED;
+		}
+		$userShare = $this->newShare();
+		$userShare->setShareOwner('shareOwner');
+		$userShare->setSharedWith('currentUser');
+		$userShare->setShareType(\OCP\Share::SHARE_TYPE_USER);
+		$userShare->setState($testStateFilter);
+		$userShare->setPermissions(\OCP\Constants::PERMISSION_ALL);
+
+		$group = $this->createMock(IGroup::class);
+		$group->method('inGroup')->with($this->currentUser)->willReturn(true);
+
+		$groupObj = $this->createMock(IGroup::class);
+		$groupObj->method('inGroup')
+			->willReturn(true);
+
+		$this->groupManager->method('get')
+			->will($this->returnValueMap([
+				['group', $group],
+				['excluded_group', $groupObj]
+			]));
+
+		$node = $this->createMock(Node::class);
+		$node->expects($this->at(0))
+			->method('lock');
+		$node->expects($this->at(1))
+			->method('unlock');
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->expects($this->once())
+			->method('get')
+			->with($requestedPath)
+			->willReturn($node);
+		$this->rootFolder->expects($this->once())
+			->method('getUserFolder')
+			->with('currentUser')
+			->willReturn($userFolder);
+
+		$this->shareManager->method('getSharedWith')
+			->will($this->returnValueMap([
+				['currentUser', \OCP\Share::SHARE_TYPE_USER, $node, -1, 0, [$userShare]],
+				['currentUser', \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0, []],
+			]));
+		$this->shareManager->method('sharingDisabledForUser')
+			->with('currentUser')
+			->willReturn(true);
+
+		$this->request
+			->method('getParam')
+			->will($this->returnValueMap([
+				['path', null, $requestedPath],
+				['state', \OCP\Share::STATE_ACCEPTED, $stateFilter],
+				['shared_with_me', null, 'true'],
+			]));
+
+		$ocs = $this->mockFormatShare();
+		$ocs->method('formatShare')->will($this->returnArgument(0));
+		$result = $ocs->getShares();
+		$this->assertEquals($userShare->getPermissions(), $result->getData()[0]->getPermissions());
+	}
+
 	public function providesAcceptRejectShare() {
 		return [
 			['acceptShare', '/target', true, \OCP\Share::STATE_ACCEPTED],

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -446,6 +446,7 @@ class ApiTest extends TestCase {
 	}
 
 	public function testGetAllSharesWithMe() {
+		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups_list', '[]');
 		$node1 = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
 		$share1->setNode($node1)
@@ -473,6 +474,7 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);
+		\OC::$server->getConfig()->deleteAppValue('core', 'shareapi_exclude_groups_list');
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -209,7 +209,6 @@ Feature: Sharing files and folders with internal users
     Then the user should see an error message on the share dialog saying "Sharing is not allowed"
     And the share-with field should not be visible in the details panel
 
-  @enterprise-issue-3037 # after the issue is fixed remove the comments on two lines and remove last line
   Scenario: user tries to re-share a file from a group which is blacklisted from sharing using webUI from shared with you page
     Given group "grp1" has been created
     And user "user1" has been added to group "grp1"
@@ -221,9 +220,8 @@ Feature: Sharing files and folders with internal users
     And the user re-logs in as "user1" using the webUI
     And the user browses to the shared-with-you page
     And the user opens the sharing tab from the file action menu of file "testimage (2).jpg" using the webUI
-    #Then the user should see an error message on the share dialog saying "Sharing is not allowed"
-    #And the share-with field should not be visible in the details panel
-    Then the share-with field should be visible in the details panel
+    Then the user should see an error message on the share dialog saying "Sharing is not allowed"
+    And the share-with field should not be visible in the details panel
     And user "user1" should not be able to share file "testimage (2).jpg" with user "User Three" using the sharing API
 
   Scenario: user shares the file/folder with another internal user and delete the share with user


### PR DESCRIPTION
When user tries to access "Shared with you"
to know the list of files/folders shared with
the user, the share tab for the files or folder
are having an issue. When the group(s) to which
the user belong is excluded from sharing, the
share options appear in the tab. This change
tries to fix the issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Share a folder/file to create guest user. And then enable `can share`. After this try to login to the guest user. Enable `Exclude groups from sharing` and add `guest_app` in the text box. The guest users `Shared with you` would show the the share side bar. The panel will show auto complete. This is the problem. And this change set tries to avoid the same. When group `guest_app` is added to be excluded, the resharing should be blocked for the users of `guest_app`, even if `can share` is checked ( as explained above).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `Shared with you` section should not show the share side bar if `guest_app` group is added to the `Exclude groups from sharing` and `can share` enabled in the file/folder shared to the guest user ( while creating guest user).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create guest user by sharing a file/folder
- Enable `can share` to the shared file/folder
- Login to the guest user
- Now add `guest_app` to the `Exclude groups from sharing` in the sharing page ( in admin settings )
- Navigate to guest users `Shared with you`
- Before applying the patch 
![before_patching](https://user-images.githubusercontent.com/3600427/52694871-1aecca00-2f91-11e9-9da8-59df4118d0a0.png)
- After applying the patch 
![after_patching1](https://user-images.githubusercontent.com/3600427/52695193-dca3da80-2f91-11e9-86fe-4e7929d7e626.png)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
