### PR TITLE
Remove lines in .htaccess added by PR 31810

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -85,7 +85,3 @@ Options -Indexes
   ModPagespeed Off
 </IfModule>
 
-#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
-
-ErrorDocument 403 /core/templates/403.php
-ErrorDocument 404 /core/templates/404.php


### PR DESCRIPTION
## Description
https://github.com/owncloud/core/pull/31810/commits/0dfe69c4ac36c0579624046876f29653da89d068 seems to have accidentally added these lines to the end of `.htaccess`

They are not in `stable10`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
