### PR TITLE
group shares should respect to users auto accept preference

### DIFF
--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -200,6 +200,7 @@ class Share20OcsControllerTest extends TestCase {
 		if (isset($attrs['displayname'])) {
 			$groupMock->method('getDisplayName')->willReturn($attrs['displayname']);
 		}
+		$groupMock->method('getUsers')->willReturn([]);
 		return $groupMock;
 	}
 

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -238,7 +238,6 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
     And folder "simple-folder-renamed" should be listed in the files page on the webUI
 
-  @issue-34705
   Scenario: User-based accepting is disabled while global is enabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user1" has logged in using the webUI
@@ -247,14 +246,11 @@ Feature: accept/decline shares coming from internal users
     And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
     And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
     And the user browses to the files page
-    Then folder "simple-folder (2)" should be listed on the webUI
-    #Then folder "simple-folder (2)" should not be listed on the webUI
+    Then folder "simple-folder (2)" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
-    And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
-    #But folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    But folder "simple-folder" should be listed in the shared-with-you page on the webUI
     And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    #And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
 
   Scenario: User-based accepting is enabled while global is enabled


### PR DESCRIPTION
## Description
If auto accept enabled by admin and if it is a group share, create sub-share for auto accept disabled users in the pending state to respect users auto accept preference.

## Related Issue
Fixes #34705 

## Motivation and Context
Removing bug.
## How Has This Been Tested?
- Enable auto-accept share in the admin sharing panel
- Create `testuser` and `testgroup`.
- add `testuser` to `testgroup`
- login with test-user and disable auto-accept share from the personal panel
- share a file to `testgroup` with admin user
- the share should be created in pending status for `testuser`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
