### PR TITLE
[stable10] Execute unit tests with postgres:10.3 as well

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -487,7 +487,7 @@ services:
         DB_TYPE: mysqlmb4
 
   postgres:
-    image: postgres:9.4
+    image: ${POSTGRES_IMAGE=postgres:9.4}
     environment:
       - POSTGRES_USER=owncloud
       - POSTGRES_PASSWORD=owncloud
@@ -670,6 +670,15 @@ matrix:
 
     - PHP_VERSION: 7.1
       DB_TYPE: postgres
+      POSTGRES_IMAGE: postgres:9.4
+      TEST_SUITE: phpunit
+      COVERAGE: true
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      DB_TYPE: postgres
+      POSTGRES_IMAGE: postgres:10.3
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true


### PR DESCRIPTION
Backport #31330

(see if this works in `stable10` these days)

Edit:
No, not working yet. Because of PHP 7.0 support in `stable10` we cannot get to `doctrine/dbal` `2.8`
We have only got to `doctrine/dbal` `2.5.3`

So postgres:10.3 has to wait a bit longer.