### PR TITLE
allow user to configure automatically accept incoming shares

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -24,8 +24,12 @@ Turning the feature off removes shared files and folders on the server for all s
 
 	<namespace>Files_Sharing</namespace>
 
+	<settings-sections>
+		<personal>OCA\Files_Sharing\Panels\Personal\Section</personal>
+	</settings-sections>
 	<settings>
 		<admin>OCA\Files_Sharing\Panels\Admin\SettingsPanel</admin>
+		<personal>OCA\Files_Sharing\Panels\Personal\PersonalPanel</personal>
 	</settings>
 
 	<background-jobs>

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -39,6 +39,11 @@ $application->registerRoutes($this, [
 			'url' => '/testremote',
 			'verb' => 'GET'
 		],
+		[
+			'name' => 'PersonalSettings#setUserConfig',
+			'url' => '/personalsettings/setuserconfig',
+			'verb' => 'POST'
+		],
 	],
 	'ocs' => [
 		[

--- a/apps/files_sharing/js/settings-personal.js
+++ b/apps/files_sharing/js/settings-personal.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+	function saveSettings() {
+		var postData = {};
+		postData[$(this).attr('name')] = $(this).is(":checked") ? "yes" : "no";
+		$.post(OC.generateUrl('apps/files_sharing/personalsettings/setuserconfig'), postData);
+	}
+
+	var userConfig = $('#files_sharing_settings');
+	userConfig.find('input[type=checkbox]').change(saveSettings);
+});

