### PR TITLE
[stable10] Backport of Skip shared files when adding recovery key

### DIFF
--- a/apps/encryption/lib/Recovery.php
+++ b/apps/encryption/lib/Recovery.php
@@ -25,6 +25,7 @@
 namespace OCA\Encryption;
 
 
+use OC\Files\FileInfo;
 use OCA\Encryption\Crypto\Crypt;
 use OCP\Encryption\Keys\IStorage;
 use OCP\IConfig;
@@ -220,6 +221,9 @@ class Recovery {
 	private function addRecoveryKeys($path) {
 		$dirContent = $this->view->getDirectoryContent($path);
 		foreach ($dirContent as $item) {
+			if ($this->isSharedStorage($item)) {
+				continue;
+			}
 			$filePath = $item->getPath();
 			if ($item['type'] === 'dir') {
 				$this->addRecoveryKeys($filePath . '/');
@@ -248,6 +252,9 @@ class Recovery {
 	private function removeRecoveryKeys($path) {
 		$dirContent = $this->view->getDirectoryContent($path);
 		foreach ($dirContent as $item) {
+			if ($this->isSharedStorage($item)) {
+				continue;
+			}
 			$filePath = $item->getPath();
 			if ($item['type'] === 'dir') {
 				$this->removeRecoveryKeys($filePath . '/');
@@ -326,5 +333,21 @@ class Recovery {
 
 	}
 
-
+	/**
+	 * check if the item is on a shared storage
+	 *
+	 * @param FileInfo $item
+	 * @return bool
+	 */
+	protected function isSharedStorage(FileInfo $item) {
+		/**
+		 * hardcoded class to prevent dependency on files_sharing app and federated share
+		 * TODO: add filter callback to view::getDirectoryContent() or its successor
+		 * so we can filter by more than just mimetype
+		 */
+		if ($item->getStorage()->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+			return true;
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
Skip shared files when recovery key is enabled
in the encryption.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Skip shared files when recovery key is enabled for user(s) in the encryption.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Skip shared files when recovery key is enabled for user(s) in th encryption.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified with the unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
