### PR TITLE
set the skeletondirectory by using the testing app

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -26,23 +26,15 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\FavoritesPage;
 use Page\FilesPage;
-use Page\FilesPageElement\ConflictDialog;
-use Page\OwncloudPage;
+use Page\SharedByLinkPage;
 use Page\SharedWithOthersPage;
 use Page\SharedWithYouPage;
 use Page\TagsPage;
-use Page\SharedByLinkPage;
 use Page\TrashbinPage;
+use Page\FilesPageElement\ConflictDialog;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use TestHelpers\DeleteHelper;
-use TestHelpers\DownloadHelper;
-use TestHelpers\HttpRequestHelper;
-use TestHelpers\OcsApiHelper;
-use Page\FilesPageBasic;
-use Page\FilesPageElement\FileActionsMenu;
-use Behat\Mink\Exception\ElementException;
-use Page\FilesPageElement\DetailsDialog;
-use TestHelpers\WebDavHelper;
+use TestHelpers\Asserts\WebDav as WebDavAssert;
 
 require_once 'bootstrap.php';
 
@@ -1796,8 +1788,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * Asserts that the content of a remote and a local file is the same
-	 * or is different
+	 * @see WebDavAssert::assertContentOfRemoteAndLocalFileIsSame
 	 * uses the current user to download the remote file
 	 *
 	 * @param string $remoteFile
@@ -1819,31 +1810,18 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		}
 		
 		$username = $this->featureContext->getCurrentUser();
-		$result = DownloadHelper::download(
+		WebDavAssert::assertContentOfRemoteAndLocalFileIsSame(
 			$baseUrl,
 			$username,
 			$this->featureContext->getUserPassword($username),
-			$remoteFile
+			$remoteFile,
+			$localFile,
+			$shouldBeSame
 		);
-		
-		$localContent = \file_get_contents($localFile);
-		$downloadedContent = $result->getBody()->getContents();
-		
-		if ($shouldBeSame) {
-			PHPUnit_Framework_Assert::assertSame(
-				$localContent, $downloadedContent
-			);
-		} else {
-			PHPUnit_Framework_Assert::assertNotSame(
-				$localContent, $downloadedContent
-			);
-		}
 	}
 
 	/**
-	 * Asserts that the content of a remote file (downloaded by DAV)
-	 * and a file in the skeleton folder of the system under test is the same
-	 * or is different
+	 * @see WebDavAssert::assertContentOfDAVFileAndSkeletonFileOnSUT
 	 * uses the current user to download the remote file
 	 *
 	 * @param string $remoteFile
@@ -1868,64 +1846,16 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		}
 
 		$username = $this->featureContext->getCurrentUser();
-		$result = DownloadHelper::download(
+		WebDavAssert::assertContentOfDAVFileAndSkeletonFileOnSUT(
 			$baseUrl,
 			$username,
 			$this->featureContext->getUserPassword($username),
-			$remoteFile
-		);
-		$downloadedContent = $result->getBody()->getContents();
-
-		//find the absolute path of the serverroot
-		$response = OcsApiHelper::sendRequest(
-			$baseUrl,
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
-			'GET',
-			"/apps/testing/api/v1/sysinfo"
+			$remoteFile,
+			$fileInSkeletonFolder,
+			$shouldBeSame
 		);
-		$responseXml = $this->featureContext->getResponseXml($response);
-		$serverRoot = (string)$responseXml->data->server_root;
-
-		//find the absolute path of the root folder of skeleton folders
-		$response = OcsApiHelper::sendRequest(
-			$baseUrl,
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			'GET',
-			"/apps/testing/api/v1/testingskeletondirectory"
-		);
-		$responseXml = $this->featureContext->getResponseXml($response);
-		$skeletonRoot = (string)$responseXml->data->rootdirectory;
-
-		//download the content of the particular file in the skeleton folder
-		$skeletonRootRelativeToServerRoot = \str_replace(
-			$serverRoot, "", $skeletonRoot
-		);
-		$fileInSkeletonFolder = "$skeletonRootRelativeToServerRoot/" .
-								\getenv('SRC_SKELETON_DIR') .
-								"/$fileInSkeletonFolder";
-		$this->featureContext->readFileInServerRoot($fileInSkeletonFolder);
-		PHPUnit_Framework_Assert::assertSame(
-			200,
-			$this->featureContext->getResponse()->getStatusCode(),
-			"Failed to read the file {$fileInSkeletonFolder}"
-		);
-		$localContent = HttpRequestHelper::getResponseXml(
-			$this->featureContext->getResponse()
-		);
-		$localContent = (string)$localContent->data->element->contentUrlEncoded;
-		$localContent = \urldecode($localContent);
-
-		if ($shouldBeSame) {
-			PHPUnit_Framework_Assert::assertSame(
-				$localContent, $downloadedContent
-			);
-		} else {
-			PHPUnit_Framework_Assert::assertNotSame(
-				$localContent, $downloadedContent
-			);
-		}
 	}
 
 	/**

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -459,11 +459,13 @@ then
 	# The endpoint to use to do occ commands via the testing app
 	# set it already here, so it can be used for remote_occ
 	# we know the TEST_SERVER_URL already
-	OCC_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/occ"
-	DIR_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/dir"
+	TESTING_APP_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/"
+	OCC_URL="${TESTING_APP_URL}occ"
+	DIR_URL="${TESTING_APP_URL}dir"
 	if [ -n "${TEST_SERVER_FED_URL}" ]
 	then
-		OCC_FED_URL="${TEST_SERVER_FED_URL}/ocs/v2.php/apps/testing/api/v1/occ"
+		TESTING_APP_FED_URL="${TEST_SERVER_FED_URL}/ocs/v2.php/apps/testing/api/v1/"
+		OCC_FED_URL="${TESTING_APP_FED_URL}occ"
 	fi
 	
 	echo "Not using php inbuilt server for running scenario ..."
@@ -502,8 +504,9 @@ else
 	export TEST_SERVER_FED_URL="http://localhost:${PORT_FED}"
 
 	# The endpoint to use to do occ commands via the testing app
-	OCC_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/occ"
-	DIR_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/dir"
+	TESTING_APP_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/"
+	OCC_URL="${TEST_SERVER_URL}occ"
+	DIR_URL="${TEST_SERVER_URL}dir"
 
 	# Give time for the PHP dev server to become available
 	# because we want to use it to get and change settings with the testing app
@@ -667,36 +670,6 @@ else
 	TESTING_ENABLED_BY_SCRIPT=false;
 fi
 
-# calculate the correct skeleton folder
-# $SRC_SKELETON_DIR is the path to the skeleton folder on the machine where the tests are executed
-# it is used for file comparisons in various tests
-
-# The testing app could be in the apps folder, or maybe another apps folder like
-# apps2 or apps-external, so be flexible about looking for the local skeleton folder.
-API_SKELETON_DIR=`find ${SCRIPT_PATH}/../../ -path "*/testing/data/apiSkeleton"`
-API_SKELETON_DIR="`( cd \"${API_SKELETON_DIR}\" && pwd )`"  # absolutized and normalized
-
-if [ "${RUNNING_API_TESTS}" = true ]
-then
-	export SRC_SKELETON_DIR="${API_SKELETON_DIR}"
-elif [ "${RUNNING_CLI_TESTS}" = true ]
-then
-	# CLI tests use the apiSkeleton so that API-based "then" steps can be used
-	# to check the state of users after CLI commands
-	export SRC_SKELETON_DIR="${API_SKELETON_DIR}"
-else
-	WEBUI_SKELETON_DIR=`find ${SCRIPT_PATH}/../../ -path "*/testing/data/webUISkeleton"`
-	WEBUI_SKELETON_DIR="`( cd \"${WEBUI_SKELETON_DIR}\" && pwd )`"  # absolutized and normalized
-	export SRC_SKELETON_DIR="${WEBUI_SKELETON_DIR}"
-fi
-
-# $SKELETON_DIR is the path to the skeleton folder on the machine where oC runs (system under test)
-# It is used to give users a defined set of files and folders for the tests
-if [ -z "${SKELETON_DIR}" ]
-then
-	export SKELETON_DIR="${SRC_SKELETON_DIR}"
-fi
-
 # table of settings to be remembered and set
 #system|app;app-name;setting-name;value;variable-type
 declare -a SETTINGS
