### PR TITLE
Remove excess slash from testingskeletondirectory URL

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -727,7 +727,7 @@ then
 	fi
 	for URL in ${TESTING_APP_URL} ${TESTING_APP_FED_URL}
 	do
-		curl -k -s -u $ADMIN_AUTH $URL/testingskeletondirectory -d "directory=${SRC_SKELETON_DIR}" > /dev/null
+		curl -k -s -u $ADMIN_AUTH ${URL}testingskeletondirectory -d "directory=${SRC_SKELETON_DIR}" > /dev/null
 	done
 else
 	for URL in ${OCC_URL} ${OCC_FED_URL}


### PR DESCRIPTION
## Description
Acceptance tests use the testing app to set the appropriate skeleton directory. When starting an acceptance test run I see:
```
[Mon Feb 25 17:31:04 2019] 10.49.210.15:53492 [200]: /ocs/v2.php/apps/testing/api/v1/occ
[Mon Feb 25 17:31:04 2019] 10.49.210.15:53496 [200]: /ocs/v2.php/apps/testing/api/v1//testingskeletondirectory
[Mon Feb 25 17:31:05 2019] 10.49.210.15:53504 [200]: /ocs/v2.php/apps/testing/api/v1/occ
```

There is an extra `/` in the `testingskeletondirectory` URL.

After this PR:
```
[Mon Feb 25 17:39:17 2019] 10.49.210.15:53840 [200]: /ocs/v2.php/apps/testing/api/v1/occ
[Mon Feb 25 17:39:17 2019] 10.49.210.15:53844 [200]: /ocs/v2.php/apps/testing/api/v1/testingskeletondirectory
[Mon Feb 25 17:39:18 2019] 10.49.210.15:53854 [200]: /ocs/v2.php/apps/testing/api/v1/occ
```

## How Has This Been Tested?
Local acceptance test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
