### PR TITLE
Session passing in acceptance tests and other code review issues

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -22,7 +22,6 @@
  *
  */
 
-use Behat\Gherkin\Node\TableNode;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\OcsApiHelper;
 

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1663,7 +1663,7 @@ trait BasicStructure {
 	 *
 	 * @param string $path
 	 *
-	 * @return string
+	 * @return void
 	 */
 	public function readFileInServerRoot($path) {
 		$response = OcsApiHelper::sendRequest(

--- a/tests/acceptance/features/bootstrap/CorsContext.php
+++ b/tests/acceptance/features/bootstrap/CorsContext.php
@@ -133,11 +133,9 @@ class CorsContext implements Context {
 	/**
 	 * @AfterScenario
 	 *
-	 * @param AfterScenarioScope $scope
-	 *
 	 * @return void
 	 */
-	public function resetAdminCors(AfterScenarioScope $scope) {
+	public function resetAdminCors() {
 		if ($this->originalAdminCorsDomains !== null) {
 			if ($this->originalAdminCorsDomains !== "") {
 				$this->featureContext->runOcc(

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -22,7 +22,6 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -419,7 +419,9 @@ class OccContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theadminAddsRemovesAsTheApplicableUserLastLocalMountUsingTheOccCommand($action, $userOrGroup, $user) {
+	public function theAdminAddsRemovesAsTheApplicableUserLastLocalMountUsingTheOccCommand(
+		$action, $userOrGroup, $user
+	) {
 		if ($action === "adds" || $action === "added") {
 			$action = "--add";
 		} else {

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -25,7 +25,6 @@ use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
 use TestHelpers\HttpRequestHelper;
-use OC\Group\Group;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2633,7 +2633,7 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function userHasBeeenGivenUnlimitedQuota($user) {
+	public function userHasBeenGivenUnlimitedQuota($user) {
 		$this->theQuotaOfUserHasBeenSetTo($user, 'none');
 	}
 

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -248,7 +248,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * Uploads a file through the public WebDAV API and sets $reponse in FeatureContext
+	 * Uploads a file through the public WebDAV API and sets the response in FeatureContext
 	 *
 	 * @param string $filename
 	 * @param string $password

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -471,37 +471,6 @@ trait Sharing {
 	/**
 	 * @param string $url
 	 * @param string $user
-	 * @param string $mimeType
-	 *
-	 * @return void
-	 */
-	private function checkUserDownload($url, $user, $mimeType) {
-		$this->response = HttpRequestHelper::get(
-			$url, $user, $this->getPasswordForUser($user)
-		);
-		PHPUnit_Framework_Assert::assertEquals(
-			200,
-			$this->response->getStatusCode()
-		);
-		
-		$buf = '';
-		$body = $this->response->getBody();
-		while (!$body->eof()) {
-			// read everything
-			$buf .= $body->read(8192);
-		}
-		if ($mimeType !== null) {
-			$finfo = new finfo;
-			PHPUnit_Framework_Assert::assertEquals(
-				$mimeType,
-				$finfo->buffer($buf, FILEINFO_MIME_TYPE)
-			);
-		}
-	}
-
-	/**
-	 * @param string $url
-	 * @param string $user
 	 * @param string $password
 	 * @param string $mimeType
 	 *

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -888,7 +888,7 @@ trait Sharing {
 	) {
 		$admin = $this->getAdminUsername();
 		$this->userHasSharedFileWithUserUsingTheSharingApi(
-			$sharer, $filepath, $admin, $permissions = null
+			$sharer, $filepath, $admin, $permissions
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -118,7 +118,7 @@ trait Sharing {
 	 *       |                 |     (default: 31, for public shares: 1)             |
 	 *       |                 |     Pass either the (total) number,                 |
 	 *       |                 |     or the keyword,                                 |
-	 *       |                 |     or an comma seperated list of keywords          |
+	 *       |                 |     or an comma separated list of keywords          |
 	 *       | shareWith       | The user or group id with which the file should     |
 	 *       |                 | be shared.                                          |
 	 *       | shareType       | The type of the share. This can be one of:          |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -344,14 +344,13 @@ trait Sharing {
 	 * @When /^the user creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with expiry "([^"]*)$"/
 	 * @Given /^the user has created a public link share of (?:file|folder) "([^"]*)" with expiry "([^"]*)$/
 	 *
-	 * @param string $user
 	 * @param string $path
 	 * @param string $expiryDate in a valid date format, e.g. "+30 days"
 	 *
 	 * @return void
 	 */
 	public function aPublicLinkShareOfIsCreatedWithExpiry(
-		$user, $path, $expiryDate
+		$path, $expiryDate
 	) {
 		$this->createAPublicShare(
 			$this->currentUser, $path, true, null, null, null, $expiryDate

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -805,7 +805,7 @@ class TagsContext implements Context {
 	 * @param string $adminOrUser
 	 * @param TableNode $table
 	 *
-	 * @return bool
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function sharedByTheUserOrAdminHasTheFollowingTags(
@@ -900,7 +900,7 @@ class TagsContext implements Context {
 	 * @param string $fileName
 	 * @param string $sharingUser
 	 *
-	 * @return bool
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function sharedByHasNoTags($fileName, $sharingUser) {

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -22,6 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use GuzzleHttp\Message\ResponseInterface;
 
 require_once 'bootstrap.php';
 
@@ -119,7 +120,7 @@ class TransferOwnershipContext implements Context {
 	 * @param string $entry
 	 * @param string $path
 	 *
-	 * @return array
+	 * @return ResponseInterface
 	 * @throws \Exception
 	 */
 	public function asFileOrFolderShouldNotExist($user, $entry, $path) {

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -102,7 +102,7 @@ class WebDavLockingContext implements Context {
 			$this->tokenOfLastLock[$user][$file] = (string)$xmlPart[0];
 		} else {
 			if ($expectToSucceed === true) {
-				PHPUnit_Framework_Assert::fail("could not find lock tocken");
+				PHPUnit_Framework_Assert::fail("could not find lock token");
 			}
 		}
 	}

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -363,7 +363,7 @@ class WebDavLockingContext implements Context {
 	 * @param string $destination
 	 * @param string $itemToUseLockOf
 	 *
-	 * @return string
+	 * @return void
 	 */
 	public function userUploadsAFileWithContentTo(
 		$user, $content, $destination, $itemToUseLockOf

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -83,8 +83,12 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	 *
 	 * @return void
 	 */
-	public function administratorSetsTheFollowingSettingsInEmailServerSettingUsingTheWebui(TableNode $emailSettingsTable) {
-		$this->adminGeneralSettingsPage->setEmailServerSettings($emailSettingsTable);
+	public function administratorSetsTheFollowingSettingsInEmailServerSettingUsingTheWebui(
+		TableNode $emailSettingsTable
+	) {
+		$this->adminGeneralSettingsPage->setEmailServerSettings(
+			$this->getSession(), $emailSettingsTable
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -229,11 +229,9 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	 *
 	 * @AfterScenario @webUI
 	 *
-	 * @param AfterScenarioScope $afterScenarioScope
-	 *
 	 * @return void
 	 */
-	public function restoreScenario(AfterScenarioScope $afterScenarioScope) {
+	public function restoreScenario() {
 		// Restore app config settings
 		AppConfigHelper::modifyAppConfigs(
 			$this->featureContext->getBaseUrl(),

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -34,7 +34,6 @@ require_once 'bootstrap.php';
  */
 class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context {
 	private $adminSharingSettingsPage;
-	private $loginPage;
 
 	/**
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2058,6 +2058,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserRestoresTheFileToLastVersionUsingTheWebui() {
-		$this->filesPage->getDetailsDialog()->restoreCurrentFileToLastVersion();
+		$this->filesPage->getDetailsDialog()->restoreCurrentFileToLastVersion(
+			$this->getSession()
+		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -30,7 +30,6 @@ use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\EmailHelper;
-use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
 use Page\GeneralErrorPage;

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -22,7 +22,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\HelpAndTipsPage;
@@ -46,8 +45,6 @@ class WebUIHelpAndTipsContext extends RawMinkContext implements Context {
 	 * @var FeatureContext
 	 */
 	private $featureContext;
-
-	private $pageTitle = "Settings - ownCloud";
 
 	/**
 	 * WebUIHelpAndTips constructor.

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -466,10 +466,10 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function thePrivacyPolicyUrlOnTheLoginPageShouldLinkTo($expectedPrivacyPolicyUrl) {
-		$actualPrivacyPolilcyUrl = $this->loginPage->getLegalUrl("Privacy Policy");
+		$actualPrivacyPolicyUrl = $this->loginPage->getLegalUrl("Privacy Policy");
 		PHPUnit_Framework_Assert::assertEquals(
 			$expectedPrivacyPolicyUrl,
-			$actualPrivacyPolilcyUrl
+			$actualPrivacyPolicyUrl
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -25,7 +25,6 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\LoginPage;
-use TestHelpers\EmailHelper;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -228,17 +228,17 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @Then a password error message should be displayed on the webUI with the text :wrongPasswordmessageText
+	 * @Then a password error message should be displayed on the webUI with the text :wrongPasswordMessageText
 	 *
-	 * @param string $wrongPasswordmessageText
+	 * @param string $wrongPasswordMessageText
 	 *
 	 * @return void
 	 */
 	public function aPasswordErrorMessageShouldBeDisplayedOnTheWebUIWithTheText(
-		$wrongPasswordmessageText
+		$wrongPasswordMessageText
 	) {
 		PHPUnit_Framework_Assert::assertEquals(
-			$wrongPasswordmessageText,
+			$wrongPasswordMessageText,
 			$this->personalGeneralSettingsPage->getWrongPasswordMessageText()
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -23,7 +23,6 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Session;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\FilesPage;
 use Page\FilesPageElement\SharingDialog;
@@ -33,10 +32,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 use TestHelpers\AppConfigHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\EmailHelper;
-use TestHelpers\SetupHelper;
-use OC\Files\External\Auth\Password\Password;
 use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;
-use Behat\Mink\Exception\ElementException;
 use GuzzleHttp\Message\ResponseInterface;
 use Page\GeneralErrorPage;
 use Page\SharedWithOthersPage;

--- a/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
@@ -52,8 +52,6 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 	 */
 	private $webUIGeneralContext;
 
-	private $uploadConflictDialogTitle = "file conflict";
-
 	/**
 	 * WebUIFilesContext constructor.
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
@@ -195,7 +195,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 		try {
 			$pageObject->closeDetailsDialog();
 		} catch (Exception $e) {
-			//ignoge if dialog cannot be closed
+			//ignore if dialog cannot be closed
 			//most likely there is no dialog open
 		}
 	}

--- a/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
@@ -65,11 +65,12 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 	/**
 	 * set email server settings
 	 *
+	 * @param Session $session
 	 * @param TableNode $emailSettingsTable
 	 *
 	 * @return void
 	 */
-	public function setEmailServerSettings($emailSettingsTable) {
+	public function setEmailServerSettings($session, $emailSettingsTable) {
 		foreach ($emailSettingsTable as $row) {
 			if ($row['setting'] === 'send mode') {
 				$this->selectFieldOption($this->sendModeTypeId, $row['value']);
@@ -92,7 +93,7 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 				$this->fillField($this->serverPortFieldId, $row['value']);
 			}
 		}
-		$this->waitForAjaxCallsToStartAndFinish($this->getSession());
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
@@ -153,7 +153,7 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 			}
 		} else {
 			throw new \Exception(
-				__METHOD__ . " invalid action: $action"
+				__METHOD__ . " invalid auth required checkbox state: $requiredState"
 			);
 		}
 	}

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -41,8 +41,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $publicShareCheckboxId = 'allowLinks';
 	protected $publicUploadCheckboxXpath = '//label[@for="allowPublicUpload"]';
 	protected $publicUploadCheckboxId = 'allowPublicUpload';
-	protected $mailNotiticationOnPublicShareCheckboxXpath = '//label[@for="allowPublicMailNotification"]';
-	protected $mailNotiticationOnPublicShareCheckboxId = 'allowPublicMailNotification';
+	protected $mailNotificationOnPublicShareCheckboxXpath = '//label[@for="allowPublicMailNotification"]';
+	protected $mailNotificationOnPublicShareCheckboxId = 'allowPublicMailNotification';
 	protected $shareFileViaSocialMediaOnPublicShareCheckboxXpath = '//label[@for="allowSocialShare"]';
 	protected $shareFileViaSocialMediaOnPublicShareCheckboxId = 'allowSocialShare';
 	protected $enforceLinkPasswordReadOnlyCheckboxXpath = '//label[@for="enforceLinkPasswordReadOnly"]';
@@ -128,8 +128,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		$this->toggleCheckbox(
 			$session,
 			$action,
-			$this->mailNotiticationOnPublicShareCheckboxXpath,
-			$this->mailNotiticationOnPublicShareCheckboxId
+			$this->mailNotificationOnPublicShareCheckboxXpath,
+			$this->mailNotificationOnPublicShareCheckboxId
 		);
 	}
 

--- a/tests/acceptance/features/lib/FavoritesPage.php
+++ b/tests/acceptance/features/lib/FavoritesPage.php
@@ -23,7 +23,6 @@
 namespace Page;
 
 use Behat\Mink\Session;
-use Page\FilesPageElement\DetailsDialog;
 use Page\FilesPageElement\FileRow;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 

--- a/tests/acceptance/features/lib/FavoritesPage.php
+++ b/tests/acceptance/features/lib/FavoritesPage.php
@@ -24,6 +24,7 @@ namespace Page;
 
 use Behat\Mink\Session;
 use Page\FilesPageElement\DetailsDialog;
+use Page\FilesPageElement\FileRow;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
@@ -92,6 +93,7 @@ class FavoritesPage extends FilesPageBasic {
 	 */
 	public function findAllFileRowsByName($name, Session $session) {
 		$fileRowElements = $this->getFileRowElementsByName($name, $session);
+		$fileRows = [];
 		foreach ($fileRowElements as $fileRowElement) {
 			$fileRow = $this->getPage('FilesPageElement\\FavoritesFileRow');
 			$fileRow->setElement($fileRowElement);

--- a/tests/acceptance/features/lib/FavoritesPage.php
+++ b/tests/acceptance/features/lib/FavoritesPage.php
@@ -75,7 +75,7 @@ class FavoritesPage extends FilesPageBasic {
 	 *
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return void
+	 * @return string
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -47,7 +47,6 @@ class FilesPage extends FilesPageBasic {
 	 * @var FilesPageCRUD $filesPageCRUDFunctions
 	 */
 	protected $filesPageCRUDFunctions;
-	private $strForNormalFileName = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
 
 	/**
 	 * @return string

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -27,7 +27,6 @@ use Page\FilesPageElement\SharingDialog;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
-use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 
 /**
  * Files page.

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -44,6 +44,7 @@ class FilesPageCRUD extends FilesPageBasic {
 	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
 	protected $fileUploadInputId = "file_upload_start";
 	protected $uploadProgressbarLabelXpath = "//div[@id='uploadprogressbar']/em";
+	protected $strForNormalFileName = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
 
 	/**
 	 * @param string $fileNamesXpath

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -165,7 +165,7 @@ class DetailsDialog extends OwncloudPage {
 	/**
 	 * find the xpath of button to revert to last version
 	 *
-	 * @return void
+	 * @return NodeElement
 	 */
 	public function getLastVersionRevertButton() {
 		$btn = $this->detailsDialogElement->find(
@@ -507,12 +507,14 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
+	 * @param Session $session
+	 *
 	 * @return void
 	 */
-	public function restoreCurrentFileToLastVersion() {
+	public function restoreCurrentFileToLastVersion($session) {
 		$revertBtn = $this->getLastVersionRevertButton();
 		$revertBtn->click();
-		$this->waitForAjaxCallsToStartAndFinish($this->getSession());
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/FavoritesFileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FavoritesFileRow.php
@@ -23,11 +23,6 @@
 
 namespace Page\FilesPageElement;
 
-use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Session;
-use Page\OwncloudPage;
-use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
-
 /**
  * Object of a row on the FilesPage
  */

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -27,7 +27,6 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
-use OC\IntegrityCheck\Helpers\FileAccessHelper;
 
 /**
  * Object of a row on the FilesPage

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -227,14 +227,14 @@ class FileRow extends OwncloudPage {
 			" xpath $this->lockStateXpath could not find lock button in row"
 		);
 		$element->click();
-		$lockDailogElement = $this->findById($this->lockDialogId);
+		$lockDialogElement = $this->findById($this->lockDialogId);
 		$this->assertElementNotNull(
-			$lockDailogElement,
+			$lockDialogElement,
 			__METHOD__ .
 			" id $this->lockDialogId could not find lock dialog"
 		);
 		$this->waitFor(
-			STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000, [$lockDailogElement, 'isVisible']
+			STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000, [$lockDialogElement, 'isVisible']
 		);
 
 		/**
@@ -242,7 +242,7 @@ class FileRow extends OwncloudPage {
 		 * @var LockDialog $lockDialog
 		 */
 		$lockDialog = $this->getPage("FilesPageElement\\LockDialog");
-		$lockDialog->setElement($lockDailogElement);
+		$lockDialog->setElement($lockDialogElement);
 		return $lockDialog;
 	}
 

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialog.php
@@ -29,7 +29,7 @@ use Page\OwncloudPage;
 use Page\FilesPageElement\LockDialogElement\LockEntry;
 
 /**
- * The Lock Dialog, lists all the locks and gives a posibility to delete them
+ * The Lock Dialog, lists all the locks and gives a possibility to delete them
  *
  */
 class LockDialog extends OwncloudPage {

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
@@ -80,7 +80,7 @@ class LockEntry extends OwncloudPage {
 	}
 
 	/**
-	 * gets the user that has locked the ressource
+	 * gets the user that has locked the resource
 	 *
 	 * @throws \Exception
 	 *

--- a/tests/acceptance/features/lib/FilesPageElement/SharedWithOthersFileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharedWithOthersFileRow.php
@@ -23,11 +23,6 @@
 
 namespace Page\FilesPageElement;
 
-use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Session;
-use Page\OwncloudPage;
-use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
-
 /**
  * Object of a row on the Shared with others page
  */

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -598,7 +598,8 @@ class SharingDialog extends OwncloudPage {
 	 */
 	public function checkPublicLinkCount(Session $session, $count) {
 		$publicLinkTitles = $this->findAll("xpath", $this->publicLinkTitleXpath);
-		if (\count($publicLinkTitles) != $count) {
+		$publicLinkTitlesCount = \count($publicLinkTitles);
+		if ($publicLinkTitlesCount != $count) {
 			throw new \Exception("Found $publicLinkTitlesCount public link entries but expected $count");
 		}
 	}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -29,7 +29,6 @@ use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use Page\OwncloudPageElement\OCDialog;
-use Behat\Mink\Exception\Exception;
 
 /**
  * The Sharing Dialog

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -241,7 +241,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @param string $name
 	 * @param Session $session
 	 *
-	 * @return void
+	 * @return EditPublicLinkPopup
 	 * @throws ElementNotFoundException
 	 */
 	public function openSharingPopupByLinkName($name, $session) {

--- a/tests/acceptance/features/lib/FilesPageElement/TrashBinFileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/TrashBinFileRow.php
@@ -23,11 +23,6 @@
 
 namespace Page\FilesPageElement;
 
-use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Session;
-use Page\OwncloudPage;
-use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
-
 /**
  * Object of a row on the FilesPage
  */

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -39,7 +39,7 @@ class LoginPage extends OwncloudPage {
 	protected $userInputId = "user";
 	protected $passwordInputId = "password";
 	protected $confirmPasswordInputId = "retypepassword";
-	protected $passwordResetConfrimMessage = "message";
+	protected $passwordResetConfirmMessage = "message";
 	protected $submitLoginId = "submit";
 	protected $lostPasswordId = "lost-password";
 	protected $setPasswordErrorMessageId = "error-message";
@@ -214,7 +214,7 @@ class LoginPage extends OwncloudPage {
 	 * @return string
 	 */
 	public function getRestPasswordConfirmError() {
-		$messageVal = $this->findById($this->passwordResetConfrimMessage)->getText();
+		$messageVal = $this->findById($this->passwordResetConfirmMessage)->getText();
 		return $messageVal;
 	}
 

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -262,7 +262,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	/**
 	 * Check if the preview of the profile pic is shown in the webui
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function isProfilePicturePreviewDisplayed() {
 		$profilePicPreview = $this->find('xpath', $this->profilePicPreviewXpath);
@@ -344,7 +344,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	/**
 	 * return if the "invalid image" message is visible
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function isFileUploadErrorMsgVisible() {
 		$errorMsg = $this->waitTillElementIsNotNull($this->invalidImageErrorMsgXpath);

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
@@ -46,7 +46,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	protected $linkedAppNameXpath = '//span[@class="token-name"]';
 	protected $disconnectButtonXpath = '//*[@data-original-title="Disconnect"]';
 	protected $createNewAppPasswordLoadingIndicatorClass = 'icon-loading-small';
-	protected $corsInputfieldXpath = "//input[@id='domain']";
+	protected $corsInputFieldXpath = "//input[@id='domain']";
 
 	/**
 	 * create a new app password for the app named $appName
@@ -151,7 +151,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	) {
 		$this->waitForOutstandingAjaxCalls($session);
 		$this->waitTillXpathIsVisible(
-			$this->corsInputfieldXpath, $timeout_msec
+			$this->corsInputFieldXpath, $timeout_msec
 		);
 	}
 }

--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -12,7 +12,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See thed
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License

--- a/tests/acceptance/features/lib/SharedWithOthersPage.php
+++ b/tests/acceptance/features/lib/SharedWithOthersPage.php
@@ -117,6 +117,7 @@ class SharedWithOthersPage extends FilesPageBasic {
 	 */
 	public function findAllFileRowsByName($name, Session $session) {
 		$fileRowElements = $this->getFileRowElementsByName($name, $session);
+		$fileRows = [];
 		foreach ($fileRowElements as $fileRowElement) {
 			$fileRow = $this->getPage('FilesPageElement\\SharedWithOthersFileRow');
 			$fileRow->setElement($fileRowElement);

--- a/tests/acceptance/features/lib/SharedWithOthersPage.php
+++ b/tests/acceptance/features/lib/SharedWithOthersPage.php
@@ -12,7 +12,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See thed
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License

--- a/tests/acceptance/features/lib/SharedWithOthersPage.php
+++ b/tests/acceptance/features/lib/SharedWithOthersPage.php
@@ -81,7 +81,7 @@ class SharedWithOthersPage extends FilesPageBasic {
 	 *
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return void
+	 * @return string
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;

--- a/tests/acceptance/features/lib/TagsPage.php
+++ b/tests/acceptance/features/lib/TagsPage.php
@@ -76,7 +76,7 @@ class TagsPage extends FilesPageBasic {
 	}
 
 	/**
-	 * @return void
+	 * @return string
 	 * @throws ElementNotFoundException
 	 */
 	protected function getFilePathInRowXpath() {

--- a/tests/acceptance/features/lib/TagsPage.php
+++ b/tests/acceptance/features/lib/TagsPage.php
@@ -157,6 +157,7 @@ class TagsPage extends FilesPageBasic {
 	 */
 	public function findAllFileRowsByName($name, Session $session) {
 		$fileRowElements = $this->getFileRowElementsByName($name, $session);
+		$fileRows = [];
 		foreach ($fileRowElements as $fileRowElement) {
 			$fileRow = $this->getPage('FilesPageElement\\SharedWithOthersFileRow');
 			$fileRow->setElement($fileRowElement);

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -161,6 +161,7 @@ class TrashbinPage extends FilesPageBasic {
 	 */
 	public function findAllFileRowsByName($name, Session $session) {
 		$fileRowElements = $this->getFileRowElementsByName($name, $session);
+		$fileRows = [];
 		foreach ($fileRowElements as $fileRowElement) {
 			$fileRow = $this->getPage('FilesPageElement\\TrashBinFileRow');
 			$fileRow->setElement($fileRowElement);

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -84,7 +84,7 @@ class TrashbinPage extends FilesPageBasic {
 	 *
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return void
+	 * @return string
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;


### PR DESCRIPTION
## Description
In acceptance test code:
1) Remove various unused `use`  statements
2) Correct various PHPdoc of return types
3) Remove various unused parameters from methods
4) Fix typos in var names, method names and comments
5) Pass `getSession()` in to everywhere in page objects. There were some deprecated usages of the `getSession()` method of a `Page` object.
6) Fix undeclared variables
and generally stop PHPstorm from shouting.

## Motivation and Context
Clean code.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
