### PR TITLE
Check for iterable responseXML->data in isUserOrGroupInSharedData

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -831,14 +831,22 @@ trait Sharing {
 		}
 		
 		$data = $this->getResponseXml()->data[0];
-		foreach ($data as $element) {
-			if ($element->share_with->__toString() === $userOrGroup
-				&& ($permissions === null
-				|| $permissionSum === (int)$element->permissions->__toString())
-			) {
-				return true;
+		if (\is_iterable($data)) {
+			foreach ($data as $element) {
+				if ($element->share_with->__toString() === $userOrGroup
+					&& ($permissions === null
+					|| $permissionSum === (int)$element->permissions->__toString())
+				) {
+					return true;
+				}
 			}
+			return false;
 		}
+		\error_log(
+			"INFORMATION: isUserOrGroupInSharedData response XML data is " .
+			\gettype($data) .
+			" and therefore does not contain share_with information."
+		);
 		return false;
 	}
 


### PR DESCRIPTION
## Description
In the acceptance test method `isUserOrGroupInSharedData`, if the `responseXML` `data` does not contain the expected array/iterable of sharing information, then the code can fall over with:
```
Warning: Invalid argument supplied for foreach() in /drone/src/tests/acceptance/features/bootstrap/Sharing.php line 834
```

Be nicer and emit an information message to say that the response data was not the expected type, and return `false` so that the caller can then "do its own thing" in response and report a more "normal" test fail message.

## Motivation and Context
When doing a backport PR #34696 there was some problem with the backported code and the responses were not happening. It would be nice to have a clearer failure in the accceptance test output/

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
