### PR TITLE
Add missing insulated disablePreviews tags to webUI feature files

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -1,4 +1,5 @@
-@webUI @comments-app-required @admin_settings-feature-required
+@webUI @insulated @disablePreviews
+@comments-app-required @admin_settings-feature-required
 Feature: admin apps settings
   As an admin
   I want to be able to manage apps settings on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -1,4 +1,4 @@
-@webUI @mailhog @admin_settings-feature-required
+@webUI @insulated @disablePreviews @mailhog @admin_settings-feature-required
 Feature: admin general settings
   As an admin
   I want to be able to manage general settings on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -1,4 +1,4 @@
-@webUI  @admin_settings-feature-required
+@webUI @insulated @disablePreviews @admin_settings-feature-required
 Feature: admin sharing settings
   As an admin
   I want to be able to manage sharing settings on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -1,4 +1,4 @@
-@webUI @admin_settings-feature-required @local_storage
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
+++ b/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
@@ -1,4 +1,4 @@
-@webUI @admin_settings-feature-required @insulated
+@webUI @insulated @disablePreviews @admin_settings-feature-required
 Feature: Help and tips page
   As an admin
   I want to be able to view a page with links to various help information

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -1,4 +1,4 @@
-@webUI @insulated  @comments-app-required
+@webUI @insulated @disablePreviews @comments-app-required
 Feature: Add, delete and edit comments in files and folders
 
   As a user

--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -1,4 +1,5 @@
-@webUI @insulated  @files_versions-app-required
+@webUI @insulated @disablePreviews
+@files_versions-app-required
 Feature: Versions of a file
 
   As a user

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -1,5 +1,4 @@
 @webUI @insulated @disablePreviews @mailhog
-
 Feature: reset the password
   As a user
   I want to reset my password

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -1,5 +1,4 @@
 @webUI @insulated @disablePreviews @mailhog
-
 Feature: reset the password using an email address
   As a user
   I want to reset my password using an email address

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @mailhog
+@webUI @insulated @disablePreviews @mailhog
 Feature: Change own email address on the personal settings page
   As a user
   I would like to change my own email address

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -1,4 +1,4 @@
-@webUI @insulated
+@webUI @insulated @disablePreviews
 Feature: Change own full name on the personal settings page
   As a user
   I would like to change my own full name

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -1,4 +1,4 @@
-@webUI @insulated
+@webUI @insulated @disablePreviews
 Feature: Change Login Password
   As a user
   I would like to change my login password

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @systemtags-app-required
+@webUI @insulated @disablePreviews @systemtags-app-required
 Feature: Creation of tags for the files and folders
   As a user
   I want to create tags for the files/folders

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @systemtags-app-required
+@webUI @insulated @disablePreviews @systemtags-app-required
 Feature: Suggestion for matching tag names
   As a user
   I want to get suggestions for adding tags from already existing tags


### PR DESCRIPTION
## Description
While investigating issue #34689 I noticed that some webUI feature files did not have the "standard" tags:
`insulated` - behat-mink-selenium will restart the browser between each scenario - gives better isolation
`disablePreviews` - when not doing tests that check for previews display, avoids the slowness of previews being constantly generated and slowly drawing up on the UI (not always directly relevant to particular tests, but does reduce the "noise" as the test logs in and the files page is displayed)

Make all the webUI feature files consistent. And it might help the issue.

## Related Issue
#34689

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
