### PR TITLE
Add acceptance tests for files:scan --groups

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -374,13 +374,31 @@ class OccContext implements Context {
 	 * @When the administrator scans the filesystem for group :group using the occ command
 	 * @Given the administrator has scanned the filesystem for group :group
 	 *
-	 * @param string $group
+	 * Used to test the --group option of the files:scan command
+	 *
+	 * @param string $group a single group name
 	 *
 	 * @return void
 	 */
 	public function theAdministratorScansTheFilesystemForGroupUsingTheOccCommand($group) {
 		$this->invokingTheCommand(
 			"files:scan --group=$group"
+		);
+	}
+
+	/**
+	 * @When the administrator scans the filesystem for groups list :groups using the occ command
+	 * @Given the administrator has scanned the filesystem for groups list :groups
+	 *
+	 * Used to test the --groups option of the files:scan command
+	 *
+	 * @param string $groups a comma-separated list of group names
+	 *
+	 * @return void
+	 */
+	public function theAdministratorScansTheFilesystemForGroupsUsingTheOccCommand($groups) {
+		$this->invokingTheCommand(
+			"files:scan --groups=$groups"
 		);
 	}
 


### PR DESCRIPTION
## Description
1) Change a scenario for `files:scan --group` into a scenario outline and addd an example for a group name that contains a comma - that is the interesting case when using the `--group` option.
2) Add a scenario that uses the `--groups` option with a comma-separated list of different group names.

## Related Issue
- Fixes #34807 

## Motivation and Context
While sorting out diffs related to `files:scan` options between core `master` and `stable10` I noticed that the `--groups` option did not have an acceptance test, so it is "easy" to add while it is in my head.

## How Has This Been Tested?
CI acceptance test run

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
