### PR TITLE
Remove unused use statements from TestHelpers

### DIFF
--- a/tests/TestHelpers/Asserts/WebDav.php
+++ b/tests/TestHelpers/Asserts/WebDav.php
@@ -25,8 +25,6 @@ use PHPUnit_Framework_Assert;
 use SimpleXMLElement;
 use Behat\Gherkin\Node\TableNode;
 use TestHelpers\DownloadHelper;
-use TestHelpers\HttpRequestHelper;
-use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 
 /**

--- a/tests/TestHelpers/Unit/DeleteHelperTest.php
+++ b/tests/TestHelpers/Unit/DeleteHelperTest.php
@@ -21,7 +21,6 @@
  */
 
 use TestHelpers\DeleteHelper;
-use TestHelpers\WebDavHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Subscriber\Mock;
 use GuzzleHttp\Message\Response;


### PR DESCRIPTION
## Description
Remove some unused `use` statements.
I noticed these while doing PHPunit version bump.

## Motivation and Context
Cleanup code.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
