### PR TITLE
strip trailing / from path used for RewriteBase

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -223,12 +223,12 @@ declare -a PREVIOUS_SETTINGS
 
 # get the sub path from an URL
 # $1 the full URL including the protocol
-# echos the path
+# echos the path without trailing slash
 function get_path_from_url() {
 	PROTOCOL="$(echo $1 | grep :// | sed -e's,^\(.*://\).*,\1,g')"
 	URL="$(echo ${1/$PROTOCOL/})"
 	PATH="$(echo ${URL} | grep / | cut -d/ -f2-)"
-	echo ${PATH}
+	echo ${PATH%/}
 }
 
 # Provide a default admin username and password.


### PR DESCRIPTION
## Description
make sure there are no double `/` when setting RewriteBase in config and htaccess

https://stackoverflow.com/a/9018877

## Motivation and Context
I ran into problems when the URL for the tests would have a trailing `/` e.g. `TEST_SERVER_FED_URL=http://172.17.0.1/owncloud-10.1.0/owncloud/`
that would result in a wrong RewriteBase in the `.htaccess` file and a internal server error

## How Has This Been Tested?
running tests setting `TEST_SERVER_URL` and `TEST_SERVER_FED_URL` to urls with and without trailing `/`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
