### PR TITLE
Makefile composer

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,7 +61,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
-      - ./tests/drone/composer-install.sh
+      - make install-composer-deps
     when:
       event: [push, pull_request]
 

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ KARMA=$(NODE_PREFIX)/node_modules/.bin/karma
 JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
 PHPUNIT="$(shell pwd)/lib/composer/phpunit/phpunit/phpunit"
 COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
+ifndef COMPOSER_BIN
+    $(error composer is not available on your system, please install composer)
+endif
 
 # bin file definitions
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,6 @@ update-composer:
 
 .PHONY: clean-composer-deps
 clean-composer-deps:
-	rm -f $(COMPOSER_BIN)
 	rm -Rf lib/composer
 	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 # Main Makefile for ownCloud development
 #
 # Requirements to run make here:
+#    - composer
 #    - node
 #    - yarn
 #
-# Both can be installed following e.g. the Debian/Ubuntu instructions at
+# Installing composer can be done via https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx
+#
+# Node/Yarn can be installed following e.g. the Debian/Ubuntu instructions at
 # https://nodejs.org/en/download/package-manager/
 #
 #  curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
@@ -38,7 +41,7 @@ YARN := $(shell command -v yarn 2> /dev/null)
 KARMA=$(NODE_PREFIX)/node_modules/.bin/karma
 JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
 PHPUNIT="$(shell pwd)/lib/composer/phpunit/phpunit/phpunit"
-COMPOSER_BIN=build/composer.phar
+COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
 
 # bin file definitions
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
@@ -115,18 +118,12 @@ help:
 
 
 #
-# Basic required tools
-#
-$(COMPOSER_BIN):
-	cd build && ./getcomposer.sh
-
-#
 # ownCloud core PHP dependencies
 #
-$(composer_deps): $(COMPOSER_BIN) composer.json composer.lock
+$(composer_deps): composer.json composer.lock
 	php $(COMPOSER_BIN) install --no-dev
 
-$(composer_dev_deps): $(COMPOSER_BIN) composer.json composer.lock
+$(composer_dev_deps): composer.json composer.lock
 	php $(COMPOSER_BIN) install
 
 .PHONY: install-composer-release-deps
@@ -139,7 +136,7 @@ install-composer-dev-deps: $(composer_dev_deps)
 install-composer-deps: install-composer-dev-deps
 
 .PHONY: update-composer
-update-composer: $(COMPOSER_BIN)
+update-composer:
 	rm -f composer.lock
 	php $(COMPOSER_BIN) install --prefer-dist
 


### PR DESCRIPTION
## Description
- modify `Makefile` so it expects and finds a pre-installed `composer` on the system, rather than downloading a copy.
- modify `.drone.yml` so it no longer tries to self-install `composer`

This makes composer-related stuff work like it does in the app repos.

This is a resolved version of PR #32213 and moves forward from that.

## Related Issue
https://github.com/owncloud/QA/issues/582

## Motivation and Context
Have a consistent CI and development environment in core as in apps.

## How Has This Been Tested?
Local 
```
make clean
make
make test-php-style
make test-php
```
to see that these still work locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes) (and CI scripting)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
