### PR TITLE
disable previews on fed server for tests tagged @disablePreviews

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -2459,4 +2459,27 @@ trait BasicStructure {
 
 		HttpRequestHelper::post($fullUrl, $adminUsername, $adminPassword);
 	}
+
+	/**
+	 * runs a function on every server (LOCAL & REMOTE).
+	 * The callable function receives the server (LOCAL or REMOTE) as first argument
+	 *
+	 * @param callable $callback
+	 *
+	 * @return mixed[]
+	 */
+	public function runFunctionOnEveryServer($callback) {
+		$previousServer = $this->getCurrentServer();
+		$result = [];
+		foreach (['LOCAL','REMOTE'] as $server) {
+			$this->usingServer($server);
+			if (($server === 'LOCAL')
+				|| $this->federatedServerExists()
+			) {
+				$result[$server] = \call_user_func($callback, $server);
+			}
+		}
+		$this->usingServer($previousServer);
+		return $result;
+	}
 }

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -113,7 +113,9 @@ trait CommandLine {
 		}
 
 		$args[] = '--no-ansi';
-
+		if ($baseUrl === null) {
+			$baseUrl = $this->getBaseUrl();
+		}
 		return SetupHelper::runOcc(
 			$args,
 			$adminUsername,
@@ -186,6 +188,9 @@ trait CommandLine {
 		$baseUrl = null,
 		$ocPath = null
 	) {
+		if ($baseUrl === null) {
+			$baseUrl = $this->getBaseUrl();
+		}
 		return $this->getSystemConfig(
 			$key,
 			$output,
@@ -220,7 +225,9 @@ trait CommandLine {
 		$args[] = $key;
 
 		$args[] = '--no-ansi';
-
+		if ($baseUrl === null) {
+			$baseUrl = $this->getBaseUrl();
+		}
 		return SetupHelper::runOcc(
 			$args,
 			$adminUsername,

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -56,7 +56,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	private $loginPage;
 
 	private $oldCSRFSetting = null;
-	private $oldPreviewSetting = null;
+	private $oldPreviewSetting = [];
 	private $createdFiles = [];
 
 	/**
@@ -641,14 +641,18 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function disablePreviewBeforeScenario() {
-		if ($this->oldPreviewSetting === null) {
-			$oldPreviewSetting = $this->featureContext->getSystemConfigValue(
-				'enable_previews'
-			);
-			$this->oldPreviewSetting = \trim($oldPreviewSetting);
-		}
-		$this->featureContext->setSystemConfig(
-			'enable_previews', 'false', 'boolean'
+		$this->featureContext->runFunctionOnEveryServer(
+			function ($server) {
+				if (!isset($this->oldPreviewSetting[$server])) {
+					$oldPreviewSetting = $this->featureContext->getSystemConfigValue(
+						'enable_previews'
+					);
+					$this->oldPreviewSetting[$server] = \trim($oldPreviewSetting);
+				}
+				$this->featureContext->setSystemConfig(
+					'enable_previews', 'false', 'boolean'
+				);
+			}
 		);
 	}
 
@@ -665,14 +669,18 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function enablePreviewBeforeScenario() {
-		if ($this->oldPreviewSetting === null) {
-			$oldPreviewSetting = $this->featureContext->getSystemConfigValue(
-				'enable_previews'
-			);
-			$this->oldPreviewSetting = \trim($oldPreviewSetting);
-		}
-		$this->featureContext->setSystemConfig(
-			'enable_previews', 'true', 'boolean'
+		$this->featureContext->runFunctionOnEveryServer(
+			function ($server) {
+				if (!isset($this->oldPreviewSetting[$server])) {
+					$oldPreviewSetting = $this->featureContext->getSystemConfigValue(
+						'enable_previews'
+					);
+					$this->oldPreviewSetting[$server] = \trim($oldPreviewSetting);
+				}
+				$this->featureContext->setSystemConfig(
+					'enable_previews', 'true', 'boolean'
+				);
+			}
 		);
 	}
 
@@ -702,13 +710,19 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$this->savedCapabilitiesChanges
 		);
 
-		if ($this->oldPreviewSetting === "") {
-			$this->featureContext->deleteSystemConfig('enable_previews');
-		} elseif ($this->oldPreviewSetting !== null) {
-			$this->featureContext->setSystemConfig(
-				'enable_previews', $this->oldPreviewSetting, 'boolean'
-			);
-		}
+		$this->featureContext->runFunctionOnEveryServer(
+			function ($server) {
+				if (isset($this->oldPreviewSetting[$server])
+					&& $this->oldPreviewSetting[$server] === ""
+				) {
+					$this->featureContext->deleteSystemConfig('enable_previews');
+				} elseif (isset($this->oldPreviewSetting[$server])) {
+					$this->featureContext->setSystemConfig(
+						'enable_previews', $this->oldPreviewSetting[$server], 'boolean'
+					);
+				}
+			}
+		);
 		
 		if ($this->oldCSRFSetting === "") {
 			$this->featureContext->deleteSystemConfig('csrf.disabled');

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -291,7 +291,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
     But as "user1" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
 
-  @skipOnEncryption
   Scenario: delete a file in a folder inside a shared folder
     Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"


### PR DESCRIPTION
## Description
when a test is tagged with `@disablePreviews` the previews should be disabled also on the federation server

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/98

## Motivation and Context
creating previews locks the file, if the test tries to delete/rename the file before the preview generation is done it fails

## How Has This Been Tested?
checked if the previews setting is set and reset correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
