### PR TITLE
[stable10] Add confirm password after new password

### DIFF
--- a/core/css/lostpassword/resetpassword.css
+++ b/core/css/lostpassword/resetpassword.css
@@ -13,3 +13,11 @@
 #password {
 	width: 100% !important;
 }
+
+#retypepassword {
+	width: 100% !important;
+}
+
+#message {
+	width: 94% !important;
+}

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -92,7 +92,7 @@ OC.Lostpassword = {
 			$('#retypepassword').val('');
 			$('#password').parent().addClass('shake');
 			$('#message').addClass('warning');
-			$('#message').text('Passwords does not match');
+			$('#message').text('Passwords do not match');
 			$('#message').show();
 			$('#password').focus();
 		}

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -75,8 +75,9 @@ OC.Lostpassword = {
 	},
 
 	resetPassword : function(event){
+		$('#password').parent().removeClass('shake');
 		event.preventDefault();
-		if ($('#password').val()){
+		if ($('#password').val() === $('#retypepassword').val()){
 			$.post(
 					$('#password').parents('form').attr('action'),
 					{
@@ -85,6 +86,15 @@ OC.Lostpassword = {
 					},
 					OC.Lostpassword.resetDone
 			);
+		} else {
+			//Password mismatch happened
+			$('#password').val('');
+			$('#retypepassword').val('');
+			$('#password').parent().addClass('shake');
+			$('#message').addClass('warning');
+			$('#message').text('Passwords does not match');
+			$('#message').show();
+			$('#password').focus();
 		}
 		if($('#encrypted-continue').is(':checked')) {
 			$('#reset-password #submit').hide();
@@ -140,4 +150,16 @@ OC.Lostpassword = {
 
 };
 
-$(document).ready(OC.Lostpassword.init);
+$(document).ready(function () {
+	OC.Lostpassword.init();
+	$('#password').keypress(function () {
+		/*
+		 The warning message should be shown only during password mismatch.
+		 Else it should not.
+		 */
+		if (($('#password').val().length >= 0) && ($('#retypepassword').val().length === 0)) {
+			$('#message').removeClass('warning');
+			$('#message').text('');
+		}
+	});
+});

--- a/core/templates/lostpassword/resetpassword.php
+++ b/core/templates/lostpassword/resetpassword.php
@@ -28,9 +28,13 @@ script('core', 'lostpassword');
 
 <form action="<?php print_unescaped($_['link']) ?>" id="reset-password" method="post">
 	<fieldset>
-		<p>
+		<p class="groupbottom<?php if (!empty($_['invalidpassword'])) {
+	?> shake<?php
+} ?>">
 			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
 			<input type="password" name="password" id="password" value="" placeholder="<?php p($l->t('New Password')); ?>" autocomplete="off" required autofocus />
+			<input type="password" name="retypepassword" id="retypepassword" value="" placeholder="<?php p($l->t('Confirm Password')); ?>"/>
+			<span id='message'></span>
 		</p>
 		<input type="submit" id="submit" value="<?php p($l->t('Reset password')); ?>" />
 		<p class="text-center">

--- a/settings/css/setpassword.css
+++ b/settings/css/setpassword.css
@@ -13,3 +13,11 @@
 #password {
 	width: 100%;
 }
+
+#retypepassword {
+	width: 100%;
+}
+
+#message {
+	width: 94%;
+}

