### PR TITLE
[stable10] Throw exception in stream_read() if attempting to read the same node multiple times

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -24,6 +24,7 @@
 namespace OCA\DAV\Upload;
 
 use Sabre\DAV\IFile;
+use Sabre\DAV\Exception\BadRequest;
 
 /**
  * Class AssemblyStream
@@ -106,6 +107,8 @@ class AssemblyStream implements \Icewind\Streams\File {
 	 * @return string
 	 */
 	public function stream_read($count) {
+		$node = null;
+		$lastNode = null;
 		do {
 			if ($this->currentStream === null) {
 				list($node, $posInNode) = $this->getNodeForPosition($this->pos);
@@ -127,7 +130,14 @@ class AssemblyStream implements \Icewind\Streams\File {
 				$read = \strlen($data);
 			}
 
+			// Only try the node twice if it's unable to be read to avoid infinite loops
+			if ($lastNode && $lastNode->getId() === $node->getId() && $read === 0) {
+				\OCP\Util::writeLog('dav', "Size mismatch for chunk '{$node->getPath()}'", \OCP\Util::ERROR);
+				throw new BadRequest('Uploading failed due to invalid or corrupt file transfer.', \OCP\AppFramework\Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
+
 			if (\feof($this->currentStream)) {
+				$lastNode = $node;
 				\fclose($this->currentStream);
 				$this->currentNode = null;
 				$this->currentStream = null;
@@ -136,7 +146,6 @@ class AssemblyStream implements \Icewind\Streams\File {
 			// returning empty data can make the caller think there is no more
 			// data left to read
 		} while ($read === 0);
-
 		// update position
 		$this->pos += $read;
 		return $data;


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/34489 to stable10

