### PR TITLE
Remove duplicate ZEND_DONT_UNLOAD_MODULES=1 from test-phpunit.sh

### DIFF
--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -13,8 +13,6 @@ if [[ "$(pwd)" == "$(cd "$(dirname "$0")"; pwd -P)" ]]; then
   exit 1
 fi
 
-export ZEND_DONT_UNLOAD_MODULES=1
-
 set_up_external_storage() {
     php occ app:enable files_external
     php occ config:app:set core enable_external_storage --value=yes


### PR DESCRIPTION
## Description
```
export ZEND_DONT_UNLOAD_MODULES=1
```
is already at line 9 of `test-phpunit.sh` in both core `stable10` and `master`

Somehow it got duplicated in `master`, so remove that duplication.

Note: these days `phpunit` is run via `Makefile` and I don't think that `test-phpunit.sh` is used by anything. But that is a different issue.

## Motivation and Context
Get core `stable10` and `master` "the same".

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
