### PR TITLE
Put back files:scan --groups option for backward-compatibility

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -106,9 +106,15 @@ class Scan extends Base {
 			)
 			->addOption(
 				'group',
-				'g',
+				'',
 				InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED,
 				'Scan user(s) under the group(s). This option can be used as --group=foo --group=bar to scan groups foo and bar'
+			)
+			->addOption(
+				'groups',
+				'g',
+				InputArgument::OPTIONAL,
+				'Scan user(s) under the group(s). This option can be used as --groups=foo,bar to scan groups foo and bar'
 			)
 			->addOption(
 				'quiet',
@@ -276,7 +282,8 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		$groups = $input->getOption('group');
+		$groups = $input->getOption('groups') ? \explode(',', $input->getOption('groups')) : [];
+		$groups = \array_unique(\array_merge($groups, $input->getOption('group')));
 		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if (\count($groups) >= 1) {

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -140,6 +140,8 @@ class ScanTest extends TestCase {
 
 	public function dataInput() {
 		return [
+			[['--groups' => 'haystack'], 'Group name haystack doesn\'t exist'],
+			[['--groups' => 'group1'], 'Starting scan for user 1 out of 1 (user1)'],
 			[['--group' => ['haystack']], 'Group name haystack doesn\'t exist'],
 			[['--group' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
 			[['--group' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
@@ -186,6 +188,9 @@ class ScanTest extends TestCase {
 
 	public function multipleGroupTest() {
 		return [
+			[['--groups' => 'group1,group2'], ''],
+			[['--groups' => 'group1,group2,group3'], ''],
+			[['--groups' => 'group1,group2', '--group' => ['group2','group3']], ''],
 			[['--group' => ['group1,x','group2']], ''],
 			[['--group' => ['group1','group2,x','group3']], '']
 		];
@@ -197,7 +202,13 @@ class ScanTest extends TestCase {
 	 */
 	public function testMultipleGroups($input) {
 		//Create 10 users in each group
-		$groups = $input['--group'];
+		$groups = [];
+		if (\array_key_exists('--groups', $input)) {
+			$groups = \explode(',', $input['--groups']);
+		}
+		if (\array_key_exists('--group', $input)) {
+			$groups = \array_merge($groups, $input['--group']);
+		}
 		$user = "user";
 		$userObj = [];
 		for ($i = 1; $i <= (10 * \count($groups)); $i++) {


### PR DESCRIPTION
## Description
PR #31719 changed the `occ files:scan` command so that you specify groups like `--group=foo --group=bar` rather than `--groups=foo,bar` - which let's the user specify group names that contain a comma `--group=Finance,Sydney --group=Admin,Singapore`
 
That change was not backward-compatible and so would have to wait for a major version release.

But we can keep the previous behavior also, so that for groups without a comma in their name the user can use `--groups` just like they have always been able to.

That makes the net change a bug fix that adds a new feature/functionality.

So this is the code to do that.

## Related Issue
#31578
#31835
PR #31719 

Also related to comparing `master` with `stable10` and getting them closer together.

## Motivation and Context

## How Has This Been Tested?
Local run of unit tests, and trying the `occ files:scan` command.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) (recovers backward-compatibility)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/742

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