--- a/settings/js/setpassword.js
+++ b/settings/js/setpassword.js
@@ -5,17 +5,28 @@
 		},
 
 		onClickSetPassword : function(event){
-			event.preventDefault();
 			var passwordObj = $('#password');
-			if (passwordObj.val()){
+			var retypePasswordObj = $('#retypepassword');
+			passwordObj.parent().removeClass('shake');
+			event.preventDefault();
+			if (passwordObj.val() === retypePasswordObj.val()) {
 				$.post(
 					passwordObj.parents('form').attr('action'),
-					{password : passwordObj.val()}
+					{password: passwordObj.val()}
 				).done(function (result) {
 					OCA.UserManagement.SetPassword._resetDone(result);
 				}).fail(function (result) {
 					OCA.UserManagement.SetPassword._onSetPasswordFail(result);
 				});
+			} else {
+				//Password mismatch happened
+				passwordObj.val('');
+				retypePasswordObj.val('');
+				passwordObj.parent().addClass('shake');
+				$('#message').addClass('warning');
+				$('#message').text('Passwords do not match');
+				$('#message').show();
+				passwordObj.focus();
 			}
 		},
 
@@ -59,4 +70,14 @@
 
 $(document).ready(function () {
 	OCA.UserManagement.SetPassword.init();
+	$('#password').keypress(function () {
+		/*
+		 The warning message should be shown only during password mismatch.
+		 Else it should not.
+		 */
+		if (($('#password').val().length >= 0) && ($('#retypepassword').val().length === 0)) {
+			$('#message').removeClass('warning');
+			$('#message').text('');
+		}
+	});
 });

--- a/settings/templates/setpassword.php
+++ b/settings/templates/setpassword.php
@@ -25,12 +25,17 @@ script('settings', 'setpassword');
 <label id="error-message" class="warning" style="display:none"></label>
 <form action="<?php print_unescaped($_['link']) ?>" id="set-password" method="post">
 	<fieldset>
-		<p>
+		<p class="groupbottom<?php if (!empty($_['invalidpassword'])) {
+	?> shake<?php
+} ?>">
 			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
 			<input type="password" name="password" id="password" value=""
 				   placeholder="<?php p($l->t('New Password')); ?>"
 				   autocomplete="off" autocapitalize="off" autocorrect="off"
 				   required autofocus />
+			<input type="password" name="retypepassword" id="retypepassword" value=""
+				   placeholder="<?php p($l->t('Confirm Password')); ?>"/>
+			<span id='message'></span>
 		</p>
 		<input type="submit" id="submit" value="<?php
 			p($l->t('Please set your password'));

--- a/settings/tests/js/setpasswordSpec.js
+++ b/settings/tests/js/setpasswordSpec.js
@@ -21,6 +21,10 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 			'placeholder="New Password"' +
 			'autocomplete="off" autocapitalize="off" autocorrect="off"' +
 			'required autofocus />' +
+			'<input type="password" name="retypepassword" id="retypepassword" value=""' +
+			'placeholder="<"Confirm Password">' +
+			' />' +
+			'<span id="message"></span>' +
 			'</p>' +
 			'<input type="submit" id="submit" value="Please set your password"' +
 			'</fieldset>' +
@@ -47,6 +51,7 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 
 			SetPassword.init();
 			$('#password').val('foo');
+			$('#retypepassword').val('foo');
 			$('#submit').click();
 
 			expect(resultSpy.calledOnce).toEqual(true);
@@ -63,6 +68,7 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 
 			SetPassword.init();
 			$('#password').val('foo');
+			$('#retypepassword').val('foo');
 			$('#submit').click();
 
 			expect(resultSpy.calledOnce).toEqual(true);

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -545,16 +545,46 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user resets/sets the password to :newPassword using the webUI
-	 * @Given the user has reset/set the password to :newPassword using the webUI
+	 * @When the user resets/sets the password to :newPassword and confirms same password using the webUI
+	 * @Given the user has reset/set the password to :newPassword and confirms same password using the webUI
 	 *
 	 * @param string $newPassword
 	 *
 	 * @return void
 	 */
