### PR TITLE
[stable10] Add per default the apps-external directory in config.php during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ core_vendor=core/vendor
 
 core_doc_files=AUTHORS COPYING README.md CHANGELOG.md
 core_src_files=$(wildcard *.php) index.html db_structure.xml .htaccess .user.ini robots.txt
-core_src_dirs=apps core l10n lib occ ocs ocs-provider ocm-provider resources settings
+core_src_dirs=apps apps-external core l10n lib occ ocs ocs-provider ocm-provider resources settings
 core_test_dirs=tests
 core_all_src=$(core_src_files) $(core_src_dirs) $(core_doc_files)
 core_config_files=config/config.sample.php config/config.apps.sample.php
@@ -265,7 +265,7 @@ $(dist_dir)/owncloud: $(composer_deps) $(core_vendor) $(core_all_src)
 	rm -Rf $@/core/vendor/*/{.bower.json,bower.json,package.json,testem.json}
 	rm -Rf $@/l10n/
 	find $@/core/ -iname \*.sh -delete
-	find $@/{apps/,lib/composer/,core/vendor/} \( \
+	find $@/{apps/,apps-external/,lib/composer/,core/vendor/} \( \
 		-name bin -o \
 		-name test -o \
 		-name tests -o \
@@ -276,7 +276,7 @@ $(dist_dir)/owncloud: $(composer_deps) $(core_vendor) $(core_all_src)
 		-name travis -o \
 		-iname \*.sh \
 		\) -print | xargs rm -Rf
-	find $@/{apps/,lib/composer/} -iname \*.exe -delete
+	find $@/{apps/,apps-external/,lib/composer/} -iname \*.exe -delete
 	# Set build
 	$(eval _BUILD="$(shell date -u --iso-8601=seconds) $(shell git rev-parse HEAD)")
 	# Replace channel in version.php
@@ -316,7 +316,7 @@ $(dist_dir)/qa/owncloud: $(composer_dev_deps) $(core_vendor) $(core_all_src) $(c
 	rm -Rf $@/core/vendor/*/{.bower.json,bower.json,package.json,testem.json}
 	rm -Rf $@/l10n/
 	find $@/core/ -iname \*.sh -delete
-	find $@/{apps/,lib/composer/,core/vendor/} \( \
+	find $@/{apps/,apps-external/,lib/composer/,core/vendor/} \( \
 		-name test -o \
 		-name examples -o \
 		-name demo -o \
@@ -325,7 +325,7 @@ $(dist_dir)/qa/owncloud: $(composer_dev_deps) $(core_vendor) $(core_all_src) $(c
 		-name travis -o \
 		-iname \*.sh \
 		\) -print | xargs rm -Rf
-	find $@/{apps/,lib/composer/} -iname \*.exe -delete
+	find $@/{apps/,apps-external/,lib/composer/} -iname \*.exe -delete
 	# Set build
 	$(eval _BUILD="$(shell date -u --iso-8601=seconds) $(shell git rev-parse HEAD)")
 	# Replace channel in version.php

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -383,6 +383,29 @@ class Setup {
 				$config->setSystemValue('logtimezone', \date_default_timezone_get());
 			}
 
+			// adding the apps-external directory by default using apps_path
+			$apps2Key = \OC::$server->getSystemConfig()->getValue('apps_paths', false);
+
+			// add the key only if it does not exist (protect against overwriting)
+			if ($apps2Key === false) {
+				$defaultAppsPaths = [
+					'apps_paths' => [
+						[
+							"path" => \OC::$SERVERROOT . '/apps',
+							"url" => "/apps",
+							"writable" => false
+						],
+						[
+							"path" => \OC::$SERVERROOT . '/apps-external',
+							"url" => "/apps-external",
+							"writable" => true
+						]
+					]
+				];
+						
+				$config->setSystemValues($defaultAppsPaths);
+			}
+
 			self::installBackgroundJobs();
 
 			// save the origin version that we installed at
@@ -390,6 +413,8 @@ class Setup {
 
 			//and we are done
 			$config->setSystemValue('installed', true);
+
+			// finished initial setup
 		}
 
 		return $error;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Backport of https://github.com/owncloud/core/pull/30889

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #29839 ([Feature Request] make the apps-external folder default used in new installations)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See the issue description regarding the benefits.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
