### PR TITLE
[stable10] Bump swiftmailer/swiftmailer (v5.4.12 => v6.2.0) 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,6 +60,8 @@ pipeline:
   composer:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
+    environment:
+      - COMPOSER_HOME=/drone/src/.cache/composer
     commands:
       - make install-composer-deps
     when:
@@ -68,6 +70,10 @@ pipeline:
   yarn:
     image: owncloudci/nodejs:latest
     pull: true
+    environment:
+      - NPM_CONFIG_CACHE=/drone/src/.cache/npm
+      - YARN_CACHE_FOLDER=/drone/src/.cache/yarn
+      - bower_storage__packages=/drone/src/.cache/bower
     commands:
       - ./tests/drone/yarn-install.sh
     when:
@@ -79,9 +85,7 @@ pipeline:
     secrets: [ cache_s3_endpoint, cache_s3_access_key, cache_s3_secret_key ]
     rebuild: true
     mount:
-      - lib/composer
-      - core/vendor
-      - build/node_modules
+      - .cache
     when:
       local: false
       event: [ push ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,7 +121,7 @@ pipeline:
       - make test-php-phan
     when:
       matrix:
-        TEST_SUITE: phan
+        TEST_SUITE: phan-70
 
   php-phan-71:
     image: owncloudci/php:7.1
@@ -638,7 +638,11 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: owncloud-coding-standard
 
-  # phan (runs multiple PHP v7.* to provide syntax checks of each PHP version)
+  # phan (runs on just PHP 7.0 because that has different dependencies for phan)
+    - TEST_SUITE: phan-70
+      PHP_VERSION: 7.0
+
+    # phan (runs multiple PHP v7.1+ to provide syntax checks of each PHP version)
     - TEST_SUITE: phan
       PHP_VERSION: 7.1
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -629,16 +629,8 @@ matrix:
       PHP_VERSION: 7.1
       COVERAGE: true
 
-    - PHP_VERSION: 5.6
-      DB_TYPE: postgres
-      TEST_SUITE: phpunit
-      INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
-
   # owncloud-coding-standard
-  # Run with PHP 5.6 because that is not supported by phan.
-  # This gives us a syntax check for PHP 5.6
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.1
       TEST_SUITE: owncloud-coding-standard
 
   # phan (runs multiple PHP v7.* to provide syntax checks of each PHP version)
@@ -685,6 +677,31 @@ matrix:
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       COVERAGE: true
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    # PHP 7.0
+    - PHP_VERSION: 7.0
+      DB_TYPE: mysql
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
+      DB_TYPE: mysqlmb4
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
+      DB_TYPE: postgres
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
+      DB_TYPE: oracle
+      TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
@@ -735,7 +752,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
   # Primary Objectstorage
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
       OBJECTSTORE: swift
@@ -1462,7 +1479,7 @@ matrix:
       CALDAV_CARDDAV_JOB: true
 
     # encryption tests
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
       DB_TYPE: mariadb

--- a/.drone.yml
+++ b/.drone.yml
@@ -64,6 +64,7 @@ pipeline:
       - COMPOSER_HOME=/drone/src/.cache/composer
     commands:
       - make install-composer-deps
+      - make vendor-bin-deps
     when:
       event: [push, pull_request]
 

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ clover.xml
 /tests/output
 .php_cs.cache
 .php_cs
+
+# CI
+.cache

--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,17 @@ vendor-bin/phan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phan/compo
 vendor-bin/phan/composer.lock: vendor-bin/phan/composer.json
 	@echo phan composer.lock is not up to date.
 
+# The first line of "php --version" output looks like:
+# PHP 7.2.16-1+ubuntu18.04.1+deb.sury.org+1 (cli) (built: Mar  7 2019 20:23:29) ( NTS )
+# We want the 2nd "word", then the first 2 numbers separated by the dot
+PHP_MINOR_VERSION = $(shell php --version | head -n 1 | cut -d' ' -f2 | cut -d'.' -f1-2)
+
 vendor-bin/phpstan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phpstan/composer.lock
+ifeq "$(PHP_MINOR_VERSION)" "7.0"
+	@echo "phpstan is not supported on PHP 7.0 so it is not being installed"
+else
 	composer bin phpstan install --no-progress
+endif
 
 vendor-bin/phpstan/composer.lock: vendor-bin/phpstan/composer.json
 	@echo phpstan composer.lock is not up to date.

--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,9 @@ vendor: composer.lock
 vendor/bamarni/composer-bin-plugin: composer.lock
 	composer install
 
+.PHONY: vendor-bin-deps
+vendor-bin-deps: vendor-bin/owncloud-codestyle/vendor vendor-bin/php_codesniffer/vendor vendor-bin/phan/vendor vendor-bin/phpstan/vendor vendor-bin/behat/vendor
+
 vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/owncloud-codestyle/composer.lock
 	composer bin owncloud-codestyle install --no-progress
 

--- a/build/OCPSinceChecker.php
+++ b/build/OCPSinceChecker.php
@@ -126,8 +126,7 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 
 echo 'Parsing all files in lib/public for the presence of @since or @deprecated on each method...' . PHP_EOL . PHP_EOL;
 
-
-$parser = new PhpParser\Parser(new PhpParser\Lexer);
+$parser = (new \PhpParser\ParserFactory())->create(\PhpParser\ParserFactory::PREFER_PHP7);
 
 /* iterate over all .php files in lib/public */
 $Directory = new RecursiveDirectoryIterator(dirname(__DIR__) . '/lib/public');

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "interfasys/lognormalizer": "^v1.0",
         "deepdiver1975/tarstreamer": "v0.1.0",
         "patchwork/jsqueeze": "^2.0",
-        "symfony/polyfill-php70": "^1.0",
         "lukasreschke/id3parser": "^0.0.3",
         "sabre/dav": "^3.2",
         "deepdiver/zipstreamer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "pimple/pimple": "3.2.3",
         "nikic/php-parser": "^4.0",
         "icewind/streams": "0.5.2",
-        "swiftmailer/swiftmailer": "^5.4",
+        "swiftmailer/swiftmailer": "^6.0",
         "guzzlehttp/guzzle": "^5.3",
         "league/flysystem": "^1.0",
         "pear/pear-core-minimal": "^v1.10",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/dbal": "^2.5",
         "phpseclib/phpseclib": "^2.0",
         "rackspace/php-opencloud": "v1.9.2",
-        "jeremeamia/superclosure": "2.1.0",
+        "jeremeamia/superclosure": "^2.4",
         "bantu/ini-get-wrapper": "v1.0.1",
         "punic/punic": "^3.1",
         "pear/archive_tar": "1.4.6",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "optimize-autoloader": true,
         "classmap-authoritative": false,
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "autoload" : {
@@ -26,7 +26,7 @@
         "roave/security-advisories": "dev-master"
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0.8",
         "doctrine/dbal": "^2.5",
         "phpseclib/phpseclib": "^2.0",
         "rackspace/php-opencloud": "v1.9.2",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/routing": "^3.1",
         "symfony/process": "^3.1",
         "pimple/pimple": "3.2.3",
-        "nikic/php-parser": "1.4.1",
+        "nikic/php-parser": "^4.0",
         "icewind/streams": "0.5.2",
         "swiftmailer/swiftmailer": "^5.4",
         "guzzlehttp/guzzle": "^5.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89d51a717d97b389e94f507d6789619a",
+    "content-hash": "9006b4be6a6d612abce42a5d2157ddba",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1383,51 +1383,6 @@
                 "php"
             ],
             "time": "2019-02-16T20:54:15+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v9.99.99",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*",
-                "vimeo/psalm": "^1"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "patchwork/jsqueeze",
@@ -2919,65 +2874,6 @@
                 }
             ],
             "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2018-09-21T06:26:08+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "shasum": ""
