### PR TITLE
allow admins to enable medial search on group and user

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -285,6 +285,13 @@ $CONFIG = array(
 'accounts.enable_medial_search' => true,
 
 /**
+ * Allow medial search on the group id. Allows finding 'test' when searching for 'es'.
+ * This is only used in the DB group backend (local groups), and won't be used against LDAP
+ * Shibboleth or any other group backend.
+ */
+'groups.enable_medial_search' => true,
+
+/**
  * Defines the minimum characters entered before a search returns results for 
  * users or groups in the share autocomplete form. Lower values increase search
  * time especially for large backends.


### PR DESCRIPTION
## Description
allow admin to enable medial search on group and user

## Related Issue
Fixes #33883 and https://github.com/owncloud/enterprise/issues/2311

## Motivation and Context
we have accounts.enable_medial_search but we should move to one option respected globally for users, and one for groups, making the results more consistent.

## How Has This Been Tested?
- Create a group with "test" gid,
- add `'groups.enable_medial_search' => true` line to config
- Sharing search dialog should list "test" group when you write "es"
- change config as `'groups.enable_medial_search' => false` 
-  Sharing search dialog should not list "test" group when you write "es"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
