### PR TITLE
Each generated birthday or death event gets a new UID

### DIFF
--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -33,6 +33,7 @@ use Sabre\VObject\Document;
 use Sabre\VObject\InvalidDataException;
 use Sabre\VObject\Property\VCard\DateAndOrTime;
 use Sabre\VObject\Reader;
+use Sabre\VObject\UUIDUtil;
 
 class BirthdayService {
 	const BIRTHDAY_CALENDAR_URI = 'contact_birthdays';
@@ -66,7 +67,7 @@ class BirthdayService {
 	 */
 	public function onCardChanged($addressBookId, $cardUri, $cardData) {
 		$targetPrincipals = $this->getAllAffectedPrincipals($addressBookId);
-		
+
 		$book = $this->cardDavBackEnd->getAddressBookById($addressBookId);
 		$targetPrincipals[] = $book['principaluri'];
 		$datesToSync = [
@@ -195,7 +196,7 @@ class BirthdayService {
 			$date
 		);
 		$vEvent->DTEND['VALUE'] = 'DATE';
-		$vEvent->{'UID'} = $doc->UID;
+		$vEvent->{'UID'} = UUIDUtil::getUUID();
 		$vEvent->{'RRULE'} = 'FREQ=YEARLY';
 		$vEvent->{'SUMMARY'} = $summary;
 		$vEvent->{'TRANSP'} = 'TRANSPARENT';


### PR DESCRIPTION
## Description
The UID for the birth and death events is reused from the original contact.
This can lead to issues because the UID is no longer unique - see https://bugzilla.mozilla.org/show_bug.cgi?id=1517165

## Related Issue
- Fixes #34653

## How Has This Been Tested?
- create contact with birthday and death date
- double check the UID of the two events
- they shall all be different

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