-            },
-            "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
             "homepage": "https://symfony.com",
             "keywords": [
                 "compatibility",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27778b04ad8239c0cac828d5652a8af3",
+    "content-hash": "afd1118f0042ec2baa0f68468c644cb0",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -587,33 +587,33 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "v1.1.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Inflector\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -650,7 +650,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2017-07-22T12:18:28+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1380,33 +1380,29 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.18",
+            "version": "v9.99.99",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db"
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
-                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.0"
+                "php": "^7"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
             },
             "suggest": {
                 "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
             },
             "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -1425,7 +1421,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2019-01-03T20:59:08+00:00"
+            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "patchwork/jsqueeze",
@@ -3762,29 +3758,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -3803,7 +3805,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4117,29 +4119,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4162,7 +4164,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -5200,11 +5202,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6",
+        "php": ">=7.0.8",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.33"
+        "php": "7.0.8"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9006b4be6a6d612abce42a5d2157ddba",
+    "content-hash": "c00b6c2d1a9694608e1f13ca45cac489",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -705,6 +705,63 @@
                 "parser"
             ],
             "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "2.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/709f21f92707308cdf8f9bcfa1af4cb26586521e",
+                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^1.0.1",
+                "php": ">= 5.5"
+            },
+            "require-dev": {
+                "dominicsayers/isemail": "dev-master",
+                "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
+                "satooshi/php-coveralls": "^1.0.1"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "EmailValidator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "time": "2018-12-04T22:38:24+00:00"
         },
         {
             "name": "guzzle/common",
@@ -2525,29 +2582,37 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.12",
+            "version": "v6.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
+                "reference": "6fa3232ff9d3f8237c0fae4b7ff05e1baa4cd707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
-                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/6fa3232ff9d3f8237c0fae4b7ff05e1baa4cd707",
+                "reference": "6fa3232ff9d3f8237c0fae4b7ff05e1baa4cd707",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "egulias/email-validator": "~2.0",
+                "php": ">=7.0.0",
+                "symfony/polyfill-iconv": "^1.0",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "require-dev": {
                 "mockery/mockery": "~0.9.1",
-                "symfony/phpunit-bridge": "~3.2"
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
+            },
+            "suggest": {
+                "ext-intl": "Needed to support internationalized email addresses",
+                "true/punycode": "Needed to support internationalized email addresses, if ext-intl is not installed"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-master": "6.2-dev"
                 }
             },
             "autoload": {
@@ -2575,7 +2640,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2018-07-31T09:26:32+00:00"
+            "time": "2019-03-10T07:52:41+00:00"
         },
         {
             "name": "symfony/console",
@@ -2769,6 +2834,127 @@
             "time": "2019-02-23T15:06:07+00:00"
         },
         {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "97001cfc283484c9691769f51cdf25259037eba2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/97001cfc283484c9691769f51cdf25259037eba2",
+                "reference": "97001cfc283484c9691769f51cdf25259037eba2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-21T06:26:08+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "89de1d44f2c059b266f22c9cc9124ddc4cd0987a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/89de1d44f2c059b266f22c9cc9124ddc4cd0987a",
+                "reference": "89de1d44f2c059b266f22c9cc9124ddc4cd0987a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.9"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-30T16:36:12+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.10.0",
             "source": {
@@ -2882,6 +3068,61 @@
                 "shim"
             ],
             "time": "2018-09-21T06:26:08+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/polyfill-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afd1118f0042ec2baa0f68468c644cb0",
+    "content-hash": "5e9a90f42857b4f71e45cbf5befa46d5",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1158,30 +1158,30 @@
         },
         {
             "name": "jeremeamia/SuperClosure",
-            "version": "2.1.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jeremeamia/super_closure.git",
-                "reference": "b712f39c671e5ead60c7ebfe662545456aade833"
+                "reference": "5707d5821b30b9a07acfb4d76949784aaa0e9ce9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jeremeamia/super_closure/zipball/b712f39c671e5ead60c7ebfe662545456aade833",
-                "reference": "b712f39c671e5ead60c7ebfe662545456aade833",
+                "url": "https://api.github.com/repos/jeremeamia/super_closure/zipball/5707d5821b30b9a07acfb4d76949784aaa0e9ce9",
+                "reference": "5707d5821b30b9a07acfb4d76949784aaa0e9ce9",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "~1.0",
-                "php": ">=5.4"
+                "nikic/php-parser": "^1.2|^2.0|^3.0|^4.0",
+                "php": ">=5.4",
+                "symfony/polyfill-php56": "^1.0"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "~0.1.2",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -1212,7 +1212,7 @@
                 "serialize",
                 "tokenizer"
             ],
