### PR TITLE
do not check empty table fields for their existance in the log file

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -70,11 +70,12 @@ trait Logging {
 					= $this->featureContext->substituteInLineCodes(
 						$expectedLogEntry[$attribute]
 					);
-				PHPUnit_Framework_Assert::assertArrayHasKey(
-					$attribute, $logEntry,
-					"could not find attribute: '$attribute' in log entry: '{$logLines[$lineNo]}'"
-				);
+
 				if ($expectedLogEntry[$attribute] !== "") {
+					PHPUnit_Framework_Assert::assertArrayHasKey(
+						$attribute, $logEntry,
+						"could not find attribute: '$attribute' in log entry: '{$logLines[$lineNo]}'"
+					);
 					$message = "log entry:\n{$logLines[$lineNo]}\n";
 					if ($comparingMode === 'with') {
 						PHPUnit_Framework_Assert::assertEquals(


### PR DESCRIPTION
## Description
if a cell in the table does not have any value, don't even check if it exists in the log line

## Motivation and Context
with that a table can check multiple lines of logs with different fields

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
