### PR TITLE
StorageNotAvailableException needs to be handled otherwise the PROPFI…

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -303,9 +303,13 @@ class FilesPlugin extends ServerPlugin {
 			});
 
 			$propFind->handle(self::SHARE_PERMISSIONS_PROPERTYNAME, function () use ($node, $httpRequest) {
-				return $node->getSharePermissions(
-					$httpRequest->getRawServerValue('PHP_AUTH_USER')
-				);
+				try {
+					return $node->getSharePermissions(
+						$httpRequest->getRawServerValue('PHP_AUTH_USER')
+					);
+				} catch (StorageNotAvailableException $ex) {
+					return null;
+				}
 			});
 
 			$propFind->handle(self::GETETAG_PROPERTYNAME, function () use ($node) {


### PR DESCRIPTION
…ND will return with http status 500

## Description
StorageNotAvailableException needs to be handled otherwise the PROPFIND will return with http status 500

## How Has This Been Tested?
Mount an external storage and make sure it is disconnected.

Failing:
```
$ curl 'http://own.cloud/remote.php/webdav/' -X PROPFIND -H 'authorization: Bearer ........ -H 'OCS-APIREQUEST: true' -H 'Connection: keep-alive' -H 'Content-Type: application/xml; charset=UTF-8'  -H 'Depth: 1' --data-binary $'<?xml version="1.0"?>\n<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n  <d:prop>\n    <oc:permissions />\n    <oc:favorite />\n    <oc:id />\n    <x:share-permissions xmlns:x="http://open-collaboration-services.org/ns" />\n    <oc:downloadURL />\n    <oc:owner-id />\n    <oc:owner-display-name />\n    <oc:privatelink />\n    <d:getcontentlength />\n    <oc:size />\n    <d:getlastmodified />\n    <d:resourcetype />\n  </d:prop>\n</d:propfind>' --compressed
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>OCP\Files\StorageNotAvailableException</s:exception>
  <s:message>Storage with mount id 3 is not available</s:message>
</d:error>
```

With this change a proper multi status response is returned

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
