### PR TITLE
[test] Do not use selenium debug on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -525,7 +525,7 @@ services:
       - APACHE_SSL_CERT_CN=server
       - APACHE_SSL_CERT=/drone/server.crt
       - APACHE_SSL_KEY=/drone/server.key
-    command: [ "/usr/local/bin/apachectl", "-e", "info" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "notice" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true
@@ -536,7 +536,7 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/src/
-    command: [ "/usr/local/bin/apachectl", "-e", "info" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "notice" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -496,7 +496,7 @@ services:
         DB_TYPE: oracle
 
   selenium:
-    image: selenium/standalone-chrome-debug:latest
+    image: selenium/standalone-chrome:latest
     pull: true
     when:
       matrix:
@@ -504,7 +504,7 @@ services:
         BROWSER: chrome
 
   selenium:
-    image: selenium/standalone-firefox-debug:3.8.1
+    image: selenium/standalone-firefox:3.8.1
     pull: true
     environment:
       - SE_OPTS=-enablePassThrough false

--- a/.drone.yml
+++ b/.drone.yml
@@ -525,7 +525,7 @@ services:
       - APACHE_SSL_CERT_CN=server
       - APACHE_SSL_CERT=/drone/server.crt
       - APACHE_SSL_KEY=/drone/server.key
-    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "info" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true
@@ -536,7 +536,7 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/src/
-    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "info" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -525,7 +525,7 @@ services:
       - APACHE_SSL_CERT_CN=server
       - APACHE_SSL_CERT=/drone/server.crt
       - APACHE_SSL_KEY=/drone/server.key
-    command: [ "/usr/local/bin/apachectl", "-e", "warn" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "error" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true
@@ -536,7 +536,7 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/src/
-    command: [ "/usr/local/bin/apachectl", "-e", "warn" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "error" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -498,6 +498,8 @@ services:
   selenium:
     image: selenium/standalone-chrome:latest
     pull: true
+    environment:
+      - JAVA_OPTS=-Dselenium.LOGGER.level=WARNING
     when:
       matrix:
         TEST_SUITE: selenium
@@ -508,6 +510,7 @@ services:
     pull: true
     environment:
       - SE_OPTS=-enablePassThrough false
+      - JAVA_OPTS=-Dselenium.LOGGER.level=WARNING
     when:
       matrix:
         TEST_SUITE: selenium

--- a/.drone.yml
+++ b/.drone.yml
@@ -525,7 +525,7 @@ services:
       - APACHE_SSL_CERT_CN=server
       - APACHE_SSL_CERT=/drone/server.crt
       - APACHE_SSL_KEY=/drone/server.key
-    command: [ "/usr/local/bin/apachectl", "-e", "notice" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "warn" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true
@@ -536,7 +536,7 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/src/
-    command: [ "/usr/local/bin/apachectl", "-e", "notice" , "-D", "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "warn" , "-D", "FOREGROUND" ]
     when:
       matrix:
         USE_SERVER: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -496,7 +496,7 @@ services:
         DB_TYPE: oracle
 
   selenium:
-    image: selenium/standalone-chrome:latest
+    image: selenium/standalone-chrome-debug:latest
     pull: true
     environment:
       - JAVA_OPTS=-Dselenium.LOGGER.level=WARNING
@@ -506,7 +506,7 @@ services:
         BROWSER: chrome
 
   selenium:
-    image: selenium/standalone-firefox:3.8.1
+    image: selenium/standalone-firefox-debug:3.8.1
     pull: true
     environment:
       - SE_OPTS=-enablePassThrough false


### PR DESCRIPTION
Results:

- taking off `-debug` from the selenium containers does not reduce the amount of logging output, but firefox seems to break more. So there is no point doing that.
- reducing the selenium log level to warning does reduce the output from, e.g. 700 lines to <200 lines. That seems worth doing.
- changing `apachectl` from `-e debug` to `-e error` has no significant effect on the size of log output. That is because the volume that is output is from the "access log" output, logging every GET, POST...

So the remaining challenge is to be able to not have the Apache access log output.