### PR TITLE
Disable signature check if the file copy fails in encrypted file

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -33,6 +33,7 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Filesystem;
 use OC\Files\Mount\Manager;
 use OC\Files\Storage\LocalTempFileTrait;
+use OC\HintException;
 use OC\Memcache\ArrayCache;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Encryption\IFile;
@@ -42,6 +43,8 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
 use OCP\ILogger;
 use OCP\Files\Cache\ICacheEntry;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Encryption extends Wrapper {
 	use LocalTempFileTrait;
@@ -85,6 +88,9 @@ class Encryption extends Wrapper {
 	/** @var  ArrayCache */
 	private $arrayCache;
 
+	/** @var EventDispatcherInterface */
+	private $eventDispatcher;
+
 	/** @var array which has information of sourcePath during rename operation */
 	private $sourcePath;
 
@@ -112,7 +118,8 @@ class Encryption extends Wrapper {
 			IStorage $keyStorage = null,
 			Update $update = null,
 			Manager $mountManager = null,
-			ArrayCache $arrayCache = null
+			ArrayCache $arrayCache = null,
+			EventDispatcherInterface $eventDispatcher = null
 		) {
 		$this->mountPoint = $parameters['mountPoint'];
 		$this->mount = $parameters['mount'];
@@ -126,6 +133,7 @@ class Encryption extends Wrapper {
 		$this->update = $update;
 		$this->mountManager = $mountManager;
 		$this->arrayCache = $arrayCache;
+		$this->eventDispatcher = ($eventDispatcher === null) ? \OC::$server->getEventDispatcher() : $eventDispatcher;
 		parent::__construct($parameters);
 	}
 
@@ -782,7 +790,7 @@ class Encryption extends Wrapper {
 					unset($this->sourcePath[$targetInternalPath]);
 				}
 				$target = $this->fopen($targetInternalPath, 'w');
-				list(, $result) = \OC_Helper::streamCopy($source, $target);
+				$result = $this->copyFile($source, $target, $sourceInternalPath);
 				\fclose($source);
 				\fclose($target);
 			} catch (\Exception $e) {
@@ -804,6 +812,49 @@ class Encryption extends Wrapper {
 			}
 		}
 		return (bool)$result;
+	}
+
+	/**
+	 * This method copies the file from the source to the target
+	 *
+	 * When the file is copied, the source file is read. And while decryption
+	 * any signature mismatch happens, then the file is tried to copy again
+	 * by disabling signature check. A custom symfony event is triggered here.
+	 *
+	 * @param resource $source
+	 * @param resource $target
+	 * @param string|null $sourceFilePath
+	 * @throws HintException, thrown when the second attempt to copy fails
+	 */
+	private function copyFile($source, $target, $sourceFilePath = null) {
+		$retry = false;
+		do {
+			try {
+				$signatureMismatchEvent = new GenericEvent("signaturemismatch", []);
+				if ($retry === true) {
+					\fseek($source, 0);
+				}
+				list(, $result) = \OC_Helper::streamCopy($source, $target);
+				if ($retry === true) {
+					unset($signatureMismatchEvent['fileName']);
+					$signatureMismatchEvent->setArguments(['retryWithIgnoreSignature' => false]);
+					$this->eventDispatcher->dispatch('files.aftersignaturemismatch', $signatureMismatchEvent);
+				}
+				break;
+			} catch (HintException $e) {
+				$this->logger->warning("The file with signature mismatch is " . $sourceFilePath);
+				$this->logger->logException($e);
+				if ($retry === true) {
+					throw $e;
+				} else {
+					$retry = true;
+				}
+				$signatureMismatchEvent->setArguments(['fileName' => $sourceFilePath]);
+				$this->eventDispatcher->dispatch('files.aftersignaturemismatch', $signatureMismatchEvent);
+			}
+		} while ($retry === true);
+
+		return $result;
 	}
 
 	/**

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -7,6 +7,7 @@ use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\User\Manager;
 use OCP\Files\Storage\IStorage;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\Files\Storage\Storage;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\Cache\Cache;
@@ -101,6 +102,9 @@ class EncryptionTest extends Storage {
 	/** @var  \OC\Memcache\ArrayCache | \PHPUnit_Framework_MockObject_MockObject */
 	private $arrayCache;
 
+	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $eventDispatcherInterface;
+
 	/** @var  integer dummy unencrypted size */
 	private $dummySize = -1;
 
@@ -187,7 +191,9 @@ class EncryptionTest extends Storage {
 						'mountPoint' => '/',
 						'mount' => $this->mount
 					],
-					$this->encryptionManager, $this->util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
+					$this->encryptionManager, $this->util, $this->logger,
+					$this->file, null, $this->keyStore, $this->update,
+					$this->mountManager, $this->arrayCache, $this->eventDispatcherInterface
 				]
 			)
 			->setMethods(['getMetaData', 'getCache', 'getEncryptionModule'])


