### PR TITLE
Handle accept decline with invalid share id

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -50,6 +50,10 @@ class CorsPlugin extends ServerPlugin {
 	 * @var string[]
 	 */
 	private $extraHeaders;
+	/**
+	 * @var bool
+	 */
+	private $alreadyExecuted = false;
 
 	/**
 	 * @param IUserSession $userSession
@@ -107,9 +111,13 @@ class CorsPlugin extends ServerPlugin {
 		}
 
 		$this->server->on('beforeMethod:*', [$this, 'setCorsHeaders']);
+		$this->server->on('exception', [$this, 'onException']);
 		$this->server->on('beforeMethod:OPTIONS', [$this, 'setOptionsRequestHeaders'], 5);
 	}
 
+	public function onException(\Throwable $ex) {
+		$this->setCorsHeaders($this->server->httpRequest, $this->server->httpResponse);
+	}
 	/**
 	 * This method sets the cors headers for all requests
 	 *
@@ -118,18 +126,23 @@ class CorsPlugin extends ServerPlugin {
 	 * @return void
 	 */
 	public function setCorsHeaders(RequestInterface $request, ResponseInterface $response) {
-		if ($request->getHeader('origin') !== null) {
-			$requesterDomain = $request->getHeader('origin');
-			// unauthenticated request shall add cors headers as well
-			$userId = null;
-			if ($this->userSession->getUser() !== null) {
-				$userId = $this->userSession->getUser()->getUID();
-			}
+		if ($request->getHeader('origin') === null) {
+			return;
+		}
+		if ($this->alreadyExecuted) {
+			return;
+		}
+		$this->alreadyExecuted = true;
+		$requesterDomain = $request->getHeader('origin');
+		// unauthenticated request shall add cors headers as well
+		$userId = null;
+		if ($this->userSession->getUser() !== null) {
+			$userId = $this->userSession->getUser()->getUID();
+		}
 
-			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, null, $this->getExtraHeaders($request));
-			foreach ($headers as $key => $value) {
-				$response->addHeader($key, \implode(',', $value));
-			}
+		$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, null, $this->getExtraHeaders($request));
+		foreach ($headers as $key => $value) {
+			$response->addHeader($key, \implode(',', $value));
 		}
 	}
 

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -32,6 +32,7 @@ use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FedShareManager;
 use OCA\FederatedFileSharing\Middleware\OcmMiddleware;
 use OCA\FederatedFileSharing\Ocm\Exception\BadRequestException;
+use OCA\FederatedFileSharing\Ocm\Exception\ForbiddenException;
 use OCA\FederatedFileSharing\Ocm\Exception\NotImplementedException;
 use OCA\FederatedFileSharing\Ocm\Exception\OcmException;
 use OCP\AppFramework\Http;
