### PR TITLE
[stable10] Align acceptance test code with user_management app

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -483,7 +483,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	) {
 		foreach ($table as $row) {
 			$userLastLogin = $this->usersPage->getLastLoginOfUser($row['username']);
-			
+
 			PHPUnit_Framework_Assert::assertContains($row['last login'], $userLastLogin);
 		}
 	}

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -44,9 +44,9 @@ class GroupList extends OwncloudPage {
 	protected $addNewGroupInputBoxId = 'newgroupname';
 	protected $addNewGroupButtonXpath = '//input[@class="button icon-add"]';
 	protected $deleteConfirmButtonXpath
-		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style,'display: none')])]//button[text()='Yes']";
+		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='Yes']";
 	protected $deleteNotConfirmButtonXpath
-		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style,'display: none')])]//button[text()='No']";
+		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='No']";
 
 	/**
 	 * sets the NodeElement for the current group list

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -53,29 +53,38 @@ class UsersPage extends OwncloudPage {
 	protected $storageLocationColumnXpath = "//td[@class='storageLocation']";
 	protected $lastLoginXpath = "//td[@class='lastLogin']";
 
-	protected $manualQuotaInputXpath = "//input[contains(@data-original-title,'Please enter storage quota')]";
+	protected $manualQuotaInputXpath
+		= "//input[contains(@data-original-title,'Please enter storage quota')]";
 	protected $settingsBtnXpath = ".//*[@id='app-settings-header']/button";
 	protected $settingContentId = "app-settings-content";
-	protected $labelMailOnUserCreateXpath = ".//label[@for='CheckboxMailOnUserCreate']";
-	protected $settingByTextXpath = ".//*[@id='userlistoptions']//label[normalize-space()='%s']";
+	protected $labelMailOnUserCreateXpath
+		= ".//label[@for='CheckboxMailOnUserCreate']";
+	protected $settingByTextXpath
+		= ".//*[@id='userlistoptions']//label[normalize-space()='%s']";
 	protected $newUserUsernameFieldId = "newusername";
 	protected $newUserPasswordFieldId = "newuserpassword";
 	protected $newUserEmailFieldId = "newemail";
 	protected $createUserBtnXpath = ".//*[@id='newuser']/input[@type='submit']";
-	protected $newUserGroupsDropDownXpath = ".//*[@id='newuser']//div[@class='groupsListContainer multiselect button']";
+	protected $newUserGroupsDropDownXpath
+		= ".//*[@id='newuser']//div[@class='groupsListContainer multiselect button']";
 	protected $newUserGroupsDropDownListTag = "li";
 	protected $newUserGroupsSelectedClass = "selected";
-	protected $newUserGroupsListXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']";
-	protected $newUserGroupXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//label[@title='%s']/..";
-	protected $newUserAddGroupBtnXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//li[@title='add group']";
-	protected $createGroupWithNewUserInputXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//input[@type='text']";
+	protected $newUserGroupsListXpath
+		= ".//*[@id='newuser']//ul[@class='multiselectoptions down']";
+	protected $newUserGroupXpath
+		= ".//*[@id='newuser']//ul[@class='multiselectoptions down']//label[@title='%s']/..";
+	protected $newUserAddGroupBtnXpath
+		= ".//*[@id='newuser']//ul[@class='multiselectoptions down']//li[@title='add group']";
+	protected $createGroupWithNewUserInputXpath
+		= ".//*[@id='newuser']//ul[@class='multiselectoptions down']//input[@type='text']";
 	protected $groupListId = "usergrouplist";
 	protected $disableUserCheckboxXpath = "//input[@type='checkbox']";
-	protected $deleteUserBtnXpath = ".//td[@class='remove']/a[@class='action delete']";
+	protected $deleteUserBtnXpath
+		= ".//td[@class='remove']/a[@class='action delete']";
 	protected $deleteConfirmBtnXpath
-		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style,'display: none')])]//button[text()='Yes']";
+		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='Yes']";
 	protected $deleteNotConfirmBtnXpath
-		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style,'display: none')])]//button[text()='No']";
+		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='No']";
 
 	protected $userNameFieldCss = ".name";
 
@@ -467,7 +476,8 @@ class UsersPage extends OwncloudPage {
 						$createUserInput->setValue($group . "\n");
 					} catch (NoSuchElement $e) {
 						// this seems to be a bug in MinkSelenium2Driver.
-						// Actually all that we need does happen, so we just don't do anything
+						// Actually all that we need does happen,
+						// so we just don't do anything
 					}
 				}
 			}
@@ -516,7 +526,9 @@ class UsersPage extends OwncloudPage {
 			}
 
 			$selectOption->click();
-			$manualQuotaInputElement = $this->find('xpath', $this->manualQuotaInputXpath);
+			$manualQuotaInputElement = $this->find(
+				'xpath', $this->manualQuotaInputXpath
+			);
 
 			if ($manualQuotaInputElement === null) {
 				throw new ElementNotFoundException(
@@ -586,9 +598,10 @@ class UsersPage extends OwncloudPage {
 	}
 
 	/**
+	 *
 	 * @param string $name
 	 * @param Session $session
-	 * @param bool $confirm  , true is to delete and false is not to delete
+	 * @param bool $confirm true is to delete and false is not to delete
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -5,9 +5,9 @@ Feature: manage user quota
   So that users can only take up a certain amount of storage space
 
   Background:
-    Given these users have been created but not initialized:
-      | username | password | displayname | email        |
-      | user1    | 1234     | User One    | u1@oc.com.np |
+    Given these users have been created with default attributes but not initialized:
+      | username |
+      | user1    |
     And the administrator has logged in using the webUI
     And the administrator has browsed to the users page
 

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -15,9 +15,9 @@ Feature: add users
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   Scenario: use the webUI to create a user with special valid characters
-    When the administrator creates a user with the name "@-_.'" and the password "pwd" using the webUI
+    When the administrator creates a user with the name "@-_.'" and the password "%regular%" using the webUI
     And the administrator logs out of the webUI
-    And the user logs in with username "@-_.'" and password "pwd" using the webUI
+    And user "@-_.'" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   Scenario Outline: use the webUI to create a user with special invalid characters
@@ -31,7 +31,7 @@ Feature: add users
       | "a+^"  | "%alt1%"    |
       | "a)~"  | "%alt2%"    |
       | "a(="  | "%alt3%"    |
-      | "a`*^" | "%regular%" |
+      | "a`*^" | "%alt4%"    |
 
   Scenario: use the webUI to create a user with empty password
     When the administrator attempts to create a user with the name "bijay" and the password "" using the webUI
@@ -54,7 +54,7 @@ Feature: add users
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
       """
       just letting you know that you now have an %productname% account.
-      
+
       Your username: guiusr1
       Access it:
       """
@@ -165,7 +165,7 @@ Feature: add users
       """
     And the reset email to "guiusr1@owncloud" should be from "owncloud@foobar.com"
 
-   Scenario Outline: admin creates a user and sets password containing special characters
+  Scenario Outline: admin creates a user and sets password containing special characters
     Given user "brand-new-user" has been deleted
     When the administrator creates a user with the name "brand-new-user" and the password "<password>" using the webUI
     And the administrator logs out of the webUI
@@ -179,7 +179,7 @@ Feature: add users
       | नेपाली                                                  | Unicode                     |
       | password with spaces         | password with spaces        |
 
-   Scenario Outline: admin creates a user without setting password and user sets password containing special characters
+  Scenario Outline: admin creates a user without setting password and user sets password containing special characters
     Given user "brand-new-user" has been deleted
     When the administrator creates a user with the name "brand-new-user" and the email "bnu@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
@@ -195,7 +195,7 @@ Feature: add users
       | नेपाली                                                  | Unicode                     |
       | password with spaces         | password with spaces        |
 
-   Scenario: admin creates a user without setting password and user sets empty spaces as password
+  Scenario: admin creates a user without setting password and user sets empty spaces as password
     Given user "brand-new-user" has been deleted
     When the administrator creates a user with the name "brand-new-user" and the email "bnu@owncloud" without a password using the webUI
     And the administrator logs out of the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -5,16 +5,16 @@ Feature: delete users
   So that I can remove users
 
   Background:
-    Given these users have been created but not initialized:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %regular% | User Two    | u2@oc.com.np |
+    Given these users have been created with default attributes but not initialized:
+      | username |
+      | user1    |
+      | user2    |
     And the administrator has logged in using the webUI
     And the administrator has browsed to the users page
 
   Scenario: use the webUI to delete a simple user
     When the administrator deletes user "user1" using the webUI and confirms the deletion using the webUI
-    And the deleted user "user1" tries to login using the password "%regular%" using the webUI
+    And the deleted user "user1" tries to login using the password "%alt1%" using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user has browsed to the login page
     And user "user2" logs in using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -5,16 +5,17 @@ Feature: disable users
   So that I can remove access to unnecessary users
 
   Background:
-    Given these users have been created but not initialized:
-      | username | password      | displayname | email        |
-      | user1    | %regular%     | User One    | u1@oc.com.np |
-      | user2    | %regular%     | User Two    | u2@oc.com.np |
+    Given these users have been created with default attributes but not initialized:
+      | username |
+      | user1    |
+      | user2    |
 
   Scenario: disable a user
     Given the administrator has logged in using the webUI
     And the administrator has browsed to the users page
     When the administrator disables user "user1" using the webUI
-    And the disabled user "user1" tries to login using the password "%regular%" from the webUI
+    Then user "user1" should be disabled
+    When the disabled user "user1" tries to login using the password "%alt1%" from the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user has browsed to the login page
     And user "user2" logs in using the webUI
@@ -29,7 +30,8 @@ Feature: disable users
     And user "subadmin" has logged in using the webUI
     And the user has browsed to the users page
     When the user disables user "user1" using the webUI
-    And the disabled user "user1" tries to login using the password "%regular%" from the webUI
+    Then user "user1" should be disabled
+    When the disabled user "user1" tries to login using the password "%alt1%" from the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user has browsed to the login page
     And user "user2" logs in using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -16,7 +16,7 @@ Feature: edit users
     Then "New User" should be shown as the name of the current user on the WebUI
     And user "user0" should exist
     And the user attributes returned by the API should include
-    | displayname | New User |
+      | displayname | New User |
 
   @skipOnEncryptionType:user-keys
   Scenario: Admin changes the password of the user

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -21,6 +21,14 @@ Feature: manage groups
       | groupname |
       | 0         |
       | false     |
+    Then these groups should be listed on the webUI:
+      |groupname     |
+      |do-not-delete |
+      |do-not-delete2|
+    But these groups should not be listed on the webUI:
+      |groupname|
+      |0        |
+      |false    |
     And the administrator reloads the users page
     Then these groups should be listed on the webUI:
       | groupname      |
@@ -56,6 +64,16 @@ Feature: manage groups
       | per%cent  |
       | hash#char |
       | q?mark    |
+    Then these groups should be listed on the webUI:
+      |groupname     |
+      |do-not-delete |
+      |do-not-delete2|
+    But these groups should not be listed on the webUI:
+      |groupname     |
+      |a/slash       |
+      |per%cent      |
+      |hash#char     |
+      |q?mark        |
     And the administrator reloads the users page
     Then these groups should be listed on the webUI:
       | groupname      |
@@ -89,6 +107,16 @@ Feature: manage groups
       | do-not-delete2 |
     And the administrator has browsed to the users page
     When the administrator deletes these groups and confirms the deletion using the webUI:
+      | groupname   |
+      | grp1        |
+      | space group |
+      | quotes'     |
+      | quotes"     |
+    Then these groups should be listed on the webUI:
+      |groupname     |
+      |do-not-delete |
+      |do-not-delete2|
+    But these groups should not be listed on the webUI:
       | groupname   |
       | grp1        |
       | space group |

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -3,27 +3,28 @@ Feature: add users
   As an admin
   I want to be able to change different settings
   So that I can see various details about users
-   Background: 
-    Given these users have been created but not initialized:
-      | username | password  | displayname | email        |
-      | user1    | %regular% | User One    | u1@oc.com.np |
-      | user2    | %regular% | User Two    | u2@oc.com.np |
+
+  Background:
+    Given these users have been created with default attributes but not initialized:
+      | username |
+      | user1    |
+      | user2    |
     And the administrator has logged in using the webUI
     And the administrator has browsed to the users page
 
-   Scenario: administrator should be able to see email of a user
+  Scenario: administrator should be able to see email of a user
     When the administrator enables the setting "Show email address" in the User Management page using the webUI
     Then the administrator should be able to see the email of these users in the User Management page:
       | username | email        |
-      | user1    | u1@oc.com.np |
-      | user2    | u2@oc.com.np |
+      | user1    | user1@example.org |
+      | user2    | user2@example.org |
 
-   Scenario: administrator should be able to see storage location of a user
+  Scenario: administrator should be able to see storage location of a user
     When the administrator enables the setting "Show storage location" in the User Management page using the webUI
     Then the administrator should be able to see the storage location of these users in the User Management page:
-      | username  | storage location |
-      | user1     | /data/user1      |
-      | user2     | /data/user2      |
+      | username | storage location |
+      | user1    | /data/user1      |
+      | user2    | /data/user2      |
 
   Scenario: administrator should be able to see last login of a user when the user is not initialized
     When the administrator enables the setting "Show last log in" in the User Management page using the webUI
@@ -32,7 +33,7 @@ Feature: add users
       | user1    | never      |
       | user2    | never      |
 
-   Scenario: administrator should be able to see last login of a user when the user is initialized
+  Scenario: administrator should be able to see last login of a user when the user is initialized
     When the administrator enables the setting "Show last log in" in the User Management page using the webUI
     And the administrator logs out of the webUI
     And user "user1" logs in using the webUI


### PR DESCRIPTION
## Description
Look at the diffs between acceptance test code in the `user_management` app and here in core `stable10`

Apply the "good stuff" from the `user_management` app to core `stable10`

See user_management PR https://github.com/owncloud/user_management/pull/164 for the stuff going the other direction.

## Motivation and Context
Keep code in sync

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

No "backport/forwardport" needed - this is test code from the user_management app.