### PR TITLE
[stable10] Bump @bower_components/bowser from 1.6.0 to 1.9.4 in /build

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -14,7 +14,7 @@
     "@bower_components/base64": "davidchambers/Base64.js#1.0.2",
     "@bower_components/blueimp-md5": "blueimp/JavaScript-MD5#1.0.1",
     "@bower_components/bootstrap": "twbs/bootstrap#3.3.6",
-    "@bower_components/bowser": "ded/bowser#1.6.0",
+    "@bower_components/bowser": "ded/bowser#1.9.4",
     "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.2",
     "@bower_components/clipboard": "zenorocha/clipboard.js#1.5.12",
     "@bower_components/davclient.js": "owncloud/davclient.js#0.1.3",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -20,9 +20,9 @@
   version "3.3.6"
   resolved "https://codeload.github.com/twbs/bootstrap/tar.gz/81df608a40bf0629a1dc08e584849bb1e43e0b7a"
 
-"@bower_components/bowser@ded/bowser#1.6.0":
-  version "1.6.0"
-  resolved "https://codeload.github.com/ded/bowser/tar.gz/5bf35ac340c3a5e6dcb142febdb3eb947c1139cb"
+"@bower_components/bowser@ded/bowser#1.9.4":
+  version "1.9.4"
+  resolved "https://codeload.github.com/ded/bowser/tar.gz/1fb99ced0e8834fd9662604bad7e0f0c3eba2786"
 
 "@bower_components/browser-update@Graffino/Browser-Update#v2.0.2":
   version "2.0.2"


### PR DESCRIPTION
## Description
Bump @bower_components/bower from 1.6.0 to 1.9.4

"the bot" has PRs to bump this to 2.1.2
master PR #34737 
stable10 PR #34738 

those can be reviewed/tested in slow time.

For now it should be easy to just do this patch version bump to `stable10`

## Motivation and Context
Get dependencies matching in `master` and `stable10`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
