### PR TITLE
Fix systemtatgs get,create and update API

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -166,10 +166,19 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getTag($tagName, $userVisible, $userAssignable, $userEditable = false) {
+	public function getTag($tagName, $userVisible, $userAssignable, $userEditable = null) {
 		$userVisible = (int)$userVisible;
 		$userAssignable = (int)$userAssignable;
-		$userEditable = (int)$userEditable;
+
+		/**
+		 * Change made inorder to make sure this API should not be broken,
+		 * if variable $userEditable is not passed to this method.
+		 */
+		if ($userEditable === null) {
+			$userEditable = $userAssignable;
+		} elseif (\is_bool($userEditable)) {
+			$userEditable = (int)$userEditable;
+		}
 
 		$result = $this->selectTagQuery
 			->setParameter('name', $tagName)
@@ -192,10 +201,19 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function createTag($tagName, $userVisible, $userAssignable, $userEditable = false) {
+	public function createTag($tagName, $userVisible, $userAssignable, $userEditable = null) {
 		$userVisible = (int)$userVisible;
 		$userAssignable = (int)$userAssignable;
-		$userEditable = (int)$userEditable;
+
+		/**
+		 * Change made inorder to make sure this API should not be broken,
+		 * if variable $userEditable is not passed to this method.
+		 */
+		if ($userEditable === null) {
+			$userEditable = 1;
+		} elseif (\is_bool($userEditable)) {
+			$userEditable = (int)$userEditable;
+		}
 
 		if ($userEditable === 1) {
 			$editable = $userAssignable;
@@ -243,10 +261,19 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function updateTag($tagId, $tagName, $userVisible, $userAssignable, $userEditable = false) {
+	public function updateTag($tagId, $tagName, $userVisible, $userAssignable, $userEditable = null) {
 		$userVisible = (int)$userVisible;
 		$userAssignable = (int)$userAssignable;
-		$userEditable = (int)$userEditable;
+
+		/**
+		 * Change made inorder to make sure this API should not be broken,
+		 * if variable $userEditable is not passed to this method.
+		 */
+		if ($userEditable === null) {
+			$userEditable = $userAssignable;
+		} elseif (\is_bool($userEditable)) {
+			$userEditable = (int)$userEditable;
+		}
 
 		try {
 			$tags = $this->getTagsByIds($tagId);

--- a/lib/public/SystemTag/ISystemTagManager.php
+++ b/lib/public/SystemTag/ISystemTagManager.php
@@ -51,7 +51,7 @@ interface ISystemTagManager {
 	 *
 	 * @param string $tagName tag name
 	 * @param bool $userVisible whether the tag is visible by users
-	 * @param bool $userAssignable whether the tag is assignable by users
+	 * @param null|bool $userAssignable whether the tag is assignable by users
 	 *
 	 * @return \OCP\SystemTag\ISystemTag system tag
 	 *
@@ -59,7 +59,7 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 */
-	public function getTag($tagName, $userVisible, $userAssignable, $userEditable = false);
+	public function getTag($tagName, $userVisible, $userAssignable, $userEditable = null);
 
 	/**
 	 * Creates the tag object using the given attributes.
@@ -67,7 +67,7 @@ interface ISystemTagManager {
 	 * @param string $tagName tag name
 	 * @param bool $userVisible whether the tag is visible by users
 	 * @param bool $userAssignable whether the tag is assignable by users
-	 * @param bool $userEditable whether the tag is editable by users
+	 * @param null|bool $userEditable whether the tag is editable by users
 	 *
 	 * @return \OCP\SystemTag\ISystemTag system tag
 	 *
@@ -75,7 +75,7 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 */
-	public function createTag($tagName, $userVisible, $userAssignable, $userEditable = false);
+	public function createTag($tagName, $userVisible, $userAssignable, $userEditable = null);
 
 	/**
 	 * Returns all known tags, optionally filtered by visibility.
@@ -96,7 +96,7 @@ interface ISystemTagManager {
 	 * @param string $newName the new tag name
 	 * @param bool $userVisible whether the tag is visible by users
 	 * @param bool $userAssignable whether the tag is assignable by users
-	 * @param bool $userEditable whether the tag is assignable by users
+	 * @param null|bool $userEditable whether the tag is assignable by users
 	 *
 	 * @throws \OCP\SystemTag\TagNotFoundException if tag with the given id does not exist
 	 * @throws \OCP\SystemTag\TagAlreadyExistsException if there is already another tag
@@ -104,7 +104,7 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 */
-	public function updateTag($tagId, $newName, $userVisible, $userAssignable, $userEditable = false);
+	public function updateTag($tagId, $newName, $userVisible, $userAssignable, $userEditable = null);
 
 	/**
 	 * Delete the given tags from the database and all their relationships.

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -223,7 +223,7 @@ class SystemTagManagerTest extends TestCase {
 
 		$testTagsById = [];
 		foreach ($expectedResults as $expectedTag) {
-			$tag = $this->tagManager->getTag($expectedTag[0], $expectedTag[1], $expectedTag[2], $expectedTag[3]);
+			$tag = $this->tagManager->getTag($expectedTag[0], $expectedTag[1], $expectedTag[2]);
 			$testTagsById[$tag->getId()] = $tag;
 		}
 
@@ -579,5 +579,33 @@ class SystemTagManagerTest extends TestCase {
 			->willReturn($userGroups);
 		$result = $this->tagManager->canUserUseStaticTagInGroup($tag1, $user);
 		$this->assertEquals($result, $expectedResult);
+	}
+
+	public function provideTagsWithDefaultParams() {
+		return [
+			['visibleTag', true, true, ['invisibleTag', false, false]],
+			['invisibleTag', false, false, ['visibleTag', true, true]],
+			['restrictedTag', true, false, ['visibleTag', true, true]],
+		];
+	}
+
+	/**
+	 * @dataProvider provideTagsWithDefaultParams
+	 */
+	public function testCreateAndGetAndUpdateAPIWithoutLastArg($tagName, $userVisible, $userAssignable, $updateTag) {
+		$createdTag = $this->tagManager->createTag($tagName, $userVisible, $userAssignable);
+		$resultTag = $this->tagManager->getTag($tagName, $userVisible, $userAssignable);
+
+		$this->assertEquals($createdTag->getName(), $resultTag->getName());
+		$this->assertEquals($createdTag->getId(), $resultTag->getId());
+		$this->assertEquals($createdTag->isUserVisible(), $resultTag->isUserVisible());
+		$this->assertEquals($createdTag->isUserAssignable(), $resultTag->isUserAssignable());
+		$this->assertEquals($createdTag->isUserEditable(), $resultTag->isUserEditable());
+
+		$this->tagManager->updateTag($resultTag->getId(), $updateTag[0], $updateTag[1], $updateTag[2]);
+		$retrieveTag = $this->tagManager->getTag($updateTag[0], $updateTag[1], $updateTag[2]);
+		$this->assertEquals($retrieveTag->getName(), $updateTag[0]);
+		$this->assertEquals($retrieveTag->isUserVisible(), $updateTag[1]);
+		$this->assertEquals($retrieveTag->isUserAssignable(), $updateTag[2]);
 	}
 }


### PR DESCRIPTION
Fix systemtags get, create and update API.
Due to recent changes made to add static tags,
the API changes are not compatible with the
older version. Hence to make them work as
before, minor changes are made.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Because of recent changes made to add static tags, there were changes made to `getTag`, `createTag` and `updateTag`. As a result they were not compatible with the older versions of oC. For example: when any of these methods were called by the user without last argument `userEditable`, the results were not as expected. The user gets result which were incorrect. Hence this change would help to rectify this problem. The API's should not break.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/34594

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix the API breakage that happened in the systemtags for `getTag`, `createTag` and `updateTag` methods.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested with unit test.
- Tested by adding small snippet code to create tag, get tag and update it and verify. Sample code :
```
\OC::$server->getSystemTagManager()->createTag('invisibleTag', false, false);
$tag = \OC::$server->getSystemTagManager()->getTag('invisibleTag', false, false);
\OC::$server->getSystemTagManager()->updateTag($tag->getId(), 'visibleTag', true, true);
```
And the output captured for the values in `$tag`:
```
name = invisibleTag
UserVisible = 0
UserAssignable = 0
UserEditable 0
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
