### PR TITLE
do not fail update or installation when .htaccess file is not writable

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -84,7 +84,7 @@ class Updater extends BasicEmitter {
 
 	/**
 	 * runs the update actions in maintenance mode, does not upgrade the source files
-	 * except the main .htaccess file
+	 * except the main .htaccess file if it is writable
 	 *
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
@@ -221,7 +221,7 @@ class Updater extends BasicEmitter {
 
 	/**
 	 * runs the update actions in maintenance mode, does not upgrade the source files
-	 * except the main .htaccess file
+	 * except the main .htaccess file if it is writable
 	 *
 	 * @param string $currentVersion current version to upgrade to
 	 * @param string $installedVersion previous version from which to upgrade from
@@ -237,7 +237,13 @@ class Updater extends BasicEmitter {
 
 		// Update .htaccess files
 		try {
-			Setup::updateHtaccess();
+			// check if we can write .htaccess
+			if (\is_file(Setup::pathToHtaccess())
+				&& \is_writable(Setup::pathToHtaccess())
+			) {
+				// Update .htaccess files
+				Setup::updateHtaccess();
+			}
 			Setup::protectDataDirectory();
 		} catch (\Exception $e) {
 			throw new \Exception($e->getMessage());


### PR DESCRIPTION
## Description
since https://github.com/owncloud/core/pull/32230 an exception is thrown when the .htaccess is read-only but it has to be possible to install or update oC when the .htaccess file is not writeable
but when `occ maintenance:update:htaccess` and the file cannot be updated the command should fail

## Related Issue
- Fixes  #34471

## Motivation and Context
see issue

## How Has This Been Tested?
- install oC with R/O `.htaccess`
- install oC with R/W `.htaccess`
- update oC with R/O `.htaccess`
- run `occ maintenance:update:htaccess` with R/O `.htaccess`
- run `occ maintenance:update:htaccess` with R/W `.htaccess`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
