### PR TITLE
Fix for File Drop view

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -1,6 +1,6 @@
 #content {
 	height: initial;
-	min-height: calc(100vh - 120px);
+	min-height: calc(100vh - 140px);
 }
 
 /* force layout to make sure the content element's height matches its contents' height */

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -931,7 +931,6 @@ div.crumb:active {
 	color: #777;
 	text-align: center;
 	margin: 0 auto;
-	padding: 20px 0;
 }
 
 #body-public footer .info a {


### PR DESCRIPTION
## Description
The File Drop view had a scroll bar. This is absolutely unnecessary. This pull request provides enough distance from the info text to the lower edge.

## Motivation and Context
The File Drop view had a scroll bar. This is absolutely unnecessary. 

## How Has This Been Tested?
Tested in Firefox and Chrome

## Screenshots:
Mobile view before:
 
<img width="323" alt="Mobile view before" src="https://user-images.githubusercontent.com/33026403/54568628-415eb480-49d8-11e9-8076-7ddcdcc7b20d.png">

Mobile view after:
 
<img width="323" alt="Mobile view after" src="https://user-images.githubusercontent.com/33026403/54568640-4cb1e000-49d8-11e9-9465-0d9b9f730775.png">

Browser view before:

<img width="866" alt="Browser view before" src="https://user-images.githubusercontent.com/33026403/54568685-7408ad00-49d8-11e9-8000-7218a26a4d6c.png">

Browser view after:

<img width="866" alt="Browser view after" src="https://user-images.githubusercontent.com/33026403/54568700-808d0580-49d8-11e9-92dc-f5337d273a87.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
