### PR TITLE
Bypass signature mismatch in the encrypted file

### DIFF
--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -28,6 +28,7 @@ namespace OC\Files\Stream;
 
 use Icewind\Streams\Wrapper;
 use OC\Encryption\Exceptions\EncryptionHeaderKeyExistsException;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Encryption extends Wrapper {
 
@@ -281,6 +282,7 @@ class Encryption extends Wrapper {
 
 	public function stream_read($count) {
 		$result = '';
+		$genericEvent = new GenericEvent('SignatureMismatch', []);
 
 		$count = \min($count, $this->unencryptedSize - $this->position);
 		while ($count > 0) {
@@ -302,6 +304,7 @@ class Encryption extends Wrapper {
 				$count -= ($this->unencryptedBlockSize - $blockPosition);
 			}
 		}
+		\OC::$server->getEventDispatcher()->dispatch('files.aftersignaturemismatch', $genericEvent);
 		return $result;
 	}
 

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -7,6 +7,8 @@ use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\User\Manager;
 use OCP\Files\Storage\IStorage;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\Files\Storage\Storage;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\Cache\Cache;
@@ -101,6 +103,9 @@ class EncryptionTest extends Storage {
 	/** @var  \OC\Memcache\ArrayCache | \PHPUnit_Framework_MockObject_MockObject */
 	private $arrayCache;
 
+	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $eventDisaptcher;
+
 	/** @var  integer dummy unencrypted size */
 	private $dummySize = -1;
 
@@ -178,6 +183,8 @@ class EncryptionTest extends Storage {
 			->disableOriginalConstructor()->getMock();
 		$this->mountManager->expects($this->any())->method('findByStorageId')->willReturn([]);
 
+		$this->eventDisaptcher = $this->createMock(EventDispatcherInterface::class);
+
 		$this->instance = $this->getMockBuilder(Encryption::class)
 			->setConstructorArgs(
 				[
@@ -187,7 +194,9 @@ class EncryptionTest extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
+					$this->encryptionManager, $this->util, $this->logger,
+					$this->file, null, $this->keyStore, $this->update,
+					$this->mountManager, $this->arrayCache, $this->eventDisaptcher
 				]
 			)
 			->setMethods(['getMetaData', 'getCache', 'getEncryptionModule'])


### PR DESCRIPTION
Bypass signature mismatch in the encrypted file.
This would be handy when files are transferred to
other users. In this changeset the HintException
is not re-thrown. Instead it is catched and the
exception is logged.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The signature check done during decryption is bypassed. The reason/motivation behind this change set is, due to known reason ( yet to be investigated ), the files have encrypted column in the file cache with values which cause signature mismatch. And this was resulting in exception, `HintException`. So if the user tries to transfer files from say `user1` to `user2`, then the transfer is aborted because of this. During this task, it is also observed that bypassing the signature does not prohibit the decryption of files. The files tested ( the txt files ) were successfully decrypted. 

Few details regarding the implementation details of this changeset:
- [x] Dependency PR https://github.com/owncloud/encryption/pull/105

I have used Symfony events to let the transfer-ownership command know which are the files affected.
The symfony event `files.aftersignaturemismatch` is transmitted from :
   - lib/private/Files/Stream/Encryption.php

The listeners of this event in the order of priority are ( the higher positive number the higher priority ):
   - apps/encryption/lib/Crypto/Crypt.php, Priority => 30, Function `signatureMismatchEvent`
   - lib/private/Files/Storage/Wrapper/Encryption.php, Priority => 20, Function `copyBetweenStorage`
   - apps/files/lib/Command/TransferOwnership.php, Priority => 10, Function `transfer`

When the signature mismatch happens, an argument `signatureMismatch` is set to true. This is verified once the read operation is completed at copyBetweenStorage and the file which has signature mismatch issue is detected and an argument `fileName` is added to this event which has value of the file name. Also this is logged in the owncloud.log file. This is verified in the transfer ownership command and an array is populated to grab the affected files. Once the rename operation in the transfer ownership is completed, the list of affected files are shown to the admin, if any are available.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bypass the signature check in the Crypt and log the affected files which have signature mismatch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create 2 users `user1` and `user2` ( kindly login to both users )
- As `user1` create a folder `test` and create files as under `test`
    - `a.txt`
    - `b.txt`
    - `big.txt`

Try to edit the database as shown below:
```
mysql> select fileid,encrypted from oc_filecache where path="files/test/a.txt";
+--------+-----------+
| fileid | encrypted |
+--------+-----------+
|     45 |         3 |
+--------+-----------+
1 row in set (0.00 sec)

mysql> select fileid,encrypted from oc_filecache where path="files/test/big.txt";
+--------+-----------+
| fileid | encrypted |
+--------+-----------+
|     66 |         1 |
+--------+-----------+
1 row in set (0.00 sec)

mysql> update oc_filecache set encrypted=7 where fileid=45;
Query OK, 1 row affected (0.00 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> update oc_filecache set encrypted=10 where fileid=66;
Query OK, 1 row affected (0.00 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> select fileid,encrypted from oc_filecache where path="files/test/a.txt";
+--------+-----------+
| fileid | encrypted |
+--------+-----------+
|     45 |         7 |
+--------+-----------+
1 row in set (0.00 sec)

mysql> select fileid,encrypted from oc_filecache where path="files/test/a.txt";
+--------+-----------+
| fileid | encrypted |
+--------+-----------+
|     45 |         7 |
+--------+-----------+
1 row in set (0.00 sec)

mysql> 
```
- Now run transferownership command as shown below:
```
 sujith@sujith-ownCloud  ~/test/owncloud   master ●  ./occ files:transfer-ownership user1 user2
Cannot load Xdebug - it was already loaded
Analysing files of user1 ...
    4 [============================]
Collecting all share information for files and folder of user1 ...
    0 [>---------------------------]
Transferring files to user2/files/transferred from user1 on 20190307_114729 ...
The affected files are : files/test/a.txt, files/test/big.txt
Restoring shares ...
    0 [>---------------------------]
 sujith@sujith-ownCloud  ~/test/owncloud   bypass-signature-check 
```
- The affected files were `a.txt` and `big.txt` were listed as shown above.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
