### PR TITLE
Bugfix/user in share20ocscontroller

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -50,6 +50,10 @@ class CorsPlugin extends ServerPlugin {
 	 * @var string[]
 	 */
 	private $extraHeaders;
+	/**
+	 * @var bool
+	 */
+	private $alreadyExecuted = false;
 
 	/**
 	 * @param IUserSession $userSession
@@ -107,9 +111,13 @@ class CorsPlugin extends ServerPlugin {
 		}
 
 		$this->server->on('beforeMethod:*', [$this, 'setCorsHeaders']);
+		$this->server->on('exception', [$this, 'onException']);
 		$this->server->on('beforeMethod:OPTIONS', [$this, 'setOptionsRequestHeaders'], 5);
 	}
 
+	public function onException(\Throwable $ex) {
+		$this->setCorsHeaders($this->server->httpRequest, $this->server->httpResponse);
+	}
 	/**
 	 * This method sets the cors headers for all requests
 	 *
@@ -118,18 +126,23 @@ class CorsPlugin extends ServerPlugin {
 	 * @return void
 	 */
 	public function setCorsHeaders(RequestInterface $request, ResponseInterface $response) {
-		if ($request->getHeader('origin') !== null) {
-			$requesterDomain = $request->getHeader('origin');
-			// unauthenticated request shall add cors headers as well
-			$userId = null;
-			if ($this->userSession->getUser() !== null) {
-				$userId = $this->userSession->getUser()->getUID();
-			}
+		if ($request->getHeader('origin') === null) {
+			return;
+		}
+		if ($this->alreadyExecuted) {
+			return;
+		}
+		$this->alreadyExecuted = true;
+		$requesterDomain = $request->getHeader('origin');
+		// unauthenticated request shall add cors headers as well
+		$userId = null;
+		if ($this->userSession->getUser() !== null) {
+			$userId = $this->userSession->getUser()->getUID();
+		}
 
-			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, null, $this->getExtraHeaders($request));
-			foreach ($headers as $key => $value) {
-				$response->addHeader($key, \implode(',', $value));
-			}
+		$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, null, $this->getExtraHeaders($request));
+		foreach ($headers as $key => $value) {
+			$response->addHeader($key, \implode(',', $value));
 		}
 	}
 

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -86,7 +86,7 @@ class Application extends App {
 				$server->getUserManager(),
 				$server->getRootFolder(),
 				$server->getURLGenerator(),
-				$server->getUserSession()->getUser(),
+				$server->getUserSession(),
 				$server->getL10N('files_sharing'),
 				$server->getConfig(),
 				$c->query(NotificationPublisher::class),

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -31,6 +31,7 @@ namespace OCA\Files_Sharing\Tests;
 use OCP\Constants;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserSession;
 use OCP\Share;
 use OCA\Files_Sharing\Service\NotificationPublisher;
 use OCA\Files_Sharing\SharingBlacklist;
@@ -108,6 +109,8 @@ class ApiTest extends TestCase {
 	 */
 	private function createOCS($request, $userId) {
 		$currentUser = \OC::$server->getUserManager()->get($userId);
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($currentUser);
 
 		$l = $this->createMock(IL10N::class);
 		$l->method('t')
@@ -123,7 +126,7 @@ class ApiTest extends TestCase {
 			\OC::$server->getUserManager(),
 			\OC::$server->getRootFolder(),
 			\OC::$server->getURLGenerator(),
-			$currentUser,
+			$userSession,
 			$l,
 			\OC::$server->getConfig(),
 			\OC::$server->getAppContainer('files_sharing')->query(NotificationPublisher::class),

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -39,9 +39,11 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IGroup;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Share;
+use function Sodium\crypto_sign_ed25519_pk_to_curve25519;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
@@ -87,6 +89,9 @@ class Share20OcsControllerTest extends TestCase {
 	/** @var IUser */
 	private $currentUser;
 
+	/** @var IUserSession */
+	private $userSession;
+
 	/** @var Share20OcsController */
 	private $ocs;
 
@@ -115,8 +120,10 @@ class Share20OcsControllerTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->currentUser = $this->createMock(IUser::class);
 		$this->currentUser->method('getUID')->willReturn('currentUser');
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->userSession->method('getUser')->willReturn($this->currentUser);
 
-		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
+		$this->userManager->method('userExists')->willReturn(true);
 
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->method('t')
@@ -143,7 +150,7 @@ class Share20OcsControllerTest extends TestCase {
 			$this->userManager,
 			$this->rootFolder,
 			$this->urlGenerator,
-			$this->currentUser,
+			$this->userSession,
 			$this->l,
 			$this->config,
 			$this->notificationPublisher,
@@ -169,7 +176,7 @@ class Share20OcsControllerTest extends TestCase {
 				$this->userManager,
 				$this->rootFolder,
 				$this->urlGenerator,
-				$this->currentUser,
+				$this->userSession,
 				$this->l,
 				$this->config,
 				$this->notificationPublisher,
@@ -495,7 +502,7 @@ class Share20OcsControllerTest extends TestCase {
 					$this->userManager,
 					$this->rootFolder,
 					$this->urlGenerator,
-					$this->currentUser,
+					$this->userSession,
 					$this->l,
 					$this->config,
 					$this->notificationPublisher,
@@ -2794,7 +2801,7 @@ class Share20OcsControllerTest extends TestCase {
 			$this->userManager,
 			$this->rootFolder,
 			$this->urlGenerator,
-			$this->currentUser,
+			$this->userSession,
 			$this->l,
 			$this->config,
 			$this->notificationPublisher,
@@ -2888,7 +2895,7 @@ class Share20OcsControllerTest extends TestCase {
 			$this->userManager,
 			$this->rootFolder,
 			$this->urlGenerator,
-			$this->currentUser,
+			$this->userSession,
 			$this->l,
 			$config,
 			$this->notificationPublisher,

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -31,7 +31,6 @@
 namespace OC\AppFramework\DependencyInjection;
 
 use OC;
-use OC\AppFramework\Core\API;
 use OC\AppFramework\Http;
 use OC\AppFramework\Http\Dispatcher;
 use OC\AppFramework\Http\Output;

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -33,13 +33,16 @@ use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
 use OC\AppFramework\Middleware\Security\Exceptions\NotLoggedInException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Core\Controller\LoginController;
+use OC\OCS\Result;
 use OC\Security\CSP\ContentSecurityPolicyManager;
+use OCP\API;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCSController;
 use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IRequest;
@@ -184,6 +187,13 @@ class SecurityMiddleware extends Middleware {
 	 * @return Response a Response object or null in case that the exception could not be handled
 	 */
 	public function afterException($controller, $methodName, \Exception $exception) {
+		if ($controller instanceof OCSController) {
+			if ($exception instanceof NotLoggedInException) {
+				return $controller->buildResponse(new Result(null, API::RESPOND_UNAUTHORISED, 'Unauthorised'));
+			}
+			return $controller->buildResponse(new Result(null, API::RESPOND_SERVER_ERROR, $exception->getMessage()));
+		}
+
 		if ($exception instanceof SecurityException) {
 			if (\stripos($this->request->getHeader('Accept'), 'html') === false) {
 				$response = new JSONResponse(


### PR DESCRIPTION
## Description
1. Share20OCSController did not use IUserSession which causes issues:
```
[Tue Feb 19 17:19:23 2019] TypeError: Argument 8 passed to OCA\Files_Sharing\Controller\Share20OcsController::__construct() must implement interface OCP\IUser, null given, called in /home/deepdiver/Development/owncloud/core/apps/files_sharing/lib/AppInfo/Application.php on line 94 at /home/deepdiver/Development/owncloud/core/apps/files_sharing/lib/Controller/Share20OcsController.php#83
```

2. Unauthorized responses are incorrect.
Before:
```
$ curl 'http://deepdiver:8080/ocs/v1.php/apps/files_sharing/api/v1/shares' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36' -H 'Referer: http://localhost:9876/debug.html' -H 'Origin: http://localhost:9876' -H 'authorization: Basic YWRtaW46YWRtaW4xNTUwNTkzMDMyNTU0' -H 'OCS-APIREQUEST: true' -H 'content-type: application/x-www-form-urlencoded' --data 'shareType=3&path=%2F%E6%96%8v
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Expire in 200 ms for 4 (transfer 0x55a7d5b22810)
* Connected to deepdiver (127.0.0.1) port 8080 (#0)
> POST /ocs/v1.php/apps/files_sharing/api/v1/shares HTTP/1.1
> Host: deepdiver:8080
> Accept: */*
> Accept-Encoding: deflate, gzip
> User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36
> Referer: http://localhost:9876/debug.html
> Origin: http://localhost:9876
> authorization: Basic YWRtaW46YWRtaW4xNTUwNTkzMDMyNTU0
> OCS-APIREQUEST: true
> content-type: application/x-www-form-urlencoded
> Content-Length: 55
> 
* upload completely sent off: 55 out of 55 bytes
< HTTP/1.1 401 Unauthorized
< Host: deepdiver:8080
< Date: Wed, 20 Feb 2019 08:09:47 +0000
< Connection: close
< X-Powered-By: PHP/7.2.15-1+0~20190209065005.16+buster~1.gbp3ad8c0
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Pragma: no-cache
< Set-Cookie: .....
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Robots-Tag: none
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Set-Cookie: ocrhbj031xi4=6k31nopbargntflcbrlsjqsah8; path=/; HttpOnly
< Cache-Control: no-cache, must-revalidate
< Content-Type: application/json; charset=utf-8
< Content-Security-Policy: default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'
< Content-Length: 43
< 
* Closing connection 0
{"message":"Current user is not logged in"}
```

After:
```
$ curl 'http://deepdiver:8080/ocs/v1.php/apps/files_sharing/api/v1/shares' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36' -H 'Referer: http://localhost:9876/debug.html' -H 'Origin: http://localhost:9876' -H 'authorization: Basic YWRtaW46YWRtaW4xNTUwNTkzMDMyNTU0' -H 'OCS-APIREQUEST: true' -H 'content-type: application/x-www-form-urlencoded' --data 'shareType=3&path=%2F%E6%96%87%E4%BB%B61550593032554.txt' --compressed -v
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Expire in 200 ms for 4 (transfer 0x55df41ea1810)
* Connected to deepdiver (127.0.0.1) port 8080 (#0)
> POST /ocs/v1.php/apps/files_sharing/api/v1/shares HTTP/1.1
> Host: deepdiver:8080
> Accept: */*
> Accept-Encoding: deflate, gzip
> User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36
> Referer: http://localhost:9876/debug.html
> Origin: http://localhost:9876
> authorization: Basic YWRtaW46YWRtaW4xNTUwNTkzMDMyNTU0
> OCS-APIREQUEST: true
> content-type: application/x-www-form-urlencoded
> Content-Length: 55
> 
* upload completely sent off: 55 out of 55 bytes
< HTTP/1.1 200 OK
< Host: deepdiver:8080
< Date: Wed, 20 Feb 2019 08:20:12 +0000
< Connection: close
< X-Powered-By: PHP/7.2.15-1+0~20190209065005.16+buster~1.gbp3ad8c0
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Pragma: no-cache
< Set-Cookie: ......
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Robots-Tag: none
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Set-Cookie: ocrhbj031xi4=judinpdhs9le7ht61ncf79vjd9; path=/; HttpOnly
< Cache-Control: no-cache, must-revalidate
< Content-Type: application/xml; charset=utf-8
< Content-Security-Policy: default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'
< Content-Length: 213
< 
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>997</statuscode>
  <message>Unauthorised</message>
  <totalitems></totalitems>
  <itemsperpage></itemsperpage>
 </meta>
 <data/>
</ocs>
* Closing connection 0
```

## Related Issue
- refs #34566 which shall add necessary acceptance tests - more fixes will come from the tests

## Motivation and Context
Don't break behavior!

## How Has This Been Tested?
- manually with curl - see above
- acceptance test need to follow - see #34566

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
