### PR TITLE
add acceptance test step theHTTPStatusCodeShouldBeOr

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1125,6 +1125,20 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @Then /^the HTTP status code should be "([^"]*)" or "([^"]*)"$/
+	 *
+	 * @param int $statusCode1
+	 * @param int $statusCode2
+	 *
+	 * @return void
+	 */
+	public function theHTTPStatusCodeShouldBeOr($statusCode1, $statusCode2) {
+		$this->theHTTPStatusCodeShouldBe(
+			[$statusCode1, $statusCode2]
+		);
+	}
+
+	/**
 	 * Check the text in an HTTP reason phrase
 	 *
 	 * @Then /^the HTTP reason phrase should be "([^"]*)"$/


### PR DESCRIPTION
## Description
Add an acceptance test step that lets us test for either of 2 HTTP status codes.

## Related Issue
https://github.com/owncloud/ransomware_protection/pull/115

## Motivation and Context
Sometimes, particularly when there is some unusual difference in behaviour in different environments, we want to be able to expect either of 2 HTTP status codes.
(note: usually such a thing turns out to be a "bug not feature" but in the meantime we want to be able to write this sort of test step)

## How Has This Been Tested?
CI  from ransomware_protection

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
