### PR TITLE
get response from featureContext

### DIFF
--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -299,7 +299,7 @@ class OCSContext implements Context {
 		PHPUnit_Framework_Assert::assertEquals(
 			$statusMessage,
 			$this->getOCSResponseStatusMessage(
-				$this->getResponse()
+				$this->featureContext->getResponse()
 			),
 			'Unexpected OCS status message in response'
 		);
@@ -329,7 +329,7 @@ class OCSContext implements Context {
 		PHPUnit_Framework_Assert::assertEquals(
 			$statusMessage->getRaw(),
 			$this->getOCSResponseStatusMessage(
-				$this->getResponse()
+				$this->featureContext->getResponse()
 			),
 			'Unexpected OCS status message in response'
 		);


### PR DESCRIPTION
## Description
the response can be found in `featureContext`
fix mistake made in  #34694
problem only surfaced when running tests of apps

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
