### PR TITLE
Add a template changelog to master branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+This is a template changelog file.
+See here for the [V10 changelog](https://github.com/owncloud/core/blob/stable10/CHANGELOG.md).
+
+## [Unreleased]
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+[Unreleased]: https://github.com/owncloud/core/compare/stable10...master

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ acceptance_test_deps=vendor-bin/behat/vendor
 nodejs_deps=build/node_modules
 core_vendor=core/vendor
 
-core_doc_files=AUTHORS COPYING README.md
+core_doc_files=AUTHORS COPYING README.md CHANGELOG.md
 core_src_files=$(wildcard *.php) index.html db_structure.xml .htaccess .user.ini robots.txt
 core_src_dirs=apps apps-external core l10n lib occ ocs ocs-provider ocm-provider resources settings
 core_test_dirs=tests


### PR DESCRIPTION
## Description
Add a template `CHANGELOG.md` to core `master` branch and put it in the `make dist` of `Makefile`

This makes `master` "work" more like `stable10`, gets `Makefile` to have 1 less diff and provides a GitHub-usable link back to the current stable10 changelog.

## Motivation and Context
Make core `stable10` and `master` be as similar as reasonable.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
