### PR TITLE
[stable10] Backport of Use the displayname in lost password emails where possible

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -259,6 +259,7 @@ class LostController extends Controller {
 	protected function sendNotificationMail($userId) {
 		$user = $this->userManager->get($userId);
 		$email = $user->getEMailAddress();
+		$name = $user->getDisplayName();
 
 		if ($email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
@@ -268,7 +269,7 @@ class LostController extends Controller {
 
 			try {
 				$message = $this->mailer->createMessage();
-				$message->setTo([$email => $userId]);
+				$message->setTo([$email => $name]);
 				$message->setSubject($this->l10n->t('%s password changed successfully', [$this->defaults->getName()]));
 				$message->setPlainBody($msgAlt);
 				$message->setHtmlBody($msg);
@@ -347,10 +348,11 @@ class LostController extends Controller {
 		$tmplAlt = new \OC_Template('core', 'lostpassword/altemail');
 		$tmplAlt->assign('link', $link);
 		$msgAlt = $tmplAlt->fetchPage();
+		$name = $userObject->getDisplayName();
 
 		try {
 			$message = $this->mailer->createMessage();
-			$message->setTo([$email => $user]);
+			$message->setTo([$email => $name]);
 			$message->setSubject($this->l10n->t('%s password reset', [$this->defaults->getName()]));
 			$message->setPlainBody($msgAlt);
 			$message->setHtmlBody($msg);

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -322,8 +322,9 @@ class LostController extends Controller {
 					return false;
 				case 1:
 					$this->logger->info('User with input as email address found. User: {user}', ['app' => 'core', 'user' => $user]);
-					$email = $users[0]->getEMailAddress();
-					$user = $users[0]->getUID();
+					$userObject = $users[0];
+					$email = $userObject->getEMailAddress();
+					$user = $userObject->getUID();
 					break;
 				default:
 					$this->logger->error('Could not send reset email because the email id is not unique. User: {user}', ['app' => 'core', 'user' => $user]);

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -80,6 +80,11 @@ class LostControllerTest extends TestCase {
 			->method('getEMailAddress')
 			->willReturn('test@example.com');
 
+		$this->existingUser
+			->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('Existing User Name');
+
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
 		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
@@ -355,7 +360,7 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(0))
 			->method('setTo')
-			->with(['test@example.com' => 'ExistingUser']);
+			->with(['test@example.com' => 'Existing User Name']);
 		$message
 			->expects($this->at(1))
 			->method('setSubject')
@@ -420,7 +425,7 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(0))
 			->method('setTo')
-			->with(['test@example.com' => 'ExistingUser']);
+			->with(['test@example.com' => 'Existing User Name']);
 		$message
 			->expects($this->at(1))
 			->method('setSubject')
@@ -503,6 +508,9 @@ class LostControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getEMailAddress')
 			->will($this->returnValue('test@example.com'));
+		$user
+			->method('getDisplayName')
+			->will($this->returnValue('ValidTokenUser'));
 
 		$message = $this->getMockBuilder('\OC\Mail\Message')
 			->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Use displayname in email to fields where possible, nicer than the uid

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Look nicer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually sending lost password mails and looking at mailhog.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
