### PR TITLE
Fix unit test of RecreateMasterKey

### DIFF
--- a/apps/encryption/tests/Command/RecreateMasterKeyTest.php
+++ b/apps/encryption/tests/Command/RecreateMasterKeyTest.php
@@ -196,25 +196,19 @@ class RecreateMasterKeyTest extends TestCase {
 				->with('user1')
 				->willReturn(true);
 
-			$outputText = '';
-			$reloginText = '';
+			$this->output->method('writeln')
+				->will($this->onConsecutiveCalls(
+					"Decryption started\n",
+					"\nDecryption completed\n",
+					"Encryption started\n",
+					"Waiting for creating new masterkey\n",
+					"New masterkey created successfully\n",
+					"\nEncryption completed successfully\n",
+					"\n\<info\>Note: All users are required to relogin.\</info\>\n"
 
-			$this->output->expects($this->at(16))
-				->method('writeln')
-				->willReturnCallback(function ($value) use (&$outputText){
-					$outputText .= $value . "\n";
-				});
-
-			$this->output->expects($this->at(17))
-				->method('writeln')
-				->willReturnCallback(function ($value) use (&$reloginText) {
-					$reloginText = $value;
-				});
+				));
 
 			$this->invokePrivate($this->recreateMasterKey, 'execute', [$this->input, $this->output]);
-			$this->assertSame("Encryption completed successfully", trim($outputText, "\n"));
-			$this->assertEquals("\n<info>Note: All users are required to relogin.</info>\n",$reloginText);
-			$outputText="";
 		} else {
 			$this->recreateMasterKey = $this->getMockBuilder('OCA\Encryption\Command\RecreateMasterKey')
 				->setConstructorArgs(


### PR DESCRIPTION
The unit test of RecreateMasterKey were
failing because the indexes pointed for
writeln method were not matching. This
patch fixes the same.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The unit test did pass in https://github.com/owncloud/encryption/pull/21. But it has been observed recently the failure in drone, regarding the failure:
```
1) OCA\Encryption\Tests\Command\RecreateMasterKeyTest::testNewMasterKey with data set #0 (true)
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-Encryption completed successfully
+<info>Note: All users are required to relogin.</info>

/home/sujith/test/owncloud/apps/encryption/tests/Command/RecreateMasterKeyTest.php:216

FAILURES!
Tests: 2, Assertions: 4, Failures: 1.
```
This is because of the wrong index of `writeln` method. I have updated the changes and verified it in my instance. And this should fix it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix the unit test failure for RecreateMasterKey.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran the unit test in my instance:
```
/home/sujith/test/owncloud/lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml --coverage-clover autotest-clover-mysql.xml --coverage-html coverage-html-mysql --log-junit autotest-results-mysql.xml ../apps/encryption/tests/Command/RecreateMasterKeyTest.php 
Cannot load Xdebug - it was already loaded
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.15-1+ubuntu18.04.1+deb.sury.org+1 with Xdebug 2.6.1
Configuration: /home/sujith/test/owncloud/tests/phpunit-autotest.xml

..                                                                  2 / 2 (100%)

Time: 5.17 seconds, Memory: 40.00MB

OK (2 tests, 7 assertions)
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
