### PR TITLE
[stable10] Backport of Checkboxes to hide quota and password

### DIFF
--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -79,5 +79,8 @@ if (\OC::$server->getGroupManager()->inGroup($username, $group)) {
 	$targetGroupObject->addUser($targetUserObject);
 }
 
-// Return Success story
-OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
+if (\OC::$server->getGroupManager()->isInGroup($username, $group)) {
+	OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
+} else {
+	OC_JSON::error();
+}

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -251,6 +251,8 @@ span.usersLastLoginTooltip { white-space: nowrap; }
 #userlist {
 	position: relative;
 }
+#userlist .password,
+#userlist .quota,
 #userlist .mailAddress,
 #userlist .enabled,
 #userlist .storageLocation,

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -1042,6 +1042,34 @@ $(document).ready(function () {
 		}
 	});
 
+	if ($('#CheckboxQuota').is(':checked')) {
+		$("#userlist .quota").show();
+	}
+	// Option to display/hide the "User Backend" column
+	$('#CheckboxQuota').click(function() {
+		if ($('#CheckboxQuota').is(':checked')) {
+			$("#userlist .quota").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_quota', 'true');
+		} else {
+			$("#userlist .quota").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_quota', 'false');
+		}
+	});
+
+	if ($('#CheckboxPassword').is(':checked')) {
+		$("#userlist .password").show();
+	}
+	// Option to display/hide the "User Backend" column
+	$('#CheckboxPassword').click(function() {
+		if ($('#CheckboxPassword').is(':checked')) {
+			$("#userlist .password").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_password', 'true');
+		} else {
+			$("#userlist .password").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_password', 'false');
+		}
+	});
+
 	// calculate initial limit of users to load
 	var initialUserCountLimit = UserList.initialUsersToLoad,
 		containerHeight = $('#app-content').height();

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -98,6 +98,24 @@ translation('settings');
 						<?php p($l->t('Show email address')) ?>
 					</label>
 				</p>
+				<p>
+					<input type="checkbox" name="Password" value="Password" id="CheckboxPassword"
+						   class="checkbox" <?php if ($_['show_password'] === 'true') {
+	print_unescaped('checked="checked"');
+} ?> />
+					<label for="CheckboxPassword">
+						<?php p($l->t('Show password field')) ?>
+					</label>
+				</p>
+				<p>
+					<input type="checkbox" name="Quota" value="Quota" id="CheckboxQuota"
+						   class="checkbox" <?php if ($_['show_quota'] === 'true') {
+	print_unescaped('checked="checked"');
+} ?> />
+					<label for="CheckboxQuota">
+						<?php p($l->t('Show quota field')) ?>
+					</label>
+				</p>
 			</div>
 		</div>
 	</div>

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -6,14 +6,14 @@
 		<?php endif; ?>
 			<th id="headerName" scope="col"><?php p($l->t('Username'))?></th>
 			<th id="headerDisplayName" scope="col"><?php p($l->t('Full Name')); ?></th>
-			<th id="headerPassword" scope="col"><?php p($l->t('Password')); ?></th>
+			<th class="password" id="headerPassword" scope="col"><?php p($l->t('Password')); ?></th>
 			<th class="mailAddress" scope="col"><?php p($l->t('Email')); ?></th>
 			<th id="headerGroups" scope="col"><?php p($l->t('Groups')); ?></th>
 		<?php if (\is_array($_['subadmins']) || $_['subadmins']): ?>
 			<th id="headerSubAdmins" scope="col"><?php p($l->t('Group Admin for')); ?></th>
 		<?php endif;?>
 			<th class="enabled" scope="col"><?php p($l->t('Enabled')); ?></th>
-			<th id="headerQuota" scope="col"><?php p($l->t('Quota')); ?></th>
+			<th class="quota" id="headerQuota" scope="col"><?php p($l->t('Quota')); ?></th>
 			<th class="storageLocation" scope="col"><?php p($l->t('Storage Location')); ?></th>
 			<th class="userBackend" scope="col"><?php p($l->t('User Backend')); ?></th>
 			<th class="lastLogin" scope="col"><?php p($l->t('Last Login')); ?></th>

--- a/settings/users.php
+++ b/settings/users.php
@@ -125,5 +125,8 @@ $tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_l
 $tmpl->assign('show_email', $config->getAppValue('core', 'umgmt_show_email', 'false'));
 $tmpl->assign('show_backend', $config->getAppValue('core', 'umgmt_show_backend', 'false'));
 $tmpl->assign('set_password', $config->getAppValue('core', 'umgmt_set_password', 'false'));
