### PR TITLE
Throw exception in getOCSResponseStatusCode if responseXml has no OCS status

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -817,10 +817,17 @@ trait BasicStructure {
 	 *
 	 * @param ResponseInterface $response
 	 *
+	 * @throws \Exception
 	 * @return string
 	 */
 	public function getOCSResponseStatusCode($response) {
-		return (string) $this->getResponseXml($response)->meta[0]->statuscode;
+		$responseXml = $this->getResponseXml($response);
+		if (isset($responseXml->meta[0], $responseXml->meta[0]->statuscode)) {
+			return (string) $responseXml->meta[0]->statuscode;
+		}
+		throw new \Exception(
+			"No OCS status code found in responseXml"
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Throw an exception in getOCSResponseStatusCode if responseXml has no OCS status

## Related Issue
During development PR #34568 had a problem where an API call returned a good HTTP status, but did not fill in the OCS status. That cause the acceptance test code to fall over in a "not very nice" way.

## How Has This Been Tested?
Local runs against development software with issues.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
