### PR TITLE
[stable10] Apply code style to build dir in stable10

### DIFF
--- a/build/OCPSinceChecker.php
+++ b/build/OCPSinceChecker.php
@@ -19,7 +19,6 @@
  *
  */
 
-
 require_once __DIR__ . '/../lib/composer/autoload.php';
 
 /**
@@ -28,7 +27,6 @@ require_once __DIR__ . '/../lib/composer/autoload.php';
  * this class checks all methods for the presence of the @since tag
  */
 class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
-
 	const INVALID_VERSIONS = ['9.2'];
 
 	/** @var string */
@@ -42,62 +40,62 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 	protected $errors = [];
 
 	public function enterNode(\PhpParser\Node $node) {
-		if($this->deprecatedClass) {
+		if ($this->deprecatedClass) {
 			return;
 		}
 
-		if($node instanceof \PhpParser\Node\Stmt\Namespace_) {
+		if ($node instanceof \PhpParser\Node\Stmt\Namespace_) {
 			$this->namespace = $node->name;
 		}
 
-		if($node instanceof \PhpParser\Node\Stmt\Interface_ or
+		if ($node instanceof \PhpParser\Node\Stmt\Interface_ or
 			$node instanceof \PhpParser\Node\Stmt\Class_) {
 			$this->className = $node->name;
 
 			/** @var \PhpParser\Comment\Doc[] $comments */
 			$comments = $node->getAttribute('comments');
 
-			if(count($comments) === 0) {
+			if (\count($comments) === 0) {
 				$this->errors[] = 'PHPDoc is needed for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}
 
-			$comment = $comments[count($comments) - 1];
+			$comment = $comments[\count($comments) - 1];
 			$text = $comment->getText();
-			if(strpos($text, '@deprecated') !== false) {
+			if (\strpos($text, '@deprecated') !== false) {
 				$this->deprecatedClass = true;
 			}
 
-			if($this->deprecatedClass === false && strpos($text, '@since') === false && strpos($text, '@deprecated') === false) {
+			if ($this->deprecatedClass === false && \strpos($text, '@since') === false && \strpos($text, '@deprecated') === false) {
 				$type = $node instanceof \PhpParser\Node\Stmt\Interface_ ? 'interface' : 'class';
 				$this->errors[] = '@since or @deprecated tag is needed in PHPDoc for ' . $type . ' ' . $this->namespace . '\\' . $this->className;
 				return;
 			}
 
-			if($this->deprecatedClass === false && ($ver = $this->checkInvalidVersions($text)) !== null) {
+			if ($this->deprecatedClass === false && ($ver = $this->checkInvalidVersions($text)) !== null) {
 				$type = $node instanceof \PhpParser\Node\Stmt\Interface_ ? 'interface' : 'class';
 				$this->errors[] = 'Specified version ' . $ver . ' does not exist for ' . $type . ' ' . $this->namespace . '\\' . $this->className;
 				return;
 			}
 		}
 
-		if($node instanceof \PhpParser\Node\Stmt\ClassMethod) {
+		if ($node instanceof \PhpParser\Node\Stmt\ClassMethod) {
 			/** @var \PhpParser\Node\Stmt\ClassMethod $node */
 			/** @var \PhpParser\Comment\Doc[] $comments */
 			$comments = $node->getAttribute('comments');
 
-			if(count($comments) === 0) {
+			if (\count($comments) === 0) {
 				$this->errors[] = 'PHPDoc is needed for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}
-			$comment = $comments[count($comments) - 1];
+			$comment = $comments[\count($comments) - 1];
 			$text = $comment->getText();
-			if(strpos($text, '@since') === false && strpos($text, '@deprecated') === false) {
+			if (\strpos($text, '@since') === false && \strpos($text, '@deprecated') === false) {
 				$this->errors[] = '@since or @deprecated tag is needed in PHPDoc for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}
 
-			if(($ver = $this->checkInvalidVersions($text)) !== null) {
+			if (($ver = $this->checkInvalidVersions($text)) !== null) {
 				$this->errors[] = 'Specified version ' . $ver . ' does not exist for ' . $this->namespace . '\\' . $this->className;
 				return;
 			}
@@ -109,10 +107,10 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 	 */
 	private function checkInvalidVersions($text) {
 		foreach (self::INVALID_VERSIONS as $ver) {
-			if (preg_match('/' . preg_quote('@since') . '\s*' . preg_quote($ver) . '/', $text) === 1) {
+			if (\preg_match('/' . \preg_quote('@since') . '\s*' . \preg_quote($ver) . '/', $text) === 1) {
 				return $ver;
 			}
-			if (preg_match('/' . preg_quote('@deprecated') . '\s*' . preg_quote($ver) . '/', $text) === 1) {
+			if (\preg_match('/' . \preg_quote('@deprecated') . '\s*' . \preg_quote($ver) . '/', $text) === 1) {
 				return $ver;
 			}
 		}
@@ -129,24 +127,24 @@ echo 'Parsing all files in lib/public for the presence of @since or @deprecated 
 $parser = (new \PhpParser\ParserFactory())->create(\PhpParser\ParserFactory::PREFER_PHP7);
 
 /* iterate over all .php files in lib/public */
-$Directory = new RecursiveDirectoryIterator(dirname(__DIR__) . '/lib/public');
+$Directory = new RecursiveDirectoryIterator(\dirname(__DIR__) . '/lib/public');
 $Iterator = new RecursiveIteratorIterator($Directory);
 $Regex = new RegexIterator($Iterator, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH);
 
 $errors = [];
 
-foreach($Regex as $file) {
-	$stmts = $parser->parse(file_get_contents($file[0]));
+foreach ($Regex as $file) {
+	$stmts = $parser->parse(\file_get_contents($file[0]));
 
 	$visitor = new SinceTagCheckVisitor();
 	$traverser = new \PhpParser\NodeTraverser();
 	$traverser->addVisitor($visitor);
 	$traverser->traverse($stmts);
 
-	$errors = array_merge($errors, $visitor->getErrors());
+	$errors = \array_merge($errors, $visitor->getErrors());
 }
 
-if(count($errors)) {
-	echo join(PHP_EOL, $errors) . PHP_EOL . PHP_EOL;
+if (\count($errors)) {
+	echo \join(PHP_EOL, $errors) . PHP_EOL . PHP_EOL;
 	exit(1);
 }

--- a/build/gen-coverage-badge.php
+++ b/build/gen-coverage-badge.php
@@ -27,7 +27,7 @@ if (!isset($argv[1])) {
 try {
 	$cloverFile = $argv[1];
 
-	$doc = simplexml_load_file($cloverFile);
+	$doc = \simplexml_load_file($cloverFile);
 
 	$metrics = [];
 	foreach ($doc->project->metrics->attributes() as $k => $v) {
@@ -50,10 +50,10 @@ try {
 	if ($percent >= 75) {
 		$color = 'green';
 	}
-	$content = file_get_contents("https://img.shields.io/badge/coverage-$percent%-$color.svg");
-	file_put_contents('coverage.svg', $content);
-} catch(Exception $ex) {
+	$content = \file_get_contents("https://img.shields.io/badge/coverage-$percent%-$color.svg");
+	\file_put_contents('coverage.svg', $content);
+} catch (Exception $ex) {
 	echo $ex->getMessage() . PHP_EOL;
-	$content = file_get_contents("https://img.shields.io/badge/coverage-ERROR-red.svg");
-	file_put_contents('coverage.svg', $content);
+	$content = \file_get_contents("https://img.shields.io/badge/coverage-ERROR-red.svg");
+	\file_put_contents('coverage.svg', $content);
 }

--- a/build/license.php
+++ b/build/license.php
@@ -45,40 +45,39 @@ class Licenses {
  *
  */
 EOD;
-		$this->licenseText = str_replace('@YEAR@', date("Y"), $this->licenseText);
+		$this->licenseText = \str_replace('@YEAR@', \date("Y"), $this->licenseText);
 	}
 
 	/**
 	 * @param string|string[] $folder
 	 * @param string|bool $gitRoot
 	 */
-	function exec($folder, $gitRoot = false) {
-
-		if (is_array($folder)) {
-			foreach($folder as $f) {
+	public function exec($folder, $gitRoot = false) {
+		if (\is_array($folder)) {
+			foreach ($folder as $f) {
 				$this->exec($f, $gitRoot);
 			}
 			return;
 		}
 
-		if ($gitRoot !== false && substr($gitRoot, -1) !== '/') {
+		if ($gitRoot !== false && \substr($gitRoot, -1) !== '/') {
 			$gitRoot .= '/';
 		}
 
-		if (is_file($folder)) {
+		if (\is_file($folder)) {
 			$this->handleFile($folder, $gitRoot);
 			return;
 		}
 
-		$excludes = array_map(function($item) use ($folder) {
+		$excludes = \array_map(function ($item) use ($folder) {
 			return $folder . '/' . $item;
 		}, ['vendor', '3rdparty', '.git', 'l10n', 'templates']);
 
 		$iterator = new RecursiveDirectoryIterator($folder, RecursiveDirectoryIterator::SKIP_DOTS);
-		$iterator = new RecursiveCallbackFilterIterator($iterator, function($item) use ($folder, $excludes){
+		$iterator = new RecursiveCallbackFilterIterator($iterator, function ($item) use ($folder, $excludes) {
 			/** @var SplFileInfo $item */
-			foreach($excludes as $exclude) {
-				if (substr($item->getPath(), 0, strlen($exclude)) === $exclude) {
+			foreach ($excludes as $exclude) {
+				if (\substr($item->getPath(), 0, \strlen($exclude)) === $exclude) {
 					return false;
 				}
 			}
@@ -93,8 +92,8 @@ EOD;
 		}
 	}
 
-	function writeAuthorsFile() {
-		ksort($this->authors);
+	public function writeAuthorsFile() {
+		\ksort($this->authors);
 		$template = "ownCloud is written by:
 @AUTHORS@
 
@@ -104,25 +103,25 @@ With help from many libraries and frameworks including:
 	jQuery
 	…
 ";
-		$authors = implode(PHP_EOL, array_map(function($author){
+		$authors = \implode(PHP_EOL, \array_map(function ($author) {
 			return " - ".$author;
 		}, $this->authors));
-		$template = str_replace('@AUTHORS@', $authors, $template);
-		file_put_contents(__DIR__.'/../AUTHORS', $template);
+		$template = \str_replace('@AUTHORS@', $authors, $template);
+		\file_put_contents(__DIR__.'/../AUTHORS', $template);
 	}
 
-	function handleFile($path, $gitRoot) {
-		$source = file_get_contents($path);
+	public function handleFile($path, $gitRoot) {
+		$source = \file_get_contents($path);
 		if ($this->isMITLicensed($source)) {
 			echo "MIT licensed file: $path" . PHP_EOL;
 			return;
 		}
 		$source = $this->eatOldLicense($source);
 		$authors = $this->getAuthors($path, $gitRoot);
-		$license = str_replace('@AUTHORS@', $authors, $this->licenseText);
+		$license = \str_replace('@AUTHORS@', $authors, $this->licenseText);
 
 		$source = "<?php" . PHP_EOL . $license . PHP_EOL . $source;
-		file_put_contents($path,$source);
+		\file_put_contents($path, $source);
 		echo "License updated: $path" . PHP_EOL;
 	}
 
@@ -131,11 +130,11 @@ With help from many libraries and frameworks including:
 	 * @return bool
 	 */
 	private function isMITLicensed($source) {
-		$lines = explode(PHP_EOL, $source);
-		while(!empty($lines)) {
+		$lines = \explode(PHP_EOL, $source);
+		while (!empty($lines)) {
 			$line = $lines[0];
-			array_shift($lines);
-			if (strpos($line, 'The MIT License') !== false) {
+			\array_shift($lines);
+			if (\strpos($line, 'The MIT License') !== false) {
 				return true;
 			}
 		}
@@ -148,51 +147,51 @@ With help from many libraries and frameworks including:
 	 * @return string
 	 */
 	private function eatOldLicense($source) {
-		$lines = explode(PHP_EOL, $source);
-		while(!empty($lines)) {
+		$lines = \explode(PHP_EOL, $source);
+		while (!empty($lines)) {
 			$line = $lines[0];
-			if (strpos($line, '<?php') !== false) {
-				array_shift($lines);
+			if (\strpos($line, '<?php') !== false) {
+				\array_shift($lines);
 				continue;
 			}
-			if (strpos($line, '/**') !== false) {
-				array_shift($lines);
+			if (\strpos($line, '/**') !== false) {
+				\array_shift($lines);
 				continue;
 			}
-			if (strpos($line, '*/') !== false ) {
-				array_shift($lines);
+			if (\strpos($line, '*/') !== false) {
+				\array_shift($lines);
 				break;
 			}
-			if (strpos($line, '*') !== false) {
-				array_shift($lines);
+			if (\strpos($line, '*') !== false) {
+				\array_shift($lines);
 				continue;
 			}
-			if (trim($line) === '') {
-				array_shift($lines);
+			if (\trim($line) === '') {
+				\array_shift($lines);
 				continue;
 			}
 			break;
 		}
 
-		return implode(PHP_EOL, $lines);
+		return \implode(PHP_EOL, $lines);
 	}
 
 	private function getAuthors($file, $gitRoot) {
 		// only add authors that changed code and not the license header
-		$licenseHeaderEndsAtLine = trim(shell_exec("grep -n '*/' $file | head -n 1 | cut -d ':' -f 1"));
-		$buildDir = getcwd();
+		$licenseHeaderEndsAtLine = \trim(\shell_exec("grep -n '*/' $file | head -n 1 | cut -d ':' -f 1"));
+		$buildDir = \getcwd();
 		if ($gitRoot) {
-			chdir($gitRoot);
-			$file = substr($file, strlen($gitRoot));
+			\chdir($gitRoot);
+			$file = \substr($file, \strlen($gitRoot));
 		}
-		$out = shell_exec("git blame --line-porcelain -L $licenseHeaderEndsAtLine, $file | sed -n 's/^author //p;s/^author-mail //p' | sed 'N;s/\\n/ /' | sort -f | uniq");
+		$out = \shell_exec("git blame --line-porcelain -L $licenseHeaderEndsAtLine, $file | sed -n 's/^author //p;s/^author-mail //p' | sed 'N;s/\\n/ /' | sort -f | uniq");
 		if ($gitRoot) {
-			chdir($buildDir);
+			\chdir($buildDir);
 		}
-		$authors = explode(PHP_EOL, $out);
+		$authors = \explode(PHP_EOL, $out);
 
-		$authors = array_filter($authors, function($author) {
-			return !in_array($author, [
+		$authors = \array_filter($authors, function ($author) {
+			return !\in_array($author, [
 				'',
 				'Not Committed Yet <not.committed.yet>',
 				'Jenkins for ownCloud <owncloud-bot@tmit.eu>',
@@ -201,26 +200,26 @@ With help from many libraries and frameworks including:
 		});
 
 		if ($gitRoot) {
-			$authors = array_map([$this, 'checkCoreMailMap'], $authors);
-			$authors = array_unique($authors);
+			$authors = \array_map([$this, 'checkCoreMailMap'], $authors);
+			$authors = \array_unique($authors);
 		}
 
-		$authors = array_map(function($author){
+		$authors = \array_map(function ($author) {
 			$this->authors[$author] = $author;
 			return " * @author $author";
 		}, $authors);
-		return implode(PHP_EOL, $authors);
+		return \implode(PHP_EOL, $authors);
 	}
 
 	private function checkCoreMailMap($author) {
 		if (empty($this->mailMap)) {
-			$content = file_get_contents(__DIR__ . '/../.mailmap');
-			$entries = explode("\n", $content);
+			$content = \file_get_contents(__DIR__ . '/../.mailmap');
+			$entries = \explode("\n", $content);
 			foreach ($entries as $entry) {
-				if (strpos($entry, '> ') === false) {
+				if (\strpos($entry, '> ') === false) {
 					$this->mailMap[$entry] = $entry;
 				} else {
-					list($use, $actual) = explode('> ', $entry);
+					list($use, $actual) = \explode('> ', $entry);
 					$this->mailMap[$actual] = $use . '>';
 				}
 			}
@@ -237,7 +236,6 @@ $licenses = new Licenses;
 if (isset($argv[1])) {
 	$licenses->exec($argv[1], isset($argv[2]) ? $argv[1] : false);
 } else {
-
 	$licenses->exec([
 		__DIR__ . '/../apps/comments',
 		__DIR__ . '/../apps/dav',


### PR DESCRIPTION
## Description
When codestyle was first applied in core `master` it was applied to the `build` folder also.
But when codestyle was back-ported to `stable10` it was no longer being applied to the `build` folder.
So code in the `build` folder got a bit out-of-sync.

This PR applies codestyle to the `build` folder in `stable10` to get the code closer to what is in `master`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
