### PR TITLE
[stable10] Backport of Add re-login information after successful action

### DIFF
--- a/apps/encryption/lib/Command/RecreateMasterKey.php
+++ b/apps/encryption/lib/Command/RecreateMasterKey.php
@@ -231,6 +231,7 @@ class RecreateMasterKey extends Command {
 				$this->keyManager->validateMasterKey();
 				$this->encryptAllUsers($input, $output);
 				$output->writeln("\nEncryption completed successfully\n");
+				$output->writeln("\n<info>Note: All users are required to relogin.</info>\n");
 			} else {
 				$output->writeln("The process is abandoned");
 			}

--- a/apps/encryption/tests/Command/RecreateMasterKeyTest.php
+++ b/apps/encryption/tests/Command/RecreateMasterKeyTest.php
@@ -196,17 +196,24 @@ class RecreateMasterKeyTest extends TestCase {
 				->with('user1')
 				->willReturn(true);
 
-			global $outputText;
+			$outputText = '';
+			$reloginText = '';
 
 			$this->output->expects($this->at(16))
 				->method('writeln')
-				->willReturnCallback(function ($value){
-					global $outputText;
+				->willReturnCallback(function ($value) use (&$outputText){
 					$outputText .= $value . "\n";
+				});
+
+			$this->output->expects($this->at(17))
+				->method('writeln')
+				->willReturnCallback(function ($value) use (&$reloginText) {
+					$reloginText = $value;
 				});
 
 			$this->invokePrivate($this->recreateMasterKey, 'execute', [$this->input, $this->output]);
 			$this->assertSame("Encryption completed successfully", trim($outputText, "\n"));
+			$this->assertEquals("\n<info>Note: All users are required to relogin.</info>\n",$reloginText);
 			$outputText="";
 		} else {
 			$this->recreateMasterKey = $this->getMockBuilder('OCA\Encryption\Command\RecreateMasterKey')


### PR DESCRIPTION
After the command is executed successfully by
recreating masterkey, the user should be informed
to relogin.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Its always nice to provide information to the user after the command has done its job. Like if the users need to relogin or not. This change set helps to improve the information shared to user after the recreate masterkey command is successfully done. It tells all users must relogin.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
An information shared to users after successful execution of recreate masterkey command, i.e, to every user should relogin.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
