### PR TITLE
[stable10] Backport of Check the retypepassword exist in the dom befo…

### DIFF
--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -157,7 +157,9 @@ $(document).ready(function () {
 		 The warning message should be shown only during password mismatch.
 		 Else it should not.
 		 */
-		if (($('#password').val().length >= 0) && ($('#retypepassword').val().length === 0)) {
+		if (($('#password').val().length >= 0)
+			&& ($('#retypepassword').length)
+			&& ($('#retypepassword').val().length === 0)) {
 			$('#message').removeClass('warning');
 			$('#message').text('');
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The issue here is, the id `retypepassword` is not available during the login. Its only available when the lostpassword.js is loaded from https://github.com/owncloud/core/blob/master/core/templates/lostpassword/resetpassword.php#L36. This issue was found in the console log and not in the UI. So in the lostpassword.js before checking if the id `retypepassword` exist, the objects `.val().length` was fetched which was throwing error in the web dev console. So in this PR, first we check if the id exist, if so then check the `.val().length` equal to zero, to remove the warning class and then empty the message text. ( copied from PR https://github.com/owncloud/core/pull/34816)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/34797

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No js errors should be seen in the dev console. Try to check the length of val(), once we verify if the id exist in the DOM.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Attached screencast here, tested on stable10 branch: 
![stable10_lostpasswd](https://user-images.githubusercontent.com/3600427/54610103-4ecc7b00-4a7a-11e9-8f50-f49801811c22.gif)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
