### PR TITLE
[stable10] Add missing insulated disablePreviews tags to settingsMenu.feature

### DIFF
--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: add users
   As an admin
   I want to be able to change different settings


### PR DESCRIPTION
Backport of user_management PR https://github.com/owncloud/user_management/pull/157

Related to issue #34689 