### PR TITLE
[stable10] Update .github/PULL_REQUEST_TEMPLATE.md with latest from master

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,19 @@ This is the bug tracker for the Server component. Find other components at https
 
 For fixing potential security issues please see https://owncloud.org/security/
 
-To make it possible for us to get your change reviewed and merged please fill out below information carefully.
+To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.
 
-Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
+Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.
 
 We will carefully discuss if your change can or has to be backported to stable branches.
+
+Please set the following labels:
+
+- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
+- Set label "backport-request" if backport is needed
+- Assignment: assign to self
+- Milestone: set the same as the ticket this PR fixes, or "development" by default
+- Reviewers: pick at least one
 -->
 
 ## Description
@@ -20,6 +28,7 @@ We will carefully discuss if your change can or has to be backported to stable b
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
 <!--- Please link to the issue here: -->
+- Fixes <issue_link>
 
 ## Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
@@ -28,6 +37,10 @@ We will carefully discuss if your change can or has to be backported to stable b
 <!--- Please describe in detail how you tested your changes. -->
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
+- test environment:
+- test case 1:
+- test case 2:
+- ...
 
 ## Screenshots (if appropriate):
 
@@ -35,15 +48,19 @@ We will carefully discuss if your change can or has to be backported to stable b
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
+- [ ] Database schema changes (next release will require increase of minor version instead of patch)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Technical debt
+- [ ] Tests only (no source changes)
 
 ## Checklist:
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.
-- [ ] I have read the **CONTRIBUTING** document.
-- [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+<!-- Tick the checkboxes when done. -->
+<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
+- [ ] Code changes
+- [ ] Unit tests added
+- [ ] Acceptance tests added
+- [ ] Documentation ticket raised: <link> 
 
+## Open tasks:
+<!-- In case of incomplete PR, please list the open tasks here -->
+- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)


### PR DESCRIPTION
## Description
Apply changes from master to stabe10 for `.github/PULL_REQUEST_TEMPLATE.md`
Just so there are no diffs of `.github` folder between `master` and `stable10`


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
