### PR TITLE
Do not use underscore in drone service names

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -573,7 +573,7 @@ services:
         USE_FEDERATED_SERVER: true
         SERVER_PROTOCOL: http
 
-  apache_webdav:
+  apache-webdav:
     image: owncloudci/php
     pull: true
     environment:
@@ -583,7 +583,7 @@ services:
       matrix:
         FILES_EXTERNAL_TYPE: webdav_apache
 
-  smb_samba:
+  smb-samba:
     image: owncloudci/samba
     pull: true
     command: "-u \"test;test\" -s \"public;/tmp;yes;no;no;test;none;test\" -S"

--- a/tests/drone/configs/config.files_external.smb-samba.php
+++ b/tests/drone/configs/config.files_external.smb-samba.php
@@ -2,7 +2,7 @@
 
 return [
 	'run'=>true,
-	'host'=>'smb_samba',
+	'host'=>'smb-samba',
 	'user'=>'test',
 	'password'=>'test',
 	'root'=>'',

--- a/tests/drone/configs/config.files_external.webdav-apache.php
+++ b/tests/drone/configs/config.files_external.webdav-apache.php
@@ -1,7 +1,7 @@
 <?php
 return [
 	'run'=>true,
-	'host'=>'apache_webdav:80/webdav',
+	'host'=>'apache-webdav:80/webdav',
 	'user'=>'username',
 	'password'=>'password',
 	'root'=>'',

--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -20,12 +20,12 @@ set_up_external_storage() {
     php occ config:app:set core enable_external_storage --value=yes
     case "${FILES_EXTERNAL_TYPE}" in
     webdav_apache)
-      wait-for-it -t 120 apache_webdav:80
+      wait-for-it -t 120 apache-webdav:80
       cp tests/drone/configs/config.files_external.webdav-apache.php apps/files_external/tests/config.webdav.php
       FILES_EXTERNAL_TEST_TO_RUN=WebdavTest.php
       ;;
     smb_samba)
-      wait-for-it -t 120 smb_samba:445
+      wait-for-it -t 120 smb-samba:445
       cp tests/drone/configs/config.files_external.smb-samba.php apps/files_external/tests/config.smb.php
       FILES_EXTERNAL_TEST_TO_RUN=SmbTest.php
       ;;


### PR DESCRIPTION
## Description
Change the names of services in drone to not contain the `_` character.

## Related Issue
This was noticed in PR #34608 which tried to make service names like `server_https`

## Motivation and Context
https://en.wikipedia.org/wiki/Hostname - host names can contain letters, numbers and '-' but not '_' (underscore).

In drone, the pipeline/service names become hosts file entries on the local system. Those are used by whichever steps and services need to find each other. If those contain `_` they might or might not work.

Our purpose in drone testing is not to prove if the various databases, Apache, SMB... services work OK with host names containing `_` - so remove this potential issue.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
