### PR TITLE
Apply code style to build dir in master

### DIFF
--- a/build/OCPSinceChecker.php
+++ b/build/OCPSinceChecker.php
@@ -19,7 +19,6 @@
  *
  */
 
-
 require_once __DIR__ . '/../lib/composer/autoload.php';
 
 /**
@@ -28,7 +27,6 @@ require_once __DIR__ . '/../lib/composer/autoload.php';
  * this class checks all methods for the presence of the @since tag
  */
 class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
-
 	const INVALID_VERSIONS = ['9.2'];
 
 	/** @var string */
@@ -42,62 +40,62 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 	protected $errors = [];
 
 	public function enterNode(\PhpParser\Node $node) {
-		if($this->deprecatedClass) {
+		if ($this->deprecatedClass) {
 			return;
 		}
 
-		if($node instanceof \PhpParser\Node\Stmt\Namespace_) {
+		if ($node instanceof \PhpParser\Node\Stmt\Namespace_) {
 			$this->namespace = $node->name;
 		}
 
-		if($node instanceof \PhpParser\Node\Stmt\Interface_ or
+		if ($node instanceof \PhpParser\Node\Stmt\Interface_ or
 			$node instanceof \PhpParser\Node\Stmt\Class_) {
 			$this->className = $node->name;
 
 			/** @var \PhpParser\Comment\Doc[] $comments */
 			$comments = $node->getAttribute('comments');
 
-			if(\count($comments) === 0) {
+			if (\count($comments) === 0) {
 				$this->errors[] = 'PHPDoc is needed for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}
 
 			$comment = $comments[\count($comments) - 1];
 			$text = $comment->getText();
-			if(\strpos($text, '@deprecated') !== false) {
+			if (\strpos($text, '@deprecated') !== false) {
 				$this->deprecatedClass = true;
 			}
 
-			if($this->deprecatedClass === false && \strpos($text, '@since') === false && \strpos($text, '@deprecated') === false) {
+			if ($this->deprecatedClass === false && \strpos($text, '@since') === false && \strpos($text, '@deprecated') === false) {
 				$type = $node instanceof \PhpParser\Node\Stmt\Interface_ ? 'interface' : 'class';
 				$this->errors[] = '@since or @deprecated tag is needed in PHPDoc for ' . $type . ' ' . $this->namespace . '\\' . $this->className;
 				return;
 			}
 
-			if($this->deprecatedClass === false && ($ver = $this->checkInvalidVersions($text)) !== null) {
+			if ($this->deprecatedClass === false && ($ver = $this->checkInvalidVersions($text)) !== null) {
 				$type = $node instanceof \PhpParser\Node\Stmt\Interface_ ? 'interface' : 'class';
 				$this->errors[] = 'Specified version ' . $ver . ' does not exist for ' . $type . ' ' . $this->namespace . '\\' . $this->className;
 				return;
 			}
 		}
 
-		if($node instanceof \PhpParser\Node\Stmt\ClassMethod) {
+		if ($node instanceof \PhpParser\Node\Stmt\ClassMethod) {
 			/** @var \PhpParser\Node\Stmt\ClassMethod $node */
 			/** @var \PhpParser\Comment\Doc[] $comments */
 			$comments = $node->getAttribute('comments');
 
-			if(\count($comments) === 0) {
+			if (\count($comments) === 0) {
 				$this->errors[] = 'PHPDoc is needed for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}
 			$comment = $comments[\count($comments) - 1];
 			$text = $comment->getText();
-			if(\strpos($text, '@since') === false && \strpos($text, '@deprecated') === false) {
+			if (\strpos($text, '@since') === false && \strpos($text, '@deprecated') === false) {
 				$this->errors[] = '@since or @deprecated tag is needed in PHPDoc for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}
 
-			if(($ver = $this->checkInvalidVersions($text)) !== null) {
+			if (($ver = $this->checkInvalidVersions($text)) !== null) {
 				$this->errors[] = 'Specified version ' . $ver . ' does not exist for ' . $this->namespace . '\\' . $this->className;
 				return;
 			}
@@ -126,7 +124,6 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 
 echo 'Parsing all files in lib/public for the presence of @since or @deprecated on each method...' . PHP_EOL . PHP_EOL;
 
-
 $parser = (new \PhpParser\ParserFactory())->create(\PhpParser\ParserFactory::PREFER_PHP7);
 
 /* iterate over all .php files in lib/public */
@@ -136,7 +133,7 @@ $Regex = new RegexIterator($Iterator, '/^.+\.php$/i', RecursiveRegexIterator::GE
 
 $errors = [];
 
-foreach($Regex as $file) {
+foreach ($Regex as $file) {
 	$stmts = $parser->parse(\file_get_contents($file[0]));
 
 	$visitor = new SinceTagCheckVisitor();
@@ -147,7 +144,7 @@ foreach($Regex as $file) {
 	$errors = \array_merge($errors, $visitor->getErrors());
 }
 
-if(\count($errors)) {
+if (\count($errors)) {
 	echo \join(PHP_EOL, $errors) . PHP_EOL . PHP_EOL;
 	exit(1);
 }

--- a/build/gen-coverage-badge.php
+++ b/build/gen-coverage-badge.php
@@ -52,7 +52,7 @@ try {
 	}
 	$content = \file_get_contents("https://img.shields.io/badge/coverage-$percent%25-$color.svg");
 	\file_put_contents('coverage.svg', $content);
-} catch(Exception $ex) {
+} catch (Exception $ex) {
 	echo $ex->getMessage() . PHP_EOL;
 	$content = \file_get_contents("https://img.shields.io/badge/coverage-ERROR-red.svg");
 	\file_put_contents('coverage.svg', $content);

--- a/build/license.php
+++ b/build/license.php
@@ -92,14 +92,14 @@ EOS;
 	 * @param string|string[] $folder
 	 * @param string|bool $gitRoot
 	 */
-	function exec($folder, $license, $gitRoot = false) {
+	public function exec($folder, $license, $gitRoot = false) {
 		if (isset($this->licenseText[$license])) {
 			echo "Unknown license $license. Supported: agpl, gpl or ocl";
 		}
 		$license = $this->licenseText[$license];
 
 		if (\is_array($folder)) {
-			foreach($folder as $f) {
+			foreach ($folder as $f) {
 				$this->exec($f, $license, $gitRoot);
 			}
 			return;
@@ -114,14 +114,14 @@ EOS;
 			return;
 		}
 
-		$excludes = \array_map(function($item) use ($folder) {
+		$excludes = \array_map(function ($item) use ($folder) {
 			return $folder . '/' . $item;
 		}, ['vendor', '3rdparty', '.git', 'l10n', 'templates']);
 
 		$iterator = new RecursiveDirectoryIterator($folder, RecursiveDirectoryIterator::SKIP_DOTS);
-		$iterator = new RecursiveCallbackFilterIterator($iterator, function($item) use ($folder, $excludes){
+		$iterator = new RecursiveCallbackFilterIterator($iterator, function ($item) use ($folder, $excludes) {
 			/** @var SplFileInfo $item */
-			foreach($excludes as $exclude) {
+			foreach ($excludes as $exclude) {
 				if (\substr($item->getPath(), 0, \strlen($exclude)) === $exclude) {
 					return false;
 				}
@@ -137,7 +137,7 @@ EOS;
 		}
 	}
 
-	function writeAuthorsFile() {
+	public function writeAuthorsFile() {
 		\ksort($this->authors);
 		$template = "ownCloud is written by:
 @AUTHORS@
@@ -148,7 +148,7 @@ With help from many libraries and frameworks including:
 	jQuery
 	…
 ";
-		$authors = \implode(PHP_EOL, \array_map(function($author){
+		$authors = \implode(PHP_EOL, \array_map(function ($author) {
 			return " - ".$author;
 		}, $this->authors));
 		$template = \str_replace('@AUTHORS@', $authors, $template);
@@ -161,7 +161,7 @@ With help from many libraries and frameworks including:
 	 * @param string $path
 	 * @param string|bool $gitRoot
 	 */
-	function handleFile($path, $license, $gitRoot) {
+	public function handleFile($path, $license, $gitRoot) {
 		$source = \file_get_contents($path);
 		if ($this->isMITLicensed($source)) {
 			echo "MIT licensed file: $path" . PHP_EOL;
@@ -172,7 +172,7 @@ With help from many libraries and frameworks including:
 		$license = \str_replace('@AUTHORS@', $authors, $license);
 
 		$source = "<?php" . PHP_EOL . $license . PHP_EOL . $source;
-		\file_put_contents($path,$source);
+		\file_put_contents($path, $source);
 		echo "License updated: $path" . PHP_EOL;
 	}
 
@@ -182,7 +182,7 @@ With help from many libraries and frameworks including:
 	 */
 	private function isMITLicensed($source) {
 		$lines = \explode(PHP_EOL, $source);
-		while(!empty($lines)) {
+		while (!empty($lines)) {
 			$line = $lines[0];
 			\array_shift($lines);
 			if (\strpos($line, 'The MIT License') !== false) {
@@ -199,7 +199,7 @@ With help from many libraries and frameworks including:
 	 */
 	private function eatOldLicense($source) {
 		$lines = \explode(PHP_EOL, $source);
-		while(!empty($lines)) {
+		while (!empty($lines)) {
 			$line = $lines[0];
 			if (\strpos($line, '<?php') !== false) {
 				\array_shift($lines);
@@ -209,7 +209,7 @@ With help from many libraries and frameworks including:
 				\array_shift($lines);
 				continue;
 			}
-			if (\strpos($line, '*/') !== false ) {
+			if (\strpos($line, '*/') !== false) {
 				\array_shift($lines);
 				break;
 			}
@@ -255,7 +255,7 @@ With help from many libraries and frameworks including:
 		}
 		$authors = \explode(PHP_EOL, $out);
 
-		$authors = \array_filter($authors, function($author) {
+		$authors = \array_filter($authors, function ($author) {
 			return !\in_array($author, [
 				'',
 				'Not Committed Yet <not.committed.yet>',
@@ -269,7 +269,7 @@ With help from many libraries and frameworks including:
 			$authors = \array_unique($authors);
 		}
 
-		$authors = \array_map(function($author){
+		$authors = \array_map(function ($author) {
 			$this->authors[$author] = $author;
 			return " * @author $author";
 		}, $authors);
@@ -305,7 +305,6 @@ if (isset($argv[1])) {
 	}
 	$licenses->exec($argv[1], $argv[2], isset($argv[3]) ? $argv[1] : false);
 } else {
-
 	$licenses->exec([
 		__DIR__ . '/../apps/comments',
 		__DIR__ . '/../apps/dav',


### PR DESCRIPTION
## Description
When codestyle was first applied in core `master` it was applied to the `build` folder but did not seem to have the rule about `if (` vs `if(` etc.

codestyle is applied in `stable10` `build` by #34832 and that made a few more automatic changes than what is in `master`

So this PR applies current codestyle to the `build` folder in `master` to get the code closer to what is in `stable10`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
