### PR TITLE
decode only the first level of JSON from log-files

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -79,6 +79,9 @@ trait Logging {
 						"could not find attribute: '$attribute' in log entry: '{$logLines[$lineNo]}'"
 					);
 					$message = "log entry:\n{$logLines[$lineNo]}\n";
+					if (!\is_string($logEntry[$attribute])) {
+						$logEntry[$attribute] = \json_encode($logEntry[$attribute]);
+					}
 					if ($comparingMode === 'with') {
 						PHPUnit_Framework_Assert::assertEquals(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],


### PR DESCRIPTION
## Description
treat everything below the first level of JSON as string
if its not a string after decode, encode it back to make it a string

## Related Issue
needed for https://github.com/owncloud/admin_audit/issues/79

## Motivation and Context
when having a log entry that is some object/array itself e.g. `"auditUsers":["admin", "user"]` it's hard to reflect that in the flat behat table.
so easier just to compare against the string
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