--- a/apps/files_sharing/lib/Controller/PersonalSettingsController.php
+++ b/apps/files_sharing/lib/Controller/PersonalSettingsController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace OCA\Files_Sharing\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+class PersonalSettingsController extends Controller {
+	const USERCONFIGS = [
+		'auto_accept_share'
+	];
+
+	/** @var IConfig $config */
+	private $config;
+
+	/** @var IUserSession $userSession */
+	private $userSession;
+
+	public function __construct(string $appName, IRequest $request, IConfig $config, IUserSession $userSession) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 */
+	public function setUserConfig() {
+		$acceptedKeys = [];
+		$rejectedKeys = [];
+
+		$params = $this->getUserRequestParams();
+		foreach ($params as $key => $value) {
+			if ($this->validateParameter($key, $value)) {
+				$this->config->setUserValue(
+					$this->userSession->getUser()->getUID(),
+					'files_sharing',
+					$key,
+					$value
+				);
+				$acceptedKeys[] = $key;
+			} else {
+				$rejectedKeys[] = $key;
+			}
+		}
+		$status = Http::STATUS_OK;
+		if (empty($acceptedKeys)) {
+			$status = Http::STATUS_BAD_REQUEST;
+		}
+		return new DataResponse(
+			['accepted' => $acceptedKeys, 'rejected' => $rejectedKeys],
+			$status
+		);
+	}
+
+	/**
+	 * @param $key
+	 * @param $value
+	 * @return bool
+	 */
+	private function validateParameter($key, $value) {
+		return \in_array($key, self::USERCONFIGS) && ($value === 'yes' || $value === 'no');
+	}
+
+	/**
+	 * Exclude params starting with '_' from request parameters
+	 *
+	 * @return array
+	 */
+	private function getUserRequestParams() {
+		return \array_filter($this->request->getParams(),
+			function ($key) {
+				return (\substr($key, 0, 1) !== '_');
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+	}
+}

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -1,8 +1,9 @@
 <?php
 /**
  * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -377,7 +378,8 @@ class Share20OcsController extends OCSController {
 
 		$shareWith = $this->request->getParam('shareWith', null);
 
-		$autoAccept = $this->config->getAppValue('core', 'shareapi_auto_accept_share', 'yes') === 'yes';
+		$globalAutoAcceptValue = $this->config->getAppValue('core', 'shareapi_auto_accept_share', 'yes');
+		$autoAccept = $this->config->getUserValue($shareWith, 'files_sharing', 'auto_accept_share', $globalAutoAcceptValue) === 'yes';
 		if ($shareType === Share::SHARE_TYPE_USER) {
 			// Valid user is required to share
 			if ($shareWith === null || !$this->userManager->userExists($shareWith)) {

--- a/apps/files_sharing/lib/Panels/Personal/PersonalPanel.php
+++ b/apps/files_sharing/lib/Panels/Personal/PersonalPanel.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Panels\Personal;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\IUserSession;
+use OCP\Settings\ISettings;
+use OCP\Template;
+
+class PersonalPanel implements ISettings {
+
+	/** @var IConfig $config */
+	private $config;
+
+	/** @var IUserSession $userSession */
+	private $userSession;
+
+	public function __construct(IConfig $config, IUserSession $userSession) {
+		$this->config = $config;
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * The panel controller method that returns a template to the UI
+	 *
+	 * @return TemplateResponse | Template
+	 */
+	public function getPanel() {
+		$autoAcceptShareEnabled = $this->config->getUserValue(
+			$this->userSession->getUser()->getUID(),
+			'files_sharing',
+			'auto_accept_share',
+			'yes'
+		);
+		$tmpl = new Template('files_sharing', 'settings-personal');
+		$tmpl->assign(
+			'userAutoAcceptShareEnabled',
+			$autoAcceptShareEnabled
+		);
+		return $tmpl;
+	}
+
+	/**
+	 * A string to identify the section in the UI / HTML and URL
+	 *s
+	 * @return string
+	 */
+	public function getSectionID() {
+		return 'sharing';
+	}
+
+	/**
+	 * The number used to order the section in the UI.
+	 *
+	 * @return int between 0 and 100, with 100 being the highest priority
+	 */
+	public function getPriority() {
+		return 100;
+	}
+}

--- a/apps/files_sharing/lib/Panels/Personal/Section.php
+++ b/apps/files_sharing/lib/Panels/Personal/Section.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\Panels\Personal;
+
+use OCP\IL10N;
+use OCP\Settings\ISection;
+
+class Section implements ISection {
+	/** @var IL10N  $l*/
+	protected $l;
+
+	public function __construct(IL10N $l) {
+		$this->l = $l;
+	}
+
+	public function getPriority() {
+		return 40;
+	}
+
+	public function getIconName() {
+		return 'share';
+	}
+
+	public function getID() {
+		return 'sharing';
+	}
+
+	public function getName() {
+		return $this->l->t('Sharing');
+	}
+}

--- a/apps/files_sharing/templates/settings-personal.php
+++ b/apps/files_sharing/templates/settings-personal.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+/** @var array $_ */
+/** @var \OCP\IL10N $l */
+script('files_sharing', 'settings-personal');
+?>
+
+<form class="section" id="files_sharing_settings">
+	<h2 class="app-name"><?php p($l->t('Sharing'));?></h2>
+	<input type="checkbox" name="auto_accept_share" id="userAutoAcceptShareInput" class="checkbox"
+			   value="1" <?php if ($_['userAutoAcceptShareEnabled'] === 'yes') {
+	print_unescaped('checked="checked"');
+} ?> />
+	<label for="userAutoAcceptShareInput">
+		<?php p($l->t('Automatically accept new incoming local user shares'));?>
+	</label><br/>
+</form>

--- a/apps/files_sharing/tests/Controller/PersonalSettingsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PersonalSettingsControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharings\Tests\Controller;
+
+use OCA\Files_Sharing\Controller\PersonalSettingsController;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use Test\TestCase;
+
+class PersonalSettingsControllerTest extends TestCase {
+
+	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+	private $config;
+
+	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+	private $userSession;
+
+	/** @var PersonalSettingsController $personalSettingsController */
+	private $personalSettingsController;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
+
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mockUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$mockUser->expects($this->any())
+			->method('getUID')
+			->willReturn('testuser');
+
+		$this->userSession->expects($this->any())
+			->method('getUser')
+			->willReturn($mockUser);
+
+		$this->personalSettingsController = new PersonalSettingsController(
+			'files_sharing',
+			$this->request,
+			$this->config,
+			$this->userSession
+		);
+	}
+
+	public function userConfigProvider() {
+		return [
+			[
+				['auto_accept_share' => 'yes', '_route' => 'setconfig'],
+				['auto_accept_share'],
+				[],
+				Http::STATUS_OK
+			],
+			[
+				['auto_accept_share' => 'yes', 'invalid_key' => 'yes'],
+				['auto_accept_share'],
+				['invalid_key'],
+				Http::STATUS_OK
+			],
+			[
+				['auto_accept_share' => 'no'],
+				['auto_accept_share'],
+				[],
+				Http::STATUS_OK
+			],
+			[
+				['invalid_key' => 'yes'],
+				[],
+				['invalid_key'],
+				Http::STATUS_BAD_REQUEST
+			],
+			[
+				['auto_accept_share' => 'invalid_value'],
+				[],
+				['auto_accept_share'],
+				Http::STATUS_BAD_REQUEST
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider userConfigProvider
+	 *
+	 * @param array $params
+	 * @param array $acceptedKeys
+	 * @param array $rejectedKeys
+	 * @param integer $statusCode
+	 */
+	public function testSetUserConfig($params, $acceptedKeys, $rejectedKeys, $statusCode) {
+		$this->request->expects($this->once())
+			->method('getParams')
+			->willReturn($params);
+		foreach ($acceptedKeys as $key) {
+			$this->config->expects($this->exactly(1))
+				->method('setUserValue')
+				->with('testuser', 'files_sharing', $key, $params[$key]);
+		}
+
+		$expected = new DataResponse(
+			['accepted' => $acceptedKeys, 'rejected' => $rejectedKeys],
+			$statusCode
+		);
+		$this->assertEquals($expected, $this->personalSettingsController->setUserConfig());
+	}
+}

--- a/apps/files_sharing/tests/Panels/Personal/PersonalPanelTest.php
+++ b/apps/files_sharing/tests/Panels/Personal/PersonalPanelTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\Tests\Panels\Personal;
+
+use OCA\Files_Sharing\Panels\Personal\PersonalPanel;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserSession;
+
+class PersonalPanelTest extends \Test\TestCase {
+
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+	private $config;
+
+	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+	private $userSession;
+
+	/** @var PersonalPanel $personalPanel */
+	private $personalPanel;
+
+	protected function setUp() {
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->personalPanel = new PersonalPanel($this->config, $this->userSession);
+	}
+
+	public function testGetSectionID() {
+		$this->assertEquals('sharing', $this->personalPanel->getSectionID());
+	}
+
+	public function testGetPriority() {
+		$this->assertEquals(100, $this->personalPanel->getPriority());
+	}
+
+	public function testGetPanel() {
+		$mockUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$mockUser->expects($this->any())
+			->method('getUID')
+			->willReturn('testuser');
+
+		$this->userSession->expects($this->any())
+			->method('getUser')
+			->willReturn($mockUser);
+
+		$templateHtml = $this->personalPanel->getPanel()->fetchPage();
+		$this->assertContains('<form class="section" id="files_sharing_settings">', $templateHtml);
+	}
+}

--- a/apps/files_sharing/tests/Panels/Personal/SectionTest.php
+++ b/apps/files_sharing/tests/Panels/Personal/SectionTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\Tests\Panels\Personal;
+
+use OCA\Files_Sharing\Panels\Personal\Section;
+use OCP\IL10N;
+
+class SectionTest extends \Test\TestCase {
+
+	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l */
+	private $l;
+
+	/** @var Section $section */
+	private $section;
+
+	protected function setUp() {
+		$this->l = $this->getMockBuilder(IL10N::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->section = new Section($this->l);
+	}
+
+	public function testGetPriority() {
+		$this->assertEquals(40, $this->section->getPriority());
+	}
+
+	public function testGetIconName() {
+		$this->assertEquals('share', $this->section->getIconName());
+	}
+
+	public function testGetID() {
+		$this->assertEquals('sharing', $this->section->getID());
+	}
+
+	public function testGetName() {
+		$this->l->expects($this->once())->method('t')->willReturn('Sharing');
+		$this->assertEquals('Sharing', $this->section->getName());
+	}
+}


### PR DESCRIPTION
## Description
Let the users decide whether they want to manually accept shares or not. 

## Related Issue
>
- Fixes `files_sharing` part of https://github.com/owncloud/enterprise/issues/3128 . There will be another PR for `federatedfilesharing`

## Motivation and Context
some users will not want that shares are accepted automatically.

## How Has This Been Tested?
Unit tests are added. Manually tested.
- When global `auto_accept_share` enabled, go Sharing Personal Panel and disable `auto accept share`, the next share should be on the pending status.
- When global `auto_accept_share` enabled, go Sharing Personal Panel and enable`auto accept share`, the next share should be accepted automatically.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
