### PR TITLE
Adjust confirm password web UI words and tests

### DIFF
--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -92,7 +92,7 @@ OC.Lostpassword = {
 			$('#retypepassword').val('');
 			$('#password').parent().addClass('shake');
 			$('#message').addClass('warning');
-			$('#message').text('Passwords does not match');
+			$('#message').text('Passwords do not match');
 			$('#message').show();
 			$('#password').focus();
 		}

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -545,8 +545,8 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user resets/sets the password to :newPassword and confirms same password using the webUI
-	 * @Given the user has reset/set the password to :newPassword and confirms same password using the webUI
+	 * @When the user resets/sets the password to :newPassword and confirms with the same password using the webUI
+	 * @Given the user has reset/set the password to :newPassword and confirms with the same password using the webUI
 	 *
 	 * @param string $newPassword
 	 *
@@ -559,8 +559,8 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @when the user resets/sets password to :newPassword and confirms with :confirmPassword using the webUI
-	 * @Given the user has resets/sets password to :newPassword and confirms with :confirmPassword using the webUI
+	 * @When the user resets/sets the password to :newPassword and confirms with :confirmPassword using the webUI
+	 * @Given the user has reset/set the password to :newPassword and confirms with :confirmPassword using the webUI
 	 *
 	 * @param string $newPassword
 	 * @param string $confirmNewPassword
@@ -573,7 +573,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then user should see password mismatch message displayed on the webUI
+	 * @Then the user should see a password mismatch message displayed on the webUI
 	 *
 	 * @param PyStringNode $string
 	 *

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -30,7 +30,7 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" and confirms same password using the webUI
+    When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
@@ -43,7 +43,7 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" and confirms same password using the webUI
+    When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
@@ -75,8 +75,8 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user has resets password to "%alt3%" and confirms with "foo" using the webUI
-    Then user should see password mismatch message displayed on the webUI
+    When the user resets the password to "%alt3%" and confirms with "foo" using the webUI
+    Then the user should see a password mismatch message displayed on the webUI
     """
     Passwords does not match
     """

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -78,5 +78,5 @@ Feature: reset the password
     When the user resets the password to "%alt3%" and confirms with "foo" using the webUI
     Then the user should see a password mismatch message displayed on the webUI
     """
-    Passwords does not match
+    Passwords do not match
     """


### PR DESCRIPTION
## Description
1) Adjust acceptance test steps that were added in PR #30981 to tidy up some of the English
2) Change "Passwords does not match" UI message to "Passwords do not match" (correction to the English)

## Related Issue
#29901

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added/adjusted
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