@@ -255,6 +256,18 @@ class RequestHandlerController extends OCSController {
 			$token = $this->request->getParam('token', null);
 			$share = $this->ocmMiddleware->getValidShare($id, $token);
 			$this->fedShareManager->acceptShare($share);
+		} catch (BadRequestException $e) {
+			return new Result(
+				null,
+				Http::STATUS_GONE,
+				$e->getMessage()
+			);
+		} catch (ForbiddenException $e) {
+			return new Result(
+				null,
+				Http::STATUS_FORBIDDEN,
+				$e->getMessage()
+			);
 		} catch (NotImplementedException $e) {
 			return new Result(
 				null,
@@ -281,6 +294,18 @@ class RequestHandlerController extends OCSController {
 			$this->ocmMiddleware->assertOutgoingSharingEnabled();
 			$share = $this->ocmMiddleware->getValidShare($id, $token);
 			$this->fedShareManager->declineShare($share);
+		} catch (BadRequestException $e) {
+			return new Result(
+				null,
+				Http::STATUS_GONE,
+				$e->getMessage()
+			);
+		} catch (ForbiddenException $e) {
+			return new Result(
+				null,
+				Http::STATUS_FORBIDDEN,
+				$e->getMessage()
+			);
 		} catch (NotImplementedException $e) {
 			return new Result(
 				null,

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
@@ -308,6 +308,42 @@ class RequestHandlerTest extends TestCase {
 		);
 	}
 
+	public function testAcceptFailedWhenInvalidShareId() {
+		$this->request->expects($this->any())
+			->method('getParam')
+			->willReturn(self::DEFAULT_TOKEN);
+
+		$this->ocmMiddleware->method('getValidShare')
+			->willThrowException(new BadRequestException());
+
+		$this->fedShareManager->expects($this->never())
+			->method('acceptShare');
+
+		$response = $this->requestHandlerController->acceptShare(2);
+		$this->assertEquals(
+			Http::STATUS_GONE,
+			$response->getStatusCode()
+		);
+	}
+
+	public function testAcceptFailedWhenShareIdHasInvalidSecret() {
+		$this->request->expects($this->any())
+			->method('getParam')
+			->willReturn(self::DEFAULT_TOKEN);
+
+		$this->ocmMiddleware->method('getValidShare')
+			->willThrowException(new ForbiddenException());
+
+		$this->fedShareManager->expects($this->never())
+			->method('acceptShare');
+
+		$response = $this->requestHandlerController->acceptShare(2);
+		$this->assertEquals(
+			Http::STATUS_FORBIDDEN,
+			$response->getStatusCode()
+		);
+	}
+
 	public function testDeclineFailedWhenSharingIsDisabled() {
 		$this->ocmMiddleware->method('assertOutgoingSharingEnabled')
 			->willThrowException(new NotImplementedException());
@@ -342,6 +378,42 @@ class RequestHandlerTest extends TestCase {
 		$response = $this->requestHandlerController->declineShare(2);
 		$this->assertEquals(
 			Http::STATUS_CONTINUE,
+			$response->getStatusCode()
+		);
+	}
+
+	public function testDeclineFailedWhenInvalidShareId() {
+		$this->request->expects($this->any())
+			->method('getParam')
+			->willReturn(self::DEFAULT_TOKEN);
+
+		$this->ocmMiddleware->method('getValidShare')
+			->willThrowException(new BadRequestException());
+
+		$this->fedShareManager->expects($this->never())
+			->method('declineShare');
+
+		$response = $this->requestHandlerController->declineShare(2);
+		$this->assertEquals(
+			Http::STATUS_GONE,
+			$response->getStatusCode()
+		);
+	}
+
+	public function testDeclineFailedWhenShareIdHasInvalidSecret() {
+		$this->request->expects($this->any())
+			->method('getParam')
+			->willReturn(self::DEFAULT_TOKEN);
+
+		$this->ocmMiddleware->method('getValidShare')
+			->willThrowException(new ForbiddenException());
+
+		$this->fedShareManager->expects($this->never())
+			->method('declineShare');
+
+		$response = $this->requestHandlerController->declineShare(2);
+		$this->assertEquals(
+			Http::STATUS_FORBIDDEN,
 			$response->getStatusCode()
 		);
 	}

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -86,7 +86,7 @@ class Application extends App {
 				$server->getUserManager(),
 				$server->getRootFolder(),
 				$server->getURLGenerator(),
-				$server->getUserSession()->getUser(),
+				$server->getUserSession(),
 				$server->getL10N('files_sharing'),
 				$server->getConfig(),
 				$c->query(NotificationPublisher::class),

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -31,6 +31,7 @@ namespace OCA\Files_Sharing\Tests;
 use OCP\Constants;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserSession;
 use OCP\Share;
 use OCA\Files_Sharing\Service\NotificationPublisher;
 use OCA\Files_Sharing\SharingBlacklist;
@@ -108,6 +109,8 @@ class ApiTest extends TestCase {
 	 */
 	private function createOCS($request, $userId) {
 		$currentUser = \OC::$server->getUserManager()->get($userId);
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($currentUser);
 
 		$l = $this->createMock(IL10N::class);
 		$l->method('t')
@@ -123,7 +126,7 @@ class ApiTest extends TestCase {
 			\OC::$server->getUserManager(),
 			\OC::$server->getRootFolder(),
 			\OC::$server->getURLGenerator(),
-			$currentUser,
+			$userSession,
 			$l,
 			\OC::$server->getConfig(),
 			\OC::$server->getAppContainer('files_sharing')->query(NotificationPublisher::class),

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -39,6 +39,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IGroup;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Share;
@@ -87,6 +88,9 @@ class Share20OcsControllerTest extends TestCase {
 	/** @var IUser */
 	private $currentUser;
 
+	/** @var IUserSession */
+	private $userSession;
+
 	/** @var Share20OcsController */
 	private $ocs;
 
@@ -115,8 +119,10 @@ class Share20OcsControllerTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->currentUser = $this->createMock(IUser::class);
 		$this->currentUser->method('getUID')->willReturn('currentUser');
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->userSession->method('getUser')->willReturn($this->currentUser);
 
-		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
+		$this->userManager->method('userExists')->willReturn(true);
 
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->method('t')
@@ -143,7 +149,7 @@ class Share20OcsControllerTest extends TestCase {
 			$this->userManager,
 			$this->rootFolder,
 			$this->urlGenerator,
-			$this->currentUser,
+			$this->userSession,
 			$this->l,
 			$this->config,
 			$this->notificationPublisher,
@@ -169,7 +175,7 @@ class Share20OcsControllerTest extends TestCase {
 				$this->userManager,
 				$this->rootFolder,
 				$this->urlGenerator,
-				$this->currentUser,
+				$this->userSession,
 				$this->l,
 				$this->config,
 				$this->notificationPublisher,
@@ -495,7 +501,7 @@ class Share20OcsControllerTest extends TestCase {
 					$this->userManager,
 					$this->rootFolder,
 					$this->urlGenerator,
-					$this->currentUser,
+					$this->userSession,
 					$this->l,
 					$this->config,
 					$this->notificationPublisher,
@@ -2794,7 +2800,7 @@ class Share20OcsControllerTest extends TestCase {
 			$this->userManager,
 			$this->rootFolder,
 			$this->urlGenerator,
-			$this->currentUser,
+			$this->userSession,
 			$this->l,
 			$this->config,
 			$this->notificationPublisher,
@@ -2888,7 +2894,7 @@ class Share20OcsControllerTest extends TestCase {
 			$this->userManager,
 			$this->rootFolder,
 			$this->urlGenerator,
-			$this->currentUser,
+			$this->userSession,
 			$this->l,
 			$config,
 			$this->notificationPublisher,

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -31,7 +31,6 @@
 namespace OC\AppFramework\DependencyInjection;
 
 use OC;
-use OC\AppFramework\Core\API;
 use OC\AppFramework\Http;
 use OC\AppFramework\Http\Dispatcher;
 use OC\AppFramework\Http\Output;

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -33,13 +33,16 @@ use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
 use OC\AppFramework\Middleware\Security\Exceptions\NotLoggedInException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Core\Controller\LoginController;
+use OC\OCS\Result;
 use OC\Security\CSP\ContentSecurityPolicyManager;
+use OCP\API;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCSController;
 use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IRequest;
@@ -184,6 +187,13 @@ class SecurityMiddleware extends Middleware {
 	 * @return Response a Response object or null in case that the exception could not be handled
 	 */
 	public function afterException($controller, $methodName, \Exception $exception) {
+		if ($controller instanceof OCSController) {
+			if ($exception instanceof NotLoggedInException) {
+				return $controller->buildResponse(new Result(null, API::RESPOND_UNAUTHORISED, 'Unauthorised'));
+			}
+			return $controller->buildResponse(new Result(null, API::RESPOND_SERVER_ERROR, $exception->getMessage()));
+		}
+
 		if ($exception instanceof SecurityException) {
 			if (\stripos($this->request->getHeader('Accept'), 'html') === false) {
 				$response = new JSONResponse(

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -33,6 +33,7 @@
 namespace OCP\AppFramework;
 
 use OC\OCS\Result;
+use OCP\API;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\OCSResponse;
 use OCP\AppFramework\Http\Response;
@@ -145,6 +146,11 @@ abstract class OCSController extends ApiController {
 				// OCS code
 				$resp->setStatusCode($statusCode);
 			}
+		}
+
+		if ($resp->getStatusCode() === API::RESPOND_UNAUTHORISED) {
+			// HTTP code
+			$resp->setStatus(401);
 		}
 
 		return $resp;

--- a/tests/acceptance/features/apiAuth/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuth/ocsDELETEAuth.feature
@@ -28,18 +28,8 @@ Feature: auth
       | 2               |/cloud/users/user0/groups                            | 997      | 401       |
       | 1               |/cloud/users/user0/subadmins                         | 997      | 401       |
       | 2               |/cloud/users/user0/subadmins                         | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/shares/123                | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares/123                | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
 
-  #merge into previous scenario when fixed
-  @issue-34626
-  Scenario Outline: send DELETE requests to OCS endpoints as admin with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "<endpoint>" using password "invalid"
-    Then the HTTP status code should be "200"
-    And the body of the response should be empty
-    #And the OCS status code should be "997"
-    Examples:
-      | ocs_api_version | endpoint                                      |
-      | 1               | /apps/files_sharing/api/v1/shares/123         |
-      | 2               | /apps/files_sharing/api/v1/shares/123         |
-      | 1               | /apps/files_sharing/api/v1/shares/pending/123 |
-      | 2               | /apps/files_sharing/api/v1/shares/pending/123 |

--- a/tests/acceptance/features/apiAuth/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuth/ocsGETAuth.feature
@@ -27,14 +27,8 @@ Feature: auth
       |/ocs/v2.php/config                                          | 200      | 200       |
       |/ocs/v1.php/privatedata/getattribute                        | 997      | 401       |
       |/ocs/v2.php/privatedata/getattribute                        | 997      | 401       |
-
-  #merge into previous scenario when fixed
-  @issue-34626
-  Scenario: using OCS anonymously
-    When a user requests "/ocs/v1.php/apps/files_sharing/api/v1/shares" with "GET" and no authentication
-    Then the HTTP status code should be "200"
-    #Then the HTTP status code should be "401"
-    #And the OCS status code should be "997"
+      |/ocs/v1.php/apps/files_sharing/api/v1/shares                | 997      | 401       |
+      |/ocs/v2.php/apps/files_sharing/api/v1/shares                | 997      | 401       |
 
   @issue-32068
   Scenario Outline: using OCS with non-admin basic auth
@@ -86,19 +80,8 @@ Feature: auth
       | 2               |/config                                          | 200      | 200       |
       | 1               |/privatedata/getattribute                        | 997      | 401       |
       | 2               |/privatedata/getattribute                        | 997      | 401       |
-
-  #merge into previous scenario when fixed
-  @issue-34626
-  Scenario Outline: using OCS as normal user with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares" using password "invalid"
-    Then the HTTP status code should be "200"
-    And the body of the response should be empty
-    #And the OCS status code should be "997"
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | 1               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
 
   Scenario Outline: using OCS with admin basic auth
     When the administrator requests "<endpoint>" with "GET" using basic auth
@@ -134,19 +117,8 @@ Feature: auth
       | 2               |/cloud/users                                     | 997      | 401       |
       | 1               |/privatedata/getattribute                        | 997      | 401       |
       | 2               |/privatedata/getattribute                        | 997      | 401       |
-
-  #merge into previous scenario when fixed
-  @issue-34626
-  Scenario Outline: using OCS as admin user with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    When the administrator sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares" using password "invalid"
-    Then the HTTP status code should be "200"
-    And the body of the response should be empty
-    #And the OCS status code should be "997"
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | 1               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
 
   Scenario Outline: using OCS with token auth of a normal user
     When user "user0" requests "<endpoint>" with "GET" using basic token auth

--- a/tests/acceptance/features/apiAuth/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuth/ocsPOSTAuth.feature
@@ -33,19 +33,8 @@ Feature: auth
       | 2               |/privatedata/deleteattribute/testing/test            | 997      | 401       |
       | 1               |/privatedata/setattribute/testing/test               | 997      | 401       |
       | 2               |/privatedata/setattribute/testing/test               | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/shares                    | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares                    | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
 
-  #merge into previous scenario when fixed
-  @issue-34626
-  Scenario Outline: send POST requests to OCS endpoints as normal user with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    When user "user0" sends HTTP method "POST" to OCS API endpoint "<endpoint>" with body using password "invalid"
-      | data        | doesnotmatter |
-    Then the HTTP status code should be "200"
-    And the body of the response should be empty
-    #And the OCS status code should be "997"
-    Examples:
-      | ocs_api_version | endpoint                                      |
-      | 1               | /apps/files_sharing/api/v1/shares             |
-      | 2               | /apps/files_sharing/api/v1/shares             |
-      | 1               | /apps/files_sharing/api/v1/shares/pending/123 |
-      | 2               | /apps/files_sharing/api/v1/shares/pending/123 |

--- a/tests/acceptance/features/apiAuth/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuth/ocsPUTAuth.feature
@@ -14,23 +14,12 @@ Feature: auth
     And the HTTP status code should be "<http-code>"
     Examples:
       | ocs_api_version |endpoint                   | ocs-code | http-code |
-      | 1               |/cloud/users/user0         | 997      | 401       |
-      | 2               |/cloud/users/user0         | 997      | 401       |
-      | 1               |/cloud/users/user0/disable | 997      | 401       |
-      | 2               |/cloud/users/user0/disable | 997      | 401       |
-      | 1               |/cloud/users/user0/enable  | 997      | 401       |
-      | 2               |/cloud/users/user0/enable  | 997      | 401       |
+      | 1               |/cloud/users/user0                     | 997      | 401       |
+      | 2               |/cloud/users/user0                     | 997      | 401       |
+      | 1               |/cloud/users/user0/disable             | 997      | 401       |
+      | 2               |/cloud/users/user0/disable             | 997      | 401       |
+      | 1               |/cloud/users/user0/enable              | 997      | 401       |
+      | 2               |/cloud/users/user0/enable              | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/shares/123  | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares/123  | 997      | 401       |
 
-  #merge into previous scenario when fixed
-  @issue-34626
-  Scenario Outline: send PUT requests to OCS endpoints as admin with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "/apps/files_sharing/api/v1/shares/123" with body using password "invalid"
-      | data        | doesnotmatter |
-    Then the HTTP status code should be "200"
-    And the body of the response should be empty
-    #And the OCS status code should be "997"
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |


### PR DESCRIPTION
## Description
1) Catch the case when an accept or decline for a non-existent federated share id is received. Return a `STATUS_GONE` `410` response. Previously this was not caught in `RequestHandlerController` and ended up becoming a `500` status. That can cause issues for the remote end, which could think that there was an internal server error for the request - the remote end might then throw an exception itself and not cleanup its view of the now non-existent share id.

2) Catch the case when an accept or decline for a share id has an invalid shared secret provided. Return a `STATUS_FORBIDDEN` `403` so that the remote end can at least handle/report that, rather than returning a `500` that might cause the remote server grief.

## Related Issue
This is on top of PR #34568 and issue #34566 

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
