### PR TITLE
[stable10] Skip acceptance test scenarios in various cases

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -52,7 +52,7 @@ Feature: admin general settings
     And the administrator sets the value of cron job to "webcron" using the webUI
     Then the background jobs mode should be "webcron"
 
-  @smokeTest
+  @smokeTest @skipOnDockerContainerTesting
   Scenario: administrator changes the log level
     Given the administrator has invoked occ command "config:system:set loglevel --value 0"
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -24,7 +24,7 @@ Feature: reset the password
       Use the following link to reset your password:
       """
 
-  @skipOnEncryption
+  @skipOnEncryption @skipOnOcV10.0 @skipOnOcV10.1
   @smokeTest
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -59,7 +59,7 @@ Feature: add users
       Access it:
       """
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.0 @skipOnOcV10.1
   Scenario Outline: user sets his own password after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI


### PR DESCRIPTION
Backport #34531 
and skip on 10.0 and 10.1 user-management-related scenarios for when the user sets their own first password. Because the workflow of that UI form has also changed for 10.2