### PR TITLE
Fix static tags filtering in the backend

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagsByIdCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsByIdCollection.php
@@ -120,6 +120,20 @@ class SystemTagsByIdCollection implements ICollection {
 		}
 
 		$tags = $this->tagManager->getAllTags($visibilityFilter, null);
+		/**
+		 * Filter out static tags if the user does not have privilege to see it.
+		 */
+		$tags =  \array_filter($tags, function ($tag) {
+			if (!$tag->isUserEditable() && $tag->isUserAssignable()) {
+				$user = $this->userSession->getUser();
+				if (($user !== null) &&
+					!$this->tagManager->canUserUseStaticTagInGroup($tag, $user)) {
+					return false;
+				}
+			}
+			return true;
+		});
+
 		return \array_map(function ($tag) {
 			return $this->makeNode($tag);
 		}, $tags);


### PR DESCRIPTION
Fix static tags filtering in the backend.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Static tags filtering was done in the frontend https://github.com/owncloud/core/pull/34116. We need to do this in the backend. The filtering is done in the method `getchildren()`. If th user does not have privilege to see the static tags, in the search, then it should be hidden for him/her.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/34440

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The backend should provide the tags which could be viewed by the user. Basically it helps the UI to filter it out.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create 3 users `admin`, `user1` and `user2`.
- Create 2 groups `group1` and assign `user1` to it. `user2` is assigned to `group2`.
- As `admin` user create 4 tags `visibleTag`, `restrictTag` ( `group1` is assgined to it ), `staticTag` ( `group2` is assigned to it) , `invisibleTag`.
- Login as `user2` and navigate to tags page, the user would see `staticTag`
    - response captured from the dev console 
```
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/testing3/remote.php/dav/systemtags/</d:href>
    <d:propstat>
      <d:prop>
        <oc:id/>
        <oc:display-name/>
        <oc:user-visible/>
        <oc:user-editable/>
        <oc:user-assignable/>
        <oc:editable-in-group/>
        <oc:can-assign/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/testing3/remote.php/dav/systemtags/2</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>2</oc:id>
        <oc:display-name>restrictTag</oc:display-name>
        <oc:user-visible>true</oc:user-visible>
        <oc:user-editable>false</oc:user-editable>
        <oc:user-assignable>false</oc:user-assignable>
        <oc:editable-in-group>false</oc:editable-in-group>
        <oc:can-assign>false</oc:can-assign>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/testing3/remote.php/dav/systemtags/3</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>3</oc:id>
        <oc:display-name>staticTag</oc:display-name>
        <oc:user-visible>true</oc:user-visible>
        <oc:user-editable>false</oc:user-editable>
        <oc:user-assignable>true</oc:user-assignable>
        <oc:editable-in-group>true</oc:editable-in-group>
        <oc:can-assign>true</oc:can-assign>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/testing3/remote.php/dav/systemtags/1</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>1</oc:id>
        <oc:display-name>visibleTag</oc:display-name>
        <oc:user-visible>true</oc:user-visible>
        <oc:user-editable>true</oc:user-editable>
        <oc:user-assignable>true</oc:user-assignable>
        <oc:editable-in-group>false</oc:editable-in-group>
        <oc:can-assign>true</oc:can-assign>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```
- Login as `user1` and navigate to tags page, the user would not see `staticTag`.
    - response captured from the dev console
```
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/testing3/remote.php/dav/systemtags/</d:href>
    <d:propstat>
      <d:prop>
        <oc:id/>
        <oc:display-name/>
        <oc:user-visible/>
        <oc:user-editable/>
        <oc:user-assignable/>
        <oc:editable-in-group/>
        <oc:can-assign/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/testing3/remote.php/dav/systemtags/2</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>2</oc:id>
        <oc:display-name>restrictTag</oc:display-name>
        <oc:user-visible>true</oc:user-visible>
        <oc:user-editable>false</oc:user-editable>
        <oc:user-assignable>false</oc:user-assignable>
        <oc:editable-in-group>true</oc:editable-in-group>
        <oc:can-assign>true</oc:can-assign>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/testing3/remote.php/dav/systemtags/1</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>1</oc:id>
        <oc:display-name>visibleTag</oc:display-name>
        <oc:user-visible>true</oc:user-visible>
        <oc:user-editable>true</oc:user-editable>
        <oc:user-assignable>true</oc:user-assignable>
        <oc:editable-in-group>false</oc:editable-in-group>
        <oc:can-assign>true</oc:can-assign>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
