### PR TITLE
First time login was not properly handled by \OC\User\Session::loginUser

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -976,7 +976,7 @@ class Session implements IUserSession, Emitter {
 	 * @return boolean True if the user can be authenticated, false otherwise
 	 * @throws LoginException if an app canceled the login process or the user is not enabled
 	 */
-	protected function loginUser(IUser $user = null, $password) {
+	public function loginUser(IUser $user = null, $password) {
 		$uid = $user === null ? '' : $user->getUID();
 		return $this->emittingCall(function () use (&$user, &$password) {
 			if ($user === null) {
@@ -995,12 +995,12 @@ class Session implements IUserSession, Emitter {
 
 			$this->setUser($user);
 			$this->setLoginName($user->getDisplayName());
-			$user->updateLastLoginTimestamp();
+			$firstTimeLogin = $user->updateLastLoginTimestamp();
 
 			$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
 
 			if ($this->isLoggedIn()) {
-				$this->prepareUserLogin();
+				$this->prepareUserLogin($firstTimeLogin);
 			} else {
 				$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
 				throw new LoginException($message);


### PR DESCRIPTION
## Description
First time login was not properly handled by \OC\User\Session::loginUser
This PR fixes this.

In addition the method is being made public to allow access.

## Motivation and Context
Login shall trigger user initialization on first time login in any case.

## How Has This Been Tested?
- :hand:
- unit tests will follow ...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
