### PR TITLE
Skip test scenarios for user_ldap-issue-378

### DIFF
--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -379,7 +379,7 @@ Feature: sharing
     #  | 1               | 400             | 400              |
       | 2               | 400             | 400              |
 
-  @issue-33733
+  @issue-33733 @skipOnLDAP @user_ldap-issue-378
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes
@@ -421,7 +421,7 @@ Feature: sharing
       | 2               | 200             | 200              |
     #  | 2               | 403             | 403              |
 
-  @issue-33733
+  @issue-33733 @skipOnLDAP @user_ldap-issue-378
   Scenario Outline: user who is excluded from sharing tries to share a folder with another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes


### PR DESCRIPTION
## Description
See the issue for details. Some new core test scenarios are failing with LDAP.
Skip them on LDAP for now, until the problem/bug can be investigated.

## Related Issue
- https://github.com/owncloud/user_ldap/issues/378

## Motivation and Context
Only run passing tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
