### PR TITLE
[stable10] Add explicit PHPUnit asserts to unit tests flagged as 'risky' by PHPUnit6

### DIFF
--- a/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
+++ b/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
@@ -93,7 +93,7 @@ class OcmMiddleware {
 	 *
 	 * @param string[] $params
 	 *
-	 * @return bool
+	 * @return void
 	 *
 	 * @throws BadRequestException
 	 */

--- a/apps/federatedfilesharing/tests/Middleware/OcmMiddlewareTest.php
+++ b/apps/federatedfilesharing/tests/Middleware/OcmMiddlewareTest.php
@@ -102,7 +102,9 @@ class OcmMiddlewareTest extends TestCase {
 		if (\is_string($expectedResult)) {
 			$this->expectException($expectedResult);
 		}
-		$this->ocmMiddleware->assertNotNull($input);
+		$this->assertNull(
+			$this->ocmMiddleware->assertNotNull($input)
+		);
 	}
 
 	public function dataTestAssertNotNull() {
@@ -204,7 +206,9 @@ class OcmMiddlewareTest extends TestCase {
 		if ($isExceptionExpected) {
 			$this->expectException(NotImplementedException::class);
 		}
-		$this->ocmMiddleware->assertIncomingSharingEnabled();
+		$this->assertNull(
+			$this->ocmMiddleware->assertIncomingSharingEnabled()
+		);
 	}
 
 	public function dataTestAssertIncomingSharingEnabled() {
@@ -225,7 +229,9 @@ class OcmMiddlewareTest extends TestCase {
 		if ($isExceptionExpected) {
 			$this->expectException(NotImplementedException::class);
 		}
-		$this->ocmMiddleware->assertOutgoingSharingEnabled();
+		$this->assertNull(
+			$this->ocmMiddleware->assertOutgoingSharingEnabled()
+		);
 	}
 
 	public function dataTestAssertOutgoingSharingEnabled() {

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -239,12 +239,20 @@ class ScanTest extends TestCase {
 		if (\count($groups) === 2) {
 			$this->assertContains('Starting scan for user 1 out of 10 (user1)', $output);
 			$this->assertContains('Starting scan for user 1 out of 10 (user11)', $output);
-		}
-		if (\count($groups) === 3) {
+		} elseif (\count($groups) === 3) {
 			$this->assertContains('Starting scan for user 1 out of 10 (user1)', $output);
 			$this->assertContains('Starting scan for user 1 out of 10 (user11)', $output);
 			$this->assertContains('Starting scan for user 1 out of 10 (user21)', $output);
 			$this->assertContains('Starting scan for user 10 out of 10 (user30)', $output);
+		} elseif (\count($groups) === 4) {
+			$this->assertContains('Starting scan for user 1 out of 10 (user1)', $output);
+			$this->assertContains('Starting scan for user 1 out of 20 (user11)', $output);
+			$this->assertContains('Starting scan for user 11 out of 20 (user21)', $output);
+			$this->assertContains('Starting scan for user 10 out of 10 (user40)', $output);
+		} else {
+			$this->fail(
+				"testMultipleGroups supports testing with 2,3, or 4 groups but the input has $groups groups"
+			);
 		}
 	}
 

--- a/apps/files_sharing/tests/AppInfo/ApplicationTest.php
+++ b/apps/files_sharing/tests/AppInfo/ApplicationTest.php
@@ -31,6 +31,8 @@ use OCA\Files_Sharing\Tests\TestCase;
 class ApplicationTest extends TestCase {
 	public function testConstructor() {
 		$app = new Application();
-		$app->getContainer()->query('Share20OcsController');
+		$this->assertNotNull(
+			$app->getContainer()->query('Share20OcsController')
+		);
 	}
 }

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -747,9 +747,13 @@ class StorageTest extends TestCase {
 		$this->logout();
 
 		if (!$this->userView->file_exists('test.txt')) {
-			$this->markTestSkipped('Skipping since the current home storage backend requires the user to logged in');
+			$this->markTestSkipped(
+				'Skipping since the current home storage backend requires the user to be logged in'
+			);
 		} else {
-			$this->userView->unlink('test.txt');
+			$this->assertNotNull(
+				$this->userView->unlink('test.txt')
+			);
 		}
 	}
 

--- a/apps/files_versions/tests/FileHelperTest.php
+++ b/apps/files_versions/tests/FileHelperTest.php
@@ -41,7 +41,9 @@ class FileHelperTest extends \Test\TestCase {
 				[$this->equalTo(FileHelper::VERSIONS_RELATIVE_PATH . '/some/long/path')],
 				[$this->equalTo(FileHelper::VERSIONS_RELATIVE_PATH . '/some/long/path/to')]
 			);
-		$fileHelper->createMissingDirectories($viewMock, $path);
+		$this->assertNull(
+			$fileHelper->createMissingDirectories($viewMock, $path)
+		);
 	}
 
 	/**

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -12,7 +12,7 @@ namespace Test\DB;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OC\DB\MDB2SchemaManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
-use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit_Framework_Constraint_IsType as IsType;
 
 /**
  * Class Connection

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -12,6 +12,7 @@ namespace Test\DB;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OC\DB\MDB2SchemaManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class Connection
@@ -181,19 +182,23 @@ class ConnectionTest extends \Test\TestCase {
 
 	public function testSetValuesSameNoError() {
 		$this->makeTestTable();
-		$this->connection->setValues('table', [
+		$numNewRows = $this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
 			'textfield' => 'foo',
 			'clobfield' => 'not_null'
 		]);
 
+		$this->assertInternalType(IsType::TYPE_INT, $numNewRows);
+
 		// this will result in 'no affected rows' on certain optimizing DBs
 		// ensure the PreConditionNotMetException isn't thrown
-		$this->connection->setValues('table', [
+		$numNewRows = $this->connection->setValues('table', [
 			'integerfield' => 1
 		], [
 			'textfield' => 'foo'
 		]);
+
+		$this->assertInternalType(IsType::TYPE_INT, $numNewRows);
 	}
 }

--- a/tests/lib/Events/EventEmitterTraitTest.php
+++ b/tests/lib/Events/EventEmitterTraitTest.php
@@ -97,6 +97,10 @@ class EventEmitterTraitTest extends TestCase {
 			$this->assertInstanceOf(GenericEvent::class, $calledAfterEvent[1]);
 			$this->assertArrayHasKey('item', $calledAfterEvent[1]);
 			$this->assertEquals('testing', $calledAfterEvent[1]->getArgument('item'));
+		} else {
+			$this->assertEquals($calledAfterEvent[0], "$className.after$eventName");
+			$this->assertArrayHasKey('item', $calledAfterEvent[1]);
+			$this->assertEquals('testing', $calledAfterEvent[1]->getArgument('item'));
 		}
 	}
 }

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -23,6 +23,7 @@
 namespace Test\Files\Storage;
 
 use OC\Files\Storage\Local;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class LocalTest
@@ -99,7 +100,7 @@ class LocalTest extends Storage {
 		$storage->file_put_contents('sym/foo', 'bar');
 	}
 
-	public function testDisallowSymlinksInsideDatadir() {
+	public function testAllowSymlinksInsideDatadir() {
 		$subDir1 = $this->tmpDir . 'sub1';
 		$subDir2 = $this->tmpDir . 'sub1/sub2';
 		$sym = $this->tmpDir . 'sub1/sym';
@@ -110,7 +111,8 @@ class LocalTest extends Storage {
 
 		$storage = new \OC\Files\Storage\Local(['datadir' => $subDir1]);
 
-		$storage->file_put_contents('sym/foo', 'bar');
+		$numBytes = $storage->file_put_contents('sym/foo', 'bar');
+		$this->assertInternalType(IsType::TYPE_INT, $numBytes);
 	}
 
 	/**

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -23,7 +23,7 @@
 namespace Test\Files\Storage;
 
 use OC\Files\Storage\Local;
-use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit_Framework_Constraint_IsType as IsType;
 
 /**
  * Class LocalTest

--- a/tests/lib/Group/Backend.php
+++ b/tests/lib/Group/Backend.php
@@ -155,7 +155,13 @@ abstract class Backend extends \Test\TestCase {
 	public function testAddDouble() {
 		$group = $this->getGroupName();
 
-		$this->backend->createGroup($group);
-		$this->backend->createGroup($group);
+		$this->assertTrue(
+			$this->backend->createGroup($group),
+			"there was a problem creating $group"
+		);
+		$this->assertFalse(
+			$this->backend->createGroup($group),
+			"there was a problem creating $group a second time"
+		);
 	}
 }

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -792,6 +792,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 				->method('info')
 				->with($this->repair->getName() . ' is not executed');
 		}
-		$this->repair->run($outputMock);
+		$this->assertNull($this->repair->run($outputMock));
 	}
 }

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -36,7 +36,11 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 	}
 
 	public function testAddDefaultPolicy() {
-		$this->contentSecurityPolicyManager->addDefaultPolicy(new \OCP\AppFramework\Http\ContentSecurityPolicy());
+		$this->assertNull(
+			$this->contentSecurityPolicyManager->addDefaultPolicy(
+				new \OCP\AppFramework\Http\ContentSecurityPolicy()
+			)
+		);
 	}
 
 	public function testGetDefaultPolicyWithPolicies() {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1196,7 +1196,9 @@ class ManagerTest extends \Test\TestCase {
 			->with($path)
 			->willReturn([]);
 
-		$this->invokePrivate($this->manager, 'userCreateChecks', [$share]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'userCreateChecks', [$share])
+		);
 	}
 
 	/**
@@ -1331,7 +1333,9 @@ class ManagerTest extends \Test\TestCase {
 			->with($path)
 			->willReturn([$share2]);
 
-		$this->invokePrivate($this->manager, 'userCreateChecks', [$share]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'userCreateChecks', [$share])
+		);
 	}
 
 	/**
@@ -1425,7 +1429,9 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_allow_group_sharing', 'yes', 'yes'],
 			]));
 
-		$this->invokePrivate($this->manager, 'groupCreateChecks', [$share]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'groupCreateChecks', [$share])
+		);
 	}
 
 	/**
@@ -1480,7 +1486,9 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_allow_group_sharing', 'yes', 'yes'],
 			]));
 
-		$this->invokePrivate($this->manager, 'groupCreateChecks', [$share]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'groupCreateChecks', [$share])
+		);
 	}
 
 	/**
@@ -1548,7 +1556,9 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_allow_public_upload', 'yes', 'yes']
 			]));
 
-		$this->invokePrivate($this->manager, 'linkCreateChecks', [$share]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'linkCreateChecks', [$share])
+		);
 	}
 
 	public function testLinkCreateChecksReadOnly() {
@@ -1563,7 +1573,9 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_allow_public_upload', 'yes', 'no']
 			]));
 
-		$this->invokePrivate($this->manager, 'linkCreateChecks', [$share]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'linkCreateChecks', [$share])
+		);
 	}
 
 	/**
@@ -1595,13 +1607,17 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->mountManager->method('findIn')->with('path')->willReturn([$mount]);
 
-		$this->invokePrivate($this->manager, 'pathCreateChecks', [$path]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'pathCreateChecks', [$path])
+		);
 	}
 
 	public function testPathCreateChecksContainsNoFolder() {
 		$path = $this->createMock('\OCP\Files\File');
 
-		$this->invokePrivate($this->manager, 'pathCreateChecks', [$path]);
+		$this->assertNull(
+			$this->invokePrivate($this->manager, 'pathCreateChecks', [$path])
+		);
 	}
 
 	public function dataIsSharingDisabledForUser() {
@@ -3432,7 +3448,9 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->defaultProvider->method('move')->with($share, 'recipient')->will($this->returnArgument(0));
 
-		$this->manager->updateShareForRecipient($share, 'recipient');
+		$this->assertNull(
+			$this->manager->updateShareForRecipient($share, 'recipient')
+		);
 	}
 
 	public function testGetSharedWith() {


### PR DESCRIPTION
Backport #34871