### PR TITLE
move OCS related steps to own context

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -24,6 +24,7 @@
 
 use Behat\Gherkin\Node\TableNode;
 use TestHelpers\AppConfigHelper;
+use TestHelpers\OcsApiHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -47,37 +48,6 @@ trait AppConfiguration {
 	 * @var array the changes made to capabilities for the test scenario
 	 */
 	private $savedCapabilitiesChanges = [];
-
-	/**
-	 * @param string $verb
-	 * @param string $url
-	 *
-	 * @return void
-	 */
-	abstract public function theUserSendsToOcsApiEndpoint($verb, $url);
-
-	/**
-	 * @param string $verb
-	 * @param string $url
-	 * @param TableNode $body
-	 *
-	 * @return void
-	 */
-	abstract public function theUserSendsToOcsApiEndpointWithBody($verb, $url, $body);
-
-	/**
-	 * @param mixed $statusCode
-	 *
-	 * @return void
-	 */
-	abstract public function theOCSStatusCodeShouldBe($statusCode);
-
-	/**
-	 * @param mixed $statusCode
-	 *
-	 * @return void
-	 */
-	abstract public function theHTTPStatusCodeShouldBe($statusCode);
 
 	/**
 	 * @When /^the administrator sets parameter "([^"]*)" of app "([^"]*)" to "([^"]*)"$/
@@ -160,7 +130,12 @@ trait AppConfiguration {
 	 * @return void
 	 */
 	public function userGetsCapabilities($username) {
-		$this->userSendsToOcsApiEndpoint($username, 'GET', '/cloud/capabilities');
+		$user = $this->getActualUsername($username);
+		$password = $this->getPasswordForUser($user);
+		$this->response = OcsApiHelper::sendRequest(
+			$this->getBaseUrl(), $user, $password, 'GET', '/cloud/capabilities',
+			[], $this->getOcsApiVersion()
+		);
 	}
 
 	/**
@@ -380,7 +355,7 @@ trait AppConfiguration {
 		);
 		$this->theHTTPStatusCodeShouldBe('200');
 		if ($this->ocsApiVersion == 1) {
-			$this->theOCSStatusCodeShouldBe('100');
+			$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		}
 
 		$this->theUserSendsToOcsApiEndpoint('get', '/cloud/apps?filter=enabled');

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -40,6 +40,12 @@ class FederationContext implements Context {
 	private $featureContext;
 
 	/**
+	 *
+	 * @var OCSContext
+	 */
+	private $ocsContext;
+
+	/**
 	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)" using the sharing API$/
 	 *
 	 * @param string $sharerUser
@@ -85,9 +91,9 @@ class FederationContext implements Context {
 			$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->featureContext->theOCSStatusCodeShouldBe(
+		$this->ocsContext->theOCSStatusCodeShouldBe(
 			'100', 'Could not share file/folder! message: "' .
-				$this->featureContext->getOCSResponseStatusMessage(
+				$this->ocsContext->getOCSResponseStatusMessage(
 					$this->featureContext->getResponse()
 				) . '"'
 		);
@@ -105,11 +111,11 @@ class FederationContext implements Context {
 		$previous = $this->featureContext->usingServer($server);
 		$this->userGetsTheListOfPendingFederatedCloudShares($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->featureContext->theOCSStatusCodeShouldBe('100');
+		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
-		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
+		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
 			'POST',
 			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",
 			null
@@ -130,7 +136,7 @@ class FederationContext implements Context {
 			$user, $server
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->featureContext->theOCSStatusCodeShouldBe('100');
+		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 	}
 
 	/**
@@ -143,11 +149,11 @@ class FederationContext implements Context {
 	public function userRetrievesInformationOfLastFederatedShare($user) {
 		$this->userGetsTheListOfFederatedCloudShares($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->featureContext->theOCSStatusCodeShouldBe('100');
+		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
-		$this->featureContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			"/apps/files_sharing/api/v1/remote_shares/{$share_id}",
@@ -165,11 +171,11 @@ class FederationContext implements Context {
 	public function userRetrievesInformationOfLastPendingFederatedShare($user) {
 		$this->userGetsTheListOfPendingFederatedCloudShares($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->featureContext->theOCSStatusCodeShouldBe('100');
+		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
-		$this->featureContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			"/apps/files_sharing/api/v1/remote_shares/{$share_id}",
@@ -187,7 +193,7 @@ class FederationContext implements Context {
 	public function userGetsTheListOfPendingFederatedCloudShares($user) {
 		$url = "/apps/files_sharing/api/v1/remote_shares/pending";
 		$this->featureContext->asUser($user);
-		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
+		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
 			'GET',
 			$url,
 			null
@@ -202,7 +208,7 @@ class FederationContext implements Context {
 	 * @return void
 	 */
 	public function userGetsTheListOfFederatedCloudShares($user) {
-		$this->featureContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, 'GET', "/apps/files_sharing/api/v1/remote_shares"
 		);
 	}
