### PR TITLE
Check the HTTP status of federated share test uploads

### DIFF
--- a/tests/acceptance/features/apiFederation/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederation/etagPropagation.feature
@@ -25,9 +25,10 @@ Feature: propagation of etags between federated and local server
     And user "user0" has stored etag of element "/"
     And using server "LOCAL"
     When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     # After fixing issue-enterprise-2848, change the following step to "should have changed"
-    Then the etag of element "/" of user "user0" on server "REMOTE" should not have changed
-    #Then the etag of element "/" of user "user0" on server "REMOTE" should have changed
+    And the etag of element "/" of user "user0" on server "REMOTE" should not have changed
+    #And the etag of element "/" of user "user0" on server "REMOTE" should have changed
 
   @issue-enterprise-2848
   Scenario: Adding a file to a federated shared folder as sharer propagates etag to root folder for recipient
@@ -37,9 +38,10 @@ Feature: propagation of etags between federated and local server
     And user "user0" has stored etag of element "/"
     And using server "LOCAL"
     When user "user1" uploads file "filesForUpload/lorem.txt" to "/PARENT/new-textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     # After fixing issue-enterprise-2848, change the following step to "should have changed"
-    Then the etag of element "/" of user "user0" on server "REMOTE" should not have changed
-    #Then the etag of element "/" of user "user0" on server "REMOTE" should have changed
+    And the etag of element "/" of user "user0" on server "REMOTE" should not have changed
+    #And the etag of element "/" of user "user0" on server "REMOTE" should have changed
 
   Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
@@ -47,7 +49,8 @@ Feature: propagation of etags between federated and local server
     And using server "REMOTE"
     And user "user0" has stored etag of element "/PARENT (2)"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-    Then the etag of element "/PARENT (2)" of user "user0" on server "REMOTE" should have changed
+    Then the HTTP status code should be "201"
+    And the etag of element "/PARENT (2)" of user "user0" on server "REMOTE" should have changed
 
   Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for recipient
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
@@ -55,7 +58,8 @@ Feature: propagation of etags between federated and local server
     And using server "REMOTE"
     And user "user0" has stored etag of element "/"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-    Then the etag of element "/" of user "user0" on server "REMOTE" should have changed
+    Then the HTTP status code should be "201"
+    And the etag of element "/" of user "user0" on server "REMOTE" should have changed
 
   Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
@@ -63,7 +67,8 @@ Feature: propagation of etags between federated and local server
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-    Then the etag of element "/PARENT" of user "user1" on server "LOCAL" should have changed
+    Then the HTTP status code should be "201"
+    And the etag of element "/PARENT" of user "user1" on server "LOCAL" should have changed
 
   Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for sharer
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
@@ -71,7 +76,8 @@ Feature: propagation of etags between federated and local server
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-    Then the etag of element "/" of user "user1" on server "LOCAL" should have changed
+    Then the HTTP status code should be "201"
+    And the etag of element "/" of user "user1" on server "LOCAL" should have changed
 
   Scenario: Adding a file to a federated shared folder as recipient propagates etag to root folder for sharer
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
@@ -79,4 +85,5 @@ Feature: propagation of etags between federated and local server
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     When user "user0" uploads file "filesForUpload/lorem.txt" to "/PARENT (2)/new-textfile.txt" using the WebDAV API
-    Then the etag of element "/" of user "user1" on server "LOCAL" should have changed
+    Then the HTTP status code should be "201"
+    And the etag of element "/" of user "user1" on server "LOCAL" should have changed

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -106,26 +106,30 @@ Feature: federated
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
-    Then the content of file "/textfile0.txt" for user "user1" on server "LOCAL" should be "BLABLABLA" plus end-of-line
+    Then the HTTP status code should be "204"
+    And the content of file "/textfile0.txt" for user "user1" on server "LOCAL" should be "BLABLABLA" plus end-of-line
 
   Scenario: Overwrite a federated shared file as recipient - remote server shares - local server receives
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
-    Then the content of file "/textfile0.txt" for user "user0" on server "REMOTE" should be "BLABLABLA" plus end-of-line
+    Then the HTTP status code should be "204"
+    And the content of file "/textfile0.txt" for user "user0" on server "REMOTE" should be "BLABLABLA" plus end-of-line
 
   Scenario: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-    Then the content of file "/PARENT/textfile0.txt" for user "user1" on server "LOCAL" should be "BLABLABLA" plus end-of-line
+    Then the HTTP status code should be "201"
+    And the content of file "/PARENT/textfile0.txt" for user "user1" on server "LOCAL" should be "BLABLABLA" plus end-of-line
 
   Scenario: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
     Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
-    Then the content of file "/PARENT/textfile0.txt" for user "user0" on server "REMOTE" should be "BLABLABLA" plus end-of-line
+    Then the HTTP status code should be "201"
+    And the content of file "/PARENT/textfile0.txt" for user "user0" on server "REMOTE" should be "BLABLABLA" plus end-of-line
 
   Scenario: Overwrite a federated shared file as recipient using old chunking
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
@@ -134,8 +138,9 @@ Feature: federated
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
-    Then the content of file "/textfile0 (2).txt" for user "user1" should be "AAAAABBBBBCCCCC"
-    Then the content of file "/textfile0.txt" for user "user0" on server "REMOTE" should be "AAAAABBBBBCCCCC"
+    Then the HTTP status code should be "201"
+    And the content of file "/textfile0 (2).txt" for user "user1" should be "AAAAABBBBBCCCCC"
+    And the content of file "/textfile0.txt" for user "user0" on server "REMOTE" should be "AAAAABBBBBCCCCC"
 
   Scenario: Overwrite a file in a federated shared folder as recipient using old chunking
     Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
@@ -144,7 +149,8 @@ Feature: federated
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
-    Then the content of file "/PARENT (2)/textfile0.txt" for user "user1" should be "AAAAABBBBBCCCCC"
+    Then the HTTP status code should be "201"
+    And the content of file "/PARENT (2)/textfile0.txt" for user "user1" should be "AAAAABBBBBCCCCC"
     And the content of file "/PARENT/textfile0.txt" for user "user0" on server "REMOTE" should be "AAAAABBBBBCCCCC"
 
   Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
@@ -160,7 +166,7 @@ Feature: federated
     And using server "LOCAL"
     When user "user1" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
-    Then as user "user0" on server "REMOTE" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
+    And as user "user0" on server "REMOTE" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
 
   @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives


### PR DESCRIPTION
## Description
Add `Then the HTTP status code should be` test steps to the `apiFederation` acceptance test scenarios.

## Related Issue
- PR #34568 

## Motivation and Context
When federation acceptance test scenarios fail (e.g. the expected etag did not change, or expected file contents did not change) then it is not obvious where the problem might be. It could be a problem with the upload, or with the interaction between the remote and local servers.

It is nicer to test the HTTP status of the upload first. Then we will quickly see when the server itself reports some problem.

e.g. PR #34568 is in development and failing some of these `apiFederation` acceptance test scenarios. In order to debug the problem, seeing the HTTP status will be helpful.

## How Has This Been Tested?
Local acceptance test run of the `apiFederation` suite.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
