### PR TITLE
skip webdav locking tests on 10.0

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnOcV10.0
 Feature: there can be only one exclusive lock on a resource
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnOcV10.0
 Feature: lock folders
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required
+@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required @skipOnOcV10.0
 Feature: persistent-locking in case of a public link
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required
+@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required @skipOnOcV10.0
 Feature: LOCKDISCOVERY for public links
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnOcV10.0
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks/resharedShares.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnOcV10.0
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks/setTimeout.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required
+@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required @skipOnOcV10.0
 Feature: set timeouts of LOCKS
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocks/unlock.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnOcV10.0
 Feature: UNLOCK locked items
 
   Background:

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnOcV10.0
 Feature: Locks
   As a user
   I would like to be able to use locks control deletion of files and folders

--- a/tests/acceptance/features/webUIWebdavLockProtection/move.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/move.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnOcV10.0
 Feature: Locks
   As a user
   I would like to be able to use locks control moving and renaming of files and folders

--- a/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnOcV10.0
 Feature: Locks
   As a user
   I would like to be able to use locks control upload of files and folders

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnOcV10.0
 Feature: Locks
   As a user
   I would like to be able to see what lock are on files and folders

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnOcV10.0
 Feature: Unlock locked files and folders
   As a user
   I would like to be able to unlock files and folders


### PR DESCRIPTION
## Description
locking was introduced in 10.1, so all the tests can be skipped in 10.0

## Motivation and Context
to make https://github.com/owncloud-docker/server/pull/77 pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
