### PR TITLE
allow to check log entries with regular expressions

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -36,9 +36,9 @@ trait Logging {
 	 * order of the table has to be the same as in the log file
 	 * empty cells in the table will not be checked!
 	 *
-	 * @Then /^the last lines of the log file should contain log-entries (with|containing) these attributes:$/
+	 * @Then /^the last lines of the log file should contain log-entries (with|containing|matching) these attributes:$/
 	 *
-	 * @param string $withOrContaining
+	 * @param string $comparingMode
 	 * @param TableNode $expectedLogEntries table with headings that correspond
 	 *                                      to the json keys in the log entry
 	 *                                      e.g.
@@ -48,7 +48,7 @@ trait Logging {
 	 * @throws \Exception
 	 */
 	public function theLastLinesOfTheLogFileShouldContainEntriesWithTheseAttributes(
-		$withOrContaining, TableNode $expectedLogEntries
+		$comparingMode, TableNode $expectedLogEntries
 	) {
 		//-1 because getRows gives also the header
 		$linesToRead = \count($expectedLogEntries->getRows()) - 1;
@@ -76,13 +76,18 @@ trait Logging {
 				);
 				if ($expectedLogEntry[$attribute] !== "") {
 					$message = "log entry:\n{$logLines[$lineNo]}\n";
-					if ($withOrContaining === 'with') {
+					if ($comparingMode === 'with') {
 						PHPUnit_Framework_Assert::assertEquals(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);
-					} else {
+					} elseif ($comparingMode === 'containing') {
 						PHPUnit_Framework_Assert::assertContains(
+							$expectedLogEntry[$attribute], $logEntry[$attribute],
+							$message
+						);
+					} elseif ($comparingMode === 'matching') {
+						PHPUnit_Framework_Assert::assertRegExp(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);


### PR DESCRIPTION
## Description
a more flexible way to check the log files

## Related Issue
needed for https://github.com/owncloud/admin_audit/issues/79
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
