### PR TITLE
make usage of admin auth tokens public

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -24,6 +24,7 @@ namespace TestHelpers;
 use Behat\Testwork\Hook\Scope\HookScope;
 use GuzzleHttp\Exception\ServerException;
 use Exception;
+use PHPUnit_Framework_Assert;
 use GuzzleHttp\Message\ResponseInterface;
 use SimpleXMLElement;
 
@@ -468,6 +469,77 @@ class SetupHelper {
 				"could not delete file $filePathFromServerRoot " . $result->getReasonPhrase()
 			);
 		}
+	}
+
+	/**
+	 * returns the content of a file in a skeleton folder
+	 *
+	 * @param string $fileInSkeletonFolder
+	 * @param string|null $baseUrl
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 *
+	 * @return string content of the file
+	 */
+	public static function readSkeletonFile(
+		$fileInSkeletonFolder,
+		$baseUrl = null,
+		$adminUsername = null,
+		$adminPassword = null
+	) {
+		$baseUrl = self::checkBaseUrl($baseUrl, "readSkeletonFile");
+		$adminUsername = self::checkAdminUsername(
+			$adminUsername, "readSkeletonFile"
+		);
+		$adminPassword = self::checkAdminPassword(
+			$adminPassword, "readSkeletonFile"
+		);
+		//find the absolute path of the serverroot
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUsername,
+			$adminPassword,
+			'GET',
+			"/apps/testing/api/v1/sysinfo"
+		);
+		$responseXml = HttpRequestHelper::getResponseXml($response);
+		$serverRoot = (string)$responseXml->data->server_root;
+		
+		//find the absolute path of the root folder of skeleton folders
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUsername,
+			$adminPassword,
+			'GET',
+			"/apps/testing/api/v1/testingskeletondirectory"
+		);
+		$responseXml = HttpRequestHelper::getResponseXml($response);
+		$skeletonRoot = (string)$responseXml->data->rootdirectory;
+		
+		//download the content of the particular file in the skeleton folder
+		$skeletonRootRelativeToServerRoot = \str_replace(
+			$serverRoot, "", $skeletonRoot
+		);
+		$fileInSkeletonFolder = \rawurlencode($fileInSkeletonFolder);
+		$fileInSkeletonFolder = "$skeletonRootRelativeToServerRoot/" .
+								\getenv('SRC_SKELETON_DIR') .
+								"/$fileInSkeletonFolder";
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUsername,
+			$adminPassword,
+			'GET',
+			"/apps/testing/api/v1/file?file={$fileInSkeletonFolder}"
+		);
+		PHPUnit_Framework_Assert::assertSame(
+			200,
+			$response->getStatusCode(),
+			"Failed to read the file {$fileInSkeletonFolder}"
+		);
+		$localContent = HttpRequestHelper::getResponseXml($response);
+		$localContent = (string)$localContent->data->element->contentUrlEncoded;
+		$localContent = \urldecode($localContent);
+		return $localContent;
 	}
 
 	/**

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -495,15 +495,8 @@ class SetupHelper {
 			$adminPassword, "readSkeletonFile"
 		);
 		//find the absolute path of the serverroot
-		$response = OcsApiHelper::sendRequest(
-			$baseUrl,
-			$adminUsername,
-			$adminPassword,
-			'GET',
-			"/apps/testing/api/v1/sysinfo"
-		);
-		$responseXml = HttpRequestHelper::getResponseXml($response);
-		$serverRoot = (string)$responseXml->data->server_root;
+		$sysInfo = self::getSysInfo($baseUrl, $adminUsername, $adminPassword);
+		$serverRoot = $sysInfo->server_root;
 		
 		//find the absolute path of the root folder of skeleton folders
 		$response = OcsApiHelper::sendRequest(

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -48,6 +48,13 @@ trait Auth {
 	private $tokenAuthHasBeenSetTo = '';
 
 	/**
+	 * @return string
+	 */
+	public function getTokenAuthHasBeenSetTo() {
+		return $this->tokenAuthHasBeenSetTo;
+	}
+
+	/**
 	 * get the client token that was last generated
 	 * app acceptance tests that have their own step code may need to use this
 	 *
@@ -330,6 +337,16 @@ trait Auth {
 	}
 
 	/**
+	 *
+	 * @return string
+	 */
+	public function generateAuthTokenForAdmin() {
+		$this->aNewBrowserSessionForHasBeenStarted($this->getAdminUsername());
+		$this->userGeneratesNewAppPasswordNamed('acceptance-test ' . \microtime());
+		return $this->appToken;
+	}
+
+	/**
 	 * delete token_auth_enforced if it was set in the scenario
 	 *
 	 * @AfterScenario
@@ -342,9 +359,7 @@ trait Auth {
 				// Because token auth is enforced, we have to use a token
 				// (app password) as the password to send to the testing app
 				// so it will authenticate us.
-				$this->aNewBrowserSessionForHasBeenStarted($this->getAdminUsername());
-				$this->userGeneratesNewAppPasswordNamed('acceptance-test ' . \microtime());
-				$appTokenForOccCommand = $this->appToken;
+				$appTokenForOccCommand = $this->generateAuthTokenForAdmin();
 			} else {
 				$appTokenForOccCommand = null;
 			}


### PR DESCRIPTION
## Description
PR on top of #34579 only need to review last commit

two new methods, so that the state of auth token enforcement can be viewed from other classes and a new auth token can be generated for admin from other classes

## Motivation and Context
need it in oauth2 tests, otherwise they cannot use the testing app correctly after enforcing token based auth

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
