### PR TITLE
[stable10] Apply code style to tests/data like happened in master

### DIFF
--- a/tests/data/app/code-checker/test-extends.php
+++ b/tests/data/app/code-checker/test-extends.php
@@ -4,5 +4,4 @@
  * Class BadClass - sub class a forbidden class is not allowed
  */
 class BadClass extends OC_Hook {
-
 }

--- a/tests/data/app/code-checker/test-implements.php
+++ b/tests/data/app/code-checker/test-implements.php
@@ -5,5 +5,4 @@
  *     NOTE: lowercase typo is intended
  */
 class BadClass implements oC_Avatar {
-
 }


### PR DESCRIPTION
## Description
At the time that code style changes were applied in core `master` by PR #31442 the coding standard was being applied to directories called `data` (e.g. `tests/data`) and so some example or test input `*.php` code had style applied to it.

By the time that code style was applied to `stable10`, `data` was in the list of excluded directories. So those code style changes did not get applied in `stable10`

Make the files the same in `stable10`

(Note: we do not care about scanning files in `data` dirs, but might as well make what we have the same in both branches)

## Motivation and Context
Make core `stable10` and `master` the same.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
