### PR TITLE
[stable10] bump "easy" dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,6 +60,8 @@ pipeline:
   composer:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
+    environment:
+      - COMPOSER_HOME=/drone/src/.cache/composer
     commands:
       - make install-composer-deps
     when:
@@ -68,6 +70,10 @@ pipeline:
   yarn:
     image: owncloudci/nodejs:latest
     pull: true
+    environment:
+      - NPM_CONFIG_CACHE=/drone/src/.cache/npm
+      - YARN_CACHE_FOLDER=/drone/src/.cache/yarn
+      - bower_storage__packages=/drone/src/.cache/bower
     commands:
       - ./tests/drone/yarn-install.sh
     when:
@@ -79,9 +85,7 @@ pipeline:
     secrets: [ cache_s3_endpoint, cache_s3_access_key, cache_s3_secret_key ]
     rebuild: true
     mount:
-      - lib/composer
-      - core/vendor
-      - build/node_modules
+      - .cache
     when:
       local: false
       event: [ push ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,7 +121,7 @@ pipeline:
       - make test-php-phan
     when:
       matrix:
-        TEST_SUITE: phan
+        TEST_SUITE: phan-70
 
   php-phan-71:
     image: owncloudci/php:7.1
@@ -638,7 +638,11 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: owncloud-coding-standard
 
-  # phan (runs multiple PHP v7.* to provide syntax checks of each PHP version)
+  # phan (runs on just PHP 7.0 because that has different dependencies for phan)
+    - TEST_SUITE: phan-70
+      PHP_VERSION: 7.0
+
+    # phan (runs multiple PHP v7.1+ to provide syntax checks of each PHP version)
     - TEST_SUITE: phan
       PHP_VERSION: 7.1
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -629,16 +629,8 @@ matrix:
       PHP_VERSION: 7.1
       COVERAGE: true
 
-    - PHP_VERSION: 5.6
-      DB_TYPE: postgres
-      TEST_SUITE: phpunit
-      INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
-
   # owncloud-coding-standard
-  # Run with PHP 5.6 because that is not supported by phan.
-  # This gives us a syntax check for PHP 5.6
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.1
       TEST_SUITE: owncloud-coding-standard
 
   # phan (runs multiple PHP v7.* to provide syntax checks of each PHP version)
@@ -685,6 +677,31 @@ matrix:
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       COVERAGE: true
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    # PHP 7.0
+    - PHP_VERSION: 7.0
+      DB_TYPE: mysql
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
+      DB_TYPE: mysqlmb4
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
+      DB_TYPE: postgres
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
+      DB_TYPE: oracle
+      TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
@@ -735,7 +752,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
   # Primary Objectstorage
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
       OBJECTSTORE: swift
@@ -1462,7 +1479,7 @@ matrix:
       CALDAV_CARDDAV_JOB: true
 
     # encryption tests
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
       DB_TYPE: mariadb

--- a/.drone.yml
+++ b/.drone.yml
@@ -64,6 +64,7 @@ pipeline:
       - COMPOSER_HOME=/drone/src/.cache/composer
     commands:
       - make install-composer-deps
+      - make vendor-bin-deps
     when:
       event: [push, pull_request]
 

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ clover.xml
 /tests/output
 .php_cs.cache
 .php_cs
+
+# CI
+.cache

--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,17 @@ vendor-bin/phan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phan/compo
 vendor-bin/phan/composer.lock: vendor-bin/phan/composer.json
 	@echo phan composer.lock is not up to date.
 
+# The first line of "php --version" output looks like:
+# PHP 7.2.16-1+ubuntu18.04.1+deb.sury.org+1 (cli) (built: Mar  7 2019 20:23:29) ( NTS )
+# We want the 2nd "word", then the first 2 numbers separated by the dot
+PHP_MINOR_VERSION = $(shell php --version | head -n 1 | cut -d' ' -f2 | cut -d'.' -f1-2)
+
 vendor-bin/phpstan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phpstan/composer.lock
+ifeq "$(PHP_MINOR_VERSION)" "7.0"
+	@echo "phpstan is not supported on PHP 7.0 so it is not being installed"
+else
 	composer bin phpstan install --no-progress
+endif
 
 vendor-bin/phpstan/composer.lock: vendor-bin/phpstan/composer.json
 	@echo phpstan composer.lock is not up to date.

--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,9 @@ vendor: composer.lock
 vendor/bamarni/composer-bin-plugin: composer.lock
 	composer install
 
+.PHONY: vendor-bin-deps
+vendor-bin-deps: vendor-bin/owncloud-codestyle/vendor vendor-bin/php_codesniffer/vendor vendor-bin/phan/vendor vendor-bin/phpstan/vendor vendor-bin/behat/vendor
+
 vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/owncloud-codestyle/composer.lock
 	composer bin owncloud-codestyle install --no-progress
 

--- a/build/OCPSinceChecker.php
+++ b/build/OCPSinceChecker.php
@@ -126,8 +126,7 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 
 echo 'Parsing all files in lib/public for the presence of @since or @deprecated on each method...' . PHP_EOL . PHP_EOL;
 
-
-$parser = new PhpParser\Parser(new PhpParser\Lexer);
+$parser = (new \PhpParser\ParserFactory())->create(\PhpParser\ParserFactory::PREFER_PHP7);
 
 /* iterate over all .php files in lib/public */
 $Directory = new RecursiveDirectoryIterator(dirname(__DIR__) . '/lib/public');

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "interfasys/lognormalizer": "^v1.0",
         "deepdiver1975/tarstreamer": "v0.1.0",
         "patchwork/jsqueeze": "^2.0",
-        "symfony/polyfill-php70": "^1.0",
         "lukasreschke/id3parser": "^0.0.3",
         "sabre/dav": "^3.2",
         "deepdiver/zipstreamer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/dbal": "^2.5",
         "phpseclib/phpseclib": "^2.0",
         "rackspace/php-opencloud": "v1.9.2",
-        "jeremeamia/superclosure": "2.1.0",
+        "jeremeamia/superclosure": "^2.4",
         "bantu/ini-get-wrapper": "v1.0.1",
         "punic/punic": "^3.1",
         "pear/archive_tar": "1.4.6",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "optimize-autoloader": true,
         "classmap-authoritative": false,
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "autoload" : {
@@ -26,7 +26,7 @@
         "roave/security-advisories": "dev-master"
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0.8",
         "doctrine/dbal": "^2.5",
         "phpseclib/phpseclib": "^2.0",
         "rackspace/php-opencloud": "v1.9.2",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/routing": "^3.1",
         "symfony/process": "^3.1",
         "pimple/pimple": "3.2.3",
-        "nikic/php-parser": "1.4.1",
+        "nikic/php-parser": "^4.0",
         "icewind/streams": "0.5.2",
         "swiftmailer/swiftmailer": "^5.4",
         "guzzlehttp/guzzle": "^5.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89d51a717d97b389e94f507d6789619a",
+    "content-hash": "9006b4be6a6d612abce42a5d2157ddba",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1383,51 +1383,6 @@
                 "php"
             ],
             "time": "2019-02-16T20:54:15+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v9.99.99",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*",
-                "vimeo/psalm": "^1"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "patchwork/jsqueeze",
@@ -2919,65 +2874,6 @@
                 }
             ],
             "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2018-09-21T06:26:08+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "shasum": ""
