### PR TITLE
move reading skeleton file in tests to own helper

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -24,6 +24,7 @@ namespace TestHelpers;
 use Behat\Testwork\Hook\Scope\HookScope;
 use GuzzleHttp\Exception\ServerException;
 use Exception;
+use PHPUnit_Framework_Assert;
 use GuzzleHttp\Message\ResponseInterface;
 use SimpleXMLElement;
 
@@ -468,6 +469,77 @@ class SetupHelper {
 				"could not delete file $filePathFromServerRoot " . $result->getReasonPhrase()
 			);
 		}
+	}
+
+	/**
+	 * returns the content of a file in a skeleton folder
+	 *
+	 * @param string $fileInSkeletonFolder
+	 * @param string|null $baseUrl
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 *
+	 * @return string content of the file
+	 */
+	public static function readSkeletonFile(
+		$fileInSkeletonFolder,
+		$baseUrl = null,
+		$adminUsername = null,
+		$adminPassword = null
+	) {
+		$baseUrl = self::checkBaseUrl($baseUrl, "readSkeletonFile");
+		$adminUsername = self::checkAdminUsername(
+			$adminUsername, "readSkeletonFile"
+		);
+		$adminPassword = self::checkAdminPassword(
+			$adminPassword, "readSkeletonFile"
+		);
+		//find the absolute path of the serverroot
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUsername,
+			$adminPassword,
+			'GET',
+			"/apps/testing/api/v1/sysinfo"
+		);
+		$responseXml = HttpRequestHelper::getResponseXml($response);
+		$serverRoot = (string)$responseXml->data->server_root;
+		
+		//find the absolute path of the root folder of skeleton folders
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUsername,
+			$adminPassword,
+			'GET',
+			"/apps/testing/api/v1/testingskeletondirectory"
+		);
+		$responseXml = HttpRequestHelper::getResponseXml($response);
+		$skeletonRoot = (string)$responseXml->data->rootdirectory;
+		
+		//download the content of the particular file in the skeleton folder
+		$skeletonRootRelativeToServerRoot = \str_replace(
+			$serverRoot, "", $skeletonRoot
+		);
+		$fileInSkeletonFolder = \rawurlencode($fileInSkeletonFolder);
+		$fileInSkeletonFolder = "$skeletonRootRelativeToServerRoot/" .
+								\getenv('SRC_SKELETON_DIR') .
+								"/$fileInSkeletonFolder";
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUsername,
+			$adminPassword,
+			'GET',
+			"/apps/testing/api/v1/file?file={$fileInSkeletonFolder}"
+		);
+		PHPUnit_Framework_Assert::assertSame(
+			200,
+			$response->getStatusCode(),
+			"Failed to read the file {$fileInSkeletonFolder}"
+		);
+		$localContent = HttpRequestHelper::getResponseXml($response);
+		$localContent = (string)$localContent->data->element->contentUrlEncoded;
+		$localContent = \urldecode($localContent);
+		return $localContent;
 	}
 
 	/**

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -495,15 +495,8 @@ class SetupHelper {
 			$adminPassword, "readSkeletonFile"
 		);
 		//find the absolute path of the serverroot
-		$response = OcsApiHelper::sendRequest(
-			$baseUrl,
-			$adminUsername,
-			$adminPassword,
-			'GET',
-			"/apps/testing/api/v1/sysinfo"
-		);
-		$responseXml = HttpRequestHelper::getResponseXml($response);
-		$serverRoot = (string)$responseXml->data->server_root;
+		$sysInfo = self::getSysInfo($baseUrl, $adminUsername, $adminPassword);
+		$serverRoot = $sysInfo->server_root;
 		
 		//find the absolute path of the root folder of skeleton folders
 		$response = OcsApiHelper::sendRequest(


### PR DESCRIPTION
## Description
move that functionality so it can be reused
## Motivation and Context
need it in oauth2 tests, that currently try to read the file locally

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
