### PR TITLE
[stable10] Rename openSettingsMenu to openAppSettingsMenu

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -291,7 +291,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAdminDisablesUserUsingTheWebui($username) {
-		$this->usersPage->openSettingsMenu();
+		$this->usersPage->openAppSettingsMenu();
 		$this->usersPage->setSetting("Show enabled/disabled option");
 		$this->usersPage->disableUser($username);
 	}
@@ -621,7 +621,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorChangesTheEmailOfUserToUsingTheWebui($username, $email) {
-		$this->usersPage->openSettingsMenu();
+		$this->usersPage->openAppSettingsMenu();
 		$this->usersPage->setSetting('Show email address');
 		$this->usersPage->changeUserEmail($this->getSession(), $username, $email);
 	}

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -286,7 +286,7 @@ class UsersPage extends OwncloudPage {
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
-	public function openSettingsMenu() {
+	public function openAppSettingsMenu() {
 		$settingsBtn = $this->find("xpath", $this->settingsBtnXpath);
 		if ($settingsBtn === null) {
 			throw new ElementNotFoundException(
@@ -334,7 +334,7 @@ class UsersPage extends OwncloudPage {
 		}
 
 		if (!$settingContentIsVisible) {
-			$this->openSettingsMenu();
+			$this->openAppSettingsMenu();
 		}
 
 		$xpathLocator = \sprintf($this->settingByTextXpath, $setting);


### PR DESCRIPTION
Backport https://github.com/owncloud/user_management/pull/139

I noticed:
https://drone.owncloud.com/owncloud/core/15756/787
```
PHP Warning: Declaration of Page\UsersPage::openSettingsMenu() should be compatible with Page\OwncloudPage::openSettingsMenu(Behat\Mink\Session $session) in /drone/src/tests/acceptance/features/lib/UsersPage.php on line 792
```

in core `stable10` which was fixed in `user_management` 4 weeks ago.