### PR TITLE
test response of files_external ocs endpoint

### DIFF
--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -55,3 +55,22 @@ Feature: external-storage
     When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/local_storage/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
     And as "user0" the files uploaded to "/local_storage/testquota.txt" with all mechanisms should exist
+
+  Scenario Outline: query OCS endpoint for information about the mount
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has been created with default attributes
+    When user "user0" sends HTTP method "GET" to OCS API endpoint "<endpoint>"
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    And the fields of the last response should include
+      | id          | A_NUMBER      |
+      | name        | local_storage |
+      | type        | dir           |
+      | backend     | Local         |
+      | scope       | system        |
+      | permissions | 1             |
+      | class       | local         |
+    Examples:
+      | ocs_api_version | endpoint                           | ocs-code | http-code |
+      | 1               | /apps/files_external/api/v1/mounts | 100      | 200       |
+      | 2               | /apps/files_external/api/v1/mounts | 200      | 200       |


### PR DESCRIPTION
## Description
a short test to check the response of `/apps/files_external/api/v1/mounts` ocs endpoint

## Related Issue
part of https://github.com/owncloud/core/issues/34566

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
