### PR TITLE
Don't show reset link on failed LDAP login

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -141,6 +141,13 @@ class LoginController extends Controller {
 		if (!$parameters['resetPasswordLink']) {
 			if ($user !== null && $user !== '') {
 				$userObj = $this->userManager->get($user);
+				if ($userObj === null) {
+					$users = $this->userManager->find($user);
+					if (\count($users) === 1) {
+						$userId = \key($users);
+						$userObj = $this->userManager->get($userId);
+					}
+				}
 				if ($userObj instanceof IUser) {
 					$parameters['canResetPassword'] = $userObj->canChangePassword();
 				}


### PR DESCRIPTION

## Description
Do not create a reset link for failed LDAP Logins

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3220

## Motivation and Context
Some Instances have DB Users and LDAP Users in parallel. They want a working reset link for DB Users and don't show a reset link for LDAP users because they cannot be changed in OC. The current behaviour is misleading and could be considered as a bug

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
