### PR TITLE
test user-based auto accepting of federation shares

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -356,6 +356,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - PublicWebDavContext:
+        - WebUIPersonalSharingSettingsContext:
 
     webUISharingInternalGroups:
       paths:

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -67,4 +67,17 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 			$this->getSession(), $action
 		);
 	}
+
+	/**
+	 * @When /^the user (disables|enables) automatically accepting remote shares from trusted servers$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 */
+	public function switchAutoAcceptingFederatedShares($action) {
+		$this->personalSharingSettingsPage->toggleAutoAcceptingFederatedShares(
+			$this->getSession(), $action
+		);
+	}
 }

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -37,7 +37,11 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 		= '//label[@for="userAutoAcceptShareInput"]';
 	protected $autoAcceptLocalSharesCheckboxXpathCheckboxId
 		= 'userAutoAcceptShareInput';
-	
+	protected $autoAcceptFederatedSharesCheckboxXpath
+		= '//label[@for="userAutoAcceptShareTrustedInput"]';
+	protected $autoAcceptFederatedSharesCheckboxXpathCheckboxId
+		= 'userAutoAcceptShareTrustedInput';
+
 	/**
 	 *
 	 * @param Session $session
@@ -51,6 +55,22 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 			$action,
 			$this->autoAcceptLocalSharesCheckboxXpath,
 			$this->autoAcceptLocalSharesCheckboxXpathCheckboxId
+		);
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param string $action "enables|disables"
+	 *
+	 * @return void
+	 */
+	public function toggleAutoAcceptingFederatedShares(Session $session, $action) {
+		$this->toggleCheckbox(
+			$session,
+			$action,
+			$this->autoAcceptFederatedSharesCheckboxXpath,
+			$this->autoAcceptFederatedSharesCheckboxXpathCheckboxId
 		);
 	}
 

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -65,6 +65,60 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user has reloaded the current page of the webUI
     Then file "lorem (2).txt" should be listed on the webUI
 
+  Scenario: User-based auto accepting is disabled while global is enabled
+    Given parameter "autoAddServers" of app "federation" has been set to "1"
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting remote shares from trusted servers
+    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
+    Then user "user1" should not see the following elements
+      | /lorem%20(2).txt |
+
+  Scenario: one user disabling user-based auto accepting while global is enabled has no effect on other users
+    Given user "user2" has been created with default attributes
+    And parameter "autoAddServers" of app "federation" has been set to "1"
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting remote shares from trusted servers
+    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user2" from server "LOCAL" using the sharing API
+    Then user "user2" should see the following elements
+      | /lorem%20(2).txt |
+
+  @issue-34708
+  Scenario: User-based auto accepting is enabled while global is disabled
+    Given parameter "autoAddServers" of app "federation" has been set to "1"
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And the user has browsed to the personal sharing settings page
+    #delete the following line when issue-34708 is fixed
+    When the user disables automatically accepting remote shares from trusted servers
+    And the user enables automatically accepting remote shares from trusted servers
+    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
+    Then user "user1" should see the following elements
+      | /lorem%20(2).txt |
+
+  @skip @issue-34742
+  Scenario: User-based & global auto accepting is enabled but remote server is not trusted
+    Given parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting remote shares from trusted servers
+    And the user enables automatically accepting remote shares from trusted servers
+    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
+    Then user "user1" should not see the following elements
+      | /lorem%20(2).txt |
+
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI


### PR DESCRIPTION
## Description
analogue to #34711 tests to check user-based auto-accepting of federated shares from trusted servers

please note: one test is skipped as we have no good way to clean-up the list of trusted servers

## Related Issue
part of tests for owncloud/enterprise#3128

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
