### PR TITLE
more tests, testing the CORS headers on OCS routes

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -133,3 +133,69 @@ Feature: CORS headers
       | 2               |/cloud/groups | 200      | 200       |
       | 1               |/cloud/users  | 100      | 200       |
       | 2               |/cloud/users  | 200      | 200       |
+
+  @issue-34679
+  Scenario Outline: CORS headers should be returned when invalid password is used
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has added "https://aphno.badal" to the list of personal CORS domains
+    When user "user0" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
+      | header | value               |
+      | Origin | https://aphno.badal |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    Then the following headers should not be set
+      | Access-Control-Allow-Headers  |
+      | Access-Control-Expose-Headers |
+      | Access-Control-Allow-Origin   |
+      | Access-Control-Allow-Methods  |
+    #Then the following headers should be set
+    #  | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+    #  | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
+    #  | Access-Control-Allow-Origin   | https://aphno.badal |
+    #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+    Examples:
+      | ocs_api_version |endpoint                                         | ocs-code | http-code |
+      | 1               |/apps/files_external/api/v1/mounts               | 997      | 401       |
+      | 2               |/apps/files_external/api/v1/mounts               | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
+      | 1               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 2               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 1               |/privatedata/getattribute                        | 997      | 401       |
+      | 2               |/privatedata/getattribute                        | 997      | 401       |
+      | 1               |/cloud/apps                                      | 997      | 401       |
+      | 2               |/cloud/apps                                      | 997      | 401       |
+      | 1               |/cloud/groups                                    | 997      | 401       |
+      | 2               |/cloud/groups                                    | 997      | 401       |
+      | 1               |/cloud/users                                     | 997      | 401       |
+      | 2               |/cloud/users                                     | 997      | 401       |
+
+  @issue-34679
+  Scenario Outline: CORS headers should be returned when invalid password is used (admin only endpoints)
+    Given using OCS API version "<ocs_api_version>"
+    And the administrator has added "https://aphno.badal" to the list of personal CORS domains
+    When the administrator sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
+      | header | value               |
+      | Origin | https://aphno.badal |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    Then the following headers should not be set
+      | Access-Control-Allow-Headers  |
+      | Access-Control-Expose-Headers |
+      | Access-Control-Allow-Origin   |
+      | Access-Control-Allow-Methods  |
+    #Then the following headers should be set
+    #  | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+    #  | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
+    #  | Access-Control-Allow-Origin   | https://aphno.badal |
+    #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+    Examples:
+      | ocs_api_version |endpoint      | ocs-code | http-code |
+      | 1               |/cloud/apps   | 997      | 401       |
+      | 2               |/cloud/apps   | 997      | 401       |
+      | 1               |/cloud/groups | 997      | 401       |
+      | 2               |/cloud/groups | 997      | 401       |
+      | 1               |/cloud/users  | 997      | 401       |
+      | 2               |/cloud/users  | 997      | 401       |

--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -29,6 +29,12 @@ Feature: CORS headers
       | 2               |/apps/files_sharing/api/v1/shares                | 200      | 200       |
       | 1               |/privatedata/getattribute                        | 100      | 200       |
       | 2               |/privatedata/getattribute                        | 200      | 200       |
+      | 1               |/cloud/apps                                      | 997      | 401       |
+      | 2               |/cloud/apps                                      | 997      | 401       |
+      | 1               |/cloud/groups                                    | 997      | 401       |
+      | 2               |/cloud/groups                                    | 997      | 401       |
+      | 1               |/cloud/users                                     | 997      | 401       |
+      | 2               |/cloud/users                                     | 997      | 401       |
 
   #merge into previous scenario when fixed
   @issue-34664
@@ -99,6 +105,12 @@ Feature: CORS headers
       | 2               |/config                                          | 200      | 200       |
       | 1               |/privatedata/getattribute                        | 100      | 200       |
       | 2               |/privatedata/getattribute                        | 200      | 200       |
+      | 1               |/cloud/apps                                      | 997      | 401       |
+      | 2               |/cloud/apps                                      | 997      | 401       |
+      | 1               |/cloud/groups                                    | 997      | 401       |
+      | 2               |/cloud/groups                                    | 997      | 401       |
+      | 1               |/cloud/users                                     | 997      | 401       |
+      | 2               |/cloud/users                                     | 997      | 401       |
 
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -151,17 +151,9 @@ class OCSContext implements Context {
 	) {
 		$user = $this->featureContext->getActualUsername($user);
 		$password = $this->featureContext->getPasswordForUser($user);
-		
-		$headers = [];
-		foreach ($headersTable as $row) {
-			$headers[$row['header']] = $row ['value'];
-		}
-		
-		$response = OcsApiHelper::sendRequest(
-			$this->featureContext->getBaseUrl(), $user, $password, $verb,
-			$url, [], $this->featureContext->getOcsApiVersion(), $headers
+		$this->userSendsToOcsApiEndpointWithHeadersAndPassword(
+			$user, $verb, $url, $password, $headersTable
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -178,6 +170,51 @@ class OCSContext implements Context {
 	) {
 		$this->userSendsToOcsApiEndpointWithHeaders(
 			$this->featureContext->getAdminUsername(), $verb, $url, $headersTable
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with headers using password "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 * @param string $password
+	 * @param TableNode $headersTable
+	 *
+	 * @return void
+	 */
+	public function userSendsToOcsApiEndpointWithHeadersAndPassword(
+		$user, $verb, $url, $password, TableNode $headersTable
+	) {
+		$user = $this->featureContext->getActualUsername($user);
+		$headers = [];
+		foreach ($headersTable as $row) {
+			$headers[$row['header']] = $row ['value'];
+		}
+		
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(), $user, $password, $verb,
+			$url, [], $this->featureContext->getOcsApiVersion(), $headers
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When /^the administrator sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with headers using password "([^"]*)"$/
+	 *
+	 * @param string $verb
+	 * @param string $url
+	 * @param string $password
+	 * @param TableNode $headersTable
+	 *
+	 * @return void
+	 */
+	public function administratorSendsToOcsApiEndpointWithHeadersAndPassword(
+		$verb, $url, $password, TableNode $headersTable
+	) {
+		$this->userSendsToOcsApiEndpointWithHeadersAndPassword(
+			$this->featureContext->getAdminUsername(), $verb, $url, $password, $headersTable
 		);
 	}
 


### PR DESCRIPTION
## Description
- test if headers are correctly returned when normal user tries to access admin-only ocs routes
- test if headers are correctly returned when various ocs routes are acceded with an invalid password  - issue #34679

## Related Issue
part of https://github.com/owncloud/core/issues/34566
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
