### PR TITLE
Revert "Fix visibility of static tags in the tags page"

### DIFF
--- a/apps/systemtags/js/systemtagsfilelist.js
+++ b/apps/systemtags/js/systemtagsfilelist.js
@@ -122,50 +122,18 @@
 		},
 
 		/**
-		 * Get the fetched tags from the filter query
-		 *
-		 * @param {Object} query select2 query object
-		 */
-		fetchedResult: function(query) {
-			var results = OC.SystemTags.collection.filterByName(query.term);
-			/**
-			 * Check if static tags are visible for this user.
-			 * If so show it, else don't.
-			 */
-			var indexToSplice = [];
-			for(var i=0; i < results.length; i++) {
-				var tagAttribute = results[i].attributes;
-				//Check if the tag is static tag
-				if (tagAttribute.userEditable === false && tagAttribute.userAssignable === true) {
-					if (!OC.isUserAdmin() && tagAttribute.editableInGroup === false) {
-						var index = i;
-						if (indexToSplice.length > 0) {
-							index -= indexToSplice.length;
-						}
-						indexToSplice.push(index);
-					}
-				}
-			}
-
-			indexToSplice.forEach(function (index) {
-				results.splice(index, 1);
-			});
-
-			query.callback({
-				results: _.invoke(results, 'toJSON')
-			});
-		},
-
-		/**
 		 * Autocomplete function for dropdown results
 		 *
 		 * @param {Object} query select2 query object
 		 */
 		_queryTagsAutocomplete: function(query) {
-			var self = this;
 			OC.SystemTags.collection.fetch({
-				success: function () {
-					self.fetchedResult(query)
+				success: function() {
+					var results = OC.SystemTags.collection.filterByName(query.term);
+
+					query.callback({
+						results: _.invoke(results, 'toJSON')
+					});
 				}
 			});
 		},

--- a/apps/systemtags/tests/js/systemtagsfilelistSpec.js
+++ b/apps/systemtags/tests/js/systemtagsfilelistSpec.js
@@ -46,7 +46,7 @@ describe('OCA.SystemTags.FileList tests', function() {
 	});
 
 	describe('filter field', function() {
-		var select2Stub, oldCollection, fetchTagsStub, isAdminStub;
+		var select2Stub, oldCollection, fetchTagsStub;
 		var $tagsField;
 
 		beforeEach(function() {
@@ -61,15 +61,6 @@ describe('OCA.SystemTags.FileList tests', function() {
 				{
 					id: '456',
 					name: 'def'
-				},
-				{
-					id: '789',
-					name: 'staticTag',
-					userAssignable: true,
-					userEditable: false,
-					userVisible: true,
-					canAssign: true,
-					editableInGroup: false
 				}
 			]);
 
@@ -79,12 +70,10 @@ describe('OCA.SystemTags.FileList tests', function() {
 				}
 			);
 			$tagsField = fileList.$el.find('[name=tags]');
-			isAdminStub = sinon.stub(OC, 'isUserAdmin').returns(false);
 		});
 		afterEach(function() {
 			select2Stub.restore();
 			fetchTagsStub.restore();
-			isAdminStub.restore();
 			OC.SystemTags.collection = oldCollection;
 		});
 		it('inits select2 on filter field', function() {
@@ -126,29 +115,6 @@ describe('OCA.SystemTags.FileList tests', function() {
 			expect(callback.calledOnce).toEqual(true);
 			expect(callback.lastCall.args[0]).toEqual({
 				results: [
-					OC.SystemTags.collection.get('456').toJSON()
-				]
-			});
-		});
-		it('fetches tag list from the global collection and removes static tag', function () {
-			var callback = sinon.stub();
-			var opts = select2Stub.firstCall.args[0];
-
-			opts.query({
-				term: "",
-				callback: callback
-			});
-
-
-			//expect(callback.notCalled).toEqual(true);
-			OCA.SystemTags.FileList.prototype.fetchedResult({
-				term: "",
-				callback: callback
-			});
-
-			expect(callback.lastCall.args[0]).toEqual({
-				results: [
-					OC.SystemTags.collection.get('123').toJSON(),
 					OC.SystemTags.collection.get('456').toJSON()
 				]
 			});


### PR DESCRIPTION
Reverts owncloud/core#34007

Fixed this in the backend. Hence we can safely revert this change set.

#### Test Done ####
- Create 4 users `admin`, `user1`, `user2` and `user3`
- Create 2 groups `group` and `group2`
- Assign `user1` and `user3` to `group1`
- Assign `user2` and `user3` to `group2`
- Create 4 tags `visibleTag`, `restrictTag` for `group1`, `staticTag` for `group2` and `invisibleTag`
- Login as `user1` and navigate to tags page. User would see only `restrictTag` and `visibleTag`
- Login as `user2` and navigate to tags page. User would see `staticTag`.
- Login as `user3` and navigate to tags page. User would see `staticTag`.
- Login as `user2` and share a folder `test` to `group1`. Assign `staticTag` and `visibleTag` to the folder.
- Login as `user1` and verify again in the tags page. The user would not see `staticTag` in the list. 