@@ -227,7 +233,7 @@ class FederationContext implements Context {
 			$this->userGetsTheListOfFederatedCloudShares($user);
 		}
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->featureContext->theOCSStatusCodeShouldBe('100');
+		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
@@ -237,7 +243,7 @@ class FederationContext implements Context {
 			$url = "/apps/files_sharing/api/v1/remote_shares/$share_id";
 		}
 		
-		$this->featureContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, 'DELETE', $url, null, $password
 		);
 	}
@@ -252,7 +258,7 @@ class FederationContext implements Context {
 	public function userRequestsSharedSecretUsingTheFederationApi($user) {
 		$url  = '/apps/federation/api/v1/request-shared-secret';
 		$this->featureContext->asUser($user);
-		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
+		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
 			'POST',
 			$url,
 			null
@@ -274,5 +280,6 @@ class FederationContext implements Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
+		$this->ocsContext = $environment->getContext('OCSContext');
 	}
 }

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -48,6 +48,12 @@ class NotificationsCoreContext implements Context {
 	private $featureContext;
 
 	/**
+	 *
+	 * @var OCSContext
+	 */
+	private $ocsContext;
+
+	/**
 	 * @return array[]
 	 */
 	public function getNotificationIds() {
@@ -110,7 +116,7 @@ class NotificationsCoreContext implements Context {
 	 * @return void
 	 */
 	public function userNumNotifications($user, $numNotifications, $missingLast) {
-		$this->featureContext->userSendsToOcsApiEndpoint(
+		$this->ocsContext->userSendsToOcsApiEndpoint(
 			$user, 'GET', '/apps/notifications/api/v1/notifications?format=json'
 		);
 		PHPUnit_Framework_Assert::assertEquals(
@@ -189,7 +195,7 @@ class NotificationsCoreContext implements Context {
 			$notificationId = \end($lastNotifications);
 		}
 
-		$this->featureContext->userSendsToOcsApiEndpoint(
+		$this->ocsContext->userSendsToOcsApiEndpoint(
 			$user,
 			'GET',
 			"/apps/notifications/api/v1/notifications/$notificationId?format=json"
@@ -250,7 +256,7 @@ class NotificationsCoreContext implements Context {
 		);
 		PHPUnit_Framework_Assert::assertEquals(200, $response->getStatusCode());
 		PHPUnit_Framework_Assert::assertEquals(
-			200, (int) $this->featureContext->getOCSResponseStatusCode($response)
+			200, (int) $this->ocsContext->getOCSResponseStatusCode($response)
 		);
 	}
 
@@ -266,6 +272,7 @@ class NotificationsCoreContext implements Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
+		$this->ocsContext = $environment->getContext('OCSContext');
 		$this->clearNotifications();
 	}
 }

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Message\ResponseInterface;
+use TestHelpers\OcsApiHelper;
+
+require_once 'bootstrap.php';
+
+/**
+ * steps needed to send requests to the OCS API
+ */
+class OCSContext implements Context {
+
+	/**
+	 *
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+
+	/**
+	 * @When /^the user sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
+	 * @Given /^the user has sent HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
+	 *
+	 * @param string $verb
+	 * @param string $url
+	 *
+	 * @return void
+	 */
+	public function theUserSendsToOcsApiEndpoint($verb, $url) {
+		$this->theUserSendsToOcsApiEndpointWithBody($verb, $url, null);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" using password "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function userSendsToOcsApiEndpoint($user, $verb, $url, $password = null) {
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
+			$verb,
+			$url,
+			null,
+			$password
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
+	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
+	 *
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 * @param TableNode|null $body
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$user, $verb, $url, $body = null, $password = null
+	) {
+		
+		/**
+		 * array of the data to be sent in the body.
+		 * contains $body data converted to an array
+		 *
+		 * @var array $bodyArray
+		 */
+		$bodyArray = [];
+		if ($body instanceof TableNode) {
+			$bodyArray = $body->getRowsHash();
+		}
+		
+		if ($user !== 'UNAUTHORIZED_USER') {
+			$user = $this->featureContext->getActualUsername($user);
+			if ($password === null) {
+				$password = $this->featureContext->getPasswordForUser($user);
+			}
+		} else {
+			$user = null;
+			$password = null;
+		}
+		
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(), $user, $password, $verb,
+			$url, $bodyArray, $this->featureContext->getOcsApiVersion()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When the administrator sends HTTP method :verb to OCS API endpoint :url
+	 * @When the administrator sends HTTP method :verb to OCS API endpoint :url using password :password
+	 *
+	 * @param string $verb
+	 * @param string $url
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function theAdministratorSendsHttpMethodToOcsApiEndpoint(
+		$verb, $url, $password = null
+	) {
+		$admin = $this->featureContext->getAdminUsername();
+		$this->userSendsToOcsApiEndpoint($admin, $verb, $url, $password);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with headers$/
+	 *
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 * @param TableNode $headersTable
+	 *
+	 * @return void
+	 */
+	public function userSendsToOcsApiEndpointWithHeaders(
+		$user, $verb, $url, TableNode $headersTable
+	) {
+		$user = $this->featureContext->getActualUsername($user);
+		$password = $this->featureContext->getPasswordForUser($user);
+		
+		$headers = [];
+		foreach ($headersTable as $row) {
+			$headers[$row['header']] = $row ['value'];
+		}
+		
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(), $user, $password, $verb,
+			$url, [], $this->featureContext->getOcsApiVersion(), $headers
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When /^the administrator sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with headers$/
+	 *
+	 * @param string $verb
+	 * @param string $url
+	 * @param TableNode $headersTable
+	 *
+	 * @return void
+	 */
+	public function administratorSendsToOcsApiEndpointWithHeaders(
+		$verb, $url, TableNode $headersTable
+	) {
+		$this->userSendsToOcsApiEndpointWithHeaders(
+			$this->featureContext->getAdminUsername(), $verb, $url, $headersTable
+		);
+	}
+
+	/**
+	 * @When the administrator sends HTTP method :verb to OCS API endpoint :url with body
+	 * @Given the administrator has sent HTTP method :verb to OCS API endpoint :url with body
+	 *
+	 * @param string $verb
+	 * @param string $url
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function theAdministratorSendsHttpMethodToOcsApiEndpointWithBody(
+		$verb, $url, TableNode $body
+	) {
+		$admin = $this->featureContext->getAdminUsername();
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$admin, $verb, $url, $body
+		);
+	}
+
+	/**
+	 * @When /^the user sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
+	 * @Given /^the user has sent HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
+	 *
+	 * @param string $verb
+	 * @param string $url
+	 * @param TableNode $body
+	 *
+	 * @return void
+	 */
+	public function theUserSendsToOcsApiEndpointWithBody($verb, $url, $body) {
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$this->featureContext->getCurrentUser(),
+			$verb,
+			$url,
+			$body
+		);
+	}
+
+	/**
+	 * @When the administrator sends HTTP method :verb to OCS API endpoint :url with body using password :password
+	 *
+	 * @param string $verb
+	 * @param string $url
+	 * @param string $password
+	 * @param TableNode $body
+	 *
+	 * @return void
+	 */
+	public function theAdministratorSendsHttpMethodToOcsApiWithBodyAndPassword(
+		$verb, $url, $password, TableNode $body
+	) {
+		$admin = $this->featureContext->getAdminUsername();
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$admin, $verb, $url, $body, $password
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body using password "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 * @param string $password
+	 * @param TableNode $body
+	 *
+	 * @return void
+	 */
+	public function userSendsHTTPMethodToOcsApiEndpointWithBodyAndPassword(
+		$user, $verb, $url, $password, $body
+	) {
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user, $verb, $url, $body, $password
+		);
+	}
+
+	/**
+	 * @Then /^the OCS status code should be "([^"]*)"$/
+	 *
+	 * @param int|int[] $statusCode
+	 * @param string $message
+	 *
+	 * @return void
+	 */
+	public function theOCSStatusCodeShouldBe($statusCode, $message = "") {
+		if ($message === "") {
+			$message = "OCS status code is not the expected value";
+		}
+		
+		$responseStatusCode = $this->getOCSResponseStatusCode(
+			$this->featureContext->getResponse()
+		);
+		if (\is_array($statusCode)) {
+			PHPUnit_Framework_Assert::assertContains(
+				$responseStatusCode, $statusCode,
+				$message
+			);
+		} else {
+			PHPUnit_Framework_Assert::assertEquals(
+				$statusCode, $responseStatusCode,
+				$message
+			);
+		}
+	}
+
+	/**
+	 * Check the text in an OCS status message
+	 *
+	 * @Then /^the OCS status message should be "([^"]*)"$/
+	 *
+	 * @param string $statusMessage
+	 *
+	 * @return void
+	 */
+	public function theOCSStatusMessageShouldBe($statusMessage) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$statusMessage,
+			$this->getOCSResponseStatusMessage(
+				$this->getResponse()
+			),
+			'Unexpected OCS status message in response'
+		);
+	}
+
+	/**
+	 * Check the text in an OCS status message.
+	 * Use this step form if the expected text contains double quotes,
+	 * single quotes and other content that theOCSStatusMessageShouldBe()
+	 * cannot handle.
+	 *
+	 * After the step, write the expected text in PyString form like:
+	 *
+	 * """
+	 * File "abc.txt" can't be shared due to reason "xyz"
+	 * """
+	 *
+	 * @Then /^the OCS status message should be:$/
+	 *
+	 * @param PyStringNode $statusMessage
+	 *
+	 * @return void
+	 */
+	public function theOCSStatusMessageShouldBePyString(
+		PyStringNode $statusMessage
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$statusMessage->getRaw(),
+			$this->getOCSResponseStatusMessage(
+				$this->getResponse()
+			),
+			'Unexpected OCS status message in response'
+		);
+	}
+
+	/**
+	 * Parses the xml answer to get ocs response which doesn't match with
+	 * http one in v1 of the api.
+	 *
+	 * @param ResponseInterface $response
+	 *
+	 * @throws \Exception
+	 * @return string
+	 */
+	public function getOCSResponseStatusCode($response) {
+		$responseXml = $this->featureContext->getResponseXml($response);
+		if (isset($responseXml->meta[0], $responseXml->meta[0]->statuscode)) {
+			return (string) $responseXml->meta[0]->statuscode;
+		}
+		throw new \Exception(
+			"No OCS status code found in responseXml"
+		);
+	}
+
+	/**
+	 * Parses the xml answer to get ocs response message which doesn't match with
+	 * http one in v1 of the api.
+	 *
+	 * @param ResponseInterface $response
+	 *
+	 * @return string
+	 */
+	public function getOCSResponseStatusMessage($response) {
+		return (string) $this->featureContext->getResponseXml($response)->meta[0]->message;
+	}
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+	}
+}

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -406,7 +406,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theAdministratorGetsTheInfoOfApp($app) {
-		$this->userSendsToOcsApiEndpoint(
+		$this->ocsContext->userSendsToOcsApiEndpoint(
 			$this->getAdminUsername(),
 			"GET",
 			"/cloud/apps/$app"
@@ -433,7 +433,7 @@ trait Provisioning {
 	public function adminSendsUserCreationRequestUsingTheProvisioningApi($user, $password) {
 		$password = $this->getActualPassword($password);
 		$bodyTable = new TableNode([['userid', $user], ['password', $password]]);
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(),
 			"POST",
 			"/cloud/users",
@@ -458,7 +458,7 @@ trait Provisioning {
 		$bodyTable = new TableNode(
 			[['userid', $user], ['password', $password], ['groups[]', $group]]
 		);
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(),
 			"POST",
 			"/cloud/users",
@@ -515,7 +515,7 @@ trait Provisioning {
 	public function userTriesToResetPasswordOfUserUsingTheProvisioningApi($user, $username, $password) {
 		$password = $this->getActualPassword($password);
 		$bodyTable = new TableNode([['key', 'password'], ['value', $password]]);
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			"PUT",
 			"/cloud/users/$username",
@@ -1681,7 +1681,7 @@ trait Provisioning {
 	) {
 		$bodyTable = new TableNode([['groupid', $group]]);
 		$user = $user === null ? $this->getAdminUsername() : $user;
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			"POST",
 			"/cloud/groups",
@@ -2685,7 +2685,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function checkAttributesForUser($user, $body) {
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(), "GET", "/cloud/users/$user",
 			null
 		);

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -41,6 +41,11 @@ class ShareesContext implements Context {
 	private $featureContext;
 
 	/**
+	 *
+	 * @var OCSContext
+	 */
+	private $ocsContext;
+	/**
 	 * @When /^the user gets the sharees using the sharing API with parameters$/
 	 *
 	 * @param TableNode $body
@@ -73,7 +78,7 @@ class ShareesContext implements Context {
 			}
 		}
 
-		$this->featureContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, 'GET', $url, null
 		);
 	}
@@ -172,5 +177,6 @@ class ShareesContext implements Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
+		$this->ocsContext = $environment->getContext('OCSContext');
 	}
 }

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -216,7 +216,7 @@ trait Sharing {
 	 */
 	public function theUserHasCreatedAShareWithSettings($body) {
 		$this->userCreatesAShareWithSettings($this->currentUser, $body);
-		$this->theOCSStatusCodeShouldBe([100, 200]);
+		$this->ocsContext->theOCSStatusCodeShouldBe([100, 200]);
 		$this->theHTTPStatusCodeShouldBe(200);
 	}
 
@@ -229,7 +229,7 @@ trait Sharing {
 	 */
 	public function theUserHasCreatedAPublicLinkShareWithSettings($body) {
 		$this->theUserCreatesAPublicLinkShareWithSettings($body);
-		$this->theOCSStatusCodeShouldBe([100, 200]);
+		$this->ocsContext->theOCSStatusCodeShouldBe([100, 200]);
 		$this->theHTTPStatusCodeShouldBe(200);
 	}
 
@@ -547,7 +547,7 @@ trait Sharing {
 		$this->createAPublicShare($sharer, $filepath);
 		PHPUnit_Framework_Assert::assertEquals(
 			404,
-			$this->getOCSResponseStatusCode($this->response)
+			$this->ocsContext->getOCSResponseStatusCode($this->response)
 		);
 	}
 
@@ -1064,7 +1064,7 @@ trait Sharing {
 		$this->createShare(
 			$sharer, $filepath, $shareType, $sharee, null, null, $permissions
 		);
-		$statusCode = $this->getOCSResponseStatusCode($this->response);
+		$statusCode = $this->ocsContext->getOCSResponseStatusCode($this->response);
 		PHPUnit_Framework_Assert::assertTrue(
 			($statusCode == 404) || ($statusCode == 403),
 			"Sharing should have failed but passed with status code $statusCode"
@@ -1092,7 +1092,7 @@ trait Sharing {
 		
 		//v1.php returns 100 as success code
 		//v2.php returns 200 in the same case
-		$this->theOCSStatusCodeShouldBe([100, 200]);
+		$this->ocsContext->theOCSStatusCodeShouldBe([100, 200]);
 	}
 
 	/**
@@ -1116,7 +1116,7 @@ trait Sharing {
 	public function userDeletesLastShareUsingTheSharingApi($user) {
 		$share_id = $this->lastShareData->data[0]->id;
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, "DELETE", $url, null
 		);
 	}
@@ -1140,7 +1140,7 @@ trait Sharing {
 	public function userGetsInfoOfLastShareUsingTheSharingApi($user) {
 		$share_id = $this->lastShareData->data[0]->id;
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, "GET", $url, null
 		);
 	}
@@ -1154,7 +1154,7 @@ trait Sharing {
 	 */
 	public function userGetsAllTheSharesSharedWithHimUsingTheSharingApi($user) {
 		$url = "/apps/files_sharing/api/v1/shares?shared_with_me=true";
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			$url,
@@ -1173,7 +1173,7 @@ trait Sharing {
 	public function userGetsAllSharesSharedWithHimFromFileOrFolderUsingTheProvisioningApi($user, $path) {
 		$url = "/apps/files_sharing/api/"
 		. "v{$this->sharingApiVersion}/shares?shared_with_me=true&path=$path";
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			$url,
@@ -1529,7 +1529,9 @@ trait Sharing {
 	) {
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->theUserSendsToOcsApiEndpointWithBody("DELETE", $url, null);
+		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
+			"DELETE", $url, null
+		);
 	}
 
 	/**
@@ -1568,7 +1570,7 @@ trait Sharing {
 			$httpRequestMethod = "POST";
 		}
 		
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, $httpRequestMethod, $url, null
 		);
 	}
@@ -1675,7 +1677,7 @@ trait Sharing {
 		
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" .
 			   "?format=json&shared_with_me=true&state=$stateCode";
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, "GET", $url, null
 		);
 		if ($this->response->getStatusCode() !== 200) {


### PR DESCRIPTION
## Description
as more steps were added to `BasicStructure.php` recently it gets longer and longer, so to make it shorter I moved out OCS related steps.
`@Given /^using OCS API version "([^"]*)"$/`is still in BasicStructure because its basically a setter

## Related Issue
part of #34566

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
