### PR TITLE
[stable10] Bump @bower_components/bootstrap from 3.3.6 to 3.3.7 in /build

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
     "@bower_components/backbone": "jashkenas/backbone#1.4.0",
     "@bower_components/base64": "davidchambers/Base64.js#1.0.2",
     "@bower_components/blueimp-md5": "blueimp/JavaScript-MD5#1.0.1",
-    "@bower_components/bootstrap": "twbs/bootstrap#3.3.6",
+    "@bower_components/bootstrap": "twbs/bootstrap#3.3.7",
     "@bower_components/bowser": "ded/bowser#1.9.4",
     "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.2",
     "@bower_components/clipboard": "zenorocha/clipboard.js#1.5.12",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -17,9 +17,9 @@
   version "1.0.1"
   resolved "https://codeload.github.com/blueimp/JavaScript-MD5/tar.gz/b84e37f2574f57be6b06d9690da865b6546b4d76"
 
-"@bower_components/bootstrap@twbs/bootstrap#3.3.6":
-  version "3.3.6"
-  resolved "https://codeload.github.com/twbs/bootstrap/tar.gz/81df608a40bf0629a1dc08e584849bb1e43e0b7a"
+"@bower_components/bootstrap@twbs/bootstrap#3.3.7":
+  version "3.3.7"
+  resolved "https://codeload.github.com/twbs/bootstrap/tar.gz/0b9c4a4007c44201dce9a6cc1a38407005c26c86"
 
 "@bower_components/bowser@ded/bowser#1.9.4":
   version "1.9.4"


### PR DESCRIPTION
## Description
Bump @bower_components/bootstrap from 3.3.6 to 3.3.7 

"the bot" has PRs to bump this to 4.3.1 
master PR #34540 
stable10 PR #34544 

those can be reviewed/tested in slow time.

For now it should be easy to just do this patch version bump to `stable10`

## Motivation and Context
Get dependencies matching in `master` and `stable10`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
