### PR TITLE
transfer ownership should only be run with cli tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -177,6 +177,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
+        - TransferOwnershipContext:
 
     cliProvisioning:
       paths:

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -1,4 +1,4 @@
-@api
+@cli
 Feature: transfer-ownership
 
   @smokeTest


### PR DESCRIPTION
## Description
Fix wrongly tagged test suites

## Related Issue
- #34519 

## Motivation and Context
Be able to run API smoketests on remote systems without cli tests interfering

## How Has This Been Tested?
🤖 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
