### PR TITLE
test user-based 'Automatically accept new incoming local user shares' setting

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -342,6 +342,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - WebUIAdminSharingSettingsContext:
+        - WebUIPersonalSharingSettingsContext:
 
     webUISharingExternal:
       paths:

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -461,6 +461,24 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator (disables|enables) the setting "([^"]*)" in the section "([^"]*)"$/
+	 *
+	 * @param string $value
+	 * @param string $setting
+	 * @param string $section
+	 *
+	 * @return void
+	 */
+	public function adminSwitchesSettingInSection($value, $setting, $section) {
+		if ($value === "enables") {
+			$value = "enabled";
+		} elseif ($value === "disables") {
+			$value = "disabled";
+		}
+		$this->settingInSectionHasBeen($setting, $section, $value);
+	}
+
+	/**
 	 * @Given /^the setting "([^"]*)" in the section "([^"]*)" has been (disabled|enabled)$/
 	 *
 	 * @param string $setting

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2019 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+require_once 'bootstrap.php';
+
+use Behat\Behat\Context\Context;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\PersonalSharingSettingsPage;
+
+/**
+ * steps for personal sharing settings
+ */
+class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Context {
+	private $personalSharingSettingsPage;
+
+	/**
+	 *
+	 * @param PersonalSharingSettingsPage $personalSharingSettingsPage
+	 */
+	public function __construct(
+		PersonalSharingSettingsPage $personalSharingSettingsPage
+	) {
+		$this->personalSharingSettingsPage = $personalSharingSettingsPage;
+	}
+
+	/**
+	 * @When the user browses to the personal sharing settings page
+	 * @Given the user has browsed to the personal sharing settings page
+	 *
+	 * @return void
+	 */
+	public function theUserBrowsesToThePersonalSharingSettingsPage() {
+		$this->personalSharingSettingsPage->open();
+		$this->personalSharingSettingsPage->waitTillPageIsLoaded(
+			$this->getSession()
+		);
+	}
+
+	/**
+	 * @When /^the user (disables|enables) automatically accepting new incoming local shares$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 */
+	public function switchAutoAcceptingLocalShares($action) {
+		$this->personalSharingSettingsPage->toggleAutoAcceptingLocalShares(
+			$this->getSession(), $action
+		);
+	}
+}

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -27,7 +27,7 @@ use Behat\Mink\Session;
 /**
  * Admin Sharing Settings page.
  */
-class AdminSharingSettingsPage extends OwncloudPage {
+class AdminSharingSettingsPage extends SharingSettingsPage {
 	
 	/**
 	 *
@@ -64,47 +64,6 @@ class AdminSharingSettingsPage extends OwncloudPage {
 	protected $excludeGroupFromSharesFieldXpath = '//div[@id="files_sharing"]//input[contains(@class,"select2-input")]';
 	protected $groupListXpath = '//div[@id="select2-drop"]//li[contains(@class, "select2-result")]';
 	protected $groupListDropDownXpath = "//div[@id='select2-drop']";
-
-	/**
-	 * toggle checkbox
-	 *
-	 * @param Session $session
-	 * @param string $action "enables|disables"
-	 * @param string $checkboxXpath
-	 * @param string $checkboxId
-	 *
-	 * @return void
-	 */
-	public function toggleCheckbox(Session $session, $action, $checkboxXpath, $checkboxId) {
-		$checkbox = $this->find("xpath", $checkboxXpath);
-		$checkCheckbox = $this->findById($checkboxId);
-		$this->assertElementNotNull(
-			$checkbox,
-			__METHOD__ .
-			" xpath $checkboxXpath " .
-			"could not find label for checkbox"
-		);
-		$this->assertElementNotNull(
-			$checkCheckbox,
-			__METHOD__ .
-			" id $checkboxId " .
-			"could not find checkbox"
-		);
-		if ($action === "disables") {
-			if ($checkCheckbox->isChecked()) {
-				$checkbox->click();
-			}
-		} elseif ($action === "enables") {
-			if ((!($checkCheckbox->isChecked()))) {
-				$checkbox->click();
-			}
-		} else {
-			throw new \Exception(
-				__METHOD__ . " invalid action: $action"
-			);
-		}
-		$this->waitForAjaxCallsToStartAndFinish($session);
-	}
 
 	/**
 	 * toggle the Share API

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2019 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Page;
+
+use Behat\Mink\Session;
+
+/**
+ * page to set personal sharing settings
+ */
+class PersonalSharingSettingsPage extends SharingSettingsPage {
+	/**
+	 *
+	 * @var string $path
+	 */
+	protected $path = '/index.php/settings/personal?sectionid=sharing';
+	protected $autoAcceptLocalSharesCheckboxXpath
+		= '//label[@for="userAutoAcceptShareInput"]';
+	protected $autoAcceptLocalSharesCheckboxXpathCheckboxId
+		= 'userAutoAcceptShareInput';
+	
+	/**
+	 *
+	 * @param Session $session
+	 * @param string $action "enables|disables"
+	 *
+	 * @return void
+	 */
+	public function toggleAutoAcceptingLocalShares(Session $session, $action) {
+		$this->toggleCheckbox(
+			$session,
+			$action,
+			$this->autoAcceptLocalSharesCheckboxXpath,
+			$this->autoAcceptLocalSharesCheckboxXpathCheckboxId
+		);
+	}
+
+	/**
+	 * there is no reliable loading indicator on the personal sharing settings page,
+	 * so just wait for the auto accept checkbox to be there and all Ajax calls to finish
+	 *
+	 * @param Session $session
+	 * @param int $timeout_msec
+	 *
+	 * @return void
+	 */
+	public function waitTillPageIsLoaded(
+		Session $session,
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	) {
+		$this->waitForOutstandingAjaxCalls($session);
+		$this->waitTillXpathIsVisible(
+			$this->autoAcceptLocalSharesCheckboxXpath, $timeout_msec
+		);
+	}
+}

--- a/tests/acceptance/features/lib/SharingSettingsPage.php
+++ b/tests/acceptance/features/lib/SharingSettingsPage.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2019 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Page;
+
+use Behat\Mink\Session;
+
+/**
+ * common things for sharing settings pages (global and personal)
+ *
+ */
+class SharingSettingsPage extends OwncloudPage {
+	/**
+	 * toggle checkbox
+	 *
+	 * @param Session $session
+	 * @param string $action "enables|disables"
+	 * @param string $checkboxXpath
+	 * @param string $checkboxId
+	 *
+	 * @return void
+	 */
+	public function toggleCheckbox(
+		Session $session, $action, $checkboxXpath, $checkboxId
+	) {
+		$checkbox = $this->find("xpath", $checkboxXpath);
+		$checkCheckbox = $this->findById($checkboxId);
+		$this->assertElementNotNull(
+			$checkbox,
+			__METHOD__ .
+			" xpath $checkboxXpath " .
+			"could not find label for checkbox"
+		);
+		$this->assertElementNotNull(
+			$checkCheckbox,
+			__METHOD__ .
+			" id $checkboxId " .
+			"could not find checkbox"
+		);
+		if ($action === "disables") {
+			if ($checkCheckbox->isChecked()) {
+				$checkbox->click();
+			}
+		} elseif ($action === "enables") {
+			if ((!($checkCheckbox->isChecked()))) {
+				$checkbox->click();
+			}
+		} else {
+			throw new \Exception(
+				__METHOD__ . " invalid action: $action"
+			);
+		}
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+}

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -237,3 +237,83 @@ Feature: accept/decline shares coming from internal users
     And the user accepts share "simple-folder-renamed" offered by user "User Two" using the webUI
     Then folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
     And folder "simple-folder-renamed" should be listed in the files page on the webUI
+
+  @issue-34705
+  Scenario: User-based accepting is disabled while global is enabled
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting new incoming local shares
+    And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
+    And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
+    And the user browses to the files page
+    Then folder "simple-folder (2)" should be listed on the webUI
+    #Then folder "simple-folder (2)" should not be listed on the webUI
+    And file "testimage (2).jpg" should not be listed on the webUI
+    And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    #But folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    #And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+
+  @issue-34708 @issue-34705
+  Scenario: User-based accepting is enabled while global is disabled
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting new incoming local shares
+    And the user enables automatically accepting new incoming local shares
+    And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
+    And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
+    And the user browses to the files page
+    Then folder "simple-folder (2)" should not be listed on the webUI
+    #Then folder "simple-folder (2)" should be listed on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    #And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
+    #And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI
+
+  @issue-34705
+  Scenario: Admin enables auto-accept setting again after user disabled personal auto-accept setting
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting new incoming local shares
+    And the administrator enables the setting "Automatically accept new incoming local user shares" in the section "Sharing"
+    And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
+    And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
+    And the user browses to the files page
+    Then folder "simple-folder (2)" should be listed on the webUI
+    #Then folder "simple-folder (2)" should not be listed on the webUI
+    And file "testimage (2).jpg" should not be listed on the webUI
+    And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    #But folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    #And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+
+  @issue-34705
+  Scenario: Admin disables auto-accept setting again after user enabled personal auto-accept setting
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting new incoming local shares
+    And the user enables automatically accepting new incoming local shares
+    And the administrator disables the setting "Automatically accept new incoming local user shares" in the section "Sharing"
+    And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
+    And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
+    And the user browses to the files page
+    Then folder "simple-folder (2)" should not be listed on the webUI
+    #Then folder "simple-folder (2)" should be listed on the webUI
+    And file "testimage (2).jpg" should be listed on the webUI
+    And folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    #And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
+    #And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    And file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI


### PR DESCRIPTION
## Description
first set of tests that check if the user-based setting for auto-accepting local shares works

## Related Issue
part of tests for https://github.com/owncloud/enterprise/issues/3128

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