### PR DESCRIPTION
Disable signature check if the file copy fials in the encrypted
file, due to signature mismatch. The code has been adjusted
so that it would try by ignoring the signature mismatch. If the
code fails again, then it would throw the exception.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
#### Problem ####
When files are transferred using transfer ownership command, if there occurs to be a signature mismatch, in any of the encrypted files, the command fails. Idea used here is to use the flag at https://github.com/owncloud/encryption/pull/106.

#### Idea used ####
- Allow signature check to happen in the transfer ownership command before the transfer happens.
- If the signature mismatch happens for any of the file, log then and there in the oc logs.
     - Disable signature check
     - Retry the transfer of file
     - Once the transfer is successful, revert back the flag to enable signature check.
     - If the file transfer fails again, throw exception which would lead to termination of transfer command.
- The transfer ownership command listens to an event which provides the way to enable/disable signature check. I preferred to do this in the transfer ownership command, because it would look really ugly to do this enable/disable of signature check in the Encryption wrapper code. Apart from this signal mechanism, I am not able to figure out a clean way to pass the file name which will be logged in the console, so that user would see the files affected in the console in real time.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Help transfer ownership command move ahead and process the transfer of file(s) and abort only when the copy of a file is failed twice ( with and without signature check).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create 2 users `user1` and `user2` ( make sure both users are logged in )
- Enable masterkey encryption
- As `user2` create a folder `test` and create 3 files inside `test` folder :
     - `a.txt`
     - `b.txt`
     - `big.txt`
- Modify the filecache table for `a.txt` and `big.txt` as shown below
```
mysql> select fileid,encrypted from oc_filecache where path="files/test/big.txt";
+--------+-----------+
| fileid | encrypted |
+--------+-----------+
|     64 |         1 |
+--------+-----------+
1 row in set (0.00 sec)

mysql> update oc_filecache set encrypted=10 where fileid=64;
Query OK, 1 row affected (0.01 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> select fileid,encrypted from oc_filecache where path="files/test/a.txt";
+--------+-----------+
| fileid | encrypted |
+--------+-----------+
|     45 |         3 |
+--------+-----------+
1 row in set (0.00 sec)

mysql> update oc_filecache set encrypted=10 where fileid=45;
Query OK, 1 row affected (0.00 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql>
```
- Now run the transfer ownership command as shown below:
```
sujith@sujith-ownCloud  ~/test/owncloud   newbypass-signature  ./occ files:transfer-ownership user1 user2                                                           
Cannot load Xdebug - it was already loaded
Analysing files of user1 ...
    4 [============================]
Collecting all share information for files and folder of user1 ...
    0 [>---------------------------]
Transferring files to user2/files/transferred from user1 on 20190308_113635 ...
The file affected by signature mismatch: files/test/a.txt
The file affected by signature mismatch: files/test/big.txt
Restoring shares ...
    0 [>---------------------------]
 sujith@sujith-ownCloud  ~/test/owncloud   newbypass-signature 
```
- User should see 2 files `a.txt` and `big.txt` will be mentioned in the console log and the oc log.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Requires https://github.com/owncloud/encryption/pull/106

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
