### PR TITLE
Bump stable10 to 10.2.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 1, 0, 4];
+$OC_Version = [10, 2, 0, 0];
 
 // The human readable string
-$OC_VersionString = '10.1.0';
+$OC_VersionString = '10.2.0 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
Bump the version in stable10 from 10.1 to 10.2 prealpha

## Related Issue
Reasons to bump the minor version include:
#34492 "Add confirm password after new password" has provided a new feature (not just a bug fix)
#34280 "Backport of Increase size of login_name from 64 to 255" has a database migration

I guess there might be other things that are not just bugfixes to 10.1.0

## Motivation and Context
Reflect the truth of what is in stable10 that has been merged since 10.1 was released.

There are some new acceptance tests in stable10 that do not work on 10.1-release. We need to skip those for at least 10.1.0, so we need to bump the version anyway.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
