### PR TITLE
wait for Ajax call when opening a file or folder

### DIFF
--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -331,7 +331,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 */
 	public function openFile($name, Session $session) {
 		$fileRow = $this->findFileRowByName($name, $session);
-		$fileRow->openFileFolder();
+		$fileRow->openFileFolder($session);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -398,10 +398,13 @@ class FileRow extends OwncloudPage {
 	/**
 	 * opens the current file or folder by clicking on the link
 	 *
+	 * @param Session $session
+	 *
 	 * @return void
 	 */
-	public function openFileFolder() {
+	public function openFileFolder(Session $session) {
 		$this->findFileLink()->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 	
 	/**


### PR DESCRIPTION
## Description
when opening folders or files in webUI tests AJAX calls are sent, we want to wait till the requests are correctly sent and finished

## Related Issue
part of https://github.com/owncloud/encryption/pull/98

## Motivation and Context
make UI tests more stable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