-            "time": "2015-03-11T20:06:43+00:00"
+            "time": "2018-03-21T22:21:57+00:00"
         },
         {
             "name": "league/flysystem",
@@ -2867,6 +2867,62 @@
             "time": "2018-09-21T13:07:52+00:00"
         },
         {
+            "name": "symfony/polyfill-php56",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php56.git",
+                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/ff208829fe1aa48ab9af356992bb7199fed551af",
+                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-util": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php56\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-21T06:26:08+00:00"
+        },
+        {
             "name": "symfony/polyfill-php70",
             "version": "v1.10.0",
             "source": {
@@ -2924,6 +2980,58 @@
                 "shim"
             ],
             "time": "2018-09-21T06:26:08+00:00"
+        },
+        {
+            "name": "symfony/polyfill-util",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-util.git",
+                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/3b58903eae668d348a7126f999b0da0f2f93611c",
+                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Util\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony utilities for portability of PHP codes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compat",
+                "compatibility",
+                "polyfill",
+                "shim"
+            ],
+            "time": "2018-09-30T16:36:12+00:00"
         },
         {
             "name": "symfony/process",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e9a90f42857b4f71e45cbf5befa46d5",
+    "content-hash": "89d51a717d97b389e94f507d6789619a",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1335,32 +1335,38 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v1.4.1",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51"
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3"
+                "php": ">=7.0"
             },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "lib/bootstrap.php"
