### PR TITLE
Adjust log level on drone to 2 (warning)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -498,6 +498,8 @@ services:
   selenium:
     image: selenium/standalone-chrome-debug:latest
     pull: true
+    environment:
+      - JAVA_OPTS=-Dselenium.LOGGER.level=WARNING
     when:
       matrix:
         TEST_SUITE: selenium
@@ -508,6 +510,7 @@ services:
     pull: true
     environment:
       - SE_OPTS=-enablePassThrough false
+      - JAVA_OPTS=-Dselenium.LOGGER.level=WARNING
     when:
       matrix:
         TEST_SUITE: selenium

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ pipeline:
       - php occ a:l
       - php occ config:system:set trusted_domains 1 --value=server
       - php occ config:system:set trusted_domains 2 --value=federated
-      - php occ log:manage --level 0
+      - php occ log:manage --level 2
       - php occ config:list
       - echo "export TEST_SERVER_FED_URL=${SERVER_PROTOCOL}://federated" > /drone/saved-settings.sh
       - php occ security:certificates:import /drone/server.crt
@@ -144,7 +144,7 @@ pipeline:
       - php occ a:l
       - php occ config:system:set trusted_domains 1 --value=server
       - php occ config:system:set trusted_domains 2 --value=federated
-      - php occ log:manage --level 0
+      - php occ log:manage --level 2
       - php occ config:list
       - php occ security:certificates:import /drone/server.crt
       - php occ security:certificates:import /drone/federated.crt


### PR DESCRIPTION
## Description
1) Set the log level to `2` `warning` for the local and federated server `owncloud.log` files when running drone acceptance tests. This reduces the length of the `owncloud` log output.
2) Set the `selenium` log level to warning. That cuts out the various selenium info messages that were logged as each scenario reset the selenium state.

## Related Issue
- #34684

## Motivation and Context
Reduce unnecessary log files in drone.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