-            },
-            "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
             "homepage": "https://symfony.com",
             "keywords": [
                 "compatibility",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27778b04ad8239c0cac828d5652a8af3",
+    "content-hash": "afd1118f0042ec2baa0f68468c644cb0",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -587,33 +587,33 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "v1.1.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Inflector\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -650,7 +650,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2017-07-22T12:18:28+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1380,33 +1380,29 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.18",
+            "version": "v9.99.99",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db"
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
-                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.0"
+                "php": "^7"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
             },
             "suggest": {
                 "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
             },
             "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -1425,7 +1421,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2019-01-03T20:59:08+00:00"
+            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "patchwork/jsqueeze",
@@ -3762,29 +3758,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -3803,7 +3805,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4117,29 +4119,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4162,7 +4164,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -5200,11 +5202,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6",
+        "php": ">=7.0.8",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.33"
+        "php": "7.0.8"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afd1118f0042ec2baa0f68468c644cb0",
+    "content-hash": "5e9a90f42857b4f71e45cbf5befa46d5",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1158,30 +1158,30 @@
         },
         {
             "name": "jeremeamia/SuperClosure",
-            "version": "2.1.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jeremeamia/super_closure.git",
-                "reference": "b712f39c671e5ead60c7ebfe662545456aade833"
+                "reference": "5707d5821b30b9a07acfb4d76949784aaa0e9ce9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jeremeamia/super_closure/zipball/b712f39c671e5ead60c7ebfe662545456aade833",
-                "reference": "b712f39c671e5ead60c7ebfe662545456aade833",
+                "url": "https://api.github.com/repos/jeremeamia/super_closure/zipball/5707d5821b30b9a07acfb4d76949784aaa0e9ce9",
+                "reference": "5707d5821b30b9a07acfb4d76949784aaa0e9ce9",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "~1.0",
-                "php": ">=5.4"
+                "nikic/php-parser": "^1.2|^2.0|^3.0|^4.0",
+                "php": ">=5.4",
+                "symfony/polyfill-php56": "^1.0"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "~0.1.2",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -1212,7 +1212,7 @@
                 "serialize",
                 "tokenizer"
             ],
