### PR TITLE
[stable10] fix occ url when running acceptance tests on build-it server

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -505,8 +505,8 @@ else
 
 	# The endpoint to use to do occ commands via the testing app
 	TESTING_APP_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/"
-	OCC_URL="${TEST_SERVER_URL}occ"
-	DIR_URL="${TEST_SERVER_URL}dir"
+	OCC_URL="${TESTING_APP_URL}occ"
+	DIR_URL="${TESTING_APP_URL}dir"
 
 	# Give time for the PHP dev server to become available
 	# because we want to use it to get and change settings with the testing app


### PR DESCRIPTION
backport of  #34761