### PR TITLE
[stable10] Use files:scan --group in acceptance tests to match master

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -380,7 +380,7 @@ class OccContext implements Context {
 	 */
 	public function theAdministratorScansTheFilesystemForGroupUsingTheOccCommand($group) {
 		$this->invokingTheCommand(
-			"files:scan --groups=$group"
+			"files:scan --group=$group"
 		);
 	}
 


### PR DESCRIPTION
## Description
PR #34754 in `stable10` and #34753 `master` adjusted `files:scan` so that you can specify groups with either the `--group` or `--groups` options.

`master` acceptance tests use `--group` so make it the same in `stable10`

See issue #34807 to get some acceptance tests for the `--groups` option.

## Motivation and Context
Get core `stable10` and `master` in sync.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
