### PR TITLE
Make sure testvalidateExpirationDateEnforceToFarIntoFuture unit test will fail if no exception is thrown

### DIFF
--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -975,6 +975,7 @@ class ManagerTest extends \Test\TestCase {
 
 		try {
 			$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+			$this->fail("expected GenericShareException but no exception was thrown");
 		} catch (\OCP\Share\Exceptions\GenericShareException $e) {
 			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getMessage());
 			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getHint());


### PR DESCRIPTION
## Description
Add a `fail` in the test path that should not happen. The test is expected to throw an exception, and the `catch` block get executed. The `fail` at the end of the `try` block ensures that if the expected exception is not thrown, then the test will fail.

Note: the test does go down the correct `catch` block at present, so the test itself does not need changing. I thought that some time in the past the exception was not being thrown, but maybe I was wrong.

## Related Issue
#34874 

## Motivation and Context
Remove the possibility of snake-oil tests.

## How Has This Been Tested?
- local unit test run and CI
- change the expected status from `404` to `403` and see that the test fails, thus confirming that the code in the `catch` block is really being executed.
- adjust the test case data so that no exception is thrown. See that the new `fail()` message happens and the test fails.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
