### PR TITLE
[stable10] files:scan --group and --groups options

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -107,8 +107,8 @@ class Scan extends Base {
 			->addOption(
 				'groups',
 				'g',
-				InputArgument::OPTIONAL,
-				'Scan user(s) under the group(s). This option can be used as --groups=foo,bar to scan groups foo and bar'
+				InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED,
+				'Scan user(s) under the group(s). This option can be used as --groups=foo --groups=bar to scan groups foo and bar'
 			)
 			->addOption(
 				'quiet',
@@ -276,7 +276,7 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		$groups = $input->getOption('groups') ? \explode(',', $input->getOption('groups')) : [];
+		$groups = $input->getOption('groups');
 		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if (\count($groups) >= 1) {

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -106,9 +106,15 @@ class Scan extends Base {
 			)
 			->addOption(
 				'group',
-				'g',
+				'',
 				InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED,
 				'Scan user(s) under the group(s). This option can be used as --group=foo --group=bar to scan groups foo and bar'
+			)
+			->addOption(
+				'groups',
+				'g',
+				InputArgument::OPTIONAL,
+				'Scan user(s) under the group(s). This option can be used as --groups=foo,bar to scan groups foo and bar'
 			)
 			->addOption(
 				'quiet',
@@ -276,7 +282,8 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		$groups = $input->getOption('group');
+		$groups = $input->getOption('groups') ? \explode(',', $input->getOption('groups')) : [];
+		$groups = \array_unique(\array_merge($groups, $input->getOption('group')));
 		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if (\count($groups) >= 1) {

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -105,10 +105,10 @@ class Scan extends Base {
 				'Limit rescan to this path, e.g., --path="/alice/files/Music", the user_id is determined by the path and the user_id parameter and --all are ignored.'
 			)
 			->addOption(
-				'groups',
+				'group',
 				'g',
 				InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED,
-				'Scan user(s) under the group(s). This option can be used as --groups=foo --groups=bar to scan groups foo and bar'
+				'Scan user(s) under the group(s). This option can be used as --group=foo --group=bar to scan groups foo and bar'
 			)
 			->addOption(
 				'quiet',
@@ -276,7 +276,7 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		$groups = $input->getOption('groups');
+		$groups = $input->getOption('group');
 		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if (\count($groups) >= 1) {

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -140,8 +140,9 @@ class ScanTest extends TestCase {
 
 	public function dataInput() {
 		return [
-			[['--groups' => 'haystack'], 'Group name haystack doesn\'t exist'],
-			[['--groups' => 'group1'], 'Starting scan for user 1 out of 1 (user1)'],
+			[['--groups' => ['haystack']], 'Group name haystack doesn\'t exist'],
+			[['--groups' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
+			[['--groups' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user2']], 'Starting scan for user 1 out of 1 (user2)']
 		];
@@ -158,7 +159,7 @@ class ScanTest extends TestCase {
 
 	public function userInputData() {
 		return [
-			[['--groups' => 'group1'], 'Starting scan for user 1 out of 200']
+			[['--groups' => ['group1']], 'Starting scan for user 1 out of 200']
 		];
 	}
 
@@ -171,7 +172,7 @@ class ScanTest extends TestCase {
 		//First we populate the users
 		$user = 'user';
 		$numberOfUsersInGroup = 210;
-		for ($i = 2; $i <= 210; $i++) {
+		for ($i = 2; $i <= $numberOfUsersInGroup; $i++) {
 			$userObj = $this->createUser($user.$i);
 			$this->groupManager->get('group1')->addUser($userObj);
 		}
@@ -180,13 +181,13 @@ class ScanTest extends TestCase {
 		$output = $this->commandTester->getDisplay();
 		$this->assertContains($expectedOutput, $output);
 		//If pagination works then below assert shouldn't fail
-		$this->assertNotContains('Starting scan for user 1 out of 210', $output);
+		$this->assertNotContains("Starting scan for user 1 out of $numberOfUsersInGroup", $output);
 	}
 
 	public function multipleGroupTest() {
 		return [
-			[['--groups' => 'group1,group2'], ''],
-			[['--groups' => 'group1,group2,group3'], '']
+			[['--groups' => ['group1,x','group2']], ''],
+			[['--groups' => ['group1','group2,x','group3']], '']
 		];
 	}
 
@@ -196,7 +197,7 @@ class ScanTest extends TestCase {
 	 */
 	public function testMultipleGroups($input) {
 		//Create 10 users in each group
-		$groups = \explode(',', $input['--groups']);
+		$groups = $input['--groups'];
 		$user = "user";
 		$userObj = [];
 		for ($i = 1; $i <= (10 * \count($groups)); $i++) {

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -140,6 +140,8 @@ class ScanTest extends TestCase {
 
 	public function dataInput() {
 		return [
+			[['--groups' => 'haystack'], 'Group name haystack doesn\'t exist'],
+			[['--groups' => 'group1'], 'Starting scan for user 1 out of 1 (user1)'],
 			[['--group' => ['haystack']], 'Group name haystack doesn\'t exist'],
 			[['--group' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
 			[['--group' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
@@ -186,6 +188,9 @@ class ScanTest extends TestCase {
 
 	public function multipleGroupTest() {
 		return [
+			[['--groups' => 'group1,group2'], ''],
+			[['--groups' => 'group1,group2,group3'], ''],
+			[['--groups' => 'group1,group2', '--group' => ['group2','group3']], ''],
 			[['--group' => ['group1,x','group2']], ''],
 			[['--group' => ['group1','group2,x','group3']], '']
 		];
@@ -197,7 +202,13 @@ class ScanTest extends TestCase {
 	 */
 	public function testMultipleGroups($input) {
 		//Create 10 users in each group
-		$groups = $input['--group'];
+		$groups = [];
+		if (\array_key_exists('--groups', $input)) {
+			$groups = \explode(',', $input['--groups']);
+		}
+		if (\array_key_exists('--group', $input)) {
+			$groups = \array_merge($groups, $input['--group']);
+		}
 		$user = "user";
 		$userObj = [];
 		for ($i = 1; $i <= (10 * \count($groups)); $i++) {

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -140,9 +140,9 @@ class ScanTest extends TestCase {
 
 	public function dataInput() {
 		return [
-			[['--groups' => ['haystack']], 'Group name haystack doesn\'t exist'],
-			[['--groups' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
-			[['--groups' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
+			[['--group' => ['haystack']], 'Group name haystack doesn\'t exist'],
+			[['--group' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
+			[['--group' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user2']], 'Starting scan for user 1 out of 1 (user2)']
 		];
@@ -159,7 +159,7 @@ class ScanTest extends TestCase {
 
 	public function userInputData() {
 		return [
-			[['--groups' => ['group1']], 'Starting scan for user 1 out of 200']
+			[['--group' => ['group1']], 'Starting scan for user 1 out of 200']
 		];
 	}
 
@@ -186,8 +186,8 @@ class ScanTest extends TestCase {
 
 	public function multipleGroupTest() {
 		return [
-			[['--groups' => ['group1,x','group2']], ''],
-			[['--groups' => ['group1','group2,x','group3']], '']
+			[['--group' => ['group1,x','group2']], ''],
+			[['--group' => ['group1','group2,x','group3']], '']
 		];
 	}
 
@@ -197,7 +197,7 @@ class ScanTest extends TestCase {
 	 */
 	public function testMultipleGroups($input) {
 		//Create 10 users in each group
-		$groups = $input['--groups'];
+		$groups = $input['--group'];
 		$user = "user";
 		$userObj = [];
 		for ($i = 1; $i <= (10 * \count($groups)); $i++) {


### PR DESCRIPTION
## Description
Backport last 2 commits from #31719 
Backport #34753 

This effectively adds `files:scan --group` in addition to the existing `files:scan --groups` option.
See explanation in https://github.com/owncloud/core/pull/34753#issue-260423010

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
