### PR TITLE
Keep build folder ... kills circular-json

### DIFF
--- a/build/modclean-patterns-owncloud/patterns.json
+++ b/build/modclean-patterns-owncloud/patterns.json
@@ -16,7 +16,6 @@
             ".spmignore",
             "AUTHORS*",
             "benchmarks",
-            "build",
             "data",
             "data-scripts",
             "docs",

--- a/build/package.json
+++ b/build/package.json
@@ -15,7 +15,7 @@
     "@bower_components/blueimp-md5": "blueimp/JavaScript-MD5#2.10.0",
     "@bower_components/bootstrap": "twbs/bootstrap#3.3.7",
     "@bower_components/bowser": "ded/bowser#1.9.4",
-    "@bower_components/browser-update": "Graffino/Browser-Update#2.0.2",
+    "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.2",
     "@bower_components/clipboard": "zenorocha/clipboard.js#v2.0.4",
     "@bower_components/davclient.js": "owncloud/davclient.js#0.1.3",
     "@bower_components/es6-promise": "components/es6-promise#v4.2.4",

--- a/build/package.json
+++ b/build/package.json
@@ -10,8 +10,6 @@
   "homepage": "https://github.com/owncloud/",
   "contributors": [],
   "dependencies": {
-    "@bower_components/Jcrop": "tapmodo/Jcrop#2.0.4",
-    "@bower_components/Snap.js": "jakiestfu/Snap.js#1.9.3",
     "@bower_components/backbone": "jashkenas/backbone#1.3.3",
     "@bower_components/base64": "davidchambers/Base64.js#1.0.2",
     "@bower_components/blueimp-md5": "blueimp/JavaScript-MD5#2.10.0",
@@ -26,7 +24,6 @@
     "@bower_components/jquery": "jquery/jquery-dist#2.2.4",
     "@bower_components/jquery-ui": "components/jqueryui#1.12.1",
     "@bower_components/jsTimezoneDetect": "HenningM/jstimezonedetect#1.0.5",
-    "@bower_components/jstzdetect": "HenningM/jstimezonedetect#1.0.6",
     "@bower_components/moment": "moment/moment#2.24.0",
     "@bower_components/select2": "ivaynberg/select2#3.5.4",
     "@bower_components/showdown": "showdownjs/showdown#1.9.0",

--- a/build/package.json
+++ b/build/package.json
@@ -57,6 +57,6 @@
   },
   "scripts": {
     "clean-modules": "modclean -r --patterns=\"default:safe,owncloud:basic\"",
-    "postinstall": "node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@bower_components'), '../core/vendor', 'junction') } catch (e) { }\""
+    "postinstall": "modclean -r --patterns=\"default:safe\" && node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@bower_components'), '../core/vendor', 'junction') } catch (e) { }\""
   }
 }

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -106,11 +106,23 @@
   version "4.4.2"
   resolved "https://codeload.github.com/dropbox/zxcvbn/tar.gz/f0735425180b130d6c57efbc044a47c0c8f1fd65"
 
-"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.0":
+"@sinonjs/commons@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
   dependencies:
     type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
+  dependencies:
+    "@sinonjs/samsam" "2.1.0"
 
 "@sinonjs/formatio@^3.1.0":
   version "3.1.0"
@@ -125,6 +137,10 @@
     "@sinonjs/commons" "^1.0.2"
     array-from "^2.1.1"
     lodash "^4.17.11"
+
+"@sinonjs/samsam@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.2.tgz#16947fce5f57258d01f1688fdc32723093c55d3f"
 
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.1"
@@ -629,8 +645,8 @@ cross-spawn@^5.0.1:
     which "^1.2.9"
 
 cryptiles@3.x.x:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.3.tgz#5e32ef824569ef14c782aefd45c1617d9795359d"
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.4.tgz#769a68c95612b56faadfcebf57ac86479cbe8322"
   dependencies:
     boom "5.x.x"
 
@@ -1695,6 +1711,10 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -1722,6 +1742,10 @@ log4js@^3.0.0:
 lolex@^2.3.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.1.tgz#e40a8c4d1f14b536aa03e42a537c7adbaf0c20be"
+
+lolex@^2.7.5:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
 
 lolex@^3.1.0:
   version "3.1.0"
@@ -1956,6 +1980,16 @@ nise@^1.4.10:
     just-extend "^4.0.2"
     lolex "^2.3.2"
     path-to-regexp "^1.7.0"