-            "time": "2015-03-11T20:06:43+00:00"
+            "time": "2018-03-21T22:21:57+00:00"
         },
         {
             "name": "league/flysystem",
@@ -2867,6 +2867,62 @@
             "time": "2018-09-21T13:07:52+00:00"
         },
         {
+            "name": "symfony/polyfill-php56",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php56.git",
+                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/ff208829fe1aa48ab9af356992bb7199fed551af",
+                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-util": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php56\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-21T06:26:08+00:00"
+        },
+        {
             "name": "symfony/polyfill-php70",
             "version": "v1.10.0",
             "source": {
@@ -2924,6 +2980,58 @@
                 "shim"
             ],
             "time": "2018-09-21T06:26:08+00:00"
+        },
+        {
+            "name": "symfony/polyfill-util",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-util.git",
+                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/3b58903eae668d348a7126f999b0da0f2f93611c",
+                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Util\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony utilities for portability of PHP codes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compat",
+                "compatibility",
+                "polyfill",
+                "shim"
+            ],
+            "time": "2018-09-30T16:36:12+00:00"
         },
         {
             "name": "symfony/process",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e9a90f42857b4f71e45cbf5befa46d5",
+    "content-hash": "89d51a717d97b389e94f507d6789619a",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1335,32 +1335,38 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v1.4.1",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51"
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3"
+                "php": ">=7.0"
             },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "lib/bootstrap.php"
-                ]
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1376,7 +1382,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-09-19T14:15:08+00:00"
+            "time": "2019-02-16T20:54:15+00:00"
         },
         {
             "name": "paragonie/random_compat",

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "9006b4be6a6d612abce42a5d2157ddba",
@@ -4324,12 +4324,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "4e04718428742618a4bf24dafca45b8645c9320d"
+                "reference": "3521da8036ce31b11490433aaae47f9601774191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/4e04718428742618a4bf24dafca45b8645c9320d",
-                "reference": "4e04718428742618a4bf24dafca45b8645c9320d",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/3521da8036ce31b11490433aaae47f9601774191",
+                "reference": "3521da8036ce31b11490433aaae47f9601774191",
                 "shasum": ""
             },
             "conflict": {
@@ -4466,7 +4466,7 @@
                 "theonedemon/phpwhois": "<=4.2.5",
                 "titon/framework": ">=0,<9.9.99",
                 "truckersmp/phpwhois": "<=4.3.1",
-                "twig/twig": "<1.20",
+                "twig/twig": "<1.38|>=2,<2.7",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.23|>=9,<9.5.4",
                 "typo3/cms-core": ">=8,<8.7.23|>=9,<9.5.4",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
@@ -4520,7 +4520,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-02-26T21:14:50+00:00"
+            "time": "2019-03-12T13:04:55+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5080,7 +5080,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/console.php
+++ b/console.php
@@ -33,10 +33,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 \define('OC_CONSOLE', 1);
 
-// Show warning if a PHP version below 7.0.8 is used, this has to happen here
+// Show warning if a PHP version below 7.0.7 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.8'.PHP_EOL;
+if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.7'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
 	exit(1);
 }

--- a/console.php
+++ b/console.php
@@ -33,10 +33,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 \define('OC_CONSOLE', 1);
 
-// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// Show warning if a PHP version below 7.0.8 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.0'.PHP_EOL;
+if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.8'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
 	exit(1);
 }

