### PR TITLE
getAppsInTar

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -17,5 +17,27 @@
     "files_external",
     "dav",
     "federatedfilesharing"
+  ],
+  "appsInTar": [
+    "comments",
+    "configreport",
+    "dav",
+    "encryption",
+    "external",
+    "federatedfilesharing",
+    "federation",
+    "files",
+    "files_external",
+    "files_sharing",
+    "files_trashbin",
+    "files_versions",
+    "files_videoplayer",
+    "firstrunwizard",
+    "market",
+    "notifications",
+    "provisioning_api",
+    "systemtags",
+    "updatenotification",
+    "user_external"
   ]
 }

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -78,6 +78,8 @@ class AppManager implements IAppManager {
 	private $shippedApps;
 	/** @var string[] */
 	private $alwaysEnabled;
+	/** @var string[] */
+	private $appsInTar;
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
 	/** @var IConfig */
@@ -537,6 +539,7 @@ class AppManager implements IAppManager {
 			$content = \json_decode(\file_get_contents($shippedJson), true);
 			$this->shippedApps = $content['shippedApps'];
 			$this->alwaysEnabled = $content['alwaysEnabled'];
+			$this->appsInTar = $content['appsInTar'];
 		}
 	}
 
@@ -546,6 +549,14 @@ class AppManager implements IAppManager {
 	public function getAlwaysEnabledApps() {
 		$this->loadShippedJson();
 		return $this->alwaysEnabled;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getAppsInTar() {
+		$this->loadShippedJson();
+		return $this->appsInTar;
 	}
 
 	/**

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -298,6 +298,14 @@ class OC_App {
 		return \OC::$server->getAppManager()->isShipped($appId);
 	}
 
+	/* Get all apps that are part of the tar file
+	 * @return string[]
+	 * @since 10.2.0
+	 */
+	public static function getAppsInTar() {
+		return \OC::$server->getAppManager()->getAppsInTar();
+	}
+
 	/**
 	 * get all enabled apps
 	 */

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -114,6 +114,12 @@ interface IAppManager {
 	 */
 	public function getAlwaysEnabledApps();
 
+	/* Get all apps that are part of the tar file
+	 * @return string[]
+	 * @since 10.2.0
+	 */
+	public function getAppsInTar();
+
 	/**
 	 * @param string $package
 	 * @param bool $skipMigrations whether to skip migrations, which would only install the code


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds `\OC_App::getAppsInTar();` including a prefilled `shipped.json` file with all apps that have been shipped in the 10.1 tar file.
Having that method, we can identify easily which apps are included in the tar file enabling upcoming PR´s to differenciate between them and manually installed once.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32048

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make apps included in tar and manually installed apps differenciable

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$tar[] = \OC_App::getAppsInTar();
var_dump($tar);
(with a prefilled shipped.json)
array(1) {
  [0]=>
  array(20) {
    [0]=>
    string(8) "comments"
    [1]=>
    string(12) "configreport"
    [2]=>
    string(3) "dav"
    [3]=>
    string(10) "encryption"
    [4]=>
    string(8) "external"
    [5]=>
    string(20) "federatedfilesharing"
    [6]=>
    string(10) "federation"
    [7]=>
    string(5) "files"
    [8]=>
    string(14) "files_external"
    [9]=>
    string(13) "files_sharing"
    [10]=>
    string(14) "files_trashbin"
    [11]=>
    string(14) "files_versions"
    [12]=>
    string(17) "files_videoplayer"
    [13]=>
    string(14) "firstrunwizard"
    [14]=>
    string(6) "market"
    [15]=>
    string(13) "notifications"
    [16]=>
    string(16) "provisioning_api"
    [17]=>
    string(10) "systemtags"
    [18]=>
    string(18) "updatenotification"
    [19]=>
    string(13) "user_external"
  }
}

(with a standard shipped.json)
array(1) {
  [0]=>
  NULL
}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
