### PR TITLE
normalize path when moving chunks to final destination

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -160,6 +160,7 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 			$this->fileView->verifyPath($this->path, $name);
 
 			$path = $this->fileView->getAbsolutePath($this->path) . '/' . $name;
+			$path = Filesystem::normalizePath($path);
 
 			if (!$info) {
 				// use a dummy FileInfo which is acceptable here since it will be refreshed after the put is complete
@@ -318,6 +319,7 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 		//
 		// TODO: resolve chunk file name here and implement "updateFile"
 		$path = $this->path . '/' . $name;
+		$path = FileSystem::normalizePath($path);
 		return $this->fileView->file_exists($path);
 	}
 


### PR DESCRIPTION
## Description
uploading files with old chunking into the root results here into `//` in the path

do: 
```
curl --user admin:admin http://localhost/owncloud-core/remote.php/webdav/aaa.txt-chunking-1234-2-0 --request PUT -d"11111" -H "OC-Chunked:1"
curl --user admin:admin http://localhost/owncloud-core/remote.php/webdav/aaa.txt-chunking-1234-2-1 --request PUT -d"11111" -H "OC-Chunked:1"
```

and check the variable in the debugger

## Related Issue
- Fixes https://github.com/owncloud/admin_audit/issues/131

## Motivation and Context
log of admin_audit shows too many `/`

## How Has This Been Tested?
check logs of admin_audit before and after the fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