--- a/console.php
+++ b/console.php
@@ -33,10 +33,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 \define('OC_CONSOLE', 1);
 
-// Show warning if a PHP version below 5.6.0 is used, this has to happen here
-// because base.php will already use 5.6 syntax.
-if (\version_compare(PHP_VERSION, '5.6.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 5.6.0'.PHP_EOL;
+// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// because base.php will already use 7.0 syntax.
+if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.0'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
 	exit(1);
 }

--- a/index.php
+++ b/index.php
@@ -27,10 +27,10 @@
  *
  */
 
-// Show warning if a PHP version below 7.0.8 is used, this has to happen here
+// Show warning if a PHP version below 7.0.7 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.8<br/>';
+if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.7<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }

--- a/index.php
+++ b/index.php
@@ -27,10 +27,10 @@
  *
  */
 
-// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// Show warning if a PHP version below 7.0.8 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.0<br/>';
+if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.8<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }

--- a/index.php
+++ b/index.php
@@ -27,10 +27,10 @@
  *
  */
 
-// Show warning if a PHP version below 5.6.0 is used, this has to happen here
-// because base.php will already use 5.6 syntax.
-if (\version_compare(PHP_VERSION, '5.6.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 5.6.0<br/>';
+// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// because base.php will already use 7.0 syntax.
+if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.0<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }

--- a/lib/private/App/CodeChecker/CodeChecker.php
+++ b/lib/private/App/CodeChecker/CodeChecker.php
@@ -24,7 +24,6 @@
 namespace OC\App\CodeChecker;
 
 use OC\Hooks\BasicEmitter;
-use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use RecursiveCallbackFilterIterator;
@@ -51,7 +50,7 @@ class CodeChecker extends BasicEmitter {
 
 	public function __construct(ICheck $checkList) {
 		$this->checkList = $checkList;
-		$this->parser = new Parser(new Lexer);
+		$this->parser = (new \PhpParser\ParserFactory())->create(\PhpParser\ParserFactory::PREFER_PHP7);
 	}
 
 	/**

--- a/tests/lib/Command/AsyncBusTest.php
+++ b/tests/lib/Command/AsyncBusTest.php
@@ -127,14 +127,6 @@ class AsyncBusTest extends TestCase {
 		$this->assertEquals('closure', self::$lastCommand);
 	}
 
-	public function testClosureSelf() {
-		$this->bus->push(function () {
-			self::$lastCommand = 'closure-self';
-		});
-		$this->runJobs();
-		$this->assertEquals('closure-self', self::$lastCommand);
-	}
-
 	public function testClosureThis() {
 		// clean class to prevent phpunit putting closure in $this
 		$test = new ThisClosureTest();
@@ -146,7 +138,7 @@ class AsyncBusTest extends TestCase {
 	public function testClosureBind() {
 		$state = 'bar';
 		$this->bus->push(function () use ($state) {
-			self::$lastCommand = 'closure-' . $state;
+			AsyncBusTest::$lastCommand = 'closure-' . $state;
 		});
 		$this->runJobs();
 		$this->assertEquals('closure-bar', self::$lastCommand);


### PR DESCRIPTION
## Description
On top of the "minimal" PR #34698 this PR also bumps dependencies that "just work easily":
1) Bump jeremeamia/superclosure 2.1.0 to 2.4.0
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 2 installs, 1 update, 0 removals
  - Installing symfony/polyfill-util (v1.10.0): Loading from cache
  - Installing symfony/polyfill-php56 (v1.10.0): Loading from cache
  - Updating jeremeamia/superclosure (2.1.0 => 2.4.0): Loading from cache
```

2. Bump nikic/php-parser (v1.4.1 => v4.2.1)
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating nikic/php-parser (v1.4.1 => v4.2.1): Loading from cache
```

3. Backport remaining parts of PR #31926 to support the php-parser bump

4. Remove `symfony/polyfill-php70`
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 0 updates, 2 removals
  - Removing paragonie/random_compat (v9.99.99)
  - Removing symfony/polyfill-php70 (v1.10.0)
```

## Related Issue

## Motivation and Context
Take an "agile" approach - apply the "easy" dependencies that can be done in a few minutes.
(`swiftmailer` version change has more to be adjusted/backported, so leave that to a later PR)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
