### PR TITLE
allow users to opt-out autocomplete in share dialog

### DIFF
--- a/apps/files_sharing/lib/Controller/PersonalSettingsController.php
+++ b/apps/files_sharing/lib/Controller/PersonalSettingsController.php
@@ -30,8 +30,9 @@ use OCP\IUserSession;
  */
 
 class PersonalSettingsController extends Controller {
-	const USERCONFIGS = [
-		'auto_accept_share'
+	const USER_CONFIGS = [
+		'auto_accept_share',
+		'allow_share_dialog_user_enumeration'
 	];
 
 	/** @var IConfig $config */
@@ -85,7 +86,7 @@ class PersonalSettingsController extends Controller {
 	 * @return bool
 	 */
 	private function validateParameter($key, $value) {
-		return \in_array($key, self::USERCONFIGS) && ($value === 'yes' || $value === 'no');
+		return \in_array($key, self::USER_CONFIGS) && ($value === 'yes' || $value === 'no');
 	}
 
 	/**

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -214,7 +214,15 @@ class ShareesController extends OCSController {
 				}
 				$this->result['exact']['users'][] = $entry;
 			} else {
-				$this->result['users'][] = $entry;
+				$userAutoCompleteEnabled = $this->config->getUserValue(
+					$user->getUID(),
+					'files_sharing',
+					'allow_share_dialog_user_enumeration',
+					'yes'
+				);
+				if ($userAutoCompleteEnabled === 'yes') {
+					$this->result['users'][] = $entry;
+				}
 			}
 		}
 

--- a/apps/files_sharing/templates/settings-personal.php
+++ b/apps/files_sharing/templates/settings-personal.php
@@ -27,14 +27,14 @@ script('files_sharing', 'settings-personal');
 
 <form class="section" id="files_sharing_settings">
 	<h2 class="app-name"><?php p($l->t('Sharing'));?></h2>
-	<?php if (isset($_['userAutoAcceptShareEnabled'])): ?>
-		<?php if ($_['userAutoAcceptShareEnabled'] === 'yes'): ?>
-			<input type="checkbox" name="auto_accept_share" id="userAutoAcceptShareInput" class="checkbox" value="1" checked="checked" />
+	<?php foreach ($_['enabled_configs'] as $key => $value): ?>
+		<?php if ($value['enabled'] === 'yes'): ?>
+			<input type="checkbox" name="<?php p($key)?>" id="<?php p($key . '_input')?>" class="checkbox" value="1" checked="checked" />
 		<?php else: ?>
-			<input type="checkbox" name="auto_accept_share" id="userAutoAcceptShareInput" class="checkbox" value="1" />
+			<input type="checkbox" name="<?php p($key)?>" id="<?php p($key . '_input')?>" class="checkbox" value="1" />
 		<?php endif; ?>
-		<label for="userAutoAcceptShareInput">
-			<?php p($l->t('Automatically accept new incoming local user shares')); ?>
+		<label for="<?php p($key . '_input')?>">
+			<?php p($l->t($value['label'])); ?>
 		</label><br/>
-	<?php endif; ?>
+	<?php endforeach;?>
 </form>

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -275,6 +275,24 @@ class ShareesTest extends TestCase {
 			[
 				'test',
 				false,
+				true,
+				[],
+				[
+					$this->getUserMock('test1', 'Test One'),
+					$this->getUserMock('test2', 'Test Two'),
+				],
+				[],
+				[],
+				false,
+				false,
+				false,
+				null,
+				//users don't want to be found with auto-complete
+				'no'
+			],
+			[
+				'test',
+				false,
 				false,
 				[],
 				[
@@ -520,6 +538,7 @@ class ShareesTest extends TestCase {
 	 * @param mixed $singleUser false for testing search or user mock when we are testing a direct match
 	 * @param mixed $shareeEnumerationGroupMembers restrict enumeration to group members
 	 * @param mixed $additionalUserInfoField
+	 * @param string $usersAutoCompletePreference
 	 */
 	public function testGetUsers(
 		$searchTerm,
@@ -532,12 +551,20 @@ class ShareesTest extends TestCase {
 		$reachedEnd,
 		$singleUser,
 		$shareeEnumerationGroupMembers = false,
-		$additionalUserInfoField = null
+		$additionalUserInfoField = null,
+		$usersAutoCompletePreference = 'yes'
 	) {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('core', 'user_additional_info_field', '')
 			->willReturn($additionalUserInfoField);
+		$this->config->method('getUserValue')
+			->with(
+				$this->isType('string'),
+				'files_sharing',
+				'allow_share_dialog_user_enumeration',
+				'yes'
+			)->willReturn($usersAutoCompletePreference);
 
 		$this->sharees = new ShareesController(
 			'files_sharing',

--- a/apps/files_sharing/tests/Panels/Personal/PersonalPanelTest.php
+++ b/apps/files_sharing/tests/Panels/Personal/PersonalPanelTest.php
@@ -63,13 +63,7 @@ class PersonalPanelTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider globalSharingConfigProvider
-	 *
-	 * @param array $globalConfigs
-	 * @param string $expectedString
-	 */
-	public function testGetPanel($globalConfigs, $expectedString) {
+	public function testGetPanelEmpty() {
 		$mockUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -80,12 +74,32 @@ class PersonalPanelTest extends \Test\TestCase {
 		$this->userSession->expects($this->any())
 			->method('getUser')
 			->willReturn($mockUser);
-		$this->config->expects($this->once())
+
+		$this->config->expects($this->any())
 			->method('getAppValue')
-			->with('core', 'shareapi_auto_accept_share', 'yes')
-			->willReturn($globalConfigs['shareapi_auto_accept_share']);
+			->willReturn('no');
 
 		$templateHtml = $this->personalPanel->getPanel()->fetchPage();
-		$this->assertContains($expectedString, $templateHtml);
+		$this->assertContains('<p>Nothing to configure.</p>', $templateHtml);
+	}
+
+	public function testGetPanelNotEmpty() {
+		$mockUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$mockUser->expects($this->any())
+			->method('getUID')
+			->willReturn('testuser');
+
+		$this->userSession->expects($this->any())
+			->method('getUser')
+			->willReturn($mockUser);
+
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->willReturn('yes');
+
+		$templateHtml = $this->personalPanel->getPanel()->fetchPage();
+		$this->assertContains('<form class="section" id="files_sharing_settings">', $templateHtml);
 	}
 }

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -36,9 +36,9 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 	protected $personalSharingPanelDivXpath
 		= '//div[@id="OCA\Files_Sharing\Panels\Personal\PersonalPanel"]';
 	protected $autoAcceptLocalSharesCheckboxXpath
-		= '//label[@for="userAutoAcceptShareInput"]';
+		= '//label[@for="auto_accept_share_input"]';
 	protected $autoAcceptLocalSharesCheckboxXpathCheckboxId
-		= 'userAutoAcceptShareInput';
+		= 'auto_accept_share_input';
 	protected $autoAcceptFederatedSharesCheckboxXpath
 		= '//label[@for="userAutoAcceptShareTrustedInput"]';
 	protected $autoAcceptFederatedSharesCheckboxXpathCheckboxId


### PR DESCRIPTION
## Description
allow users to opt-out autocomplete in sharing dialog

Also, I made some changes to simplify adding a new config option to personal sharing panel.
## Related Issue
https://github.com/owncloud/enterprise/issues/3142

## Motivation and Context
some users do not want to be found via autocomplete

## How Has This Been Tested?
Manually tested by  applying the following steps:
- Create a user `test`
- Login with `admin`
- Enable `Allow username autocompletion in share dialog` checkbox within the sharing admin panel 
- Login with `test`
- Disable `Allow finding you via autocomplete in share dialog` from personal sharing panel with `test` user
- As an admin, search `tes` keyword in share dialog, `test` should not be listed
- Enable `Allow finding you via autocomplete in share dialog` from personal sharing panel with `test` user
- As an admin, search `tes` keyword in share dialog, `test` should be listed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