-	public function theUserResetsThePasswordToUsingTheWebui($newPassword) {
+	public function theUserResetsThePasswordWithSameConfirmationToUsingTheWebui($newPassword) {
 		$newPassword = $this->featureContext->getActualPassword($newPassword);
-		$this->loginPage->resetThePassword($newPassword, $this->getSession());
+		$confirmNewPassword = $this->featureContext->getActualPassword($newPassword);
+		$this->loginPage->resetThePassword($newPassword, $confirmNewPassword, $this->getSession());
+	}
+
+	/**
+	 * @when the user resets/sets password to :newPassword and confirms with :confirmPassword using the webUI
+	 * @Given the user has resets/sets password to :newPassword and confirms with :confirmPassword using the webUI
+	 *
+	 * @param string $newPassword
+	 * @param string $confirmNewPassword
+	 *
+	 * @return void
+	 */
+	public function theUserResetsPasswordWIthDiffConfirmUsingTheWebUI($newPassword, $confirmNewPassword) {
+		$newPassword = $this->featureContext->getActualPassword($newPassword);
+		$this->loginPage->resetThePassword($newPassword, $confirmNewPassword, $this->getSession());
+	}
+
+	/**
+	 * @Then user should see password mismatch message displayed on the webUI
+	 *
+	 * @param PyStringNode $string
+	 *
+	 * @return void
+	 */
+	public function theUserResetConfirmPasswordErrorMessage(PyStringNode $string) {
+		$expectedString = $string->getRaw();
+		$passwordMismatchMessage = $this->loginPage->getRestPasswordConfirmError();
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedString, $passwordMismatchMessage
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -545,8 +545,8 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user resets/sets the password to :newPassword and confirms same password using the webUI
-	 * @Given the user has reset/set the password to :newPassword and confirms same password using the webUI
+	 * @When the user resets/sets the password to :newPassword and confirms with the same password using the webUI
+	 * @Given the user has reset/set the password to :newPassword and confirms with the same password using the webUI
 	 *
 	 * @param string $newPassword
 	 *
@@ -559,8 +559,8 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @when the user resets/sets password to :newPassword and confirms with :confirmPassword using the webUI
-	 * @Given the user has resets/sets password to :newPassword and confirms with :confirmPassword using the webUI
+	 * @When the user resets/sets the password to :newPassword and confirms with :confirmPassword using the webUI
+	 * @Given the user has reset/set the password to :newPassword and confirms with :confirmPassword using the webUI
 	 *
 	 * @param string $newPassword
 	 * @param string $confirmNewPassword
@@ -573,7 +573,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then user should see password mismatch message displayed on the webUI
+	 * @Then the user should see a password mismatch message displayed on the webUI
 	 *
 	 * @param PyStringNode $string
 	 *

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -38,6 +38,8 @@ class LoginPage extends OwncloudPage {
 	protected $path = '/index.php/login';
 	protected $userInputId = "user";
 	protected $passwordInputId = "password";
+	protected $confirmPasswordInputId = "retypepassword";
+	protected $passwordResetConfrimMessage = "message";
 	protected $submitLoginId = "submit";
 	protected $lostPasswordId = "lost-password";
 	protected $setPasswordErrorMessageId = "error-message";
@@ -196,14 +198,24 @@ class LoginPage extends OwncloudPage {
 	/**
 	 *
 	 * @param string $newPassword
+	 * @param string $confirmNewPassword
 	 * @param Session $session
 	 *
 	 * @return void
 	 */
-	public function resetThePassword($newPassword, Session $session) {
+	public function resetThePassword($newPassword, $confirmNewPassword, Session $session) {
 		$this->fillField($this->passwordInputId, $newPassword);
+		$this->fillField($this->confirmPasswordInputId, $confirmNewPassword);
 		$this->findById($this->submitLoginId)->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRestPasswordConfirmError() {
+		$messageVal = $this->findById($this->passwordResetConfrimMessage)->getText();
+		return $messageVal;
 	}
 
 	/**

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -30,7 +30,7 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" and confirms same password using the webUI
+    When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
@@ -43,7 +43,7 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" and confirms same password using the webUI
+    When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
@@ -75,8 +75,8 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user has resets password to "%alt3%" and confirms with "foo" using the webUI
-    Then user should see password mismatch message displayed on the webUI
+    When the user resets the password to "%alt3%" and confirms with "foo" using the webUI
+    Then the user should see a password mismatch message displayed on the webUI
     """
     Passwords does not match
     """

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -78,5 +78,5 @@ Feature: reset the password
     When the user resets the password to "%alt3%" and confirms with "foo" using the webUI
     Then the user should see a password mismatch message displayed on the webUI
     """
-    Passwords does not match
+    Passwords do not match
     """

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -30,7 +30,7 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" using the webUI
+    When the user resets the password to "%alt3%" and confirms same password using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
@@ -43,7 +43,7 @@ Feature: reset the password
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" using the webUI
+    When the user resets the password to "%alt3%" and confirms same password using the webUI
     Then the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
@@ -69,3 +69,14 @@ Feature: reset the password
       """
       Could not reset password because the token does not match
       """
+
+  @skipOnEncryption
+  Scenario: When new password and confirmation password are different does not reset user password
+    When the user requests the password reset link using the webUI
+    And the user follows the password reset link from email address "user1@example.org"
+    Then the user should be redirected to a webUI page with the title "%productname%"
+    When the user has resets password to "%alt3%" and confirms with "foo" using the webUI
+    Then user should see password mismatch message displayed on the webUI
+    """
+    Passwords does not match
+    """

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -64,7 +64,7 @@ Feature: add users
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
       """
       Password changed successfully
@@ -105,7 +105,7 @@ Feature: add users
     When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
     And the user follows the password set link received by "guiusr1@owncloud" in Email number 2 using the webUI
     Then the user should be redirected to the general error webUI page with the title "%productname%"
     And an error should be displayed on the general error webUI page saying "The token provided is invalid."
@@ -116,7 +116,7 @@ Feature: add users
     And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "correct@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
     And the user logs in with username "guiusr1" and password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
@@ -136,7 +136,7 @@ Feature: add users
     And the administrator logs out of the webUI
     And the user follows the password set link received by "mistake@owncloud" using the webUI
     And the user follows the password set link received by "correct@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
     And the user logs in with username "guiusr1" and password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
@@ -144,7 +144,7 @@ Feature: add users
     When the administrator creates a user with the name "user1" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
       """
       Password changed successfully
@@ -170,7 +170,7 @@ Feature: add users
     When the administrator creates a user with the name "brand-new-user" and the email "bnu@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "bnu@owncloud" using the webUI
-    And the user sets the password to "<password>" using the webUI
+    And the user sets the password to "<password>" and confirms with the same password using the webUI
     And the user logs in with username "brand-new-user" and password "<password>" using the webUI
     Then user "brand-new-user" should exist
     And the user should be redirected to a webUI page with the title "Files - %productname%"
@@ -186,5 +186,5 @@ Feature: add users
     When the administrator creates a user with the name "brand-new-user" and the email "bnu@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "bnu@owncloud" using the webUI
-    And the user sets the password to " " using the webUI
+    And the user sets the password to " " and confirms with the same password using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -76,6 +76,20 @@ Feature: add users
       | guiusr1  | simple user-name      |
       | a@-_.'b  | complicated user-name |
 
+  Scenario Outline: user sets his own password but retypes it wrongly after being created with an Email address only
+    When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    And the user sets the password to "%regular%" and confirms with "foo" using the webUI
+    Then the user should see a password mismatch message displayed on the webUI
+      """
+      Passwords do not match
+      """
+    Examples:
+      | username | comment               |
+      | guiusr1  | simple user-name      |
+      | a@-_.'b  | complicated user-name |
+
   Scenario Outline: webUI refuses to create users with invalid Email addresses
     When the administrator creates a user with the name "guiusr1" and the email "<email>" without a password using the webUI
     Then notifications should be displayed on the webUI with the text


### PR DESCRIPTION
Backport PRs #30981 and #34490 
And adjust confirm password steps for `webUIManageUsersGroups/addUsers.feature` which only exists in core ``stable10``
Backport https://github.com/owncloud/user_management/pull/146 changes for user_management issue https://github.com/owncloud/user_management/issues/147