### PR TITLE
Sync code for 'add events for user preference changes' 31266 and 31307

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -45,7 +45,9 @@ class AllConfig implements IConfig {
 	/** @var IDBConnection */
 	private $connection;
 
+	/** @var EventDispatcher */
 	private $eventDispatcher;
+
 	/**
 	 * 3 dimensional array with the following structure:
 	 * [ $userId =>
@@ -69,7 +71,10 @@ class AllConfig implements IConfig {
 	private $userCache;
 
 	/**
+	 * AllConfig constructor.
+	 *
 	 * @param SystemConfig $systemConfig
+	 * @param EventDispatcher|null $eventDispatcher
 	 */
 	public function __construct(SystemConfig $systemConfig, EventDispatcher $eventDispatcher) {
 		$this->userCache = new CappedMemoryCache();
@@ -300,8 +305,9 @@ class AllConfig implements IConfig {
 		$arguments = ['uid' => $userId, 'key' => $key, 'app' => $appName];
 		$this->eventDispatcher->dispatch('userpreferences.beforeDeleteValue',
 			new GenericEvent(null, $arguments));
-		$sql  = 'DELETE FROM `*PREFIX*preferences` '.
-				'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?';
+
+		$sql = 'DELETE FROM `*PREFIX*preferences` '.
+			'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?';
 		$this->connection->executeUpdate($sql, [$userId, $appName, $key]);
 
 		if (isset($this->userCache[$userId], $this->userCache[$userId][$appName])) {
@@ -326,7 +332,7 @@ class AllConfig implements IConfig {
 		$arguments = ['uid' => $userId];
 		$this->eventDispatcher->dispatch('userpreferences.beforeDeleteUser', new GenericEvent(null, $arguments));
 
-		$sql  = 'DELETE FROM `*PREFIX*preferences` '.
+		$sql = 'DELETE FROM `*PREFIX*preferences` '.
 			'WHERE `userid` = ?';
 		$this->connection->executeUpdate($sql, [$userId]);
 
@@ -350,8 +356,8 @@ class AllConfig implements IConfig {
 		$arguments = ['app' => $appName];
 		$this->eventDispatcher->dispatch('userpreferences.beforeDeleteApp', new GenericEvent(null, $arguments));
 
-		$sql  = 'DELETE FROM `*PREFIX*preferences` '.
-				'WHERE `appid` = ?';
+		$sql = 'DELETE FROM `*PREFIX*preferences` '.
+			'WHERE `appid` = ?';
 		$this->connection->executeUpdate($sql, [$appName]);
 
 		foreach ($this->userCache as &$userCache) {
@@ -420,10 +426,10 @@ class AllConfig implements IConfig {
 
 			$placeholders = (\sizeof($chunk) === 50) ? $placeholders50 :  \implode(',', \array_fill(0, \sizeof($chunk), '?'));
 
-			$query    = 'SELECT `userid`, `configvalue` ' .
-						'FROM `*PREFIX*preferences` ' .
-						'WHERE `appid` = ? AND `configkey` = ? ' .
-						'AND `userid` IN (' . $placeholders . ')';
+			$query = 'SELECT `userid`, `configvalue` ' .
+				'FROM `*PREFIX*preferences` ' .
+				'WHERE `appid` = ? AND `configkey` = ? ' .
+				'AND `userid` IN (' . $placeholders . ')';
 			$result = $this->connection->executeQuery($query, $queryParams);
 
 			while ($row = $result->fetch()) {

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -55,9 +55,9 @@ class AllConfigTest extends \Test\TestCase {
 		$config->deleteUserValue('userDelete', 'appDelete', 'keyDelete');
 
 		$result = $this->connection->executeQuery(
-				'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences` WHERE `userid` = ?',
-				['userDelete']
-			)->fetch();
+			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences` WHERE `userid` = ?',
+			['userDelete']
+		)->fetch();
 		$actualCount = $result['count'];
 
 		$this->assertEquals(0, $actualCount, 'There was one value in the database and after the tests there should be no entry left.');
@@ -225,7 +225,7 @@ class AllConfigTest extends \Test\TestCase {
 		$connectionMock->expects($this->once())
 			->method('executeQuery')
 			->with($this->equalTo('SELECT `configvalue` FROM `*PREFIX*preferences` '.
-					'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?'),
+				'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?'),
 				$this->equalTo(['userSetUnchanged', 'appSetUnchanged', 'keySetUnchanged']))
 			->will($this->returnValue($resultMock));
 		$connectionMock->expects($this->never())
@@ -337,10 +337,10 @@ class AllConfigTest extends \Test\TestCase {
 		$value = $config->getUserValueForUsers('appFetch2', 'keyFetch1',
 			['userFetch1', 'userFetch2', 'userFetch3', 'userFetch5']);
 		$this->assertEquals([
-				'userFetch1' => 'value1',
-				'userFetch2' => 'value2',
-				'userFetch3' => 3,
-				'userFetch5' => 'value5'
+			'userFetch1' => 'value1',
+			'userFetch2' => 'value2',
+			'userFetch3' => 3,
+			'userFetch5' => 'value5'
 		], $value);
 
 		$value = $config->getUserValueForUsers('appFetch2', 'keyFetch1',


### PR DESCRIPTION
## Description
PR #31266 "Add events for user preference changes" happened in `stable10`
PR #31307 was the forward-port to `master`
But these had some lines different (formatting and PHPdoc...)

This PR syncs the code in `master` to match the "good stuff" in `stable10`

(see PR #34820 for code going the other way)

Between the 2 PRs, this gets the code in sync.

## Motivation and Context
Make code the same in `stable10` and `master`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
