### PR TITLE
[stable10] Backport user_management 169

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -861,12 +861,5 @@ class UsersPage extends OwncloudPage {
 				__METHOD__ . " timeout waiting for user list to load on users page"
 			);
 		}
-
-		$this->waitForOutstandingAjaxCalls($session);
-
-		// We have tried long enough, and cannot yet find what is the extra thing
-		// that we have to wait for until the page is properly loaded.
-		// ToDo: sort out the real reason that we need to sleep here.
-		\sleep(1);
 	}
 }


### PR DESCRIPTION
Backport https://github.com/owncloud/user_management/pull/169

Note: this backports the code deletion on `UsersPage.php`
The `.drone.yml` line:
```
- php occ config:system:set --value true --type boolean integrity.check.disabled
```
is not needed in core `stable10` because there is not any integrity check issue in the core `stable10` QA tarball.
