### PR TITLE
Tidy variable references in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -176,13 +176,13 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - OBJECTSTORE=$OBJECTSTORE
+      - OBJECTSTORE=${OBJECTSTORE}
     commands:
       - cd /drone/src/apps
       - git clone https://github.com/owncloud/files_primary_s3.git
       - cd files_primary_s3
       - composer install
-      - cp tests/drone/$${OBJECTSTORE}.config.php /drone/src/config
+      - cp tests/drone/${OBJECTSTORE}.config.php /drone/src/config
       - cd /drone/src
       - php occ a:l
       - php occ a:e files_primary_s3


### PR DESCRIPTION
## Description
Tidy up some variable references, just so that we have consistent use of `${}` to avoid people wondering why it is done differently for `OBJECTSTORE`

## Motivation and Context
Have consistent variable references in the drone script.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