-                ]
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1376,7 +1382,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-09-19T14:15:08+00:00"
+            "time": "2019-02-16T20:54:15+00:00"
         },
         {
             "name": "paragonie/random_compat",

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "9006b4be6a6d612abce42a5d2157ddba",
@@ -4324,12 +4324,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "4e04718428742618a4bf24dafca45b8645c9320d"
+                "reference": "3521da8036ce31b11490433aaae47f9601774191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/4e04718428742618a4bf24dafca45b8645c9320d",
-                "reference": "4e04718428742618a4bf24dafca45b8645c9320d",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/3521da8036ce31b11490433aaae47f9601774191",
+                "reference": "3521da8036ce31b11490433aaae47f9601774191",
                 "shasum": ""
             },
             "conflict": {
@@ -4466,7 +4466,7 @@
                 "theonedemon/phpwhois": "<=4.2.5",
                 "titon/framework": ">=0,<9.9.99",
                 "truckersmp/phpwhois": "<=4.3.1",
-                "twig/twig": "<1.20",
+                "twig/twig": "<1.38|>=2,<2.7",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.23|>=9,<9.5.4",
                 "typo3/cms-core": ">=8,<8.7.23|>=9,<9.5.4",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
@@ -4520,7 +4520,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-02-26T21:14:50+00:00"
+            "time": "2019-03-12T13:04:55+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5080,7 +5080,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/console.php
+++ b/console.php
@@ -33,10 +33,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 \define('OC_CONSOLE', 1);
 
-// Show warning if a PHP version below 7.0.8 is used, this has to happen here
+// Show warning if a PHP version below 7.0.7 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.8'.PHP_EOL;
+if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.7'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
 	exit(1);
 }

--- a/console.php
+++ b/console.php
@@ -33,10 +33,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 \define('OC_CONSOLE', 1);
 
-// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// Show warning if a PHP version below 7.0.8 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.0'.PHP_EOL;
+if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.8'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
 	exit(1);
 }

