### PR TITLE
[stable10] Add drone step to print the server logs in case of failure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -645,7 +645,7 @@ matrix:
       COVERAGE: true
 
   # owncloud-coding-standard
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: owncloud-coding-standard
 
   # phan (runs on just PHP 7.0 because that has different dependencies for phan)

--- a/.drone.yml
+++ b/.drone.yml
@@ -652,7 +652,7 @@ matrix:
     - TEST_SUITE: phan-70
       PHP_VERSION: 7.0
 
-    # phan (runs multiple PHP v7.1+ to provide syntax checks of each PHP version)
+  # phan (runs multiple PHP v7.1+ to provide syntax checks of each PHP version)
     - TEST_SUITE: phan
       PHP_VERSION: 7.1
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -440,6 +440,16 @@ pipeline:
       matrix:
         CALDAV_CARDDAV_JOB: true
 
+  print-log:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cat /drone/src/data/owncloud.log
+    when:
+      status:  [ failure ]
+      matrix:
+        TEST_SUITE: phpunit
+
   notify:
     image: plugins/slack:1
     pull: true


### PR DESCRIPTION
1) Backport #28043 commit https://github.com/owncloud/core/pull/28043/commits/203bb4b033d306158c29f204378c066cf2a4b542

which somehow has never found its way back to `stable10`

2) Run `owncloud-coding-standard` on PHP 7.3 just to be the same as in `master` (we are about to do PHP 7.3 support anyway) We have `phan` running on PHP 7.0, 7.1, 7.2 which provides us an effective lint check already for those PHP versions.

3) Fixup a comment indent that got different between `stable10` and `master`