### PR TITLE
[stable10] Implement waitTillPageIsLoaded for UsersPage

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -798,4 +798,35 @@ class UsersPage extends OwncloudPage {
 			$this->waitForAjaxCallsToStartAndFinish($session);
 		}
 	}
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param int $timeout_msec
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function waitTillPageIsLoaded(
+		Session $session,
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	) {
+		$currentTime = \microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
+			if ($this->findById($this->groupListId) !== null) {
+				break;
+			}
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+			$currentTime = \microtime(true);
+		}
+
+		if ($currentTime > $end) {
+			throw new \Exception(
+				__METHOD__ . " timeout waiting for users page to load"
+			);
+		}
+
+		$this->waitForOutstandingAjaxCalls($session);
+	}
 }


### PR DESCRIPTION
## Description
`UsersPage` was falling back to the `waitTillPageIsLoaded()` method in `OwncloudPage` and that method looks for the "loading" indicator. That is not what happens on the users page.

The users page is delivered with a pre-populated lists of groups in `groupListId` - when that becomes available then the page is there, and then we can wait for any AJAX calls (e.g. the call that loads the first batch of users)

This is a "backport" for `user_management` PR https://github.com/owncloud/user_management/pull/162

## Related Issue
https://github.com/owncloud/user_ldap/issues/386

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