--- a/console.php
+++ b/console.php
@@ -33,10 +33,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 \define('OC_CONSOLE', 1);
 
-// Show warning if a PHP version below 5.6.0 is used, this has to happen here
-// because base.php will already use 5.6 syntax.
-if (\version_compare(PHP_VERSION, '5.6.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 5.6.0'.PHP_EOL;
+// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// because base.php will already use 7.0 syntax.
+if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.0'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
 	exit(1);
 }

--- a/index.php
+++ b/index.php
@@ -27,10 +27,10 @@
  *
  */
 
-// Show warning if a PHP version below 7.0.8 is used, this has to happen here
+// Show warning if a PHP version below 7.0.7 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.8<br/>';
+if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.7<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }

--- a/index.php
+++ b/index.php
@@ -27,10 +27,10 @@
  *
  */
 
-// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// Show warning if a PHP version below 7.0.8 is used, this has to happen here
 // because base.php will already use 7.0 syntax.
-if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.0.0<br/>';
+if (\version_compare(PHP_VERSION, '7.0.8') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.8<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }

--- a/index.php
+++ b/index.php
@@ -27,10 +27,10 @@
  *
  */
 
-// Show warning if a PHP version below 5.6.0 is used, this has to happen here
-// because base.php will already use 5.6 syntax.
-if (\version_compare(PHP_VERSION, '5.6.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 5.6.0<br/>';
+// Show warning if a PHP version below 7.0.0 is used, this has to happen here
+// because base.php will already use 7.0 syntax.
+if (\version_compare(PHP_VERSION, '7.0.0') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.0.0<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }

--- a/lib/private/App/CodeChecker/CodeChecker.php
+++ b/lib/private/App/CodeChecker/CodeChecker.php
@@ -24,7 +24,6 @@
 namespace OC\App\CodeChecker;
 
 use OC\Hooks\BasicEmitter;
-use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use RecursiveCallbackFilterIterator;
@@ -51,7 +50,7 @@ class CodeChecker extends BasicEmitter {
 
 	public function __construct(ICheck $checkList) {
 		$this->checkList = $checkList;
-		$this->parser = new Parser(new Lexer);
+		$this->parser = (new \PhpParser\ParserFactory())->create(\PhpParser\ParserFactory::PREFER_PHP7);
 	}
 
 	/**

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -21,6 +21,8 @@
 
 namespace OC\Mail;
 
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use OCP\IConfig;
 use OCP\Mail\IMailer;
 use OCP\ILogger;
@@ -44,7 +46,7 @@ use OCP\ILogger;
  * @package OC\Mail
  */
 class Mailer implements IMailer {
-	/** @var \Swift_SmtpTransport|\Swift_SendmailTransport|\Swift_MailTransport Cached transport */
+	/** @var \Swift_SmtpTransport|\Swift_SendmailTransport Cached transport */
 	private $instance = null;
 	/** @var IConfig */
 	private $config;
@@ -117,9 +119,6 @@ class Mailer implements IMailer {
 			'recipients' => \json_encode($allRecipients),
 			'subject' => $message->getSubject()
 		]);
-		if ($debugMode && isset($mailLogger)) {
-			$this->logger->debug($mailLogger->dump(), ['app' => 'core']);
-		}
 
 		return $failedRecipients;
 	}
@@ -131,7 +130,8 @@ class Mailer implements IMailer {
 	 * @return bool True if the mail address is valid, false otherwise
 	 */
 	public function validateMailAddress($email) {
-		return \Swift_Validate::email($this->convertEmail($email));
+		$validator = new EmailValidator();
+		return $validator->isValid($this->convertEmail($email), new RFCValidation());
 	}
 
 	/**
@@ -159,26 +159,21 @@ class Mailer implements IMailer {
 	/**
 	 * Returns whatever transport is configured within the config
 	 *
-	 * @return \Swift_SmtpTransport|\Swift_SendmailTransport|\Swift_MailTransport
+	 * @return \Swift_SmtpTransport|\Swift_SendmailTransport
 	 */
 	protected function getInstance() {
 		if ($this->instance !== null) {
 			return $this->instance;
 		}
 
-		switch ($this->config->getSystemValue('mail_smtpmode', 'php')) {
-			case 'smtp':
-				$instance = $this->getSMTPInstance();
-				break;
-			case 'sendmail':
-				// FIXME: Move into the return statement but requires proper testing
-				//       for SMTP and mail as well. Thus not really doable for a
-				//       minor release.
-				$instance = \Swift_Mailer::newInstance($this->getSendMailInstance());
-				break;
-			default:
-				$instance = $this->getMailInstance();
-				break;
+		$mailMode = $this->config->getSystemValue('mail_smtpmode', 'php');
+		if ($mailMode === 'smtp') {
+			$instance = $this->getSmtpInstance();
+		} else {
+			// FIXME: Move into the return statement but requires proper testing
+			//       for SMTP and mail as well. Thus not really doable for a
+			//       minor release.
+			$instance = new \Swift_Mailer($this->getSendMailInstance());
 		}
 
 		// Register plugins
@@ -203,7 +198,7 @@ class Mailer implements IMailer {
 	 * @return \Swift_SmtpTransport
 	 */
 	protected function getSmtpInstance() {
-		$transport = \Swift_SmtpTransport::newInstance();
+		$transport = new \Swift_SmtpTransport();
 		$transport->setTimeout($this->config->getSystemValue('mail_smtptimeout', 10));
 		$transport->setHost($this->config->getSystemValue('mail_smtphost', '127.0.0.1'));
 		$transport->setPort($this->config->getSystemValue('mail_smtpport', 25));
@@ -235,15 +230,6 @@ class Mailer implements IMailer {
 				break;
 		}
 
-		return \Swift_SendmailTransport::newInstance($binaryPath . ' -bs');
-	}
-
-	/**
-	 * Returns the mail transport
-	 *
-	 * @return \Swift_MailTransport
-	 */
-	protected function getMailInstance() {
-		return \Swift_MailTransport::newInstance();
+		return new \Swift_SendmailTransport($binaryPath . ' -bs');
 	}
 }

--- a/tests/lib/Command/AsyncBusTest.php
+++ b/tests/lib/Command/AsyncBusTest.php
@@ -127,14 +127,6 @@ class AsyncBusTest extends TestCase {
 		$this->assertEquals('closure', self::$lastCommand);
 	}
 
-	public function testClosureSelf() {
-		$this->bus->push(function () {
-			self::$lastCommand = 'closure-self';
-		});
-		$this->runJobs();
-		$this->assertEquals('closure-self', self::$lastCommand);
-	}
-
 	public function testClosureThis() {
 		// clean class to prevent phpunit putting closure in $this
 		$test = new ThisClosureTest();
@@ -146,7 +138,7 @@ class AsyncBusTest extends TestCase {
 	public function testClosureBind() {
 		$state = 'bar';
 		$this->bus->push(function () use ($state) {
-			self::$lastCommand = 'closure-' . $state;
+			AsyncBusTest::$lastCommand = 'closure-' . $state;
 		});
 		$this->runJobs();
 		$this->assertEquals('closure-bar', self::$lastCommand);

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -34,6 +34,7 @@ use OCP\Util;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
+use OC\Mail\Message;
 
 /**
  * Class MailNotificationsTest
@@ -60,19 +61,19 @@ class MailNotificationsTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
+		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
-		$this->mailer = $this->getMockBuilder('\OCP\Mail\IMailer')
+		$this->mailer = $this->getMockBuilder(IMailer::class)
 			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()->getMock();
 		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
-		$this->defaults = $this->getMockBuilder('\OCP\Defaults')
+		$this->defaults = $this->getMockBuilder(Defaults::class)
 				->disableOriginalConstructor()->getMock();
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 				->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->createMock('\OCP\IURLGenerator');
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->eventDispatcher = new EventDispatcher();
 
 		$this->l10n->expects($this->any())
@@ -97,7 +98,7 @@ class MailNotificationsTest extends TestCase {
 	}
 
 	public function testSendLinkShareMailWithoutReplyTo() {
-		$message = $this->getMockBuilder('\OC\Mail\Message')
+		$message = $this->getMockBuilder(Message::class)
 			->disableOriginalConstructor()->getMock();
 
 		$message
@@ -144,7 +145,7 @@ class MailNotificationsTest extends TestCase {
 	}
 
 	public function testSendLinkShareMailWithRecipientAndOptions() {
-		$message = $this->getMockBuilder('\OC\Mail\Message')
+		$message = $this->getMockBuilder(Message::class)
 			->disableOriginalConstructor()->getMock();
 
 		$message
@@ -211,7 +212,7 @@ class MailNotificationsTest extends TestCase {
 	}
 
 	public function testSendLinkShareMailPersonalNote() {
-		$message = $this->getMockBuilder('\OC\Mail\Message')
+		$message = $this->getMockBuilder(Message::class)
 			->disableOriginalConstructor()->getMock();
 
 		$message
@@ -290,7 +291,7 @@ class MailNotificationsTest extends TestCase {
 	 * @param array $expectedTo
 	 */
 	public function testSendLinkShareMailWithReplyTo($to, array $expectedTo) {
-		$message = $this->getMockBuilder('\OC\Mail\Message')
+		$message = $this->getMockBuilder(Message::class)
 			->disableOriginalConstructor()->getMock();
 
 		$message
@@ -396,7 +397,7 @@ class MailNotificationsTest extends TestCase {
 		$this->setupMailerMock('TestUser shared »<welcome>.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
 
 		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
-		$mailNotifications = $this->getMockBuilder('OC\Share\MailNotifications')
+		$mailNotifications = $this->getMockBuilder(MailNotifications::class)
 			->setMethods(['getItemSharedWithUser'])
 			->setConstructorArgs([
 				$this->user,
@@ -416,7 +417,7 @@ class MailNotificationsTest extends TestCase {
 				['file_target' => '/<welcome>.txt', 'item_source' => 123, 'expiration' => '2017-01-01T15:03:01.012345Z'],
 			]);
 
-		$recipient = $this->getMockBuilder('\OCP\IUser')
+		$recipient = $this->getMockBuilder(IUser::class)
 				->disableOriginalConstructor()->getMock();
 		$recipient
 				->expects($this->once())
@@ -445,7 +446,7 @@ class MailNotificationsTest extends TestCase {
 		$this->setupMailerMock('TestUser shared »<welcome>.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
 
 		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
-		$mailNotifications = $this->getMockBuilder('OC\Share\MailNotifications')
+		$mailNotifications = $this->getMockBuilder(MailNotifications::class)
 			->setMethods(['getItemSharedWithUser'])
 			->setConstructorArgs([
 				$this->user,
@@ -465,7 +466,7 @@ class MailNotificationsTest extends TestCase {
 				['file_target' => '/<welcome>.txt', 'item_source' => 123, 'expiration' => 'foo'],
 			]);
 
-		$recipient = $this->getMockBuilder('\OCP\IUser')
+		$recipient = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()->getMock();
 		$recipient
 			->expects($this->once())
@@ -539,7 +540,7 @@ class MailNotificationsTest extends TestCase {
 	 */
 	public function testSendInternalShareMailNoMail($emptiness) {
 		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
-		$mailNotifications = $this->getMockBuilder('OC\Share\MailNotifications')
+		$mailNotifications = $this->getMockBuilder(MailNotifications::class)
 			->setMethods(['getItemSharedWithUser'])
 			->setConstructorArgs([
 				$this->user,
@@ -553,7 +554,7 @@ class MailNotificationsTest extends TestCase {
 			])
 			->getMock();
 
-		$recipient = $this->getMockBuilder('\OCP\IUser')
+		$recipient = $this->getMockBuilder(IUser::class)
 				->disableOriginalConstructor()->getMock();
 		$recipient
 				->expects($this->once())
@@ -563,7 +564,7 @@ class MailNotificationsTest extends TestCase {
 				->expects($this->once())
 				->method('getDisplayName')
 				->willReturn('No mail 1');
-		$recipient2 = $this->getMockBuilder('\OCP\IUser')
+		$recipient2 = $this->getMockBuilder(IUser::class)
 				->disableOriginalConstructor()->getMock();
 		$recipient2
 				->expects($this->once())
@@ -618,7 +619,7 @@ class MailNotificationsTest extends TestCase {
 	 * @param string $subject
 	 */
 	protected function setupMailerMock($subject, $to, $exceptionOnSend = true) {
-		$message = $this->getMockBuilder('\OC\Mail\Message')
+		$message = $this->getMockBuilder(Message::class)
 				->disableOriginalConstructor()->getMock();
 
 		$message

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -9,6 +9,11 @@
 namespace Test;
 
 use OC_Util;
+use OCP\Files\Folder;
+use OCP\App\IAppManager;
+use OCP\IUser;
+use OCP\IGroupManager;
+use OCP\IConfig;
 
 /**
  * @group DB
@@ -258,11 +263,11 @@ class UtilTest extends \Test\TestCase {
 		$oldWebRoot = \OC::$WEBROOT;
 		\OC::$WEBROOT = '';
 
-		$appManager = $this->createMock('\OCP\App\IAppManager');
+		$appManager = $this->createMock(IAppManager::class);
 		$appManager->expects($this->any())
 			->method('isEnabledForUser')
 			->will($this->returnCallback(function ($appId) use ($enabledApps) {
-				return \in_array($appId, $enabledApps);
+				return \in_array($appId, $enabledApps, true);
 			}));
 		Dummy_OC_Util::$appManager = $appManager;
 
@@ -373,7 +378,7 @@ class UtilTest extends \Test\TestCase {
 	public function testCopySkeletonDirectoryDoesNotExist() {
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', '/not/existing/Directory');
-		$userFolder = $this->createMock('\OCP\Files\Folder');
+		$userFolder = $this->createMock(Folder::class);
 		\OC_Util::copySkeleton('testuser', $userFolder);
 
 		$config->deleteSystemValue('skeletondirectory');
@@ -395,7 +400,7 @@ class UtilTest extends \Test\TestCase {
 		\chmod($skeletonDir, 0);
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', $skeletonDir);
-		$userFolder = $this->createMock('\OCP\Files\Folder');
+		$userFolder = $this->createMock(Folder::class);
 		\OC_Util::copySkeleton('testuser', $userFolder);
 
 		$config->deleteSystemValue('skeletondirectory');
@@ -417,7 +422,7 @@ class UtilTest extends \Test\TestCase {
 		\chmod($skeletonDir . '/a-file', 0);
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', $skeletonDir);
-		$userFolder = $this->createMock('\OCP\Files\Folder');
+		$userFolder = $this->createMock(Folder::class);
 		\OC_Util::copySkeleton('testuser', $userFolder);
 
 		$config->deleteSystemValue('skeletondirectory');


### PR DESCRIPTION
## Description
On top of the "easy" PRs #34698 and #34732 now bump `swiftmailer` in `stable10`

1. Bump swiftmailer/swiftmailer (v5.4.12 => v6.2.0)
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 4 installs, 1 update, 0 removals
  - Installing symfony/polyfill-php72 (v1.10.0): Loading from cache
  - Installing symfony/polyfill-intl-idn (v1.10.0): Loading from cache
  - Installing symfony/polyfill-iconv (v1.10.0): Loading from cache
  - Installing egulias/email-validator (2.1.7): Loading from cache
  - Updating swiftmailer/swiftmailer (v5.4.12 => v6.2.0): Loading from cache
```

2. Backport "Adopt to Swift Mail v6" from `master` PR #29943


## Related Issue

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
