### PR TITLE
[stable10] Backport of Remove bundled docs from community edition

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -460,20 +460,6 @@ class OC_App {
 		$urlGenerator = \OC::$server->getURLGenerator();
 
 		$settings = [];
-		// by default, settings only contain the help menu
-		if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY &&
-			\OC::$server->getSystemConfig()->getValue('knowledgebaseenabled', true) == true
-		) {
-			$settings = [
-				[
-					"id" => "help",
-					"order" => 1000,
-					"href" => $urlGenerator->linkToRoute('settings_help'),
-					"name" => $l->t("Help"),
-					"icon" => $urlGenerator->imagePath("settings", "help.svg")
-				]
-			];
-		}
 
 		// if the user is logged-in
 		if (OC_User::isLoggedIn()) {

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -76,11 +76,9 @@ $application->registerRoutes($this, [
 
 /** @var $this \OCP\Route\IRouter */
 
-// Settings pages
-$this->create('settings_help', '/settings/help')
-	->actionInclude('settings/help.php');
 $this->create('settings_users', '/settings/users')
 	->actionInclude('settings/users.php');
+
 // Settings ajax actions
 // users
 $this->create('settings_ajax_setquota', '/settings/ajax/setquota.php')


### PR DESCRIPTION
Remove bundled docs from community edition.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Remove bundled docs link from the community edition. The changes made in this PR to achieve this include:
- Grepped through the code base and removed `Help` in the legacy/app.php.
- Also removed `settings_help` from the routes.php

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/34510

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove docs link from the community edition. Removed the `Help` from the settings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Disabled enterprise_key
- Clicked `Settings` link and this is what we could see 
![admin_stable10](https://user-images.githubusercontent.com/3600427/53352094-31f3ca80-3948-11e9-84e7-6a5ea2d3df5f.png)
- Navigate to `settings/help` ( manually type in the addressbar after the http://localhost/, or wherever your oC instance is pointing to ), user will not see help page.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
