### PR TITLE
[stable10] [CalDAV] In case of a cancel message the status has to be …

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -113,6 +113,7 @@ class IMipPlugin extends SabreIMipPlugin {
 				break;
 			case 'CANCEL':
 				$subject = 'Cancelled: ' . $summary;
+				$iTipMessage->message->VEVENT->STATUS = 'CANCELLED';
 				break;
 		}
 


### PR DESCRIPTION
…set inside the VEVENT

backport #34468 