@@ -709,7 +682,7 @@ SETTINGS+=("app;core;backgroundjobs_mode;webcron")
 SETTINGS+=("system;;sharing.federation.allowHttpFallback;true;boolean")
 SETTINGS+=("app;core;enable_external_storage;yes")
 SETTINGS+=("system;;files_external_allow_create_new_local;true")
-SETTINGS+=("system;;skeletondirectory;${SKELETON_DIR}")
+SETTINGS+=("system;;skeletondirectory;;")
 
 # Set various settings
 for URL in ${OCC_URL} ${OCC_FED_URL}
@@ -739,6 +712,29 @@ do
 		fi
 	done
 done
+
+#set the skeleton folder
+if [ -z "${SKELETON_DIR}" ]
+then
+	# calculate the correct skeleton folder
+	if [ "${RUNNING_API_TESTS}" = true ] || [ "${RUNNING_CLI_TESTS}" = true ]
+	then
+		# CLI tests use the apiSkeleton so that API-based "then" steps can be used
+		# to check the state of users after CLI commands
+		export SRC_SKELETON_DIR="apiSkeleton"
+	else
+		export SRC_SKELETON_DIR="webUISkeleton"
+	fi
+	for URL in ${TESTING_APP_URL} ${TESTING_APP_FED_URL}
+	do
+		curl -k -s -u $ADMIN_AUTH $URL/testingskeletondirectory -d "directory=${SRC_SKELETON_DIR}" > /dev/null
+	done
+else
+	for URL in ${OCC_URL} ${OCC_FED_URL}
+	do
+		remote_occ ${ADMIN_AUTH} ${URL} "config:system:set skeletondirectory --value=${SKELETON_DIR}"
+	done
+fi
 
 #Enable and disable apps as required for default
 if [ -z "${APPS_TO_DISABLE}" ]


### PR DESCRIPTION
## Description
don't try to guess and set the skeleton directory from outside of the SUT use the new endpoint of the testingapp for that 
needs https://github.com/owncloud/testing/pull/88

## Related Issue
- Fixes #34483

## Motivation and Context
guessing the correct skeleton directory by the test runner is not reliably, we need to let the SUT do it itself

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