+
+nise@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.5.tgz#979a97a19c48d627bb53703726ae8d53ce8d4b3e"
+  dependencies:
+    "@sinonjs/formatio" "3.0.0"
+    just-extend "^3.0.0"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-pre-gyp@^0.10.0:
   version "0.10.2"
@@ -2524,7 +2558,21 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-"sinon@>= 1.7.1", sinon@^7.2.4:
+"sinon@>= 1.7.1":
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-6.3.5.tgz#0f6d6a5b4ebaad1f6e8e019395542d1d02c144a0"
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.2"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^2.7.5"
+    nise "^1.4.5"
+    supports-color "^5.5.0"
+    type-detect "^4.0.8"
+
+sinon@^7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.4.tgz#d834b9a38d8533b4ca3274a9a9ffa8e54c95d10c"
   dependencies:
@@ -2664,8 +2712,8 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.1.tgz#b79a089a732e346c6e0714830f36285cd38191a2"
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.0.tgz#1d4963a2fbffe58050aa9084ca20be81741c07de"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -2792,6 +2840,10 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 throttleit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
@@ -2858,7 +2910,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8:
+type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -2,14 +2,6 @@
 # yarn lockfile v1
 
 
-"@bower_components/Jcrop@tapmodo/Jcrop#2.0.4":
-  version "2.0.4"
-  resolved "https://codeload.github.com/tapmodo/Jcrop/tar.gz/80f645b69fc938b3823d92d74e5019036d04a9ca"
-
-"@bower_components/Snap.js@jakiestfu/Snap.js#1.9.3":
-  version "0.0.0"
-  resolved "https://codeload.github.com/jakiestfu/Snap.js/tar.gz/8538051df8e2c82a39d2603b6dfd8219ce8f04e6"
-
 "@bower_components/backbone@jashkenas/backbone#1.3.3":
   version "1.3.3"
   resolved "https://codeload.github.com/jashkenas/backbone/tar.gz/8ec88604732944f197b352a6be22c8216ea9d3a1"
@@ -72,10 +64,6 @@
   version "1.0.5"
   resolved "https://codeload.github.com/HenningM/jstimezonedetect/tar.gz/2efb16c850d8447109eff40d4b1495acd8168812"
 
-"@bower_components/jstzdetect@HenningM/jstimezonedetect#1.0.6":
-  version "1.0.6"
-  resolved "https://codeload.github.com/HenningM/jstimezonedetect/tar.gz/bd595ed253292934991a414979007f3d51a1547d"
-
 "@bower_components/moment@moment/moment#2.24.0":
   version "2.24.0"
   resolved "https://codeload.github.com/moment/moment/tar.gz/96d0d6791ab495859d09a868803d31a55c917de1"
@@ -118,7 +106,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/formatio@^3.0.0":
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
   dependencies:
@@ -129,6 +117,12 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.1.0.tgz#6ac9d1eb1821984d84c4996726e45d1646d8cce5"
   dependencies:
     "@sinonjs/samsam" "^2 || ^3"
+
+"@sinonjs/samsam@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  dependencies:
+    array-from "^2.1.1"
 
 "@sinonjs/samsam@^2 || ^3", "@sinonjs/samsam@^3.1.1":
   version "3.1.1"
@@ -1131,7 +1125,7 @@ glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-good-listener@^1.2.2:
+good-listener@^1.1.6:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
   dependencies:
@@ -1571,6 +1565,10 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
 
 just-extend@^4.0.2:
   version "4.0.2"
@@ -2506,7 +2504,7 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-select@^1.1.2:
+select@^1.0.6:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
@@ -2848,9 +2846,9 @@ throttleit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
 
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+tiny-emitter@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-1.2.0.tgz#6dc845052cb08ebefc1874723b58f24a648c3b6f"
 
 tmp@0.0.33, tmp@0.0.x:
   version "0.0.33"


### PR DESCRIPTION
Forward port from stable10 PR #33665 
"Keep build folder ... kills circular-json"
and
"Adding modclean to have smaller release tar balls" https://github.com/owncloud/core/pull/34784/commits/b84b14fb78f3ddd1c7c928c7dff636205aedb0dc - which was the reason for a diff between stable10 and master in `package.json` `postinstall` line.

I missed cherry-pick of these to master in PRs #34794 and #34796 

And https://github.com/owncloud/core/commit/dbe937349dc36062e1294076e67c8b588ba881d0 gets `package.json` in `master` closer to `stable10`