### PR TITLE
No need to pin behat to PHP 5.6

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,9 +1,4 @@
 {
-    "config" : {
-        "platform": {
-            "php": "5.6.33"
-        }
-    },
     "require": {
         "behat/behat": "^3.0",
         "behat/mink-extension": "^2.2",


### PR DESCRIPTION
## Description
When ``behat`` was moved to ``vendor-bin`` in core ``stable10`` it was at first necessary to pin it to a version compatible with PHP 5.6. See comment https://github.com/owncloud/core/pull/34219#pullrequestreview-195070659 At that time there was a ``stable10`` code freeze and I did not pursue large changes/removals from ``composer.lock``

Since that time, there has been better merging of all the other version bump PRs to ``stable10`` and I got the chance to really do "composer update" and find other components in the main core ``stable10`` ``composer.lock`` that were not needed.

There are no longer "remnants" in the root ``composer.lock`` to cause problems.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
