### PR TITLE
[stable10] Add ownCloud motto change password email

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -263,12 +263,15 @@ class LostController extends Controller {
 		if ($email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
 			$msg = $tmpl->fetchPage();
+			$tmplAlt = new \OC_Template('core', 'lostpassword/altnotify');
+			$msgAlt = $tmplAlt->fetchPage();
 
 			try {
 				$message = $this->mailer->createMessage();
 				$message->setTo([$email => $userId]);
 				$message->setSubject($this->l10n->t('%s password changed successfully', [$this->defaults->getName()]));
-				$message->setPlainBody($msg);
+				$message->setPlainBody($msgAlt);
+				$message->setHtmlBody($msg);
 				$message->setFrom([$this->from => $this->defaults->getName()]);
 				$this->mailer->send($message);
 			} catch (\Exception $e) {

--- a/core/templates/lostpassword/altnotify.php
+++ b/core/templates/lostpassword/altnotify.php
@@ -1,0 +1,5 @@
+<?php
+p($l->t('Password changed successfully'));
+
+print_unescaped("\n\n");
+print_unescaped($this->inc('plain.mail.footer'));

--- a/core/templates/lostpassword/notify.php
+++ b/core/templates/lostpassword/notify.php
@@ -1,2 +1,32 @@
-<?php
-echo $l->t('Password changed successfully');
+<table cellspacing="0" cellpadding="0" border="0" width="100%">
+	<tr><td>
+			<table cellspacing="0" cellpadding="0" border="0" width="600px">
+				<tr>
+					<td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
+					<td bgcolor="<?php p($theme->getMailHeaderColor());?>">
+						<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+					</td>
+				</tr>
+				<tr><td colspan="2">&nbsp;</td></tr>
+				<tr>
+					<td width="20px">&nbsp;</td>
+					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
+						<?php
+						p($l->t('Password changed successfully'));
+						?>
+					</td>
+				</tr>
+				<tr><td colspan="2">&nbsp;</td></tr>
+				<tr>
+					<td width="20px">&nbsp;</td>
+					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
+						<?php print_unescaped($this->inc('html.mail.footer')); ?>
+					</td>
+				</tr>
+				<tr>
+					<td colspan="2">&nbsp;</td>
+				</tr>
+			</table>
+		</td></tr>
+</table>
+

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -188,12 +188,15 @@ class Controller {
 		if ($email !== null && $email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
 			$msg = $tmpl->fetchPage();
+			$tmplAlt = new \OC_Template('core', 'lostpassword/altnotify');
+			$msgAlt = $tmplAlt->fetchPage();
 
 			try {
 				$message = $mailer->createMessage();
 				$message->setTo([$email => $username]);
 				$message->setSubject($l10n->t('%s password changed successfully', [$defaults->getName()]));
-				$message->setPlainBody($msg);
+				$message->setPlainBody($msgAlt);
+				$message->setHtmlBody($msg);
 				$message->setFrom([$from => $defaults->getName()]);
 				$mailer->send($message);
 			} catch (\Exception $e) {

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -517,9 +517,13 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(2))
 			->method('setPlainBody')
-			->with('Password changed successfully');
+			->with($this->stringContains('Password changed successfully'));
 		$message
 			->expects($this->at(3))
+			->method('setHtmlBody')
+			->with($this->stringContains('Password changed successfully'));
+		$message
+			->expects($this->at(4))
 			->method('setFrom')
 			->with(['lostpassword-noreply@localhost' => null]);
 		$this->mailer


### PR DESCRIPTION
Backport of #34470 

## Description
- Added the motto as footer
- Added alternative Plain text page for notify email
- Update notify email with html template.