### PR TITLE
Fix Webdav error page, include CSP and message

### DIFF
--- a/apps/dav/lib/Files/BrowserErrorPagePlugin.php
+++ b/apps/dav/lib/Files/BrowserErrorPagePlugin.php
@@ -80,19 +80,22 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 		}
 		$this->server->httpResponse->addHeaders($headers);
 		$this->server->httpResponse->setStatus($httpCode);
-		$body = $this->generateBody();
+		$body = $this->generateBody($ex);
 		$this->server->httpResponse->setBody($body);
+		$this->server->httpResponse->setHeader('Content-Security-Policy', "default-src 'self'; img-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self';");
 		$this->sendResponse();
 	}
 
 	/**
 	 * @codeCoverageIgnore
+	 * @param \Exception $ex
 	 * @return bool|string
 	 */
-	public function generateBody() {
+	public function generateBody(\Exception $ex) {
 		$request = \OC::$server->getRequest();
 		$content = new OC_Template('dav', 'exception', 'guest');
 		$content->assign('title', $this->server->httpResponse->getStatusText());
+		$content->assign('hint', $ex->getMessage());
 		$content->assign('remoteAddr', $request->getRemoteAddress());
 		$content->assign('requestID', $request->getId());
 		return $content->fetchPage();

--- a/apps/dav/templates/exception.php
+++ b/apps/dav/templates/exception.php
@@ -6,6 +6,9 @@ style('core', ['styles', 'header']);
 ?>
 <span class="error error-wide">
 	<h2><strong><?php p($_['title']) ?></strong></h2>
+	<?php if (isset($_['hint']) && $_['hint']): ?>
+		<p class='hint'><?php p($_['hint']) ?></p>
+	<?php endif;?>
 	<br>
 
 	<h2><strong><?php p($l->t('Technical details')) ?></strong></h2>


### PR DESCRIPTION
## Description
Add CSP to Webdav error page.
Include exception message.

## Related Issue
- Discovered with https://github.com/owncloud/core/pull/33992

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Enable firewall app
1. Upload a file "test.txt"
1. Apply a new system tag "forbidden"
1. Create a firewall rule to block based on this tag
1. Try downloading the file

Before this fix: error page is missing styles, browser console full of errors.
After this fix: page renders properly, no more errors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