+$tmpl->assign('send_email', $config->getAppValue('core', 'umgmt_send_email', 'false'));
+$tmpl->assign('show_password', $config->getAppValue('core', 'umgmt_show_password', 'true'));
+$tmpl->assign('show_quota', $config->getAppValue('core', 'umgmt_show_quota', 'true'));
 
 $tmpl->printPage();

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -400,6 +400,62 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the administrator should be able to see the quota of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldBeAbleToSeeQuotaOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$visible = $this->usersPage->isQuotaColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(true, $visible);
+		}
+	}
+
+	/**
+	 * @Then /^the administrator should not be able to see the quota of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldNotBeAbleToSeeQuotaOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$visible = $this->usersPage->isQuotaColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(false, $visible);
+		}
+	}
+
+	/**
+	 * @Then /^the administrator should be able to see the password of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table table of usernames column with a heading | username |
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldBeAbleToSeePasswordColumnOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$visible = $this->usersPage->isPasswordColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(true, $visible);
+		}
+	}
+
+	/**
+	 * @Then /^the administrator should not be able to see the password of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table table of usernames column with a heading | username |
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldNotbeAbleToSeePasswordColumnOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$visible = $this->usersPage->isPasswordColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(false, $visible);
+		}
+	}
+
+	/**
 	 * @Then /^the administrator should be able to see the storage location of these users in the User Management page:$/
 	 *
 	 * @param TableNode $table table of usernames and storage locations with a heading | username | and | storage location |

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -48,6 +48,8 @@ class UsersPage extends OwncloudPage {
 	protected $quotaOptionXpath = "//option[contains(text(), '%s')]";
 
 	protected $emailColumnXpath = "//td[@class='mailAddress']";
+	protected $passwordColumnXpath = "//td[@class='password']";
+	protected $quotaColumnXpath = "//td[@class='quota']";
 	protected $storageLocationColumnXpath = "//td[@class='storageLocation']";
 	protected $lastLoginXpath = "//td[@class='lastLogin']";
 
@@ -166,6 +168,56 @@ class UsersPage extends OwncloudPage {
 
 		return $this->getTrimmedText($userEmail);
 	}
+
+	/**
+	 * @param string $username
+	 *
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public function isPasswordColumnOfUserVisible($username) {
+		$userTr = $this->findUserInTable($username);
+		$userPassword = $userTr->find('xpath', $this->passwordColumnXpath);
+
+		if ($userPassword === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->passwordColumnXpath " .
+				"password column of user " . $username . " not found"
+			);
+		}
+
+		if (!$userPassword->isVisible()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param string $username
+	 *
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public function isQuotaColumnOfUserVisible($username) {
+		$userTr = $this->findUserInTable($username);
+		$userQuota = $userTr->find('xpath', $this->quotaColumnXpath);
+
+		if ($userQuota === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->quotaColumnXpath " .
+				"quota column of user " . $username . " not found"
+			);
+		}
+
+		if (!$userQuota->isVisible()) {
+			return false;
+		}
+		return true;
+	}
+
 	/**
 	 * @param string $username
 	 *

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -43,3 +43,40 @@ Feature: add users
       | username | last login  |
       | user1    | seconds ago |
       | user2    | never       |
+
+  Scenario: administrator should be able to see password column of user
+    When the administrator enables the setting "Show password field" in the User Management page using the webUI
+    Then the administrator should be able to see the password of these users in the User Management page:
+      | username |
+      | user1    |
+      | user2    |
+
+  Scenario: administrator should not be able to see password column of user
+    When the administrator disables the setting "Show password field" in the User Management page using the webUI
+    Then the administrator should not be able to see the password of these users in the User Management page:
+      | username |
+      | user1    |
+      | user2    |
+
+  Scenario: administrator should be able to see quota of user
+    When the administrator enables the setting "Show quota field" in the User Management page using the webUI
+    Then the administrator should be able to see the quota of these users in the User Management page:
+      | username |   quota   |
+      | user1    |   Default |
+      | user2    |   Default |
+
+  Scenario: administrator should be able to see updated quota of user when enabled show quota field
+    Given the administrator has changed the quota of user "user1" to "Unlimited"
+    And the administrator has changed the quota of user "user2" to "5 GB"
+    When the administrator enables the setting "Show quota field" in the User Management page using the webUI
+    Then the administrator should be able to see the quota of these users in the User Management page:
+      | username |   quota     |
+      | user1    |   Unlimited |
+      | user2    |   5 GB      |
+
+  Scenario: administrator should not be able to see quota of user
+    When the administrator disables the setting "Show quota field" in the User Management page using the webUI
+    Then the administrator should not be able to see the quota of these users in the User Management page:
+      | username |
+      | user1    |
+      | user2    |


### PR DESCRIPTION
Add checkboxes to show and hide quota and
password.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add the checkboxes to hide quota and password in the user page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add the checkboxes to hide quota and password in the user page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  [x] Verified in the UI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
