### PR TITLE
improve waiting creating of shares

### DIFF
--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -78,20 +78,13 @@ Feature: sharing
     And as "user1" folder "/merge-test-inside-twogroups-perms (2)" should not exist
     And as "user1" folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
-  @issue-34235 @skipOnLDAP
   Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
     Given user "user0" has created folder "/merge-test-outside-groups-renamebeforesecondshare"
     When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
     And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
     And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
-    # issue-34235 bug is that usually user1 continues to see the share with the correct renamed name,
-    # but sometimes reverts to seeing the share with the original name.
-    # when the bug is fixed, delete the following test step, and uncomment the test steps below it
-    Then as "user1" exactly one of these folders should exist
-      | /merge-test-outside-groups-renamebeforesecondshare         |
-      | /merge-test-outside-groups-renamebeforesecondshare-renamed |
-    #Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "oc:permissions" with value "SRDNVCK"
-    #And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
+    Then as user "user1" folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" should contain a property "oc:permissions" with value "SRDNVCK"
+    And as "user1" folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
 
   @skipOnLDAP @user_ldap-issue-274
   Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -85,16 +85,14 @@ trait Sharing {
 	 * @return void
 	 */
 	private function waitToCreateShare() {
-		$time = \time();
 		if (($this->localLastShareTime !== null)
-			&& (($time - $this->localLastShareTime) < 1)
+			&& ((\microtime(true) - $this->localLastShareTime) < 1)
 		) {
 			// prevent creating two shares with the same "stime" which is
 			// based on seconds, this affects share merging order and could
 			// affect expected test result order
 			\sleep(1);
 		}
-		$this->localLastShareTime = $time;
 	}
 
 	/**
@@ -666,6 +664,7 @@ trait Sharing {
 			$this->sharingApiVersion
 		);
 		$this->lastShareData = $this->getResponseXml();
+		$this->localLastShareTime = \microtime(true);
 	}
 
 	/**


### PR DESCRIPTION
## Description
this code fixes two issues with the waiting:
1. the time was remembered before the share was created, but the creation itself might have happened in the next second, so the code would not sleep and create the next share in the same second
2. saving the time in sec. can still lead to problems if the time on the system where the tests run and the time on SUT are off by 0.x. The test runner creates the share at sec 1.9 and remembers (int)1, SUT is off by 0.2sec and creates the share at 2.1. When the test runner creates the next share its 2.1 for it, it compares 2-1 and decides not to wait, but for the SUT its only 2.3 and it creates the share in the same second

remembering the  microtime makes sure we always wait at least 1sec

Hope that this also fixes the problem on LDAP

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #34235

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
