### PR TITLE
Add test case for files:scan --group with commas in the group name

### DIFF
--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -44,20 +44,20 @@ Feature: Files Operations command
     Then the propfind result should not contain these entries:
       | /hello2.txt |
 
-  Scenario: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
+  Scenario Outline: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
     Given using new DAV path
     And these users have been created with default attributes:
       | username |
       | user1    |
       | user2    |
-    And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
+    And group "<groupname>" has been created
+    And user "user1" has been added to group "<groupname>"
+    And user "user2" has been added to group "<groupname>"
     And user "user1" has created folder "/local_storage/folder1"
     And the administrator has set the external storage "local_storage" to be never scanned automatically
-    And user "user1" has shared folder "/local_storage/folder1" with group "grp1"
+    And user "user1" has shared folder "/local_storage/folder1" with group "<groupname>"
     And the administrator has scanned the filesystem for all users
-    And the administrator has scanned the filesystem for group "grp1"
+    And the administrator has scanned the filesystem for group "<groupname>"
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
@@ -65,13 +65,17 @@ Feature: Files Operations command
     When user "user2" requests "/remote.php/dav/files/user2/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should not contain these entries:
       | /hello1.txt |
-    When the administrator scans the filesystem for group "grp1" using the occ command
+    When the administrator scans the filesystem for group "<groupname>" using the occ command
     And user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
       | /hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/folder1" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
       | /hello1.txt |
+    Examples:
+      | groupname            |
+      | grp1                 |
+      | commas,in,group,name |
 
   Scenario: administrator should be able to create a local mount for a specific user
     Given using new DAV path


### PR DESCRIPTION
## Description
The `files:scan --group` command was added in order to support group names that contain a comma.
So it would be nice to have an acceptance test that checks this.

This was noticed while getting core `stable10` and `master` code in sync, and it is trivial to make the scenario outline with an extra example.

(another scenario for `files:scan --groups` command will come later)

## Related Issue
- Part of #34807 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
