### PR TITLE
Skip acceptance test scenarios in various cases

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -52,7 +52,7 @@ Feature: admin general settings
     And the administrator sets the value of cron job to "webcron" using the webUI
     Then the background jobs mode should be "webcron"
 
-  @smokeTest
+  @smokeTest @skipOnDockerContainerTesting
   Scenario: administrator changes the log level
     Given the administrator has invoked occ command "config:system:set loglevel --value 0"
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -24,7 +24,7 @@ Feature: reset the password
       Use the following link to reset your password: <a href=
       """
 
-  @skipOnEncryption
+  @skipOnEncryption @skipOnOcV10.0 @skipOnOcV10.1
   @smokeTest
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI


### PR DESCRIPTION
## Description
In the server docker container the log level is set from outside. Trying to set it in the UI has no effect, so skip the test in that case. Tag it `skipOnDockerContainerTesting`

The password reset UI workflow changed recently so the password has to be typed twice. Tag those tests `skipOnOcV10.0` `skipOnOcV10.1` as they will no longer work against those versions of ownCloud.

## Related Issue
Reference https://github.com/owncloud-docker/server/pull/77
and comment https://github.com/owncloud-docker/server/pull/77#issuecomment-464743047

## Motivation and Context
Make the appropriate tests run on systems-under-test

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
