### PR TITLE
[WIP] Bump phpunit 7

### DIFF
--- a/apps/comments/tests/unit/Dav/EntityCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/EntityCollectionTest.php
@@ -33,17 +33,17 @@ use OCP\Comments\ICommentsManager;
 
 class EntityCollectionTest extends \Test\TestCase {
 
-	/** @var \OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Comments\ICommentsManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $commentsManager;
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var \OCP\ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\ILogger|\PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
 	/** @var \OCA\Comments\Dav\EntityCollection */
 	protected $collection;
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
-	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $dispatcher;
 
 	public function setUp() {

--- a/apps/comments/tests/unit/Dav/EntityTypeCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/EntityTypeCollectionTest.php
@@ -33,19 +33,19 @@ use OCP\Comments\ICommentsManager;
 
 class EntityTypeCollectionTest extends \Test\TestCase {
 
-	/** @var \OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Comments\ICommentsManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $commentsManager;
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var \OCP\ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\ILogger|\PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
 	/** @var \OCA\Comments\Dav\EntityTypeCollection */
 	protected $collection;
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
 
 	protected $childMap = [];
-	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $dispatcher;
 
 	public function setUp() {

--- a/apps/comments/tests/unit/Dav/RootCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/RootCollectionTest.php
@@ -30,19 +30,19 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class RootCollectionTest extends \Test\TestCase {
 
-	/** @var \OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Comments\ICommentsManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $commentsManager;
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var \OCP\ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\ILogger|\PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
 	/** @var \OCA\Comments\Dav\RootCollection */
 	protected $collection;
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
 	/** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
 	protected $dispatcher;
-	/** @var \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject */
 	protected $user;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/AppInfo/ApplicationTest.php
+++ b/apps/dav/tests/unit/AppInfo/ApplicationTest.php
@@ -57,7 +57,7 @@ class ApplicationTest extends TestCase {
 		});
 
 		// assert setupContactsProvider() is proper
-		/** @var IManager | \PHPUnit_Framework_MockObject_MockObject $cm */
+		/** @var IManager | \PHPUnit\Framework\MockObject\MockObject $cm */
 		$cm = $this->getMockBuilder('OCP\Contacts\IManager')->disableOriginalConstructor()->getMock();
 		$app->setupContactsProvider($cm, 'xxx');
 		$this->assertTrue(true);

--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -34,7 +34,7 @@ class AvatarHomeTest extends TestCase {
 	/** @var AvatarHome */
 	private $home;
 
-	/** @var IAvatarManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAvatarManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $avatarManager;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
@@ -28,14 +28,14 @@ use Test\TestCase;
 
 class AvatarNodeTest extends TestCase {
 	public function testGetName() {
-		/** @var IAvatar | \PHPUnit_Framework_MockObject_MockObject $a */
+		/** @var IAvatar | \PHPUnit\Framework\MockObject\MockObject $a */
 		$a = $this->createMock(IAvatar::class);
 		$n = new AvatarNode(1024, 'png', $a);
 		$this->assertEquals('1024.png', $n->getName());
 	}
 
 	public function testGetContentType() {
-		/** @var IAvatar | \PHPUnit_Framework_MockObject_MockObject $a */
+		/** @var IAvatar | \PHPUnit\Framework\MockObject\MockObject $a */
 		$a = $this->createMock(IAvatar::class);
 		$n = new AvatarNode(1024, 'png', $a);
 		$this->assertEquals('image/png', $n->getContentType());
@@ -50,7 +50,7 @@ class AvatarNodeTest extends TestCase {
 	public function testGetOperation($realImage, $mime, $imageFunction) {
 		$image = $this->createMock(IImage::class);
 		$image->expects($this->once())->method('resource')->willReturn($realImage);
-		/** @var IAvatar | \PHPUnit_Framework_MockObject_MockObject $a */
+		/** @var IAvatar | \PHPUnit\Framework\MockObject\MockObject $a */
 		$a = $this->createMock(IAvatar::class);
 		$a->expects($this->once())->method('get')->with(1024)->willReturn($image);
 		$n = new AvatarNode(1024, $mime, $a);

--- a/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanPropertiesTest.php
@@ -35,9 +35,9 @@ use Test\Traits\UserTrait;
  */
 class CleanPropertiesTest extends TestCase {
 	use UserTrait;
-	/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject */
 	private $connection;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 	/** @var CleanProperties */
 	private $cleanProperties;

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
@@ -43,10 +43,10 @@ abstract class AbstractCalDavBackendTest extends TestCase {
 	/** @var CalDavBackend */
 	protected $backend;
 
-	/** @var Principal | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Principal | \PHPUnit\Framework\MockObject\MockObject */
 	protected $principal;
 
-	/** @var GroupPrincipalBackend | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var GroupPrincipalBackend | \PHPUnit\Framework\MockObject\MockObject */
 	protected $groupPrincipal;
 
 	/** @var IConfig */

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -98,7 +98,7 @@ class CalDavBackendTest extends AbstractCalDavBackendTest {
 	 */
 	public function testCalendarSharing($userCanRead, $userCanWrite, $groupCanRead, $groupCanWrite, $add) {
 
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$l10n

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -49,7 +49,7 @@ class CalendarTest extends TestCase {
 	}
 
 	public function testDelete() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->once())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
@@ -69,7 +69,7 @@ class CalendarTest extends TestCase {
 	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testDeleteFromGroup() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->never())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
@@ -105,7 +105,7 @@ class CalendarTest extends TestCase {
 	 * @dataProvider dataPropPatch
 	 */
 	public function testPropPatch($mutations, $throws) {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -128,7 +128,7 @@ class CalendarTest extends TestCase {
 	 * @dataProvider providesReadOnlyInfo
 	 */
 	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet, $uri = 'default') {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 		$calendarInfo = [
@@ -206,7 +206,7 @@ class CalendarTest extends TestCase {
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
 			$calObject0, $calObject1, $calObject2
@@ -292,7 +292,7 @@ EOD;
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL, 'calendardata' => $calData];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
 			$calObject0, $calObject1, $calObject2

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
@@ -37,11 +37,11 @@ class PluginTest extends TestCase {
 	private $plugin;
 	/** @var Server */
 	private $server;
-	/** @var Calendar | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Calendar | \PHPUnit\Framework\MockObject\MockObject */
 	private $book;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -34,13 +34,13 @@ use OC\Log;
 class IMipPluginTest extends TestCase {
 	public function testDelivery(): void {
 		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
+		/** @var Mailer | \PHPUnit\Framework\MockObject\MockObject $mailer */
 		$mailer = $this->createMock(Mailer::class);
 		$mailer->method('createMessage')->willReturn($mailMessage);
 		$mailer->expects($this->once())->method('send');
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+		/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject $logger */
 		$logger = $this->createMock(Log::class);
-		/** @var IRequest| \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest| \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 
 		$plugin = new IMipPlugin($mailer, $logger, $request);
@@ -65,13 +65,13 @@ class IMipPluginTest extends TestCase {
 
 	public function testFailedDeliveryWithException(): void {
 		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
+		/** @var Mailer | \PHPUnit\Framework\MockObject\MockObject $mailer */
 		$mailer = $this->createMock(Mailer::class);
 		$mailer->method('createMessage')->willReturn($mailMessage);
 		$mailer->method('send')->willThrowException(new \Exception());
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+		/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject $logger */
 		$logger = $this->createMock(Log::class);
-		/** @var IRequest| \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest| \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 
 		$plugin = new IMipPlugin($mailer, $logger, $request);
@@ -96,14 +96,14 @@ class IMipPluginTest extends TestCase {
 
 	public function testFailedDelivery(): void {
 		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
+		/** @var Mailer | \PHPUnit\Framework\MockObject\MockObject $mailer */
 		$mailer = $this->createMock(Mailer::class);
 		$mailer->method('createMessage')->willReturn($mailMessage);
 		$mailer->method('send')->willReturn(['foo@example.net']);
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+		/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject $logger */
 		$logger = $this->createMock(Log::class);
 		$logger->expects(self::once())->method('error')->with('Unable to deliver message to {failed}', ['app' => 'dav', 'failed' => 'foo@example.net']);
-		/** @var IRequest| \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest| \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 
 		$plugin = new IMipPlugin($mailer, $logger, $request);
@@ -128,13 +128,13 @@ class IMipPluginTest extends TestCase {
 
 	public function testDeliveryOfCancel(): void {
 		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
+		/** @var Mailer | \PHPUnit\Framework\MockObject\MockObject $mailer */
 		$mailer = $this->createMock(Mailer::class);
 		$mailer->method('createMessage')->willReturn($mailMessage);
 		$mailer->expects($this->once())->method('send');
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+		/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject $logger */
 		$logger = $this->createMock(Log::class);
-		/** @var IRequest| \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest| \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 
 		$plugin = new IMipPlugin($mailer, $logger, $request);

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -40,16 +40,16 @@ class AddressBookImplTest extends TestCase {
 	/** @var  array */
 	private $addressBookInfo;
 
-	/** @var  AddressBook | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  AddressBook | \PHPUnit\Framework\MockObject\MockObject */
 	private $addressBook;
 
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 
-	/** @var  CardDavBackend | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  CardDavBackend | \PHPUnit\Framework\MockObject\MockObject */
 	private $backend;
 
-	/** @var  VCard | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  VCard | \PHPUnit\Framework\MockObject\MockObject */
 	private $vCard;
 
 	public function setUp() {
@@ -86,7 +86,7 @@ class AddressBookImplTest extends TestCase {
 
 	public function testSearch() {
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | AddressBookImpl $addressBookImpl */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
 			->setConstructorArgs(
 				[
@@ -132,7 +132,7 @@ class AddressBookImplTest extends TestCase {
 	public function testCreate($properties) {
 		$uid = 'uid';
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | AddressBookImpl $addressBookImpl */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
 			->setConstructorArgs(
 				[
@@ -172,7 +172,7 @@ class AddressBookImplTest extends TestCase {
 		$uri = 'bla.vcf';
 		$properties = ['URI' => $uri, 'UID' => $uid, 'FN' => 'John Doe'];
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | AddressBookImpl $addressBookImpl */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
 			->setConstructorArgs(
 				[
@@ -255,7 +255,7 @@ class AddressBookImplTest extends TestCase {
 	}
 
 	public function testCreateUid() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | AddressBookImpl $addressBookImpl */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
 			->setConstructorArgs(
 				[

--- a/apps/dav/tests/unit/CardDAV/AddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookTest.php
@@ -29,7 +29,7 @@ use Test\TestCase;
 
 class AddressBookTest extends TestCase {
 	public function testDelete() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
 		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
 		$backend->expects($this->once())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
@@ -48,7 +48,7 @@ class AddressBookTest extends TestCase {
 	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testDeleteFromGroup() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
 		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
 		$backend->expects($this->never())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
@@ -67,7 +67,7 @@ class AddressBookTest extends TestCase {
 	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testPropPatch() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
 		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -82,7 +82,7 @@ class AddressBookTest extends TestCase {
 	 * @dataProvider providesReadOnlyInfo
 	 */
 	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet) {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
 		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 		$calendarInfo = [

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -35,11 +35,11 @@ class BirthdayServiceTest extends TestCase {
 
 	/** @var BirthdayService */
 	private $service;
-	/** @var CalDavBackend | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject */
 	private $calDav;
-	/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject */
 	private $cardDav;
-	/** @var GroupPrincipalBackend | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var GroupPrincipalBackend | \PHPUnit\Framework\MockObject\MockObject */
 	private $groupPrincipalBackend;
 
 	public function setUp() {
@@ -107,7 +107,7 @@ class BirthdayServiceTest extends TestCase {
 			]);
 		$this->cardDav->expects($this->once())->method('getShares')->willReturn([]);
 
-		/** @var BirthdayService | \PHPUnit_Framework_MockObject_MockObject $service */
+		/** @var BirthdayService | \PHPUnit\Framework\MockObject\MockObject $service */
 		$service = $this->getMockBuilder(BirthdayService::class)
 			->setMethods(['buildDateFromContact', 'birthdayEvenChanged'])
 			->setConstructorArgs([$this->calDav, $this->cardDav, $this->groupPrincipalBackend])

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -49,10 +49,10 @@ class CardDavBackendTest extends TestCase {
 	/** @var CardDavBackend */
 	private $backend;
 
-	/** @var Principal | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Principal | \PHPUnit\Framework\MockObject\MockObject */
 	private $principal;
 
-	/** @var GroupPrincipalBackend | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var GroupPrincipalBackend | \PHPUnit\Framework\MockObject\MockObject */
 	private $groupPrincipal;
 
 	/** @var  IDBConnection */
@@ -170,7 +170,7 @@ class CardDavBackendTest extends TestCase {
 	 */
 	public function testCardOperations() {
 
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)
 				->setConstructorArgs([$this->db, $this->principal, $this->groupPrincipal, null])
 				->setMethods(['updateProperties', 'purgeProperties'])->getMock();

--- a/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
+++ b/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
@@ -30,11 +30,11 @@ use Test\TestCase;
 
 class ContactsManagerTest extends TestCase {
 	public function test() {
-		/** @var IManager | \PHPUnit_Framework_MockObject_MockObject $cm */
+		/** @var IManager | \PHPUnit\Framework\MockObject\MockObject $cm */
 		$cm = $this->getMockBuilder('OCP\Contacts\IManager')->disableOriginalConstructor()->getMock();
 		$cm->expects($this->exactly(2))->method('registerAddressBook');
 		$urlGenerator = $this->getMockBuilder('OCP\IUrlGenerator')->disableOriginalConstructor()->getMock();
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backEnd */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backEnd */
 		$backEnd = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
 		$backEnd->method('getAddressBooksForUser')->willReturn([
 				[]

--- a/apps/dav/tests/unit/CardDAV/ConverterTest.php
+++ b/apps/dav/tests/unit/CardDAV/ConverterTest.php
@@ -25,7 +25,7 @@ namespace OCA\DAV\Tests\unit\CardDAV;
 use OCA\DAV\CardDAV\Converter;
 use OCP\IImage;
 use OCP\IUser;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ConverterTest extends TestCase {
@@ -122,7 +122,7 @@ class ConverterTest extends TestCase {
 	 * @param $displayName
 	 * @param $eMailAddress
 	 * @param $cloudId
-	 * @return IUser | PHPUnit_Framework_MockObject_MockObject
+	 * @return IUser | PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getUserMock($displayName, $eMailAddress, $cloudId) {
 		$image0 = $this->getMockBuilder(IImage::class)->disableOriginalConstructor()->getMock();

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -33,17 +33,17 @@ use Test\TestCase;
 
 class ImageExportPluginTest extends TestCase {
 
-	/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $response;
-	/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var ImageExportPlugin | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ImageExportPlugin | \PHPUnit\Framework\MockObject\MockObject */
 	private $plugin;
 	/** @var Server */
 	private $server;
-	/** @var Tree | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	public function setUp() {
@@ -128,7 +128,7 @@ class ImageExportPluginTest extends TestCase {
 	 * @param $cardData
 	 */
 	public function testGetPhoto($expected, $cardData) {
-		/** @var Card | \PHPUnit_Framework_MockObject_MockObject $card */
+		/** @var Card | \PHPUnit\Framework\MockObject\MockObject $card */
 		$card = $this->getMockBuilder('Sabre\CardDAV\Card')->disableOriginalConstructor()->getMock();
 		$card->expects($this->once())->method('get')->willReturn($cardData);
 

--- a/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
@@ -38,13 +38,13 @@ class PluginTest extends TestCase {
 	private $plugin;
 	/** @var Server */
 	private $server;
-	/** @var IShareable | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IShareable | \PHPUnit\Framework\MockObject\MockObject */
 	private $book;
 
 	public function setUp() {
 		parent::setUp();
 		
-		/** @var Auth | \PHPUnit_Framework_MockObject_MockObject $authBackend */
+		/** @var Auth | \PHPUnit\Framework\MockObject\MockObject $authBackend */
 		$authBackend = $this->getMockBuilder('OCA\DAV\Connector\Sabre\Auth')->disableOriginalConstructor()->getMock();
 		$authBackend->method('isDavAuthenticated')->willReturn(true);
 

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -65,7 +65,7 @@ class SyncServiceTest extends TestCase {
 	}
 
 	public function testEnsureSystemAddressBookExists() {
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->exactly(1))->method('createAddressBook');
 		$backend->expects($this->at(0))->method('getAddressBooksByUri')->willReturn(null);
@@ -79,7 +79,7 @@ class SyncServiceTest extends TestCase {
 	}
 
 	public function testUpdateAndDeleteUser() {
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
 
@@ -91,10 +91,10 @@ class SyncServiceTest extends TestCase {
 			'carddata' => "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 3.4.8//EN\r\nUID:test-user\r\nFN:test-user\r\nN:test-user;;;;\r\nEND:VCARD\r\n\r\n"
 		]);
 
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
 
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
 		$user->method('getBackendClassName')->willReturn('unittest');
 		$user->method('getUID')->willReturn('test-user');
@@ -113,7 +113,7 @@ class SyncServiceTest extends TestCase {
 	 * @param int $createCount
 	 * @param int $updateCount
 	 * @param int $deleteCount
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function getBackendMock($createCount, $updateCount, $deleteCount) {
 		$backend = $this->getMockBuilder(CardDavBackend::class)
@@ -128,12 +128,12 @@ class SyncServiceTest extends TestCase {
 	/**
 	 * @param $backend
 	 * @param $response
-	 * @return SyncService|\PHPUnit_Framework_MockObject_MockObject
+	 * @return SyncService|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function getSyncServiceMock($backend, $response) {
 		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
 		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
-		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $ss */
+		/** @var SyncService | \PHPUnit\Framework\MockObject\MockObject $ss */
 		$ss = $this->getMockBuilder(SyncService::class)
 			->setMethods(['ensureSystemAddressBookExists', 'requestSyncReport', 'download'])
 			->setConstructorArgs([$backend, $userManager, $logger])

--- a/apps/dav/tests/unit/Connector/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/PublicAuthTest.php
@@ -37,11 +37,11 @@ use OCP\Share\IManager;
  */
 class PublicAuthTest extends \Test\TestCase {
 
-	/** @var ISession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession|\PHPUnit\Framework\MockObject\MockObject */
 	private $session;
-	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $shareManager;
 	/** @var \OCA\DAV\Connector\PublicAuth */
 	private $auth;

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -47,17 +47,17 @@ use Test\TestCase;
  * @group DB
  */
 class AuthTest extends TestCase {
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
 	/** @var Auth */
 	private $auth;
-	/** @var Session | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Session | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $twoFactorManager;
-	/** @var AccountModuleManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AccountModuleManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $accountModuleManager;
 
 	public function setUp() {
@@ -246,11 +246,11 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGet() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
@@ -291,11 +291,11 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenAndCorrectlyDavAuthenticated() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -343,11 +343,11 @@ class AuthTest extends TestCase {
 	 * @expectedExceptionMessage 2FA challenge not passed.
 	 */
 	public function testAuthenticateAlreadyLoggedInWithoutTwoFactorChallengePassed() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -394,11 +394,11 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGetAndDesktopClient() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -443,11 +443,11 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForGet() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -480,11 +480,11 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithCsrfTokenForGet() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -520,11 +520,11 @@ class AuthTest extends TestCase {
 	 * @expectedException Sabre\DAV\Exception\NotAuthenticated
 	 */
 	public function testAutenticateWithLoggedInUserButLoginExceptionThrown() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -554,7 +554,7 @@ class AuthTest extends TestCase {
 	 * @expectedExceptionMessage Cannot authenticate over ajax calls
 	 */
 	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjax() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $httpRequest */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $httpRequest */
 		$httpRequest = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -575,7 +575,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjaxButUserIsStillLoggedIn() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $httpRequest */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $httpRequest */
 		$httpRequest = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -25,7 +25,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
 use OCP\IConfig;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
@@ -34,7 +34,7 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
 class BlockLegacyClientPluginTest extends TestCase {
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 	/** @var BlockLegacyClientPlugin */
 	private $blockLegacyClientVersionPlugin;
@@ -66,7 +66,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 	 * @expectedExceptionMessage Unsupported client version.
 	 */
 	public function testBeforeHandlerException($userAgent) {
-		/** @var \Sabre\HTTP\RequestInterface | PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var \Sabre\HTTP\RequestInterface | PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
 		$request
 			->expects($this->once())
@@ -101,7 +101,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 	 * @param string $userAgent
 	 */
 	public function testBeforeHandlerSuccess($userAgent) {
-		/** @var \Sabre\HTTP\RequestInterface | PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var \Sabre\HTTP\RequestInterface | PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
 		$request
 			->expects($this->once())
@@ -119,7 +119,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 	}
 
 	public function testBeforeHandlerNoUserAgent() {
-		/** @var \Sabre\HTTP\RequestInterface | PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var \Sabre\HTTP\RequestInterface | PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
 		$request
 			->expects($this->once())

--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -43,12 +43,12 @@ class CorsPluginTest extends TestCase {
 	private $plugin;
 
 	/**
-	 * @var IUserSession | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IUserSession | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $userSession;
 
 	/**
-	 * @var IConfig | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IConfig | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $config;
 
@@ -70,7 +70,7 @@ class CorsPluginTest extends TestCase {
 
 		$this->plugin = new CorsPlugin($this->userSession);
 
-		/** @var ServerPlugin | \PHPUnit_Framework_MockObject_MockObject $extraMethodPlugin */
+		/** @var ServerPlugin | \PHPUnit\Framework\MockObject\MockObject $extraMethodPlugin */
 		$extraMethodPlugin = $this->createMock(ServerPlugin::class);
 		$extraMethodPlugin->method('getHTTPMethods')
 			->with('owncloud/remote.php/dav/files/user1/target/path')

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -66,9 +66,9 @@ class TestDoubleFileView extends \OC\Files\View {
  */
 class DirectoryTest extends \Test\TestCase {
 
-	/** @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject */
 	private $view;
-	/** @var \OC\Files\FileInfo | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Files\FileInfo | \PHPUnit\Framework\MockObject\MockObject */
 	private $info;
 
 	protected function setUp() {

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -28,7 +28,7 @@ use OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin as PluginToTest;
 use OCP\Files\ExcludeForbiddenException;
 use OCP\Files\FileContentNotAllowedException;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\InsufficientStorage;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Server;
@@ -56,7 +56,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 	/** @var PluginToTest */
 	private $plugin;
 
-	/** @var TestLogger | PHPUnit_Framework_MockObject_MockObject */
+	/** @var TestLogger | PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	private function init() {

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -66,7 +66,7 @@ class FileTest extends TestCase {
 	 */
 	private $user;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
 	public function setUp() {
@@ -95,7 +95,7 @@ class FileTest extends TestCase {
 	}
 
 	/**
-	 * @return \PHPUnit_Framework_MockObject_MockObject | Storage
+	 * @return \PHPUnit\Framework\MockObject\MockObject | Storage
 	 */
 	private function getMockStorage() {
 		$storage = $this->createMock(Storage\IStorage::class);
@@ -181,7 +181,7 @@ class FileTest extends TestCase {
 			->setConstructorArgs([['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]])
 			->getMock();
 		Filesystem::mount($storage, [], $this->user . '/');
-		/** @var View | \PHPUnit_Framework_MockObject_MockObject $view */
+		/** @var View | \PHPUnit\Framework\MockObject\MockObject $view */
 		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath', 'resolvePath'])
 			->setConstructorArgs([])
@@ -254,7 +254,7 @@ class FileTest extends TestCase {
 			->getMock();
 		Filesystem::mount($storage, [], $this->user . '/');
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath', 'resolvePath'])
@@ -315,7 +315,7 @@ class FileTest extends TestCase {
 		$storage->method('fopen')
 			->willReturn($this->getStream('qwertz'));
 		Filesystem::mount($storage, [], $this->user . '/');
-		/** @var View | \PHPUnit_Framework_MockObject_MockObject $view */
+		/** @var View | \PHPUnit\Framework\MockObject\MockObject $view */
 		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath', 'resolvePath'])
 			->setConstructorArgs([])
@@ -445,7 +445,7 @@ class FileTest extends TestCase {
 			null
 		);
 
-		/** @var File | \PHPUnit_Framework_MockObject_MockObject $file */
+		/** @var File | \PHPUnit\Framework\MockObject\MockObject $file */
 		$file = $this->getMockBuilder(File::class)
 			->setConstructorArgs([$view, $info, null, $request])
 			->setMethods(['header'])

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -63,12 +63,12 @@ class FilesPluginTest extends TestCase {
 	const DATA_FINGERPRINT_PROPERTYNAME = FilesPlugin::DATA_FINGERPRINT_PROPERTYNAME;
 
 	/**
-	 * @var Server | \PHPUnit_Framework_MockObject_MockObject
+	 * @var Server | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $server;
 
 	/**
-	 * @var Tree | \PHPUnit_Framework_MockObject_MockObject
+	 * @var Tree | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $tree;
 
@@ -78,12 +78,12 @@ class FilesPluginTest extends TestCase {
 	private $plugin;
 
 	/**
-	 * @var IConfig | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IConfig | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $config;
 
 	/**
-	 * @var IRequest | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IRequest | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $request;
 
@@ -120,7 +120,7 @@ class FilesPluginTest extends TestCase {
 	/**
 	 * @param string $class
 	 * @param string $path
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function createTestNode($class, $path = '/dummypath') {
 		$node = $this->getMockBuilder($class)
@@ -162,7 +162,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForFile() {
-		/** @var File | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var File | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode(File::class);
 
 		$propFind = new PropFind(
@@ -221,7 +221,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesStorageNotAvailable() {
-		/** @var File | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var File | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode(File::class);
 
 		$propFind = new PropFind(
@@ -260,7 +260,7 @@ class FilesPluginTest extends TestCase {
 			0
 		);
 
-		/** @var File | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var File | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode(File::class);
 		$node
 			->method('getDavPermissions')
@@ -275,7 +275,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForDirectory() {
-		/** @var Directory | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var Directory | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode(Directory::class);
 
 		$propFind = new PropFind(
@@ -310,7 +310,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForRootDirectory() {
-		/** @var Directory | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var Directory | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -345,7 +345,7 @@ class FilesPluginTest extends TestCase {
 	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetPropertiesWhenNoPermission() {
-		/** @var Directory | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var Directory | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -522,11 +522,11 @@ class FilesPluginTest extends TestCase {
 	 * @param string $contentDispositionHeader
 	 */
 	public function testDownloadHeaders($isClumsyAgent, $contentDispositionHeader) {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -577,11 +577,11 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testAdditionalHeaders() {
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -36,19 +36,19 @@ use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 
 class FilesReportPluginTest extends \Test\TestCase {
-	/** @var \Sabre\DAV\Server|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \Sabre\DAV\Server|\PHPUnit\Framework\MockObject\MockObject */
 	private $server;
 
-	/** @var \Sabre\DAV\Tree|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \Sabre\DAV\Tree|\PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
 
-	/** @var ISystemTagObjectMapper|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISystemTagObjectMapper|\PHPUnit\Framework\MockObject\MockObject */
 	private $tagMapper;
 
-	/** @var ISystemTagManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISystemTagManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $tagManager;
 
-	/** @var ITags|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITags|\PHPUnit\Framework\MockObject\MockObject */
 	private $privateTags;
 
 	/** @var  \OCP\IUserSession */
@@ -57,13 +57,13 @@ class FilesReportPluginTest extends \Test\TestCase {
 	/** @var FilesReportPluginImplementation */
 	private $plugin;
 
-	/** @var View|\PHPUnit_Framework_MockObject_MockObject **/
+	/** @var View|\PHPUnit\Framework\MockObject\MockObject **/
 	private $view;
 
-	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject **/
+	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject **/
 	private $groupManager;
 
-	/** @var Folder|\PHPUnit_Framework_MockObject_MockObject **/
+	/** @var Folder|\PHPUnit\Framework\MockObject\MockObject **/
 	private $userFolder;
 
 	public function setUp() {
@@ -371,7 +371,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with('222')
 			->will($this->returnValue([$filesNode2]));
 
-		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit_Framework_MockObject_MockObject $reportTargetNode */
+		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);
@@ -421,7 +421,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with('222')
 			->will($this->returnValue([$filesNode2]));
 
-		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit_Framework_MockObject_MockObject $reportTargetNode */
+		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);

--- a/apps/dav/tests/unit/Connector/Sabre/FilesSearchReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesSearchReportPluginTest.php
@@ -33,16 +33,16 @@ use Sabre\DAV\Server;
 use Sabre\DAV\PropFind;
 
 class FilesSearchReportPluginTest extends \Test\TestCase {
-	/** @var Server|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Server|\PHPUnit\Framework\MockObject\MockObject */
 	private $server;
 
-	/** @var Tree|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Tree|\PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
 
-	/** @var ISearch|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISearch|\PHPUnit\Framework\MockObject\MockObject */
 	private $searchService;
 
-	/** @var FilesSearchReportPlugin|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var FilesSearchReportPlugin|\PHPUnit\Framework\MockObject\MockObject */
 	private $plugin;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -30,11 +30,11 @@ use Sabre\DAV\PropPatch;
 use Test\TestCase;
 
 class PrincipalTest extends TestCase {
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 	/** @var \OCA\DAV\Connector\Sabre\Principal */
 	private $connector;
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $groupManager;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -39,10 +39,10 @@ use OC\Files\View;
  */
 class QuotaPluginTest extends TestCase {
 
-	/** @var \Sabre\DAV\Server | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject */
 	private $server;
 
-	/** @var \OCA\DAV\Connector\Sabre\QuotaPlugin | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\DAV\Connector\Sabre\QuotaPlugin | \PHPUnit\Framework\MockObject\MockObject */
 	private $plugin;
 
 	private function init($quota, $checkedPath = '') {

--- a/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
+++ b/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
@@ -23,7 +23,7 @@
 namespace OCA\DAV\Tests\unit\DAV;
 
 use OCA\DAV\Files\BrowserErrorPagePlugin;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\NotFound;
 
 class BrowserErrorPagePluginTest extends \Test\TestCase {
@@ -34,11 +34,11 @@ class BrowserErrorPagePluginTest extends \Test\TestCase {
 	 * @param $exception
 	 */
 	public function test($expectedCode, $exception) {
-		/** @var BrowserErrorPagePlugin | PHPUnit_Framework_MockObject_MockObject $plugin */
+		/** @var BrowserErrorPagePlugin | PHPUnit\Framework\MockObject\MockObject $plugin */
 		$plugin = $this->getMockBuilder('OCA\DAV\Files\BrowserErrorPagePlugin')->setMethods(['sendResponse', 'generateBody'])->getMock();
 		$plugin->expects($this->once())->method('generateBody')->willReturn(':boom:');
 		$plugin->expects($this->once())->method('sendResponse');
-		/** @var \Sabre\DAV\Server | PHPUnit_Framework_MockObject_MockObject $server */
+		/** @var \Sabre\DAV\Server | PHPUnit\Framework\MockObject\MockObject $server */
 		$server = $this->getMockBuilder('Sabre\DAV\Server')->disableOriginalConstructor()->getMock();
 		$server->expects($this->once())->method('on');
 		$httpResponse = $this->getMockBuilder('Sabre\HTTP\Response')->disableOriginalConstructor()->getMock();

--- a/apps/dav/tests/unit/DAV/CopyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/CopyPluginTest.php
@@ -37,15 +37,15 @@ use OCA\DAV\Files\ICopySource;
 
 class CopyPluginTest extends TestCase {
 
-	/** @var Server | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Server | \PHPUnit\Framework\MockObject\MockObject */
 	private $server;
 	/** @var CopyPlugin */
 	private $plugin;
-	/** @var Tree | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
-	/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $response;
 
 	public function setUp() {
@@ -55,9 +55,9 @@ class CopyPluginTest extends TestCase {
 		$this->server = $this->createMock(Server::class);
 		$this->tree = $this->createMock(Tree::class);
 		$this->server->tree = $this->tree;
-		/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$this->request = $this->createMock(RequestInterface::class);
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$this->response = $this->createMock(ResponseInterface::class);
 
 		$this->plugin->initialize($this->server);

--- a/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
+++ b/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
@@ -24,13 +24,13 @@ namespace OCA\DAV\Tests\unit\DAV;
 
 use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\IGroupManager;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\PropPatch;
 use OC\Group\Group;
 
 class GroupPrincipalTest extends \Test\TestCase {
 
-	/** @var IGroupManager | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | PHPUnit\Framework\MockObject\MockObject */
 	private $groupManager;
 
 	/** @var GroupPrincipalBackend */
@@ -172,7 +172,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 
 	/**
 	 * @param $gid
-	 * @return PHPUnit_Framework_MockObject_MockObject
+	 * @return PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function mockGroup($gid) {
 		$fooUser = $this->getMockBuilder(Group::class)

--- a/apps/dav/tests/unit/DAV/HookManagerTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerTest.php
@@ -57,17 +57,17 @@ class HookManagerTest extends TestCase {
 			->getMock();
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $syncService */
+		/** @var SyncService | \PHPUnit\Framework\MockObject\MockObject $syncService */
 		$syncService = $this->getMockBuilder(SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var CalDavBackend | \PHPUnit_Framework_MockObject_MockObject $cal */
+		/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject $cal */
 		$cal = $this->getMockBuilder(CalDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -80,7 +80,7 @@ class HookManagerTest extends TestCase {
 				'{http://apple.com/ns/ical/}calendar-color' => '#1d2d44'
 			]);
 
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $card */
 		$card = $this->getMockBuilder(CardDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -99,17 +99,17 @@ class HookManagerTest extends TestCase {
 			->getMock();
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $syncService */
+		/** @var SyncService | \PHPUnit\Framework\MockObject\MockObject $syncService */
 		$syncService = $this->getMockBuilder(SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var CalDavBackend | \PHPUnit_Framework_MockObject_MockObject $cal */
+		/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject $cal */
 		$cal = $this->getMockBuilder(CalDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -118,7 +118,7 @@ class HookManagerTest extends TestCase {
 		]);
 		$cal->expects($this->never())->method('createCalendar');
 
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $card */
 		$card = $this->getMockBuilder(CardDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -137,17 +137,17 @@ class HookManagerTest extends TestCase {
 			->getMock();
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $syncService */
+		/** @var SyncService | \PHPUnit\Framework\MockObject\MockObject $syncService */
 		$syncService = $this->getMockBuilder(SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var CalDavBackend | \PHPUnit_Framework_MockObject_MockObject $cal */
+		/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject $cal */
 		$cal = $this->getMockBuilder(CalDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -162,7 +162,7 @@ class HookManagerTest extends TestCase {
 				'{http://apple.com/ns/ical/}calendar-color' => '#1d2d44',
 			]);
 
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $card */
 		$card = $this->getMockBuilder(CardDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -180,20 +180,20 @@ class HookManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$userManager->expects($this->once())->method('get')->willReturn($user);
 
-		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $syncService */
+		/** @var SyncService | \PHPUnit\Framework\MockObject\MockObject $syncService */
 		$syncService = $this->getMockBuilder(SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$syncService->expects($this->once())
 			->method('deleteUser');
 
-		/** @var CalDavBackend | \PHPUnit_Framework_MockObject_MockObject $cal */
+		/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject $cal */
 		$cal = $this->getMockBuilder(CalDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -203,7 +203,7 @@ class HookManagerTest extends TestCase {
 		$cal->expects($this->once())->method('deleteCalendar');
 		$cal->expects($this->once())->method('deleteAllSharesForUser');
 
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $card */
 		$card = $this->getMockBuilder(CardDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/DAV/HookManagerZsyncTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerZsyncTest.php
@@ -91,22 +91,22 @@ class HookManagerZsyncTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $syncService */
+		/** @var SyncService | \PHPUnit\Framework\MockObject\MockObject $syncService */
 		$syncService = $this->getMockBuilder(SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var CalDavBackend | \PHPUnit_Framework_MockObject_MockObject $cal */
+		/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject $cal */
 		$cal = $this->getMockBuilder(CalDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
+		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $card */
 		$card = $this->getMockBuilder(CardDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/DAV/LazyOpsPluginTest.php
+++ b/apps/dav/tests/unit/DAV/LazyOpsPluginTest.php
@@ -41,13 +41,13 @@ class LazyOpsPluginTest extends TestCase {
 	private $plugin;
 	/** @var ILogger */
 	private $logger;
-	/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var JobStatusMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $jobStatusMapper;
-	/** @var IShutdownManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IShutdownManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $shutdownManager;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/DAV/LockPluginTest.php
+++ b/apps/dav/tests/unit/DAV/LockPluginTest.php
@@ -40,15 +40,15 @@ use Test\TestCase;
  */
 class LockPluginTest extends TestCase {
 
-	/** @var Server | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Server | \PHPUnit\Framework\MockObject\MockObject */
 	private $server;
 	/** @var LockPlugin */
 	private $plugin;
-	/** @var Tree | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
-	/** @var LockMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var LockMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $lockMapper;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
@@ -38,13 +38,13 @@ class PluginTest extends TestCase {
 	private $plugin;
 	/** @var Server */
 	private $server;
-	/** @var IShareable | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IShareable | \PHPUnit\Framework\MockObject\MockObject */
 	private $book;
 
 	public function setUp() {
 		parent::setUp();
 		
-		/** @var Auth | \PHPUnit_Framework_MockObject_MockObject $authBackend */
+		/** @var Auth | \PHPUnit\Framework\MockObject\MockObject $authBackend */
 		$authBackend = $this->getMockBuilder('OCA\DAV\Connector\Sabre\Auth')->disableOriginalConstructor()->getMock();
 		$authBackend->method('isDavAuthenticated')->willReturn(true);
 

--- a/apps/dav/tests/unit/DAV/ZsyncPluginTest.php
+++ b/apps/dav/tests/unit/DAV/ZsyncPluginTest.php
@@ -36,9 +36,9 @@ class ZsyncPluginTest extends TestCase {
 	private $plugin;
 	/** @var \OC\Files\View */
 	private $view;
-	/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $response;
-	/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/Files/FileLocksBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileLocksBackendTest.php
@@ -44,9 +44,9 @@ class FileLocksBackendTest extends TestCase {
 
 	/** @var FileLocksBackend */
 	private $plugin;
-	/** @var Tree | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
-	/** @var IPersistentLockingStorage | IStorage | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IPersistentLockingStorage | IStorage | \PHPUnit\Framework\MockObject\MockObject */
 	private $storageOfFileToBeLocked;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/Files/FilesHomeTest.php
+++ b/apps/dav/tests/unit/Files/FilesHomeTest.php
@@ -32,9 +32,9 @@ class FilesHomeTest extends TestCase {
 
 	/** @var FilesHome */
 	private $filesHome;
-	/** @var Directory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Directory | \PHPUnit\Framework\MockObject\MockObject */
 	private $rootNode;
-	/** @var View | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var View | \PHPUnit\Framework\MockObject\MockObject */
 	private $view;
 
 	protected function setUp() {
@@ -44,7 +44,7 @@ class FilesHomeTest extends TestCase {
 		]);
 
 		$this->rootNode = $this->createMock(Directory::class);
-		/** @var IMountManager | \PHPUnit_Framework_MockObject_MockObject $mountManager */
+		/** @var IMountManager | \PHPUnit\Framework\MockObject\MockObject $mountManager */
 		$mountManager = $this->createMock(IMountManager::class);
 
 		$this->filesHome->init($this->rootNode, $this->view, $mountManager);

--- a/apps/dav/tests/unit/Files/PreviewPluginTest.php
+++ b/apps/dav/tests/unit/Files/PreviewPluginTest.php
@@ -42,15 +42,15 @@ use OCP\Files\FileInfo;
 
 class PreviewPluginTest extends TestCase {
 
-	/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IPreviewNode | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IPreviewNode | \PHPUnit\Framework\MockObject\MockObject */
 	private $previewNode;
-	/** @var IPreview | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IPreview | \PHPUnit\Framework\MockObject\MockObject */
 	private $previewManager;
 	/** @var PreviewPlugin */
 	private $plugin;
-	/** @var ResponseInterface| \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ResponseInterface| \PHPUnit\Framework\MockObject\MockObject */
 	private $response;
 
 	public function setUp() {
@@ -62,28 +62,28 @@ class PreviewPluginTest extends TestCase {
 		$this->previewNode = $this->createMock([IPreviewNode::class, FileInfo::class]);
 
 		$this->request = $this->createMock(RequestInterface::class);
-		/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject $response */
 		$this->response = $this->createMock(ResponseInterface::class);
 
 		$this->initPlugin();
 	}
 
 	private function initPlugin() {
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$timeFactory->method('getTime')->willReturn(1234567);
 
 		$this->plugin = new PreviewPlugin($timeFactory, $this->previewManager);
 
-		/** @var IFileNode | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var IFileNode | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createMock(IFileNode::class);
 		$node->method('getNode')->willReturn($this->previewNode);
 
-		/** @var Tree | \PHPUnit_Framework_MockObject_MockObject $tree */
+		/** @var Tree | \PHPUnit\Framework\MockObject\MockObject $tree */
 		$tree = $this->createMock(Tree::class);
 		$tree->method('getNodeForPath')->willReturn($node);
 
-		/** @var Server | \PHPUnit_Framework_MockObject_MockObject $server */
+		/** @var Server | \PHPUnit\Framework\MockObject\MockObject $server */
 		$server = $this->createMock(Server::class);
 		$server->tree = $tree;
 

--- a/apps/dav/tests/unit/JobStatus/HomeTest.php
+++ b/apps/dav/tests/unit/JobStatus/HomeTest.php
@@ -35,7 +35,7 @@ use Test\TestCase;
  */
 class HomeTest extends TestCase {
 	public function testGetName() {
-		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		/** @var JobStatusMapper | \PHPUnit\Framework\MockObject\MockObject $mapper */
 		$mapper = $this->createMock(JobStatusMapper::class);
 		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
 		$this->assertEquals('user1', $home->getName());
@@ -45,14 +45,14 @@ class HomeTest extends TestCase {
 	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
 	 */
 	public function testGetChildren() {
-		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		/** @var JobStatusMapper | \PHPUnit\Framework\MockObject\MockObject $mapper */
 		$mapper = $this->createMock(JobStatusMapper::class);
 		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
 		$home->getChildren();
 	}
 
 	public function testGetChild() {
-		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		/** @var JobStatusMapper | \PHPUnit\Framework\MockObject\MockObject $mapper */
 		$mapper = $this->createMock(JobStatusMapper::class);
 
 		$jobStatusEntity = new JobStatusEntity();
@@ -67,7 +67,7 @@ class HomeTest extends TestCase {
 	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetChildNotFound() {
-		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		/** @var JobStatusMapper | \PHPUnit\Framework\MockObject\MockObject $mapper */
 		$mapper = $this->createMock(JobStatusMapper::class);
 
 		$ex = new DoesNotExistException('');

--- a/apps/dav/tests/unit/JobStatus/JobStatusTest.php
+++ b/apps/dav/tests/unit/JobStatus/JobStatusTest.php
@@ -37,7 +37,7 @@ class JobStatusTest extends TestCase {
 	private $jobStatus;
 	/** @var JobStatusEntity */
 	private $jobStatusEntity;
-	/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var JobStatusMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $mapper;
 
 	protected function setUp() {

--- a/apps/dav/tests/unit/Repair/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Repair/RemoveInvalidSharesTest.php
@@ -48,12 +48,12 @@ class RemoveInvalidSharesTest extends TestCase {
 
 	public function test(): void {
 		$db = \OC::$server->getDatabaseConnection();
-		/** @var Principal | \PHPUnit_Framework_MockObject_MockObject $principal */
+		/** @var Principal | \PHPUnit\Framework\MockObject\MockObject $principal */
 		$principal = $this->createMock(Principal::class);
-		/** @var GroupPrincipalBackend | \PHPUnit_Framework_MockObject_MockObject $groupPrincipal */
+		/** @var GroupPrincipalBackend | \PHPUnit\Framework\MockObject\MockObject $groupPrincipal */
 		$groupPrincipal = $this->createMock(GroupPrincipalBackend::class);
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $output */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $output */
 		$output = $this->createMock(IOutput::class);
 
 		$repair = new RemoveInvalidShares($db, $principal, $groupPrincipal);

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -39,7 +39,7 @@ class ServerTest extends \Test\TestCase {
 	 * @dataProvider providesUris
 	 */
 	public function test($uri, array $plugins) {
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $r */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $r */
 		$r = $this->createMock(IRequest::class);
 		$r->expects($this->any())->method('getRequestUri')->willReturn($uri);
 		$s = new Server($r, '/');

--- a/apps/dav/tests/unit/TreeTest.php
+++ b/apps/dav/tests/unit/TreeTest.php
@@ -28,9 +28,9 @@ use Test\TestCase;
 
 class TreeTest1 extends TestCase {
 
-	/** @var ICollection | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICollection | \PHPUnit\Framework\MockObject\MockObject */
 	private $rootNode;
-	/** @var Tree | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
 
 	public function providesPaths() {

--- a/apps/dav/tests/unit/Upload/ChunkLocationProviderTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkLocationProviderTest.php
@@ -30,13 +30,13 @@ use org\bovigo\vfs\vfsStream;
 use Test\TestCase;
 
 class ChunkLocationProviderTest extends TestCase {
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ChunkLocationProvider | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ChunkLocationProvider | \PHPUnit\Framework\MockObject\MockObject */
 	private $provider;
-	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
 	private $user;
-	/** @var IStorageFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IStorageFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $factory;
 
 	protected function setUp() {

--- a/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
@@ -31,12 +31,12 @@ use Test\TestCase;
 class ChunkingPluginTest extends TestCase {
 
 	/**
-	 * @var \Sabre\DAV\Server | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $server;
 
 	/**
-	 * @var \Sabre\DAV\Tree | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \Sabre\DAV\Tree | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $tree;
 
@@ -44,9 +44,9 @@ class ChunkingPluginTest extends TestCase {
 	 * @var ChunkingPlugin
 	 */
 	private $plugin;
-	/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $response;
 
 	public function setUp() {

--- a/apps/dav/tests/unit/Upload/ChunkingPluginZsyncTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginZsyncTest.php
@@ -31,17 +31,17 @@ class ChunkingPluginZsyncTest extends TestCase {
 	const TEST_CHUNKING_USER1 = "test-chunking-user1";
 
 	/**
-	 * @var \Sabre\DAV\Server | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $server;
 
 	/**
-	 * @var \Sabre\DAV\Tree | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \Sabre\DAV\Tree | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $tree;
 
 	/**
-	 * @var OC\Files\View | \PHPUnit_Framework_MockObject_MockObject
+	 * @var OC\Files\View | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $view;
 
@@ -49,9 +49,9 @@ class ChunkingPluginZsyncTest extends TestCase {
 	 * @var ChunkingPluginZsync
 	 */
 	private $plugin;
-	/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ResponseInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $response;
 
 	public function setUp() {

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -32,10 +32,10 @@ class AddressHandlerTest extends \Test\TestCase {
 	/** @var  AddressHandler */
 	private $addressHandler;
 
-	/** @var  IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 
-	/** @var  IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $il10n;
 
 	public function setUp() {

--- a/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
@@ -47,42 +47,42 @@ use OCP\Share\IShare;
  */
 class OcmControllerTest extends TestCase {
 	/**
-	 * @var IRequest | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IRequest | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $request;
 
 	/**
-	 * @var OcmMiddleware | \PHPUnit_Framework_MockObject_MockObject
+	 * @var OcmMiddleware | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $ocmMiddleware;
 
 	/**
-	 * @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $urlGenerator;
 
 	/**
-	 * @var IAppManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IAppManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $appManager;
 
 	/**
-	 * @var IUserManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IUserManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $userManager;
 
 	/**
-	 * @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject
+	 * @var AddressHandler | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $addressHandler;
 
 	/**
-	 * @var FedShareManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var FedShareManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $fedShareManager;
 
 	/**
-	 * @var ILogger | \PHPUnit_Framework_MockObject_MockObject
+	 * @var ILogger | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $logger;
 

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
@@ -53,7 +53,7 @@ class RequestHandlerTest extends TestCase {
 	const DEFAULT_TOKEN = 'abc';
 
 	/**
-	 * @var IRequest | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IRequest | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $request;
 
@@ -63,17 +63,17 @@ class RequestHandlerTest extends TestCase {
 	private $ocmMiddleware;
 
 	/**
-	 * @var IUserManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IUserManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $userManager;
 
 	/**
-	 * @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject
+	 * @var AddressHandler | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $addressHandler;
 
 	/**
-	 * @var FedShareManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var FedShareManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $fedShareManager;
 

--- a/apps/federatedfilesharing/tests/Controller/SharingPersonalSettingsControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/SharingPersonalSettingsControllerTest.php
@@ -32,13 +32,13 @@ use Test\TestCase;
 
 class SharingPersonalSettingsControllerTest extends TestCase {
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject $config */
 	private $config;
 
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 	private $userSession;
 
 	/** @var SharingPersonalSettingsController $personalSettingsController */

--- a/apps/federatedfilesharing/tests/FedShareManagerTest.php
+++ b/apps/federatedfilesharing/tests/FedShareManagerTest.php
@@ -44,31 +44,31 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * @group DB
  */
 class FedShareManagerTest extends TestCase {
-	/** @var FederatedShareProvider | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var FederatedShareProvider | \PHPUnit\Framework\MockObject\MockObject */
 	private $federatedShareProvider;
 
-	/** @var Notifications | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Notifications | \PHPUnit\Framework\MockObject\MockObject */
 	private $notifications;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 
-	/** @var ActivityManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ActivityManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $activityManager;
 
-	/** @var NotificationManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var NotificationManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $notificationManager;
 
-	/** @var FedShareManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var FedShareManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $fedShareManager;
 
-	/** @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AddressHandler | \PHPUnit\Framework\MockObject\MockObject */
 	private $addressHandler;
 
-	/** @var Permissions | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Permissions | \PHPUnit\Framework\MockObject\MockObject */
 	private $permissions;
 
-	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $eventDispatcher;
 
 	protected function setUp() {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -54,9 +54,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	protected $connection;
 	/** @var EventDispatcherInterface */
 	protected $eventDispatcher;
-	/** @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AddressHandler | \PHPUnit\Framework\MockObject\MockObject */
 	protected $addressHandler;
-	/** @var Notifications | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Notifications | \PHPUnit\Framework\MockObject\MockObject */
 	protected $notifications;
 	/** @var TokenHandler */
 	protected $tokenHandler;
@@ -64,11 +64,11 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	protected $l;
 	/** @var ILogger */
 	protected $logger;
-	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject */
 	protected $rootFolder;
-	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var  IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
 	/** @var IManager */

--- a/apps/federatedfilesharing/tests/Middleware/OcmMiddlewareTest.php
+++ b/apps/federatedfilesharing/tests/Middleware/OcmMiddlewareTest.php
@@ -47,27 +47,27 @@ class OcmMiddlewareTest extends TestCase {
 	private $ocmMiddleware;
 
 	/**
-	 * @var FederatedShareProvider | \PHPUnit_Framework_MockObject_MockObject
+	 * @var FederatedShareProvider | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $federatedShareProvider;
 
 	/**
-	 * @var IAppManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IAppManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $appManager;
 
 	/**
-	 * @var IUserManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IUserManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $userManager;
 
 	/**
-	 * @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject
+	 * @var AddressHandler | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $addressHandler;
 
 	/**
-	 * @var ILogger | \PHPUnit_Framework_MockObject_MockObject
+	 * @var ILogger | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $logger;
 

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -37,22 +37,22 @@ use OCA\FederatedFileSharing\BackgroundJob\RetryJob;
 
 class NotificationsTest extends \Test\TestCase {
 
-	/** @var  AddressHandler | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  AddressHandler | \PHPUnit\Framework\MockObject\MockObject */
 	private $addressHandler;
 
-	/** @var  IClientService | \PHPUnit_Framework_MockObject_MockObject*/
+	/** @var  IClientService | \PHPUnit\Framework\MockObject\MockObject*/
 	private $httpClientService;
 
-	/** @var  DiscoveryManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  DiscoveryManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $discoveryManager;
 
-	/** @var NotificationManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var NotificationManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $notificationManager;
 
-	/** @var  IJobList | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IJobList | \PHPUnit\Framework\MockObject\MockObject */
 	private $jobList;
 
-	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
 	public function setUp() {
@@ -74,7 +74,7 @@ class NotificationsTest extends \Test\TestCase {
 	 * get instance of Notifications class
 	 *
 	 * @param array $mockedMethods methods which should be mocked
-	 * @return Notifications | \PHPUnit_Framework_MockObject_MockObject
+	 * @return Notifications | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function getInstance(array $mockedMethods = []) {
 		if (empty($mockedMethods)) {

--- a/apps/federatedfilesharing/tests/Panels/SharingPersonalPanelTest.php
+++ b/apps/federatedfilesharing/tests/Panels/SharingPersonalPanelTest.php
@@ -27,10 +27,10 @@ use OCP\IUserSession;
 
 class SharingPersonalPanelTest extends \Test\TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject $config */
 	private $config;
 
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 	private $userSession;
 
 	/** @var SharingPersonalPanel $personalPanel */

--- a/apps/federatedfilesharing/tests/TokenHandlerTest.php
+++ b/apps/federatedfilesharing/tests/TokenHandlerTest.php
@@ -31,7 +31,7 @@ class TokenHandlerTest extends \Test\TestCase {
 	/** @var  TokenHandler */
 	private $tokenHandler;
 
-	/** @var  ISecureRandom | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  ISecureRandom | \PHPUnit\Framework\MockObject\MockObject */
 	private $secureRandom;
 
 	/** @var int */

--- a/apps/federation/tests/API/OCSAuthAPITest.php
+++ b/apps/federation/tests/API/OCSAuthAPITest.php
@@ -35,22 +35,22 @@ use Test\TestCase;
 
 class OCSAuthAPITest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IRequest */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IRequest */
 	private $request;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | ISecureRandom  */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | ISecureRandom  */
 	private $secureRandom;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | JobList */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | JobList */
 	private $jobList;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers */
 	private $trustedServers;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | DbHandler */
 	private $dbHandler;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | ILogger */
 	private $logger;
 
 	/** @var  OCSAuthAPIController */
@@ -131,7 +131,7 @@ class OCSAuthAPITest extends TestCase {
 		$url = 'url';
 		$token = 'token';
 
-		/** @var OCSAuthAPIController | \PHPUnit_Framework_MockObject_MockObject $ocsAuthApi */
+		/** @var OCSAuthAPIController | \PHPUnit\Framework\MockObject\MockObject $ocsAuthApi */
 		$ocsAuthApi = $this->getMockBuilder(OCSAuthAPIController::class)
 			->setConstructorArgs(
 				[

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -43,25 +43,25 @@ use Test\TestCase;
  */
 class GetSharedSecretTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IClient */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IClient */
 	private $httpClient;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IJobList */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IJobList */
 	private $jobList;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IURLGenerator */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IURLGenerator */
 	private $urlGenerator;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers  */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers  */
 	private $trustedServers;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | DbHandler */
 	private $dbHandler;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | ILogger */
 	private $logger;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IResponse */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IResponse */
 	private $response;
 
 	/** @var GetSharedSecret */
@@ -97,7 +97,7 @@ class GetSharedSecretTest extends TestCase {
 	 * @param bool $retainBackgroundJob
 	 */
 	public function testExecute($isTrustedServer, $retainBackgroundJob) {
-		/** @var GetSharedSecret |\PHPUnit_Framework_MockObject_MockObject $getSharedSecret */
+		/** @var GetSharedSecret |\PHPUnit\Framework\MockObject\MockObject $getSharedSecret */
 		$getSharedSecret = $this->getMockBuilder('OCA\Federation\BackgroundJob\GetSharedSecret')
 			->setConstructorArgs(
 				[

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -35,22 +35,22 @@ use Test\TestCase;
 
 class RequestSharedSecretTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IClient */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IClient */
 	private $httpClient;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IJobList */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IJobList */
 	private $jobList;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IURLGenerator */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IURLGenerator */
 	private $urlGenerator;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | DbHandler */
 	private $dbHandler;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers */
 	private $trustedServers;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IResponse */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IResponse */
 	private $response;
 
 	/** @var  RequestSharedSecret */
@@ -84,7 +84,7 @@ class RequestSharedSecretTest extends TestCase {
 	 * @param bool $retainBackgroundJob
 	 */
 	public function testExecute($isTrustedServer, $retainBackgroundJob) {
-		/** @var RequestSharedSecret |\PHPUnit_Framework_MockObject_MockObject $requestSharedSecret */
+		/** @var RequestSharedSecret |\PHPUnit\Framework\MockObject\MockObject $requestSharedSecret */
 		$requestSharedSecret = $this->getMockBuilder('OCA\Federation\BackgroundJob\RequestSharedSecret')
 			->setConstructorArgs(
 				[

--- a/apps/federation/tests/Controller/SettingsControllerTest.php
+++ b/apps/federation/tests/Controller/SettingsControllerTest.php
@@ -31,13 +31,13 @@ class SettingsControllerTest extends TestCase {
 	/** @var SettingsController  */
 	private $controller;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IRequest */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IRequest */
 	private $request;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IL10N */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IL10N */
 	private $l10n;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCA\Federation\TrustedServers */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCA\Federation\TrustedServers */
 	private $trustedServers;
 
 	public function setUp() {

--- a/apps/federation/tests/DAV/FedAuthTest.php
+++ b/apps/federation/tests/DAV/FedAuthTest.php
@@ -35,7 +35,7 @@ class FedAuthTest extends TestCase {
 	 * @param string $password
 	 */
 	public function testFedAuth($expected, $user, $password) {
-		/** @var DbHandler | \PHPUnit_Framework_MockObject_MockObject $db */
+		/** @var DbHandler | \PHPUnit\Framework\MockObject\MockObject $db */
 		$db = $this->getMockBuilder('OCA\Federation\DbHandler')->disableOriginalConstructor()->getMock();
 		$db->method('auth')->willReturn(true);
 		$auth = new FedAuth($db);

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -37,7 +37,7 @@ class DbHandlerTest extends TestCase {
 	/** @var  DbHandler */
 	private $dbHandler;
 
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $il10n;
 
 	/** @var  IDBConnection */

--- a/apps/federation/tests/HooksTest.php
+++ b/apps/federation/tests/HooksTest.php
@@ -28,7 +28,7 @@ use Test\TestCase;
 
 class HooksTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers */
 	private $trustedServers;
 
 	/** @var  Hooks */

--- a/apps/federation/tests/Middleware/AddServerMiddlewareTest.php
+++ b/apps/federation/tests/Middleware/AddServerMiddlewareTest.php
@@ -31,16 +31,16 @@ use Test\TestCase;
 
 class AddServerMiddlewareTest extends TestCase {
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | ILogger */
 	private $logger;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IL10N */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IL10N */
 	private $l10n;
 
 	/** @var  AddServerMiddleware */
 	private $middleware;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | Controller */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | Controller */
 	private $controller;
 
 	public function setUp() {

--- a/apps/federation/tests/SyncFederationAddressbooksTest.php
+++ b/apps/federation/tests/SyncFederationAddressbooksTest.php
@@ -32,7 +32,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 	private $callBacks = [];
 
 	public function testSync() {
-		/** @var DbHandler | \PHPUnit_Framework_MockObject_MockObject $dbHandler */
+		/** @var DbHandler | \PHPUnit\Framework\MockObject\MockObject $dbHandler */
 		$dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')->
 			disableOriginalConstructor()->
 			getMock();
@@ -62,7 +62,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 	}
 
 	public function testException() {
-		/** @var DbHandler | \PHPUnit_Framework_MockObject_MockObject $dbHandler */
+		/** @var DbHandler | \PHPUnit\Framework\MockObject\MockObject $dbHandler */
 		$dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')->
 		disableOriginalConstructor()->
 		getMock();

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -38,34 +38,34 @@ use Test\TestCase;
 
 class TrustedServersTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers */
 	private $trustedServers;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | DbHandler */
 	private $dbHandler;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IClientService */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IClientService */
 	private $httpClientService;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | IClient */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | IClient */
 	private $httpClient;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | IResponse */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | IResponse */
 	private $response;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | ILogger */
 	private $logger;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | IJobList */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | IJobList */
 	private $jobList;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | ISecureRandom */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | ISecureRandom */
 	private $secureRandom;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | IConfig */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | IConfig */
 	private $config;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | EventDispatcherInterface */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | EventDispatcherInterface */
 	private $dispatcher;
 
 	public function setUp() {
@@ -100,7 +100,7 @@ class TrustedServersTest extends TestCase {
 	 * @param bool $success
 	 */
 	public function testAddServer($success) {
-		/** @var \PHPUnit_Framework_MockObject_MockObject|TrustedServers $trustedServers */
+		/** @var \PHPUnit\Framework\MockObject\MockObject|TrustedServers $trustedServers */
 		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
 			->setConstructorArgs(
 				[
@@ -256,7 +256,7 @@ class TrustedServersTest extends TestCase {
 	public function testIsOwnCloudServer($statusCode, $isValidOwnCloudVersion, $expected) {
 		$server = 'server1';
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers $trustedServers */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers $trustedServers */
 		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
 			->setConstructorArgs(
 				[

--- a/apps/files/tests/ActivityTest.php
+++ b/apps/files/tests/ActivityTest.php
@@ -37,19 +37,19 @@ class ActivityTest extends TestCase {
 	/** @var \OCP\Activity\IManager */
 	private $activityManager;
 
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCA\Files\ActivityHelper|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Files\ActivityHelper|\PHPUnit\Framework\MockObject\MockObject */
 	protected $activityHelper;
 
-	/** @var \OCP\L10N\IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\L10N\IFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l10nFactory;
 
 	/** @var \OCA\Files\Activity */

--- a/apps/files/tests/BackgroundJob/CleanupPersistentFileLocksTest.php
+++ b/apps/files/tests/BackgroundJob/CleanupPersistentFileLocksTest.php
@@ -27,7 +27,7 @@ use Test\TestCase;
 
 class CleanupPersistentFileLocksTest extends TestCase {
 	public function testJob(): void {
-		/** @var LockMapper | \PHPUnit_Framework_MockObject_MockObject $lockMapper */
+		/** @var LockMapper | \PHPUnit\Framework\MockObject\MockObject $lockMapper */
 		$lockMapper = $this->createMock(LockMapper::class);
 		$lockMapper->expects(self::once())->method('cleanup');
 		$job = new CleanupPersistentFileLocks($lockMapper);

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -60,17 +60,17 @@ class ScanTest extends TestCase {
 	private $groupManager;
 
 	/**
-	 * @var ILockingProvider | \PHPUnit_Framework_MockObject_MockObject
+	 * @var ILockingProvider | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $lockingProvider;
 
 	/**
-	 * @var IMimeTypeLoader | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IMimeTypeLoader | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $mimeTypeLoader;
 
 	/**
-	 * @var IConfig | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IConfig | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $config;
 

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -432,7 +432,7 @@ class ViewControllerTest extends TestCase {
 			->will($this->returnValue([]));
 
 		if ($useShowFile) {
-			$this->setExpectedException('OCP\Files\NotFoundException');
+			$this->expectException('OCP\Files\NotFoundException');
 			$this->viewController->showFile(123);
 		} else {
 			$response = $this->viewController->index('MyDir', 'MyView', '123');

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -48,25 +48,25 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @package OCA\Files\Tests\Controller
  */
 class ViewControllerTest extends TestCase {
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 	/** @var IL10N */
 	private $l10n;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 	/** @var EventDispatcherInterface */
 	private $eventDispatcher;
-	/** @var ViewController | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ViewController | \PHPUnit\Framework\MockObject\MockObject */
 	private $viewController;
 	/** @var IUser */
 	private $user;
 	/** @var IUserSession */
 	private $userSession;
-	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $appManager;
-	/** @var Folder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Folder | \PHPUnit\Framework\MockObject\MockObject */
 	private $rootFolder;
 
 	public function setUp() {

--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -64,7 +64,7 @@ class TagServiceTest extends \Test\TestCase {
 		$user = $this->createUser($this->user, 'test');
 		\OC_User::setUserId($this->user);
 		\OC_Util::setupFS($this->user);
-		/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock('\OCP\IUserSession');
 		$userSession->expects($this->any())
 			->method('getUser')

--- a/apps/files_external/tests/Command/ApplicableTest.php
+++ b/apps/files_external/tests/Command/ApplicableTest.php
@@ -26,9 +26,9 @@ use OCA\Files_External\Command\Applicable;
 
 class ApplicableTest extends CommandTest {
 	private function getInstance($storageService) {
-		/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock('\OCP\IUserManager');
-		/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject $groupManager */
+		/** @var \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject $groupManager */
 		$groupManager = $this->createMock('\OCP\IGroupManager');
 
 		$userManager->expects($this->any())

--- a/apps/files_external/tests/Command/CommandTest.php
+++ b/apps/files_external/tests/Command/CommandTest.php
@@ -34,7 +34,7 @@ use Test\TestCase;
 abstract class CommandTest extends TestCase {
 	/**
 	 * @param IStorageConfig[] $mounts
-	 * @return \OCP\Files\External\Service\IGlobalStoragesService|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\Files\External\Service\IGlobalStoragesService|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getGlobalStorageService(array $mounts = []) {
 		$mock = $this->createMock('OCP\Files\External\Service\IGlobalStoragesService');
@@ -45,10 +45,10 @@ abstract class CommandTest extends TestCase {
 	}
 
 	/**
-	 * @param \PHPUnit_Framework_MockObject_MockObject $mock
+	 * @param \PHPUnit\Framework\MockObject\MockObject $mock
 	 * @param IStorageConfig[] $mounts
 	 */
-	protected function bindMounts(\PHPUnit_Framework_MockObject_MockObject $mock, array $mounts) {
+	protected function bindMounts(\PHPUnit\Framework\MockObject\MockObject $mock, array $mounts) {
 		$mock->expects($this->any())
 			->method('getStorage')
 			->will($this->returnCallback(function ($id) use ($mounts) {

--- a/apps/files_external/tests/Command/ListCommandTest.php
+++ b/apps/files_external/tests/Command/ListCommandTest.php
@@ -34,16 +34,16 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class ListCommandTest extends CommandTest {
 	/**
-	 * @return \OCA\Files_External\Command\ListCommand|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCA\Files_External\Command\ListCommand|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function getInstance() {
-		/** @var \OCP\Files\External\Service\IGlobalStoragesService|\PHPUnit_Framework_MockObject_MockObject $globalService */
+		/** @var \OCP\Files\External\Service\IGlobalStoragesService|\PHPUnit\Framework\MockObject\MockObject $globalService */
 		$globalService = $this->createMock('\OCP\Files\External\Service\IGlobalStoragesService');
-		/** @var \OC\Files\External\Service\IUserStoragesService|\PHPUnit_Framework_MockObject_MockObject $userService */
+		/** @var \OC\Files\External\Service\IUserStoragesService|\PHPUnit\Framework\MockObject\MockObject $userService */
 		$userService = $this->createMock('\OCP\Files\External\Service\IUserStoragesService');
-		/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock('\OCP\IUserManager');
-		/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock('\OCP\IUserSession');
 
 		return new ListCommand($globalService, $userService, $userSession, $userManager);

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -54,28 +54,28 @@ class ShareesTest extends TestCase {
 	/** @var ShareesController */
 	protected $sharees;
 
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
-	/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
-	/** @var \OCP\Contacts\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Contacts\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCP\Share\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Share\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $shareManager;
 
-	/** @var SharingBlacklist|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var SharingBlacklist|\PHPUnit\Framework\MockObject\MockObject */
 	protected $sharingBlacklist;
 
 	protected function setUp() {
@@ -138,7 +138,7 @@ class ShareesTest extends TestCase {
 	 * @param string $displayName
 	 * @param string $email
 	 * @param array $terms Search terms for the user
-	 * @return \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getUserMock($uid, $displayName, $email = null, $terms = []) {
 		$user = $this->getMockBuilder(IUser::class)
@@ -166,7 +166,7 @@ class ShareesTest extends TestCase {
 
 	/**
 	 * @param string $gid
-	 * @return \OCP\IGroup|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\IGroup|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getGroupMock($gid, $displayName = null) {
 		$group = $this->getMockBuilder(IGroup::class)
@@ -1517,7 +1517,7 @@ class ShareesTest extends TestCase {
 	 * @param string $message
 	 */
 	public function testSearchInvalid($message, $search = '', $itemType = null, $page = 1, $perPage = 200) {
-		/** @var ShareesController | \PHPUnit_Framework_MockObject_MockObject $sharees */
+		/** @var ShareesController | \PHPUnit\Framework\MockObject\MockObject $sharees */
 		$sharees = $this->getMockBuilder(ShareesController::class)
 			->setConstructorArgs([
 				'files_sharing',
@@ -1668,7 +1668,7 @@ class ShareesTest extends TestCase {
 	 */
 	public function testSearchSharees($searchTerm, $itemType, array $shareTypes, $page, $perPage, $shareWithGroupOnly,
 									  $mockedUserResult, $mockedGroupsResult, $mockedRemotesResult, $expected, $nextLink) {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | ShareesController $sharees */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | ShareesController $sharees */
 		$sharees = $this->getMockBuilder(ShareesController::class)
 			->setConstructorArgs([
 				'files_sharing',
@@ -1928,7 +1928,7 @@ class ShareesTest extends TestCase {
 			->with($user->getUID())
 			->willReturn(true);
 
-		/** @var ShareesController | \PHPUnit_Framework_MockObject_MockObject $sharees */
+		/** @var ShareesController | \PHPUnit\Framework\MockObject\MockObject $sharees */
 		$sharees = $this->getMockBuilder(ShareesController::class)
 			->setConstructorArgs([
 				'files_sharing',

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1025,7 +1025,7 @@ class ApiTest extends TestCase {
 		$this->assertTrue($result->succeeded());
 
 		$meta = $result->getMeta();
-		$this->assertTrue($result->succeeded(), $meta['message']);
+		$this->assertTrue($result->succeeded(), (string) $meta['message']);
 
 		$share1 = $this->shareManager->getShareById('ocinternal:' . $share1->getId());
 		$this->assertEquals(1, $share1->getPermissions());

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -37,7 +37,7 @@ class CapabilitiesTest extends \Test\TestCase {
 	 */
 	protected $userSearch;
 
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $l10n;
 
 	/**

--- a/apps/files_sharing/tests/Controller/PersonalSettingsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PersonalSettingsControllerTest.php
@@ -32,13 +32,13 @@ use Test\TestCase;
 
 class PersonalSettingsControllerTest extends TestCase {
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject $config */
 	private $config;
 
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 	private $userSession;
 
 	/** @var PersonalSettingsController $personalSettingsController */

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -64,22 +64,22 @@ use OC\Files\Cache\Cache;
  */
 class Share20OcsControllerTest extends TestCase {
 
-	/** @var \OC\Share20\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Share20\Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $shareManager;
 
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $groupManager;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
 
-	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject */
 	private $rootFolder;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
 	/** @var IURLGenerator */
@@ -163,7 +163,7 @@ class Share20OcsControllerTest extends TestCase {
 	}
 
 	/**
-	 * @return Share20OcsController | \PHPUnit_Framework_MockObject_MockObject
+	 * @return Share20OcsController | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function mockFormatShare() {
 		return $this->getMockBuilder(Share20OcsController::class)

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -59,19 +59,19 @@ class ShareControllerTest extends \Test\TestCase {
 	private $appName = 'files_sharing';
 	/** @var ShareController */
 	private $shareController;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
-	/** @var \OCP\IPreview | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IPreview | \PHPUnit\Framework\MockObject\MockObject */
 	private $previewManager;
-	/** @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var  \OC\Share20\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  \OC\Share20\Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $shareManager;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
-	/** @var EventDispatcher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EventDispatcher | \PHPUnit\Framework\MockObject\MockObject */
 	private $eventDispatcher;
 
 	protected function setUp() {

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -50,7 +50,7 @@ class ManagerTest extends TestCase {
 	/** @var \OC\Files\Mount\Manager */
 	private $mountManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	private $eventDispatcher;
 
 	private $uid;

--- a/apps/files_sharing/tests/HooksTest.php
+++ b/apps/files_sharing/tests/HooksTest.php
@@ -37,27 +37,27 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class HooksTest extends TestCase {
 
 	/**
-	 * @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject
+	 * @var EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $eventDispatcher;
 
 	/**
-	 * @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $urlGenerator;
 
 	/**
-	 * @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $rootFolder;
 
 	/**
-	 * @var \OCP\Share\IManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OCP\Share\IManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $shareManager;
 
 	/**
-	 * @var NotificationPublisher | \PHPUnit_Framework_MockObject_MockObject
+	 * @var NotificationPublisher | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $notificationPublisher;
 

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -42,19 +42,19 @@ class MountProviderTest extends TestCase {
 	/** @var MountProvider */
 	private $provider;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
-	/** @var IUser|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
 	private $user;
 
-	/** @var IStorageFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IStorageFactory|\PHPUnit\Framework\MockObject\MockObject */
 	private $loader;
 
-	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $shareManager;
 
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	public function setUp() {

--- a/apps/files_sharing/tests/Panels/Admin/SettingsPanelTest.php
+++ b/apps/files_sharing/tests/Panels/Admin/SettingsPanelTest.php
@@ -25,10 +25,10 @@ use OCA\Files_Sharing\SharingBlacklist;
 use OCA\Files_Sharing\Panels\Admin\SettingsPanel;
 
 class SettingsPanelTest extends \Test\TestCase {
-	/** @var SharingBlacklist | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var SharingBlacklist | \PHPUnit\Framework\MockObject\MockObject */
 	private $sharingBlacklist;
 
-	/** @var SettingsPanel | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var SettingsPanel | \PHPUnit\Framework\MockObject\MockObject */
 	private $settingsPanel;
 
 	protected function setUp() {

--- a/apps/files_sharing/tests/Panels/Personal/PersonalPanelTest.php
+++ b/apps/files_sharing/tests/Panels/Personal/PersonalPanelTest.php
@@ -27,10 +27,10 @@ use OCP\IUserSession;
 
 class PersonalPanelTest extends \Test\TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject $config */
 	private $config;
 
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 	private $userSession;
 
 	/** @var PersonalPanel $personalPanel */

--- a/apps/files_sharing/tests/Panels/Personal/SectionTest.php
+++ b/apps/files_sharing/tests/Panels/Personal/SectionTest.php
@@ -25,7 +25,7 @@ use OCP\IL10N;
 
 class SectionTest extends \Test\TestCase {
 
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l */
 	private $l;
 
 	/** @var Section $section */

--- a/apps/files_sharing/tests/Service/NotificationPublisherTest.php
+++ b/apps/files_sharing/tests/Service/NotificationPublisherTest.php
@@ -36,13 +36,13 @@ use OCP\IUser;
  */
 class NotificationPublisherTest extends TestCase {
 
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $groupManager;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 
-	/** @var \OCP\Notification\IManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Notification\IManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $notificationManager;
 
 	/** @var IURLGenerator */

--- a/apps/files_sharing/tests/SharingBlacklistTest.php
+++ b/apps/files_sharing/tests/SharingBlacklistTest.php
@@ -26,10 +26,10 @@ use OCP\GroupInterface;
 use OCA\Files_Sharing\SharingBlacklist;
 
 class SharingBlacklistTest extends \Test\TestCase {
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
-	/** @var SharingBlacklist | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var SharingBlacklist | \PHPUnit\Framework\MockObject\MockObject */
 	private $sharingBlacklist;
 
 	public function setUp() {

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -40,10 +40,10 @@ class CleanUpTest extends TestCase {
 	/** @var  CleanUp */
 	protected $cleanup;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | Manager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | Manager */
 	protected $userManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IRootFolder */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IRootFolder */
 	protected $rootFolder;
 
 	/** @var \OC\DB\Connection */

--- a/apps/files_trashbin/tests/QuotaTest.php
+++ b/apps/files_trashbin/tests/QuotaTest.php
@@ -25,10 +25,10 @@ use OCP\IUserManager;
 
 class QuotaTest extends \Test\TestCase {
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject  */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject  */
 	private $userManager;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject  */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject  */
 	protected $config;
 
 	protected function setUp() {

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -645,7 +645,7 @@ class StorageTest extends TestCase {
 	 */
 	public function testSingleStorageDeleteFileFail() {
 		/**
-		 * @var \OC\Files\Storage\Temporary | \PHPUnit_Framework_MockObject_MockObject $storage
+		 * @var \OC\Files\Storage\Temporary | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
 			->setConstructorArgs([[]])
@@ -682,7 +682,7 @@ class StorageTest extends TestCase {
 	 */
 	public function testSingleStorageDeleteFolderFail() {
 		/**
-		 * @var \OC\Files\Storage\Temporary | \PHPUnit_Framework_MockObject_MockObject $storage
+		 * @var \OC\Files\Storage\Temporary | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
 			->setConstructorArgs([[]])

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -39,10 +39,10 @@ class CleanupTest extends TestCase {
 	/** @var  CleanUp */
 	protected $cleanup;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | Manager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | Manager */
 	protected $userManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IRootFolder */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IRootFolder */
 	protected $rootFolder;
 
 	public function setUp() {

--- a/apps/provisioning_api/tests/GroupsTest.php
+++ b/apps/provisioning_api/tests/GroupsTest.php
@@ -34,13 +34,13 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class GroupsTest extends \Test\TestCase {
-	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
-	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
-	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
-	/** @var \OC\SubAdmin|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\SubAdmin|\PHPUnit\Framework\MockObject\MockObject */
 	protected $subAdminManager;
 	/** @var Groups */
 	protected $api;
@@ -70,7 +70,7 @@ class GroupsTest extends \Test\TestCase {
 
 	/**
 	 * @param string $gid
-	 * @return \OCP\IGroup|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\IGroup|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function createGroup($gid) {
 		$group = $this->createMock('OCP\IGroup');
@@ -82,7 +82,7 @@ class GroupsTest extends \Test\TestCase {
 
 	/**
 	 * @param string $uid
-	 * @return \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function createUser($uid) {
 		$user = $this->createMock('OCP\IUser');

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -35,7 +35,7 @@ use OCP\API;
 use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase as OriginalTest;
 use OCP\IUser;
 use OC\SubAdmin;
@@ -44,17 +44,17 @@ use OC\Authentication\TwoFactorAuth\Manager;
 
 class UsersTest extends OriginalTest {
 	
-	/** @var IUserManager | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var \OC\Group\Manager | PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Group\Manager | PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
-	/** @var IUserSession | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
-	/** @var ILogger | PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var Users | PHPUnit_Framework_MockObject_MockObject */
+	/** @var Users | PHPUnit\Framework\MockObject\MockObject */
 	protected $api;
-	/** @var \OC\Authentication\TwoFactorAuth\Manager | PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Authentication\TwoFactorAuth\Manager | PHPUnit\Framework\MockObject\MockObject */
 	private $twoFactorAuthManager;
 
 	protected function tearDown() {

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -34,17 +34,17 @@ use Test\TestCase;
 
 class BackgroundJobTest extends TestCase {
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $notificationManager;
-	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
-	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $appManager;
-	/** @var IClientService|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IClientService|\PHPUnit\Framework\MockObject\MockObject */
 	protected $client;
-	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
 	protected $urlGenerator;
 
 	public function setUp() {
@@ -60,7 +60,7 @@ class BackgroundJobTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return BackgroundJob|\PHPUnit_Framework_MockObject_MockObject
+	 * @return BackgroundJob|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getJob(array $methods = []) {
 		if (empty($methods)) {
@@ -350,7 +350,7 @@ class BackgroundJobTest extends TestCase {
 
 	/**
 	 * @param string[] $userIds
-	 * @return IUser[]|\PHPUnit_Framework_MockObject_MockObject[]
+	 * @return IUser[]|\PHPUnit\Framework\MockObject\MockObject[]
 	 */
 	protected function getUsers(array $userIds) {
 		$users = [];
@@ -366,7 +366,7 @@ class BackgroundJobTest extends TestCase {
 
 	/**
 	 * @param $gid
-	 * @return \OCP\IGroup|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\IGroup|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getGroup($gid) {
 		$group = $this->createMock('OCP\IGroup');

--- a/apps/updatenotification/tests/Notification/NotifierTest.php
+++ b/apps/updatenotification/tests/Notification/NotifierTest.php
@@ -29,9 +29,9 @@ use Test\TestCase;
 
 class NotifierTest extends TestCase {
 
-	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $notificationManager;
-	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l10nFactory;
 
 	public function setUp() {
@@ -43,7 +43,7 @@ class NotifierTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return Notifier|\PHPUnit_Framework_MockObject_MockObject
+	 * @return Notifier|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getNotifier(array $methods = []) {
 		if (empty($methods)) {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "bamarni/composer-bin-plugin": "^1.2",
         "jakub-onderka/php-console-highlighter": "^0.4",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.5",
         "roave/security-advisories": "dev-master"
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
     "extra": {
         "bamarni-bin": {
             "bin-links": false
+        },
+        "cleaner-ignore": {
+            "phpunit/phpunit": ["phpunit.xsd"]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "bamarni/composer-bin-plugin": "^1.2",
         "jakub-onderka/php-console-highlighter": "^0.4",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^7.5",
         "roave/security-advisories": "dev-master"
     },
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2cb0783b86cf4cc4920b103a174e4c2",
+    "content-hash": "1fd37e6d0f318c8d500f9ff84f4b182a",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -3817,6 +3817,108 @@
             "time": "2018-06-11T23:09:50+00:00"
         },
         {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0.1",
             "source": {
@@ -4033,40 +4135,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -4081,7 +4183,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -4092,7 +4194,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4282,16 +4384,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.27",
+            "version": "6.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
                 "shasum": ""
             },
             "require": {
@@ -4300,33 +4402,35 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -4334,7 +4438,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -4360,33 +4464,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:50:59+00:00"
+            "time": "2019-02-01T05:22:47+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -4394,7 +4498,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -4409,7 +4513,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -4420,7 +4524,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4673,30 +4777,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -4727,38 +4831,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4785,32 +4889,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -4835,34 +4939,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -4902,27 +5006,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -4930,7 +5034,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4953,33 +5057,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -4999,32 +5104,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -5052,7 +5202,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -5198,63 +5348,44 @@
             "time": "2019-02-06T07:57:58+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.4.23",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/57f1ce82c997f5a8701b89ef970e36bb657fd09c",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:06:07+00:00"
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fd37e6d0f318c8d500f9ff84f4b182a",
+    "content-hash": "1ccbfb436109d1f0fe3e2f4f68874e83",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -3818,22 +3818,22 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -3869,20 +3869,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -3916,7 +3916,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4135,40 +4135,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -4194,29 +4194,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -4231,7 +4234,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -4241,7 +4244,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -4286,28 +4289,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -4322,7 +4325,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -4331,33 +4334,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-02-20T10:12:59+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4380,57 +4383,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2018-10-30T05:52:18+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.14",
+            "version": "7.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+                "reference": "eb343b86753d26de07ecba7868fa983104361948"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/eb343b86753d26de07ecba7868fa983104361948",
+                "reference": "eb343b86753d26de07ecba7868fa983104361948",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -4438,7 +4441,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -4464,67 +4467,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-02-01T05:22:47+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2018-08-09T05:50:03+00:00"
+            "time": "2019-03-16T07:31:17+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4777,30 +4720,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4837,32 +4780,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4887,34 +4831,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -4939,7 +4889,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-02-01T05:27:49+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5206,25 +5156,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -5244,7 +5194,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ccbfb436109d1f0fe3e2f4f68874e83",
+    "content-hash": "5f1e04646de23e3370731bc9be4e801b",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",

--- a/tests/Core/Command/Config/App/DeleteConfigTest.php
+++ b/tests/Core/Command/Config/App/DeleteConfigTest.php
@@ -25,12 +25,12 @@ use OC\Core\Command\Config\App\DeleteConfig;
 use Test\TestCase;
 
 class DeleteConfigTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Config/App/GetConfigTest.php
+++ b/tests/Core/Command/Config/App/GetConfigTest.php
@@ -28,11 +28,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class GetConfigTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Config/App/SetConfigTest.php
+++ b/tests/Core/Command/Config/App/SetConfigTest.php
@@ -25,12 +25,12 @@ use OC\Core\Command\Config\App\SetConfig;
 use Test\TestCase;
 
 class SetConfigTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Config/ImportTest.php
+++ b/tests/Core/Command/Config/ImportTest.php
@@ -25,12 +25,12 @@ use OC\Core\Command\Config\Import;
 use Test\TestCase;
 
 class ImportTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Config/ListConfigsTest.php
+++ b/tests/Core/Command/Config/ListConfigsTest.php
@@ -26,14 +26,14 @@ use OCP\IConfig;
 use Test\TestCase;
 
 class ListConfigsTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $appConfig;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $systemConfig;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Config/System/DeleteConfigTest.php
+++ b/tests/Core/Command/Config/System/DeleteConfigTest.php
@@ -25,12 +25,12 @@ use OC\Core\Command\Config\System\DeleteConfig;
 use Test\TestCase;
 
 class DeleteConfigTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $systemConfig;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Config/System/GetConfigTest.php
+++ b/tests/Core/Command/Config/System/GetConfigTest.php
@@ -28,11 +28,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class GetConfigTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $systemConfig;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 	/** @var \Symfony\Component\Console\Command\Command */
 	protected $command;

--- a/tests/Core/Command/Config/System/SetConfigTest.php
+++ b/tests/Core/Command/Config/System/SetConfigTest.php
@@ -25,12 +25,12 @@ use OC\Core\Command\Config\System\SetConfig;
 use Test\TestCase;
 
 class SetConfigTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $systemConfig;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -36,28 +36,28 @@ class ChangeKeyStorageRootTest extends TestCase {
 	/** @var ChangeKeyStorageRoot */
 	protected $changeKeyStorageRoot;
 
-	/** @var View | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var View | \PHPUnit\Framework\MockObject\MockObject */
 	protected $view;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/**  @var Util | \PHPUnit_Framework_MockObject_MockObject */
+	/**  @var Util | \PHPUnit\Framework\MockObject\MockObject */
 	protected $util;
 
-	/** @var QuestionHelper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var QuestionHelper | \PHPUnit\Framework\MockObject\MockObject */
 	protected $questionHelper;
 
-	/** @var InputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var InputInterface | \PHPUnit\Framework\MockObject\MockObject */
 	protected $inputInterface;
 
-	/** @var OutputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var OutputInterface | \PHPUnit\Framework\MockObject\MockObject */
 	protected $outputInterface;
 
-	/** @var \OCP\UserInterface |  \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\UserInterface |  \PHPUnit\Framework\MockObject\MockObject */
 	protected $userInterface;
 
 	public function setUp() {

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -26,25 +26,25 @@ use Test\TestCase;
 
 class DecryptAllTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IConfig */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IConfig */
 	protected $config;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\Encryption\IManager  */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Encryption\IManager  */
 	protected $encryptionManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\App\IAppManager  */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\App\IAppManager  */
 	protected $appManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject  | \Symfony\Component\Console\Input\InputInterface */
+	/** @var \PHPUnit\Framework\MockObject\MockObject  | \Symfony\Component\Console\Input\InputInterface */
 	protected $consoleInput;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \Symfony\Component\Console\Output\OutputInterface */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Output\OutputInterface */
 	protected $consoleOutput;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \Symfony\Component\Console\Helper\QuestionHelper */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Helper\QuestionHelper */
 	protected $questionHelper;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OC\Encryption\DecryptAll */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OC\Encryption\DecryptAll */
 	protected $decryptAll;
 
 	public function setUp() {

--- a/tests/Core/Command/Encryption/DisableTest.php
+++ b/tests/Core/Command/Encryption/DisableTest.php
@@ -25,11 +25,11 @@ use OC\Core\Command\Encryption\Disable;
 use Test\TestCase;
 
 class DisableTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Encryption/EnableTest.php
+++ b/tests/Core/Command/Encryption/EnableTest.php
@@ -25,13 +25,13 @@ use OC\Core\Command\Encryption\Enable;
 use Test\TestCase;
 
 class EnableTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $manager;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -26,25 +26,25 @@ use Test\TestCase;
 
 class EncryptAllTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IConfig */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IConfig */
 	protected $config;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\Encryption\IManager  */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Encryption\IManager  */
 	protected $encryptionManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\App\IAppManager  */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\App\IAppManager  */
 	protected $appManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject  | \Symfony\Component\Console\Input\InputInterface */
+	/** @var \PHPUnit\Framework\MockObject\MockObject  | \Symfony\Component\Console\Input\InputInterface */
 	protected $consoleInput;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \Symfony\Component\Console\Output\OutputInterface */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Output\OutputInterface */
 	protected $consoleOutput;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \Symfony\Component\Console\Helper\QuestionHelper */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Helper\QuestionHelper */
 	protected $questionHelper;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\Encryption\IEncryptionModule */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Encryption\IEncryptionModule */
 	protected $encryptionModule;
 
 	/** @var  EncryptAll */

--- a/tests/Core/Command/Encryption/SetDefaultModuleTest.php
+++ b/tests/Core/Command/Encryption/SetDefaultModuleTest.php
@@ -25,11 +25,11 @@ use OC\Core\Command\Encryption\SetDefaultModule;
 use Test\TestCase;
 
 class SetDefaultModuleTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $manager;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Group/DeleteTest.php
+++ b/tests/Core/Command/Group/DeleteTest.php
@@ -25,11 +25,11 @@ use OC\Core\Command\Group\Delete;
 use Test\TestCase;
 
 class DeleteTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Log/ManageTest.php
+++ b/tests/Core/Command/Log/ManageTest.php
@@ -25,11 +25,11 @@ use OC\Core\Command\Log\Manage;
 use Test\TestCase;
 
 class ManageTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Log/OwnCloudTest.php
+++ b/tests/Core/Command/Log/OwnCloudTest.php
@@ -25,11 +25,11 @@ use OC\Core\Command\Log\OwnCloud;
 use Test\TestCase;
 
 class OwnCloudTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Maintenance/DataFingerprintTest.php
+++ b/tests/Core/Command/Maintenance/DataFingerprintTest.php
@@ -31,11 +31,11 @@ use Test\TestCase;
 
 class DataFingerprintTest extends TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 	/** @var \Symfony\Component\Console\Command\Command */
 	private $command;

--- a/tests/Core/Command/Maintenance/Mimetype/UpdateDBTest.php
+++ b/tests/Core/Command/Maintenance/Mimetype/UpdateDBTest.php
@@ -32,9 +32,9 @@ class UpdateDBTest extends TestCase {
 	/** @var IMimeTypeLoader */
 	protected $loader;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/Maintenance/SingleUserTest.php
+++ b/tests/Core/Command/Maintenance/SingleUserTest.php
@@ -25,11 +25,11 @@ use OC\Core\Command\Maintenance\SingleUser;
 use Test\TestCase;
 
 class SingleUserTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/System/CronTest.php
+++ b/tests/Core/Command/System/CronTest.php
@@ -39,13 +39,13 @@ use Test\Traits\UserTrait;
 class CronTest extends TestCase {
 	use UserTrait;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
-	/** @var IJobList | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IJobList | \PHPUnit\Framework\MockObject\MockObject */
 	private $jobList;
-	/** @var ITempManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITempManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $tempManager;
 
 	/** @var CommandTester */

--- a/tests/Core/Command/User/DeleteTest.php
+++ b/tests/Core/Command/User/DeleteTest.php
@@ -30,7 +30,7 @@ use Test\TestCase;
 
 class DeleteTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject|IUserManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IUserManager */
 	protected $userManager;
 
 	/** @var CommandTester */

--- a/tests/Core/Command/User/InactiveTest.php
+++ b/tests/Core/Command/User/InactiveTest.php
@@ -29,11 +29,11 @@ use Test\TestCase;
 
 class InactiveTest extends TestCase {
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/User/LastSeenTest.php
+++ b/tests/Core/Command/User/LastSeenTest.php
@@ -25,11 +25,11 @@ use OC\Core\Command\User\LastSeen;
 use Test\TestCase;
 
 class LastSeenTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	/** @var \Symfony\Component\Console\Command\Command */

--- a/tests/Core/Command/User/ModifyTest.php
+++ b/tests/Core/Command/User/ModifyTest.php
@@ -39,15 +39,15 @@ use Test\Traits\UserTrait;
 class ModifyTest extends TestCase {
 	use UserTrait;
 
-	/** @var  IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
-	/** @var  IMailer | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IMailer | \PHPUnit\Framework\MockObject\MockObject */
 	protected $mailer;
-	/** @var  InputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  InputInterface | \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
 
-	/** @var  OutputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  OutputInterface | \PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	protected function setUp() {

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -44,15 +44,15 @@ use Test\TestCase;
  * @package Tests\Core\Command\User
  */
 class ResetPasswordTest extends TestCase {
-	/** @var  IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
-	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var  ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
-	/** @var  EnvironmentHelper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  EnvironmentHelper | \PHPUnit\Framework\MockObject\MockObject */
 	private $environmentHelper;
-	/** @var LostController | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var LostController | \PHPUnit\Framework\MockObject\MockObject */
 	private $lostController;
 	/** @var  ResetPassword */
 	private $resetPassword;

--- a/tests/Core/Command/User/SettingTest.php
+++ b/tests/Core/Command/User/SettingTest.php
@@ -25,15 +25,15 @@ use OC\Core\Command\User\Setting;
 use Test\TestCase;
 
 class SettingTest extends TestCase {
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \OCP\IDBConnection|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IDBConnection|\PHPUnit\Framework\MockObject\MockObject */
 	protected $connection;
-	/** @var \Symfony\Component\Console\Input\InputInterface|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \Symfony\Component\Console\Input\InputInterface|\PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleInput;
-	/** @var \Symfony\Component\Console\Output\OutputInterface|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \Symfony\Component\Console\Output\OutputInterface|\PHPUnit\Framework\MockObject\MockObject */
 	protected $consoleOutput;
 
 	protected function setUp() {

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -51,27 +51,27 @@ class AvatarControllerTest extends TestCase {
 
 	/** @var \OC\Core\Controller\AvatarController */
 	private $avatarController;
-	/** @var IAvatar | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAvatar | \PHPUnit\Framework\MockObject\MockObject */
 	private $avatarMock;
-	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
 	private $userMock;
-	/** @var File | \PHPUnit_Framework_MockObject_MockObject*/
+	/** @var File | \PHPUnit\Framework\MockObject\MockObject*/
 	private $avatarFile;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $l10N;
-	/** @var IAvatarManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAvatarManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $avatarManager;
-	/** @var \OC\Cache\File | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Cache\File | \PHPUnit\Framework\MockObject\MockObject */
 	private $cache;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
-	/** @var Folder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Folder | \PHPUnit\Framework\MockObject\MockObject */
 	private $rootFolder;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	protected function setUp() {

--- a/tests/Core/Controller/CronControllerTest.php
+++ b/tests/Core/Controller/CronControllerTest.php
@@ -39,13 +39,13 @@ class CronControllerTest extends TestCase {
 
 	/** @var CronController */
 	private $controller;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
-	/** @var IJobList | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IJobList | \PHPUnit\Framework\MockObject\MockObject */
 	private $jobList;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
 
 	protected function setUp() {

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -38,19 +38,19 @@ use Test\TestCase;
 class LoginControllerTest extends TestCase {
 	/** @var LoginController */
 	private $loginController;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
-	/** @var Session | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Session | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
-	/** @var Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $twoFactorManager;
 
 	public function setUp() {
@@ -325,7 +325,7 @@ class LoginControllerTest extends TestCase {
 	}
 
 	public function testLoginWithValidCredentials() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$password = 'secret';
 		$indexPageUrl = 'some url';
@@ -368,7 +368,7 @@ class LoginControllerTest extends TestCase {
 	}
 
 	public function testLoginWithValidCredentialsAndRedirectUrl() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
@@ -401,7 +401,7 @@ class LoginControllerTest extends TestCase {
 	}
 	
 	public function testLoginWithTwoFactorEnforced() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
@@ -438,7 +438,7 @@ class LoginControllerTest extends TestCase {
 	}
 
 	public function testToNotLeakLoginName() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -34,7 +34,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -48,25 +48,25 @@ class LostControllerTest extends TestCase {
 	private $lostController;
 	/** @var IUser */
 	private $existingUser;
-	/** @var IURLGenerator | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 	/** @var IL10N */
 	private $l10n;
-	/** @var IUserManager | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 	/** @var \OC_Defaults */
 	private $defaults;
-	/** @var IConfig | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var IMailer | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IMailer | PHPUnit\Framework\MockObject\MockObject */
 	private $mailer;
-	/** @var ISecureRandom | PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISecureRandom | PHPUnit\Framework\MockObject\MockObject */
 	private $secureRandom;
-	/** @var ITimeFactory | PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
-	/** @var IRequest | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var ILogger | PHPUnit_Framework_MockObject_MockObject*/
+	/** @var ILogger | PHPUnit\Framework\MockObject\MockObject*/
 	private $logger;
 	/** @var Session */
 	private $userSession;

--- a/tests/Core/Controller/OccControllerTest.php
+++ b/tests/Core/Controller/OccControllerTest.php
@@ -35,13 +35,13 @@ use Test\TestCase;
 class OccControllerTest extends TestCase {
 	const TEMP_SECRET = 'test';
 
-	/** @var \OC\AppFramework\Http\Request | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\AppFramework\Http\Request | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var  \OC\Core\Controller\OccController | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  \OC\Core\Controller\OccController | \PHPUnit\Framework\MockObject\MockObject */
 	private $controller;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var  Application | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  Application | \PHPUnit\Framework\MockObject\MockObject */
 	private $console;
 
 	public function testFromInvalidLocation() {

--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -34,18 +34,18 @@ use Test\TestCase;
 
 class TwoFactorChallengeControllerTest extends TestCase {
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $twoFactorManager;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 
-	/** @var TwoFactorChallengeController|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var TwoFactorChallengeController|\PHPUnit\Framework\MockObject\MockObject */
 	private $controller;
 
 	protected function setUp() {

--- a/tests/Core/Middleware/AccountModuleMiddlewareTest.php
+++ b/tests/Core/Middleware/AccountModuleMiddlewareTest.php
@@ -35,16 +35,16 @@ use OC\Core\Controller\TwoFactorChallengeController;
 
 class AccountModuleMiddlewareTest extends TestCase {
 
-	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
-	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Manager|\PHPUnit\Framework\MockObject\MockObject */
 	private $manager;
 
-	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
 
-	/** @var IControllerMethodReflector|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IControllerMethodReflector|\PHPUnit\Framework\MockObject\MockObject */
 	private $reflector;
 
 	/** @var AccountModuleMiddleware */

--- a/tests/Core/Middleware/TwoFactorMiddlewareTest.php
+++ b/tests/Core/Middleware/TwoFactorMiddlewareTest.php
@@ -35,16 +35,16 @@ use Test\TestCase;
 
 class TwoFactorMiddlewareTest extends TestCase {
 
-	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Manager|\PHPUnit\Framework\MockObject\MockObject */
 	private $twoFactorManager;
 
-	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
 
-	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 
-	/** @var IControllerMethodReflector|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IControllerMethodReflector|\PHPUnit\Framework\MockObject\MockObject */
 	private $reflector;
 
 	/** @var Request */

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -43,21 +43,21 @@ use Test\TestCase;
  */
 class CheckSetupControllerTest extends TestCase {
 
-	/** @var CheckSetupController | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var CheckSetupController | \PHPUnit\Framework\MockObject\MockObject */
 	private $checkSetupController;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var IClientService | \PHPUnit_Framework_MockObject_MockObject*/
+	/** @var IClientService | \PHPUnit\Framework\MockObject\MockObject*/
 	private $clientService;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 	/** @var OC_Util */
 	private $util;
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $l10n;
-	/** @var Checker | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Checker | \PHPUnit\Framework\MockObject\MockObject */
 	private $checker;
 
 	public function setUp() {
@@ -451,7 +451,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
-		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
+		/** @var ClientException | \PHPUnit\Framework\MockObject\MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')
@@ -485,7 +485,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
-		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
+		/** @var ClientException | \PHPUnit\Framework\MockObject\MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -43,13 +43,13 @@ class GroupsControllerTest extends TestCase {
 	/** @var string */
 	private $appName;
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
 
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $groupManager;
 
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
 
 	/** @var GroupsController */

--- a/tests/Settings/Controller/MailSettingsControllerTest.php
+++ b/tests/Settings/Controller/MailSettingsControllerTest.php
@@ -119,7 +119,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			->with('demo@owncloud.com')
 			->will($this->returnValue(true));
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject $config */
+		/** @var \PHPUnit\Framework\MockObject\MockObject $config */
 		$config = $this->container['Config'];
 		$config->expects($this->exactly(2))
 			->method('setSystemValues');

--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -22,14 +22,13 @@
 namespace TestHelpers;
 
 use GuzzleHttp\Message\ResponseInterface;
-use PHPUnit_Framework_Assert;
 
 /**
  * Helper to set various configurations through the testing app
  *
  * @author Artur Neumann <artur@jankaritech.com>
  */
-class AppConfigHelper {
+class AppConfigHelper extends \PHPUnit\Framework\Assert {
 	/**
 	 * @param string $baseUrl
 	 * @param string $user
@@ -226,7 +225,7 @@ class AppConfigHelper {
 			'/cloud/capabilities',
 			null
 		);
-		PHPUnit_Framework_Assert::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(200, $response->getStatusCode());
 		return $response;
 	}
 
@@ -265,9 +264,9 @@ class AppConfigHelper {
 			$body,
 			$ocsApiVersion
 		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		self::assertEquals("200", $response->getStatusCode());
 		if ($ocsApiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals(
+			self::assertEquals(
 				"100", self::getOCSResponse($response)
 			);
 		}
@@ -297,9 +296,9 @@ class AppConfigHelper {
 			$body,
 			$ocsApiVersion
 		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		self::assertEquals("200", $response->getStatusCode());
 		if ($ocsApiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals(
+			self::assertEquals(
 				"100", self::getOCSResponse($response)
 			);
 		}
@@ -328,9 +327,9 @@ class AppConfigHelper {
 			$body,
 			$ocsApiVersion
 		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		self::assertEquals("200", $response->getStatusCode());
 		if ($ocsApiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals(
+			self::assertEquals(
 				"100", self::getOCSResponse($response)
 			);
 		}
@@ -358,9 +357,9 @@ class AppConfigHelper {
 			$body,
 			$ocsApiVersion
 		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		self::assertEquals("200", $response->getStatusCode());
 		if ($ocsApiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals(
+			self::assertEquals(
 				"100", self::getOCSResponse($response)
 			);
 		}
@@ -387,9 +386,9 @@ class AppConfigHelper {
 			null,
 			$ocsApiVersion
 		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		self::assertEquals("200", $response->getStatusCode());
 		if ($ocsApiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals(
+			self::assertEquals(
 				"100", self::getOCSResponse($response)
 			);
 		}
@@ -421,9 +420,9 @@ class AppConfigHelper {
 			null,
 			$ocsApiVersion
 		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		self::assertEquals("200", $response->getStatusCode());
 		if ($ocsApiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals(
+			self::assertEquals(
 				"100", self::getOCSResponse($response)
 			);
 		}

--- a/tests/TestHelpers/Asserts/WebDav.php
+++ b/tests/TestHelpers/Asserts/WebDav.php
@@ -21,7 +21,6 @@
  */
 namespace TestHelpers\Asserts;
 
-use PHPUnit_Framework_Assert;
 use SimpleXMLElement;
 use Behat\Gherkin\Node\TableNode;
 use TestHelpers\DownloadHelper;
@@ -30,7 +29,7 @@ use TestHelpers\SetupHelper;
 /**
  * WebDAV related asserts
  */
-class WebDav {
+class WebDav extends \PHPUnit\Framework\Assert {
 	/**
 	 *
 	 * @param string $element exception|message|reason
@@ -43,7 +42,7 @@ class WebDav {
 	public static function assertDavResponseElementIs(
 		$element, $expectedValue, $responseXml
 	) {
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		self::assertArrayHasKey(
 			'value', $responseXml, '$responseXml seems not to be a valid array'
 		);
 		if ($element === "exception") {
@@ -53,8 +52,8 @@ class WebDav {
 		} elseif ($element === "reason") {
 			$result = $responseXml['value'][3]['value'];
 		}
-		
-		PHPUnit_Framework_Assert::assertEquals(
+
+		self::assertEquals(
 			$expectedValue, $result,
 			"Expected '$expectedValue' in element $element got '$result'"
 		);
@@ -74,7 +73,7 @@ class WebDav {
 			$xmlPart = $responseXmlObject->xpath(
 				"//d:prop/oc:share-types/oc:share-type[.=" . $row[0] . "]"
 			);
-			PHPUnit_Framework_Assert::assertNotEmpty(
+			self::assertNotEmpty(
 				$xmlPart, "cannot find share-type '" . $row[0] . "'"
 			);
 		}
@@ -106,11 +105,11 @@ class WebDav {
 		$downloadedContent = $result->getBody()->getContents();
 		
 		if ($shouldBeSame) {
-			PHPUnit_Framework_Assert::assertSame(
+			self::assertSame(
 				$localContent, $downloadedContent
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertNotSame(
+			self::assertNotSame(
 				$localContent, $downloadedContent
 			);
 		}
@@ -157,11 +156,11 @@ class WebDav {
 		);
 		
 		if ($shouldBeSame) {
-			PHPUnit_Framework_Assert::assertSame(
+			self::assertSame(
 				$localContent, $downloadedContent
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertNotSame(
+			self::assertNotSame(
 				$localContent, $downloadedContent
 			);
 		}

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -24,7 +24,6 @@ namespace TestHelpers;
 use Behat\Testwork\Hook\Scope\HookScope;
 use GuzzleHttp\Exception\ServerException;
 use Exception;
-use PHPUnit_Framework_Assert;
 use GuzzleHttp\Message\ResponseInterface;
 use SimpleXMLElement;
 
@@ -34,7 +33,7 @@ use SimpleXMLElement;
  * @author Artur Neumann <artur@jankaritech.com>
  *
  */
-class SetupHelper {
+class SetupHelper extends \PHPUnit\Framework\Assert {
 
 	/**
 	 * @var string
@@ -524,7 +523,7 @@ class SetupHelper {
 			'GET',
 			"/apps/testing/api/v1/file?file={$fileInSkeletonFolder}"
 		);
-		PHPUnit_Framework_Assert::assertSame(
+		self::assertSame(
 			200,
 			$response->getStatusCode(),
 			"Failed to read the file {$fileInSkeletonFolder}"

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -23,7 +23,6 @@ namespace TestHelpers;
 
 use GuzzleHttp\Message\ResponseInterface;
 use Exception;
-use PHPUnit_Framework_Assert;
 use SimpleXMLElement;
 
 /**
@@ -32,7 +31,7 @@ use SimpleXMLElement;
  * @author Artur Neumann <artur@jankaritech.com>
  *
  */
-class TagsHelper {
+class TagsHelper extends \PHPUnit\Framework\Assert {
 	/**
 	 * tags a file
 	 *
@@ -105,7 +104,7 @@ class TagsHelper {
 	 */
 	public static function getTagIdFromTagData($tagData) {
 		$tagID = $tagData->xpath(".//oc:id");
-		\PHPUnit_Framework_Assert::assertArrayHasKey(
+		self::assertArrayHasKey(
 			0, $tagID, "cannot find id of tag"
 		);
 		
@@ -166,7 +165,7 @@ class TagsHelper {
 		$tagData = $tagList->xpath(
 			"//d:prop//oc:display-name[text() ='$tagDisplayName']/.."
 		);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		self::assertArrayHasKey(
 			0, $tagData,
 			"cannot find 'oc:display-name' property with text '$tagDisplayName'"
 		);

--- a/tests/TestHelpers/Unit/DeleteHelperTest.php
+++ b/tests/TestHelpers/Unit/DeleteHelperTest.php
@@ -29,7 +29,7 @@ use GuzzleHttp\Subscriber\History;
 /**
  * Unit tests for TestHelpers\DeleteHelper;
  */
-class DeleteHelperTest extends PHPUnit_Framework_TestCase {
+class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * Setup http client, mock requests, and attach history

--- a/tests/TestHelpers/Unit/WebDavHelperTest.php
+++ b/tests/TestHelpers/Unit/WebDavHelperTest.php
@@ -29,7 +29,7 @@ use GuzzleHttp\Subscriber\History;
 /**
  * Test for WebDavHelper
  */
-class WebDavHelperTest extends PHPUnit_Framework_TestCase {
+class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Setup mock response, client and listen for all requests
 	 * through history.

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -23,7 +23,6 @@ namespace TestHelpers;
 
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Stream\Stream;
-use PHPUnit_Framework_Assert;
 
 /**
  * Helper for Uploads
@@ -31,7 +30,7 @@ use PHPUnit_Framework_Assert;
  * @author Artur Neumann <artur@jankaritech.com>
  *
  */
-class UploadHelper {
+class UploadHelper extends \PHPUnit\Framework\Assert {
 	/**
 	 *
 	 * @param string $baseUrl             URL of owncloud
@@ -250,10 +249,10 @@ class UploadHelper {
 			\fwrite($file, 'a'); // write a dummy char at SIZE position
 		}
 		\fclose($file);
-		PHPUnit_Framework_Assert::assertEquals(
+		self::assertEquals(
 			1, \file_exists($name)
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		self::assertEquals(
 			$size, \filesize($name)
 		);
 	}
@@ -270,7 +269,7 @@ class UploadHelper {
 		$file = \fopen($name, 'w');
 		\fwrite($file, $text);
 		\fclose($file);
-		PHPUnit_Framework_Assert::assertEquals(
+		self::assertEquals(
 			1, \file_exists($name)
 		);
 	}

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -99,7 +99,7 @@ trait AppConfiguration {
 	) {
 		$this->theAdministratorGetsCapabilitiesCheckResponse();
 
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedValue,
 			$this->getAppParameter($capabilitiesApp, $capabilitiesPath)
 		);
@@ -146,7 +146,7 @@ trait AppConfiguration {
 	 */
 	public function userGetsCapabilitiesCheckResponse($username) {
 		$this->userGetsCapabilities($username);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -360,12 +360,12 @@ trait AppConfiguration {
 		$this->theUserSendsToOcsApiEndpoint('get', '/cloud/apps?filter=enabled');
 		$this->theHTTPStatusCodeShouldBe('200');
 		if ($enabled) {
-			PHPUnit_Framework_Assert::assertContains(
+			PHPUnit\Framework\Assert::assertContains(
 				'testing',
 				$this->response->getBody()->getContents()
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertNotContains(
+			PHPUnit\Framework\Assert::assertNotContains(
 				'testing',
 				$this->response->getBody()->getContents()
 			);

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -144,7 +144,7 @@ class AppManagementContext implements Context {
 	 * @return void
 	 */
 	public function appPathIs($appId, $dir) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->featureContext->getServerRoot() . "/$dir/$appId",
 			\trim($this->cmdOutput)
 		);

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -959,12 +959,12 @@ trait BasicStructure {
 		}
 
 		if (\is_array($statusCode)) {
-			PHPUnit_Framework_Assert::assertContains(
+			PHPUnit\Framework\Assert::assertContains(
 				$this->response->getStatusCode(), $statusCode,
 				$message
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$statusCode, $this->response->getStatusCode(), $message
 			);
 		}
@@ -994,7 +994,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theHTTPReasonPhraseShouldBe($reasonPhrase) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$reasonPhrase,
 			$this->getResponse()->getReasonPhrase(),
 			'Unexpected HTTP reason phrase in response'
@@ -1022,7 +1022,7 @@ trait BasicStructure {
 	public function theHTTPReasonPhraseShouldBePyString(
 		PyStringNode $reasonPhrase
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$reasonPhrase->getRaw(),
 			$this->getResponse()->getReasonPhrase(),
 			'Unexpected HTTP reason phrase in response'
@@ -1039,7 +1039,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theXMLKey1Key2ValueShouldBe($key1, $key2, $idText) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$idText,
 			$this->getXMLKey1Key2Value($this->response, $key1, $key2)
 		);
@@ -1058,7 +1058,7 @@ trait BasicStructure {
 	public function theXMLKey1Key2Key3ValueShouldBe(
 		$key1, $key2, $key3, $idText
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$idText,
 			$this->getXMLKey1Key2Key3Value($this->response, $key1, $key2, $key3)
 		);
@@ -1080,7 +1080,7 @@ trait BasicStructure {
 		$value = $this->getXMLKey1Key2Key3AttributeValue(
 			$this->response, $key1, $key2, $key3, $attribute
 		);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			\version_compare($value, '0.0.1') >= 0,
 			"attribute $attribute value $value is not a valid version string"
 		);
@@ -1626,7 +1626,7 @@ trait BasicStructure {
 		);
 
 		if (!\strlen($edition)) {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				"Cannot get edition from capabilities"
 			);
 		}
@@ -1638,7 +1638,7 @@ trait BasicStructure {
 		);
 
 		if (!\strlen($edition)) {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				"Cannot get productname from capabilities"
 			);
 		}
@@ -1650,11 +1650,11 @@ trait BasicStructure {
 		if ($runOccStatus === 0) {
 			$output = \explode("- ", $this->lastStdOut);
 			$version = \explode(": ", $output[3]);
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				"version", $version[0]
 			);
 			$versionString = \explode(": ", $output[4]);
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				"versionstring", $versionString[0]
 			);
 			$jsonExpectedDecoded['version'] = \trim($version[1]);
@@ -1664,7 +1664,7 @@ trait BasicStructure {
 				$jsonExpectedEncoded, $jsonRespondedEncoded
 			);
 		} else {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				"Cannot get version variables from occ - status $runOccStatus"
 			);
 		}
@@ -1698,7 +1698,7 @@ trait BasicStructure {
 	 */
 	public function theFileWithContentShouldExistInTheServerRoot($path, $content) {
 		$this->readFileInServerRoot($path);
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			200,
 			$this->getResponse()->getStatusCode(),
 			"Failed to read the file {$path}"
@@ -1708,7 +1708,7 @@ trait BasicStructure {
 		$fileContent = (string)$fileContent->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($fileContent);
 
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			$content,
 			$fileContent,
 			"The content of the file does not match with '{$content}'"
@@ -1724,7 +1724,7 @@ trait BasicStructure {
 	 */
 	public function theFileShouldNotExistInTheServerRoot($path) {
 		$this->readFileInServerRoot($path);
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			404,
 			$this->getResponse()->getStatusCode(),
 			"The file '{$path}' exists in the server root"
@@ -1737,7 +1737,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theResponseBodyShouldBeEmpty() {
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$this->getResponse()->getBody()->getContents()
 		);
 	}
@@ -2049,7 +2049,7 @@ trait BasicStructure {
 			$this->getOcsApiVersion()
 		);
 		$configkeyValue = \json_decode(\json_encode($this->getResponseXml($response)->data[0]->element->value), 1)[0];
-		PHPUnit_Framework_Assert::assertEquals($value, $configkeyValue);
+		PHPUnit\Framework\Assert::assertEquals($value, $configkeyValue);
 	}
 
 	/**
@@ -2130,9 +2130,9 @@ trait BasicStructure {
 		$should = ($shouldOrNot !== "not");
 
 		if ($should) {
-			PHPUnit_Framework_Assert::assertTrue($this->checkConfigKeyInApp($key, $appID));
+			PHPUnit\Framework\Assert::assertTrue($this->checkConfigKeyInApp($key, $appID));
 		} else {
-			PHPUnit_Framework_Assert::assertFalse($this->checkConfigKeyInApp($key, $appID));
+			PHPUnit\Framework\Assert::assertFalse($this->checkConfigKeyInApp($key, $appID));
 		}
 	}
 
@@ -2148,11 +2148,11 @@ trait BasicStructure {
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
 			foreach ($table as $item) {
-				PHPUnit_Framework_Assert::assertTrue($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
+				PHPUnit\Framework\Assert::assertTrue($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
 			}
 		} else {
 			foreach ($table as $item) {
-				PHPUnit_Framework_Assert::assertFalse($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
+				PHPUnit\Framework\Assert::assertFalse($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
 			}
 		}
 	}
@@ -2234,7 +2234,7 @@ trait BasicStructure {
 			"/apps/testing/api/v1/lockprovisioning",
 			["global" => "true"]
 		);
-		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		PHPUnit\Framework\Assert::assertEquals("200", $response->getStatusCode());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -51,7 +51,7 @@ class CapabilitiesContext implements Context {
 
 		foreach ($formData->getHash() as $row) {
 			$row['value'] = $this->featureContext->substituteInLineCodes($row['value']);
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$row['value'] === "EMPTY" ? '' : $row['value'],
 				$this->featureContext->getParameterValueFromXml(
 					$capabilitiesXML,
@@ -78,7 +78,7 @@ class CapabilitiesContext implements Context {
 			$this->featureContext->getCurrentUser()
 		);
 		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$value === "EMPTY" ? '' : $value,
 			$this->featureContext->getParameterValueFromXml(
 				$capabilitiesXML,
@@ -99,7 +99,7 @@ class CapabilitiesContext implements Context {
 		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
 
 		foreach ($formData->getHash() as $row) {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$this->featureContext->parameterValueExistsInXml(
 					$capabilitiesXML,
 					$row['capability'],

--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -134,7 +134,7 @@ class CommentsContext implements Context {
 					break;
 				}
 			}
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$commentFound,
 				"Comment with actorId = '$expectedElement[0]' " .
 				"and message = '$expectedElement[1]' not found"
@@ -173,7 +173,7 @@ class CommentsContext implements Context {
 			$user, $commentsPath, $properties
 		);
 		$messages = $elementList->xpath("//d:prop/oc:message");
-		PHPUnit_Framework_Assert::assertCount(
+		PHPUnit\Framework\Assert::assertCount(
 			(int) $numberOfComments, $messages
 		);
 	}

--- a/tests/acceptance/features/bootstrap/CorsContext.php
+++ b/tests/acceptance/features/bootstrap/CorsContext.php
@@ -95,7 +95,7 @@ class CorsContext implements Context {
 			]
 		);
 		$domains = \json_decode($this->featureContext->getStdOutOfOccCommand());
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			$domain, $domains, "CORS domain was not added correctly"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -60,7 +60,7 @@ class EmailContext implements Context {
 		$expectedContent = $this->featureContext->substituteInLineCodes(
 			$expectedContent
 		);
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			$expectedContent,
 			EmailHelper::getBodyOfLastEmail($this->localMailhogUrl, $address)
 		);
@@ -75,7 +75,7 @@ class EmailContext implements Context {
 	 * @return void
 	 */
 	public function theResetEmailSenderEmailAddressShouldBe($receiverAddress, $senderAddress) {
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			$senderAddress,
 			EmailHelper::getSenderOfEmail($this->localMailhogUrl, $receiverAddress)
 		);
@@ -90,7 +90,7 @@ class EmailContext implements Context {
 	 * @throws \Exception
 	 */
 	public function assertThatEmailDoesntExistWithTheAddress($address) {
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			EmailHelper::emailReceived(
 				EmailHelper::getLocalMailhogUrl(), $address
 			),

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -77,7 +77,7 @@ class FilesVersionsContext implements Context {
 		$path, $user, $count
 	) {
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
-		PHPUnit_Framework_Assert::assertNotNull($fileId, "file $path not found");
+		PHPUnit\Framework\Assert::assertNotNull($fileId, "file $path not found");
 		$this->theVersionFolderOfFileIdShouldContainElements($fileId, $user, $count);
 	}
 
@@ -95,7 +95,7 @@ class FilesVersionsContext implements Context {
 	) {
 		$responseXml = $this->listVersionFolder($user, "/meta/$fileId/v", 1);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getetag");
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$count, \count($xmlPart) - 1,
 			"could not find $count version element(s) in \n" . $responseXml->asXML()
 		);
@@ -119,7 +119,7 @@ class FilesVersionsContext implements Context {
 			$user, "/meta/$fileId/v", 1, ['getcontentlength']
 		);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getcontentlength");
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$length, (int)$xmlPart[$index]
 		);
 	}

--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -81,7 +81,7 @@ trait Logging {
 				}
 
 				if ($expectedLogEntry[$attribute] !== "") {
-					PHPUnit_Framework_Assert::assertArrayHasKey(
+					PHPUnit\Framework\Assert::assertArrayHasKey(
 						$attribute, $logEntry,
 						"could not find attribute: '$attribute' in log entry: '{$logLines[$lineNo]}'"
 					);
@@ -90,17 +90,17 @@ trait Logging {
 						$logEntry[$attribute] = \json_encode($logEntry[$attribute]);
 					}
 					if ($comparingMode === 'with') {
-						PHPUnit_Framework_Assert::assertEquals(
+						PHPUnit\Framework\Assert::assertEquals(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);
 					} elseif ($comparingMode === 'containing') {
-						PHPUnit_Framework_Assert::assertContains(
+						PHPUnit\Framework\Assert::assertContains(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);
 					} elseif ($comparingMode === 'matching') {
-						PHPUnit_Framework_Assert::assertRegExp(
+						PHPUnit\Framework\Assert::assertRegExp(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);
@@ -332,7 +332,7 @@ trait Logging {
 					}
 				}
 			}
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$match,
 				"found a log entry that should not be there\n$logLine\n"
 			);

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -94,7 +94,7 @@ class NotificationsCoreContext implements Context {
 		$notifications = $this->getArrayOfNotificationsResponded(
 			$this->featureContext->getResponse()
 		);
-		PHPUnit_Framework_Assert::assertCount(
+		PHPUnit\Framework\Assert::assertCount(
 			(int) $numNotifications, $notifications
 		);
 
@@ -119,13 +119,13 @@ class NotificationsCoreContext implements Context {
 		$this->ocsContext->userSendsToOcsApiEndpoint(
 			$user, 'GET', '/apps/notifications/api/v1/notifications?format=json'
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->featureContext->getResponse()->getStatusCode()
 		);
 
 		$previousNotificationIds = [];
 		if ($missingLast) {
-			PHPUnit_Framework_Assert::assertNotEmpty($this->getNotificationIds());
+			PHPUnit\Framework\Assert::assertNotEmpty($this->getNotificationIds());
 			$previousNotificationIds = $this->getLastNotificationIds();
 		}
 
@@ -139,7 +139,7 @@ class NotificationsCoreContext implements Context {
 				$now[] = $this->getDeletedNotification();
 			}
 
-			PHPUnit_Framework_Assert::assertEquals($previousNotificationIds, $now);
+			PHPUnit\Framework\Assert::assertEquals($previousNotificationIds, $now);
 		}
 	}
 
@@ -200,7 +200,7 @@ class NotificationsCoreContext implements Context {
 			'GET',
 			"/apps/notifications/api/v1/notifications/$notificationId?format=json"
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->featureContext->getResponse()->getStatusCode()
 		);
 		$response = \json_decode(
@@ -208,20 +208,20 @@ class NotificationsCoreContext implements Context {
 		);
 
 		foreach ($formData->getRowsHash() as $key => $value) {
-			PHPUnit_Framework_Assert::assertArrayHasKey(
+			PHPUnit\Framework\Assert::assertArrayHasKey(
 				$key, $response['ocs']['data']
 			);
 			if ($regex) {
 				$value = $this->featureContext->substituteInLineCodes(
 					$value, ['preg_quote' => ['/'] ]
 				);
-				PHPUnit_Framework_Assert::assertNotFalse(
+				PHPUnit\Framework\Assert::assertNotFalse(
 					(bool)\preg_match($value, $response['ocs']['data'][$key]),
 					"'$value' does not match '{$response['ocs']['data'][$key]}'"
 				);
 			} else {
 				$value = $this->featureContext->substituteInLineCodes($value);
-				PHPUnit_Framework_Assert::assertEquals(
+				PHPUnit\Framework\Assert::assertEquals(
 					$value, $response['ocs']['data'][$key]
 				);
 			}
@@ -254,8 +254,8 @@ class NotificationsCoreContext implements Context {
 			"DELETE",
 			'/apps/testing/api/v1/notifications'
 		);
-		PHPUnit_Framework_Assert::assertEquals(200, $response->getStatusCode());
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(200, $response->getStatusCode());
+		PHPUnit\Framework\Assert::assertEquals(
 			200, (int) $this->ocsContext->getOCSResponseStatusCode($response)
 		);
 	}

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -311,12 +311,12 @@ class OCSContext implements Context {
 			$this->featureContext->getResponse()
 		);
 		if (\is_array($statusCode)) {
-			PHPUnit_Framework_Assert::assertContains(
+			PHPUnit\Framework\Assert::assertContains(
 				$responseStatusCode, $statusCode,
 				$message
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$statusCode, $responseStatusCode,
 				$message
 			);
@@ -333,7 +333,7 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theOCSStatusMessageShouldBe($statusMessage) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$statusMessage,
 			$this->getOCSResponseStatusMessage(
 				$this->featureContext->getResponse()
@@ -363,7 +363,7 @@ class OCSContext implements Context {
 	public function theOCSStatusMessageShouldBePyString(
 		PyStringNode $statusMessage
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$statusMessage->getRaw(),
 			$this->getOCSResponseStatusMessage(
 				$this->featureContext->getResponse()

--- a/tests/acceptance/features/bootstrap/OccAppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/OccAppManagementContext.php
@@ -116,7 +116,7 @@ class OccAppManagementContext implements Context {
 	public function theAppNameReturnedByTheOccCommandShouldBe($appName) {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputArray = \json_decode($lastOutput, true);
-		PHPUnit_Framework_Assert::assertEquals($appName, \key($lastOutputArray['apps']));
+		PHPUnit\Framework\Assert::assertEquals($appName, \key($lastOutputArray['apps']));
 	}
 
 	/**
@@ -166,7 +166,7 @@ class OccAppManagementContext implements Context {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputArray = \json_decode($lastOutput, true);
 		$actualAppEnabledStatus = $lastOutputArray['apps'][$appName]['enabled'];
-		PHPUnit_Framework_Assert::assertEquals($appStatus, $actualAppEnabledStatus);
+		PHPUnit\Framework\Assert::assertEquals($appStatus, $actualAppEnabledStatus);
 	}
 
 	/**
@@ -184,7 +184,7 @@ class OccAppManagementContext implements Context {
 		$appsSimplified = $this->featureContext->simplifyArray($apps);
 
 		foreach ($appsSimplified as $app) {
-			PHPUnit_Framework_Assert::assertContains($app, $lastOutputApps);
+			PHPUnit\Framework\Assert::assertContains($app, $lastOutputApps);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -152,7 +152,7 @@ class OccContext implements Context {
 			$commandOutput,
 			$text
 		);
-		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
 			1,
 			\count($lines),
 			"The command output did not contain the expected text on stdout '$text'\n" .
@@ -178,7 +178,7 @@ class OccContext implements Context {
 			$commandOutput,
 			$text
 		);
-		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
 			1,
 			\count($lines),
 			"The command output did not contain the expected text on stderr '$text'\n" .
@@ -193,11 +193,11 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function theOccCommandJsonOutputShouldNotReturnAnyData() {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			\trim($this->featureContext->getStdOutOfOccCommand()),
 			"[]"
 		);
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$this->featureContext->getStdErrOfOccCommand()
 		);
 	}
@@ -456,7 +456,7 @@ class OccContext implements Context {
 			"config:app:get core backgroundjobs_mode"
 		);
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit_Framework_Assert::assertEquals($mode, \trim($lastOutput));
+		PHPUnit\Framework\Assert::assertEquals($mode, \trim($lastOutput));
 	}
 
 	/**
@@ -471,7 +471,7 @@ class OccContext implements Context {
 			"config:app:get core OC_Channel"
 		);
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit_Framework_Assert::assertEquals($value, \trim($lastOutput));
+		PHPUnit\Framework\Assert::assertEquals($value, \trim($lastOutput));
 	}
 
 	/**
@@ -486,7 +486,7 @@ class OccContext implements Context {
 			"config:system:get loglevel"
 		);
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit_Framework_Assert::assertEquals($logLevel, \trim($lastOutput));
+		PHPUnit\Framework\Assert::assertEquals($logLevel, \trim($lastOutput));
 	}
 
 	/**
@@ -577,7 +577,7 @@ class OccContext implements Context {
 	 */
 	public function systemConfigKeyShouldHaveValue($key, $value) {
 		$config = \trim($this->featureContext->getSystemConfigValue($key));
-		PHPUnit_Framework_Assert::assertSame($value, $config);
+		PHPUnit\Framework\Assert::assertSame($value, $config);
 	}
 
 	/**
@@ -588,7 +588,7 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function systemConfigKeyShouldNotExist($key) {
-		PHPUnit_Framework_Assert::assertEmpty($this->featureContext->getSystemConfig($key)['stdOut']);
+		PHPUnit\Framework\Assert::assertEmpty($this->featureContext->getSystemConfig($key)['stdOut']);
 	}
 
 	/**
@@ -609,12 +609,12 @@ class OccContext implements Context {
 	 */
 	public function theCommandOutputShouldContainTheAppsConfigs() {
 		$config_list = \json_decode($this->featureContext->getStdOutOfOccCommand(), true);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			'apps',
 			$config_list,
 			"The occ output does not contain apps configs"
 		);
-		PHPUnit_Framework_Assert::assertNotEmpty(
+		PHPUnit\Framework\Assert::assertNotEmpty(
 			$config_list['apps'],
 			"The occ output does not contain apps configs"
 		);
@@ -627,12 +627,12 @@ class OccContext implements Context {
 	 */
 	public function theCommandOutputShouldContainTheSystemConfigs() {
 		$config_list = \json_decode($this->featureContext->getStdOutOfOccCommand(), true);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			'system',
 			$config_list,
 			"The occ output does not contain system configs"
 		);
-		PHPUnit_Framework_Assert::assertNotEmpty(
+		PHPUnit\Framework\Assert::assertNotEmpty(
 			$config_list['system'],
 			"The occ output does not contain system configs"
 		);
@@ -649,7 +649,7 @@ class OccContext implements Context {
 		$this->invokingTheCommand(
 			"versions:cleanup $user"
 		);
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			"Delete versions of   $user",
 			\trim($this->featureContext->getStdOutOfOccCommand())
 		);
@@ -664,7 +664,7 @@ class OccContext implements Context {
 		$this->invokingTheCommand(
 			"versions:cleanup"
 		);
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			"Delete all versions",
 			\trim($this->featureContext->getStdOutOfOccCommand())
 		);

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -438,7 +438,7 @@ class OccUsersGroupsContext implements Context {
 			"user:setting $username core lang"
 		);
 		$responseLanguage = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit_Framework_Assert::assertEquals($language, \trim($responseLanguage));
+		PHPUnit\Framework\Assert::assertEquals($language, \trim($responseLanguage));
 	}
 
 	/**
@@ -461,8 +461,8 @@ class OccUsersGroupsContext implements Context {
 			$result = $lastOutputUsers;
 		}
 		foreach ($useridTable as $row) {
-			PHPUnit_Framework_Assert::assertArrayHasKey($row['uid'], $result);
-			PHPUnit_Framework_Assert::assertContains($row['display name'], $result);
+			PHPUnit\Framework\Assert::assertArrayHasKey($row['uid'], $result);
+			PHPUnit\Framework\Assert::assertContains($row['display name'], $result);
 		}
 	}
 
@@ -478,10 +478,10 @@ class OccUsersGroupsContext implements Context {
 		$lastOutputGroups = \json_decode($lastOutput, true);
 
 		foreach ($groupTableNode as $row) {
-			PHPUnit_Framework_Assert::assertContains($row['group'], $lastOutputGroups);
+			PHPUnit\Framework\Assert::assertContains($row['group'], $lastOutputGroups);
 			$lastOutputGroups = \array_diff($lastOutputGroups, [$row['group']]);
 		}
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$lastOutputGroups,
 			"more than the expected groups are returned\n" .
 			\print_r($lastOutputGroups, true)
@@ -499,7 +499,7 @@ class OccUsersGroupsContext implements Context {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputUser = \json_decode($lastOutput, true);
 		$lastOutputDisplayName = \array_column($lastOutputUser, 'displayName')[0];
-		PHPUnit_Framework_Assert::assertEquals($displayName, $lastOutputDisplayName);
+		PHPUnit\Framework\Assert::assertEquals($displayName, $lastOutputDisplayName);
 	}
 
 	/**
@@ -527,7 +527,7 @@ class OccUsersGroupsContext implements Context {
 	 */
 	public function theCommandOutputOfUserLastSeenShouldBeNever() {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			"has never logged in.",
 			$lastOutput
 		);
@@ -543,7 +543,7 @@ class OccUsersGroupsContext implements Context {
 	public function theTotalUsersReturnedByTheCommandShouldBe($noOfUsers) {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		\preg_match("/\|\s+total users\s+\|\s+(\d+)\s+\|/", $lastOutput, $actualUsers);
-		PHPUnit_Framework_Assert::assertEquals($noOfUsers, $actualUsers[1]);
+		PHPUnit\Framework\Assert::assertEquals($noOfUsers, $actualUsers[1]);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -900,7 +900,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldExist($user) {
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$this->userExists($user),
 			"User '$user' should exist but does not exist"
 		);
@@ -914,7 +914,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldNotExist($user) {
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->userExists($user),
 			"User '$user' should not exist but does exist"
 		);
@@ -929,7 +929,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function groupShouldExist($group) {
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$this->groupExists($group),
 			"Group '$group' should exist but does not exist"
 		);
@@ -943,7 +943,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function groupShouldNotExist($group) {
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->groupExists($group),
 			"Group '$group' should not exist but does exist"
 		);
@@ -1351,8 +1351,8 @@ trait Provisioning {
 		$this->theAdministratorGetsAllTheGroupsOfUser($user);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 		\sort($respondedArray);
-		PHPUnit_Framework_Assert::assertContains($group, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertContains($group, $respondedArray);
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -1372,8 +1372,8 @@ trait Provisioning {
 		);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 		\sort($respondedArray);
-		PHPUnit_Framework_Assert::assertNotContains($group, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertNotContains($group, $respondedArray);
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2062,7 +2062,7 @@ trait Provisioning {
 		$this->adminMakesUserSubadminOfGroupUsingTheProvisioningApi(
 			$user, $group
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2147,7 +2147,7 @@ trait Provisioning {
 			$users = $usersList->getRows();
 			$usersSimplified = $this->simplifyArray($users);
 			$respondedArray = $this->getArrayOfUsersResponded($this->response);
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$usersSimplified, $respondedArray, "", 0.0, 10, true
 			);
 		}
@@ -2165,7 +2165,7 @@ trait Provisioning {
 			$groups = $groupsList->getRows();
 			$groupsSimplified = $this->simplifyArray($groups);
 			$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$groupsSimplified, $respondedArray, "", 0.0, 10, true
 			);
 		}
@@ -2180,7 +2180,7 @@ trait Provisioning {
 	 */
 	public function theGroupsReturnedByTheApiShouldInclude($group) {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		PHPUnit_Framework_Assert::assertContains($group, $respondedArray);
+		PHPUnit\Framework\Assert::assertContains($group, $respondedArray);
 	}
 
 	/**
@@ -2192,7 +2192,7 @@ trait Provisioning {
 	 */
 	public function theGroupsReturnedByTheApiShouldNotInclude($group) {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		PHPUnit_Framework_Assert::assertNotContains($group, $respondedArray);
+		PHPUnit\Framework\Assert::assertNotContains($group, $respondedArray);
 	}
 
 	/**
@@ -2204,7 +2204,7 @@ trait Provisioning {
 	 */
 	public function theUsersReturnedByTheApiShouldNotInclude($user) {
 		$respondedArray = $this->getArrayOfUsersResponded($this->response);
-		PHPUnit_Framework_Assert::assertNotContains($user, $respondedArray);
+		PHPUnit\Framework\Assert::assertNotContains($user, $respondedArray);
 	}
 
 	/**
@@ -2216,7 +2216,7 @@ trait Provisioning {
 		$tableRows = $groupsOrUsersList->getRows();
 		$simplifiedTableRows = $this->simplifyArray($tableRows);
 		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$simplifiedTableRows, $respondedArray, "", 0.0, 10, true
 		);
 	}
@@ -2255,7 +2255,7 @@ trait Provisioning {
 		$appsSimplified = $this->simplifyArray($apps);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
 		foreach ($appsSimplified as $app) {
-			PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
+			PHPUnit\Framework\Assert::assertContains($app, $respondedArray);
 		}
 	}
 
@@ -2272,7 +2272,7 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
-		PHPUnit_Framework_Assert::assertNotContains($appName, $respondedArray);
+		PHPUnit\Framework\Assert::assertNotContains($appName, $respondedArray);
 	}
 
 	/**
@@ -2285,11 +2285,11 @@ trait Provisioning {
 	 */
 	public function userShouldBeASubadminOfGroup($user, $group) {
 		$this->theAdministratorGetsAllTheSubadminsOfGroupUsingTheProvisioningApi($group);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 		$listOfSubadmins = $this->getArrayOfSubadminsResponded($this->response);
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			$user,
 			$listOfSubadmins
 		);
@@ -2306,7 +2306,7 @@ trait Provisioning {
 	public function userShouldNotBeASubadminOfGroup($user, $group) {
 		$this->theAdministratorGetsAllTheSubadminsOfGroupUsingTheProvisioningApi($group);
 		$listOfSubadmins = $this->getArrayOfSubadminsResponded($this->response);
-		PHPUnit_Framework_Assert::assertNotContains(
+		PHPUnit\Framework\Assert::assertNotContains(
 			$user,
 			$listOfSubadmins
 		);
@@ -2321,7 +2321,7 @@ trait Provisioning {
 	 */
 	public function theDisplayNameReturnedByTheApiShouldBe($expectedDisplayName) {
 		$responseDisplayName = (string) $this->getResponseXml()->data[0]->displayname;
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedDisplayName,
 			$responseDisplayName
 		);
@@ -2349,7 +2349,7 @@ trait Provisioning {
 	 */
 	public function theEmailAddressReturnedByTheApiShouldBe($expectedEmailAddress) {
 		$responseEmailAddress = (string) $this->getResponseXml()->data[0]->email;
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedEmailAddress,
 			$responseEmailAddress
 		);
@@ -2377,7 +2377,7 @@ trait Provisioning {
 	 */
 	public function theQuotaDefinitionReturnedByTheApiShouldBe($expectedQuotaDefinition) {
 		$responseQuotaDefinition = (string) $this->getResponseXml()->data[0]->quota->definition;
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedQuotaDefinition,
 			$responseQuotaDefinition
 		);
@@ -2485,8 +2485,8 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
-		PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertContains($app, $respondedArray);
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2504,8 +2504,8 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
-		PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertContains($app, $respondedArray);
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2522,17 +2522,17 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 		$respondedArray = $this->getArrayOfAppInfoResponded($this->response);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			'version',
 			$respondedArray,
 			"app info returned for $app app does not have a version"
 		);
 		$appVersion = $respondedArray['version'];
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			\substr_count($appVersion, '.') > 1,
 			"app version '$appVersion' returned in app info is not a valid version string"
 		);
@@ -2551,7 +2551,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			"false", $this->getResponseXml()->data[0]->enabled
 		);
 	}
@@ -2569,7 +2569,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			"true", $this->getResponseXml()->data[0]->enabled
 		);
 	}
@@ -2667,7 +2667,7 @@ trait Provisioning {
 				$data = $data->$field_name;
 			}
 			if ($data != $value) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"$field has value $data"
 				);
 			}
@@ -2697,7 +2697,7 @@ trait Provisioning {
 	 */
 	public function theApiShouldNotReturnAnyData() {
 		$responseData = $this->getResponseXml()->data[0];
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$responseData,
 			"Response data is not empty but it should be empty"
 		);
@@ -2710,7 +2710,7 @@ trait Provisioning {
 	 */
 	public function theListOfUsersReturnedByTheApiShouldBeEmpty() {
 		$usersList = $this->getResponseXml()->data[0]->users[0];
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$usersList,
 			"Users list is not empty but it should be empty"
 		);
@@ -2723,7 +2723,7 @@ trait Provisioning {
 	 */
 	public function theListOfGroupsReturnedByTheApiShouldBeEmpty() {
 		$groupsList = $this->getResponseXml()->data[0]->groups[0];
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$groupsList,
 			"Groups list is not empty but it should be empty"
 		);

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -229,7 +229,7 @@ class PublicWebDavContext implements Context {
 	public function publiclyUploadingShouldNotWork() {
 		$this->publicUploadContent('whateverfilefortesting.txt', '', 'test');
 		$response = $this->featureContext->getResponse();
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			($response->getStatusCode() == 507)
 			|| (
 				($response->getStatusCode() >= 400)
@@ -250,7 +250,7 @@ class PublicWebDavContext implements Context {
 		$content = 'test';
 		$this->publicUploadContent($path, '', $content);
 		$response = $this->featureContext->getResponse();
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			($response->getStatusCode() == 201),
 			"upload should have passed but failed with code " .
 			$response->getStatusCode()

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -97,7 +97,7 @@ class SearchContext implements Context {
 		$fileResult = $this->featureContext->findEntryFromPropfindResponse(
 			$path
 		);
-		PHPUnit_Framework_Assert::assertNotFalse(
+		PHPUnit\Framework\Assert::assertNotFalse(
 			$fileResult, "could not find file/folder '$path'"
 		);
 		$fileProperties = $fileResult['value'][1]['value'][0]['value'];
@@ -105,14 +105,14 @@ class SearchContext implements Context {
 			$foundProperty = false;
 			foreach ($fileProperties as $fileProperty) {
 				if ($fileProperty['name'] === $property['name']) {
-					PHPUnit_Framework_Assert::assertRegExp(
+					PHPUnit\Framework\Assert::assertRegExp(
 						"/" . $property['value'] . "/", $fileProperty['value']
 					);
 					$foundProperty = true;
 					break;
 				}
 			}
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$foundProperty, "could not find property '" . $property['name'] . "'"
 			);
 		}

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -96,7 +96,7 @@ class ShareesContext implements Context {
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(), $shareeType
 		);
-		PHPUnit_Framework_Assert::assertEquals($sharees, $respondedArray);
+		PHPUnit\Framework\Assert::assertEquals($sharees, $respondedArray);
 	}
 
 	/**
@@ -117,7 +117,7 @@ class ShareesContext implements Context {
 			$firstEntry = "";
 		}
 
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$respondedArray,
 			"'$shareeType' array should be empty, but it starts with $firstEntry"
 		);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -371,10 +371,10 @@ trait Sharing {
 
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 		$this->response = HttpRequestHelper::get($fullUrl, $token, "", $headers);
-		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
 			400, $this->response->getStatusCode(), 'download must fail'
 		);
-		PHPUnit_Framework_Assert::assertLessThanOrEqual(
+		PHPUnit\Framework\Assert::assertLessThanOrEqual(
 			499, $this->response->getStatusCode(), '4xx error expected'
 		);
 	}
@@ -429,7 +429,7 @@ trait Sharing {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $token, $password
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			401,
 			$this->response->getStatusCode()
 		);
@@ -454,7 +454,7 @@ trait Sharing {
 		$this->response = HttpRequestHelper::get(
 			$url, $user, $this->getPasswordForUser($user), $headers
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			206,
 			$this->response->getStatusCode()
 		);
@@ -464,7 +464,7 @@ trait Sharing {
 			// read everything
 			$buf .= $body->read(8192);
 		}
-		PHPUnit_Framework_Assert::assertSame($content, $buf);
+		PHPUnit\Framework\Assert::assertSame($content, $buf);
 	}
 
 	/**
@@ -481,7 +481,7 @@ trait Sharing {
 		$password = $this->getActualPassword($password);
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 		$this->response = HttpRequestHelper::get($url, $user, $password, $headers);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200,
 			$this->response->getStatusCode()
 		);
@@ -496,7 +496,7 @@ trait Sharing {
 
 		if ($mimeType !== null) {
 			$finfo = new finfo;
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$mimeType,
 				$finfo->buffer($buf, FILEINFO_MIME_TYPE)
 			);
@@ -513,7 +513,7 @@ trait Sharing {
 	 */
 	public function shouldNotBeAbleToCreatePublicLinkShare($sharer, $filepath) {
 		$this->createAPublicShare($sharer, $filepath);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			404,
 			$this->ocsContext->getOCSResponseStatusCode($this->response)
 		);
@@ -543,7 +543,7 @@ trait Sharing {
 	 */
 	public function theUserHasAddedExpirationDateToLastShare() {
 		$this->theUserAddsExpirationDateToLastShare();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200,
 			$this->response->getStatusCode()
 		);
@@ -708,7 +708,7 @@ trait Sharing {
 	 */
 	public function checkSharedFileInResponse($filename) {
 		$filename = \ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			true,
 			$this->isFieldInResponse('file_target', "/$filename")
 		);
@@ -723,7 +723,7 @@ trait Sharing {
 	 */
 	public function checkSharedFileNotInResponse($filename) {
 		$filename = \ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			false,
 			$this->isFieldInResponse('file_target', "/$filename")
 		);
@@ -738,7 +738,7 @@ trait Sharing {
 	 */
 	public function checkSharedFileAsPathInResponse($filename) {
 		$filename = \ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			true,
 			$this->isFieldInResponse('path', "/$filename")
 		);
@@ -753,7 +753,7 @@ trait Sharing {
 	 */
 	public function checkSharedFileAsPathNotInResponse($filename) {
 		$filename = \ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			false,
 			$this->isFieldInResponse('path', "/$filename")
 		);
@@ -767,7 +767,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function checkSharedUserInResponse($user) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			true,
 			$this->isFieldInResponse('share_with', "$user")
 		);
@@ -781,7 +781,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function checkSharedUserNotInResponse($user) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			false,
 			$this->isFieldInResponse('share_with', "$user")
 		);
@@ -867,7 +867,7 @@ trait Sharing {
 		$this->userSharesFileWithUserUsingTheSharingApi(
 			$user1, $filepath, $user2, $permissions
 		);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$this->isUserOrGroupInSharedData($user2, $permissions),
 			"User $user1 failed to share $filepath with user $user2"
 		);
@@ -1006,7 +1006,7 @@ trait Sharing {
 			$user, $filepath, $group, $permissions
 		);
 
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			true,
 			$this->isUserOrGroupInSharedData($group, $permissions)
 		);
@@ -1041,7 +1041,7 @@ trait Sharing {
 			$sharer, $filepath, $shareType, $sharee, null, null, $permissions
 		);
 		$statusCode = $this->ocsContext->getOCSResponseStatusCode($this->response);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			($statusCode == 404) || ($statusCode == 403),
 			"Sharing should have failed but passed with status code $statusCode"
 		);
@@ -1262,7 +1262,7 @@ trait Sharing {
 	public function checkingLastShareIDIsIncluded() {
 		$share_id = $this->lastShareData->data[0]->id;
 		if (!$this->isFieldInResponse('id', $share_id)) {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				"Share id $share_id not found in response"
 			);
 		}
@@ -1276,7 +1276,7 @@ trait Sharing {
 	public function checkingLastShareIDIsNotIncluded() {
 		$share_id = $this->lastShareData->data[0]->id;
 		if ($this->isFieldInResponse('id', $share_id)) {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				"Share id $share_id has been found in response"
 			);
 		}
@@ -1303,7 +1303,7 @@ trait Sharing {
 	 */
 	public function checkingTheResponseEntriesCount($count) {
 		$actualCount = \count($this->getResponseXml()->data[0]);
-		PHPUnit_Framework_Assert::assertEquals($count, $actualCount);
+		PHPUnit\Framework\Assert::assertEquals($count, $actualCount);
 	}
 
 	/**
@@ -1320,7 +1320,7 @@ trait Sharing {
 			foreach ($fd as $field => $value) {
 				$value = $this->replaceValuesFromTable($field, $value);
 				if (!$this->isFieldInShareResponse($field, $value)) {
-					PHPUnit_Framework_Assert::fail(
+					PHPUnit\Framework\Assert::fail(
 						"$field doesn't have value $value"
 					);
 				}
@@ -1342,7 +1342,7 @@ trait Sharing {
 			foreach ($fd as $field => $value) {
 				$value = $this->replaceValuesFromTable($field, $value);
 				if (!$this->isFieldInResponse($field, $value)) {
-					PHPUnit_Framework_Assert::fail(
+					PHPUnit\Framework\Assert::fail(
 						"$field doesn't have value $value"
 					);
 				}
@@ -1445,7 +1445,7 @@ trait Sharing {
 
 			if ($elementRows[0][0] === '') {
 				//It shouldn't have public shares
-				PHPUnit_Framework_Assert::assertEquals(\count($dataResponded), 0);
+				PHPUnit\Framework\Assert::assertEquals(\count($dataResponded), 0);
 				return;
 			}
 			foreach ($elementRows as $expectedElementsArray) {
@@ -1453,11 +1453,11 @@ trait Sharing {
 				$nameFound = false;
 				foreach ($dataResponded as $elementResponded) {
 					if ((string)$elementResponded->name[0] === $expectedElementsArray[2]) {
-						PHPUnit_Framework_Assert::assertEquals(
+						PHPUnit\Framework\Assert::assertEquals(
 							$expectedElementsArray[0],
 							(string)$elementResponded->path[0]
 						);
-						PHPUnit_Framework_Assert::assertEquals(
+						PHPUnit\Framework\Assert::assertEquals(
 							$expectedElementsArray[1],
 							(string)$elementResponded->permissions[0]
 						);
@@ -1465,7 +1465,7 @@ trait Sharing {
 						break;
 					}
 				}
-				PHPUnit_Framework_Assert::assertTrue(
+				PHPUnit\Framework\Assert::assertTrue(
 					$nameFound,
 					"Shared link name {$expectedElementsArray[2]} not found"
 				);
@@ -1590,14 +1590,14 @@ trait Sharing {
 			$row['path'] = \rtrim($row['path'], "/");
 			foreach ($usersShares as $share) {
 				try {
-					PHPUnit_Framework_Assert::assertArraySubset($row, $share);
+					PHPUnit\Framework\Assert::assertArraySubset($row, $share);
 					$found = true;
 					break;
-				} catch (PHPUnit_Framework_ExpectationFailedException $e) {
+				} catch (PHPUnit\Framework\ExpectationFailedException $e) {
 				}
 			}
 			if (!$found) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"could not find the share with this attributes " .
 					\print_r($row, true)
 				);
@@ -1614,7 +1614,7 @@ trait Sharing {
 	 */
 	public function assertThatNoSharesAreSharedWithUser($user) {
 		$usersShares = $this->getAllSharesSharedWithUser($user);
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$usersShares, "user has " . \count($usersShares) . " share(s)"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -113,26 +113,26 @@ class TagsContext implements Context {
 		$userAssignable = ($userAttributes[1]) ? 'true' : 'false';
 		
 		$tagDisplayName = $tagData->xpath(".//oc:display-name");
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			0, $tagDisplayName, "cannot find 'oc:display-name' property"
 		);
 		$tagDisplayName = $tagDisplayName[0]->__toString();
 		
 		$tagUserVisible = $tagData->xpath(".//oc:user-visible");
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			0, $tagUserVisible, "cannot find 'oc:user-visible' property"
 		);
 		$tagUserVisible = $tagUserVisible[0]->__toString();
 		
 		$tagUserAssignable = $tagData->xpath(".//oc:user-assignable");
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			0, $tagUserAssignable, "cannot find 'oc:user-assignable' property"
 		);
 		$tagUserAssignable = $tagUserAssignable[0]->__toString();
 		if (($tagUserVisible !== $userVisible)
 			|| ($tagUserAssignable !== $userAssignable)
 		) {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				"tag $tagDisplayName is not of type $type"
 			);
 		}
@@ -327,7 +327,7 @@ class TagsContext implements Context {
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
 			$tagData = $this->requestTagByDisplayName($user, $rowDisplayName);
 			if ($tagData === null) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"tag $rowDisplayName is not in propfind answer"
 				);
 			} else {
@@ -346,7 +346,7 @@ class TagsContext implements Context {
 	 */
 	public function tagShouldNotExistForUser($tagDisplayName, $user) {
 		$tagData = $this->requestTagByDisplayName($user, $tagDisplayName);
-		PHPUnit_Framework_Assert::assertNull(
+		PHPUnit\Framework\Assert::assertNull(
 			$tagData, "tag $tagDisplayName is in propfind answer"
 		);
 	}
@@ -425,7 +425,7 @@ class TagsContext implements Context {
 			);
 		}
 		$canAssign = $tagData->xpath(".//oc:can-assign[text() = '$expected']");
-		PHPUnit_Framework_Assert::assertArrayHasKey(0, $canAssign, $errorMessage);
+		PHPUnit\Framework\Assert::assertArrayHasKey(0, $canAssign, $errorMessage);
 	}
 
 	/**
@@ -442,15 +442,15 @@ class TagsContext implements Context {
 		$tagData = $this->requestTagByDisplayName(
 			$this->featureContext->getAdminUsername(), $tagName, true
 		);
-		PHPUnit_Framework_Assert::assertNotNull(
+		PHPUnit\Framework\Assert::assertNotNull(
 			$tagData, "Tag $tagName wasn't found for admin user"
 		);
 		$this->assertTypeOfTag($tagData, $type);
 		$groupsOfTag = $tagData->xpath(".//oc:groups");
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			0, $groupsOfTag, "cannot find oc:groups element"
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$groupsOfTag[0],
 			$groups,
 			"Tag has groups '{$groupsOfTag[0]}' instead of the expected '$groups'"
@@ -793,7 +793,7 @@ class TagsContext implements Context {
 		$user, $fileName, $sharingUser, $status
 	) {
 		$this->requestTagsForFile($user, $fileName, $sharingUser);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$status, $this->featureContext->getResponse()->getStatusCode()
 		);
 	}
@@ -839,7 +839,7 @@ class TagsContext implements Context {
 			$found = false;
 			foreach ($tagList as $tagData) {
 				$displayName = $tagData->xpath(".//oc:display-name");
-				PHPUnit_Framework_Assert::assertArrayHasKey(
+				PHPUnit\Framework\Assert::assertArrayHasKey(
 					0, $displayName, "cannot find 'oc:display-name' property"
 				);
 				if ($displayName[0]->__toString() === $rowDisplayName) {
@@ -849,7 +849,7 @@ class TagsContext implements Context {
 				}
 			}
 			if ($found === false) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"tag $rowDisplayName is not in propfind answer"
 				);
 			}
@@ -909,7 +909,7 @@ class TagsContext implements Context {
 		// The array of tags has a single "empty" item at the start.
 		// If there are no tags, then the array should have just this
 		// one entry.
-		PHPUnit_Framework_Assert::assertCount(1, $tagList);
+		PHPUnit\Framework\Assert::assertCount(1, $tagList);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -55,7 +55,7 @@ class TrashbinContext implements Context {
 			$this->featureContext->getResponse()->getBody(), true
 		);
 		if (isset($decodedResponse['status'])) {
-			PHPUnit_Framework_Assert::assertNotEquals(
+			PHPUnit\Framework\Assert::assertNotEquals(
 				'error', $decodedResponse['status']
 			);
 		}
@@ -100,7 +100,7 @@ class TrashbinContext implements Context {
 
 		$firstEntry = $this->findFirstTrashedEntry($user, \trim($sections[0], '/'));
 
-		PHPUnit_Framework_Assert::assertNotNull($firstEntry);
+		PHPUnit\Framework\Assert::assertNotNull($firstEntry);
 
 		// query was on the main element ?
 		if (\count($sections) === 1) {
@@ -126,7 +126,7 @@ class TrashbinContext implements Context {
 			}
 		}
 
-		PHPUnit_Framework_Assert::assertTrue($found);
+		PHPUnit\Framework\Assert::assertTrue($found);
 	}
 
 	/**
@@ -172,7 +172,7 @@ class TrashbinContext implements Context {
 			$this->featureContext->getResponse()->getBody(), true
 		);
 		if (isset($decodedResponse['status'])) {
-			PHPUnit_Framework_Assert::assertNotEquals(
+			PHPUnit\Framework\Assert::assertNotEquals(
 				'error', $decodedResponse['status']
 			);
 		}
@@ -213,7 +213,7 @@ class TrashbinContext implements Context {
 	 */
 	public function elementInTrashIsRestored($user, $originalPath) {
 		$this->restoreElement($user, $originalPath);
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath is still in the trashbin"
 		);
@@ -230,7 +230,7 @@ class TrashbinContext implements Context {
 	public function elementIsInTrashCheckingOriginalPath(
 		$user, $originalPath
 	) {
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath wasn't found in the trashbin"
 		);
@@ -247,7 +247,7 @@ class TrashbinContext implements Context {
 	public function elementIsNotInTrashCheckingOriginalPath(
 		$user, $originalPath
 	) {
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath was found in the trashbin"
 		);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -449,7 +449,7 @@ trait WebDav {
 		$this->response = $this->makeDavRequest(
 			$user, "MOVE", $fileSource, $headers
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			201, $this->response->getStatusCode()
 		);
 	}
@@ -606,10 +606,10 @@ trait WebDav {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
 		$this->downloadFileAsUserUsingPassword($user, $fileName, $password);
-		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
 			400, $this->getResponse()->getStatusCode(), 'download must fail'
 		);
-		PHPUnit_Framework_Assert::assertLessThanOrEqual(
+		PHPUnit\Framework\Assert::assertLessThanOrEqual(
 			499, $this->getResponse()->getStatusCode(), '4xx error expected'
 		);
 	}
@@ -635,7 +635,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function downloadedContentShouldBe($content) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$content, (string)$this->response->getBody()
 		);
 	}
@@ -986,16 +986,16 @@ trait WebDav {
 		$url = $this->getBaseUrlWithoutPath() . $url;
 		$response = HttpRequestHelper::get($url, $user, $this->getPasswordForUser($user));
 		$result = \json_decode($response->getBody()->getContents(), true);
-		PHPUnit_Framework_Assert::assertNotNull($result, "'$response' is not valid JSON");
+		PHPUnit\Framework\Assert::assertNotNull($result, "'$response' is not valid JSON");
 		foreach ($table->getTable() as $row) {
 			$expectedKey = $row[0];
-			PHPUnit_Framework_Assert::assertArrayHasKey(
+			PHPUnit\Framework\Assert::assertArrayHasKey(
 				$expectedKey, $result, "response does not have expected key '$expectedKey'"
 			);
 			$expectedValue = $this->substituteInLineCodes(
 				$row[1], ['preg_quote' => ['/'] ]
 			);
-			PHPUnit_Framework_Assert::assertNotFalse(
+			PHPUnit\Framework\Assert::assertNotFalse(
 				(bool)\preg_match($expectedValue, $result[$expectedKey]),
 				"'$expectedValue' does not match '$result[$expectedKey]'"
 			);
@@ -1041,7 +1041,7 @@ trait WebDav {
 	public function asFileOrFolderShouldExist($user, $entry, $path) {
 		$path = $this->substituteInLineCodes($path);
 		$this->responseXmlObject = $this->listFolder($user, $path, 0);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$this->isEtagValid(),
 			"$entry '$path' expected to exist but not found"
 		);
@@ -1066,7 +1066,7 @@ trait WebDav {
 				$numEntriesThatExist = $numEntriesThatExist + 1;
 			}
 		}
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			1,
 			$numEntriesThatExist,
 			"exactly one of these $entries should exist but found $numEntriesThatExist $entries"
@@ -1145,12 +1145,12 @@ trait WebDav {
 			if ($expectedToBeListed
 				&& (!isset($element[0]) || $element[0]->__toString() !== $webdavPath)
 			) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"$webdavPath is not in propfind answer but should"
 				);
 			} elseif (!$expectedToBeListed && isset($element[0])
 			) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"$webdavPath is in propfind answer but should not be"
 				);
 			}
@@ -1273,7 +1273,7 @@ trait WebDav {
 	public function userUploadsAFileToWithChunks(
 		$user, $source, $destination, $noOfChunks = 2, $chunkingVersion = null, $async = false, $headers = []
 	) {
-		PHPUnit_Framework_Assert::assertGreaterThan(
+		PHPUnit\Framework\Assert::assertGreaterThan(
 			0, $noOfChunks, "What does it mean to have $noOfChunks chunks?"
 		);
 		//use the chunking version that works with the set dav version
@@ -1285,7 +1285,7 @@ trait WebDav {
 			}
 		}
 		$this->useSpecificChunking($chunkingVersion);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			WebDavHelper::isValidDavChunkingCombination(
 				($this->usingOldDavPath) ? 1 : 2,
 				$this->chunkingToUse
@@ -1396,7 +1396,7 @@ trait WebDav {
 	 */
 	public function theHTTPStatusCodeOfAllUploadResponsesShouldBe($statusCode) {
 		foreach ($this->uploadResponses as $response) {
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$statusCode,
 				$response->getStatusCode(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
@@ -1413,7 +1413,7 @@ trait WebDav {
 	 */
 	public function theHTTPReasonPhraseOfAllUploadResponsesShouldBe($reasonPhrase) {
 		foreach ($this->uploadResponses as $response) {
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				$reasonPhrase,
 				$response->getReasonPhrase(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected reason phrase'
@@ -1461,12 +1461,12 @@ trait WebDav {
 		$minStatusCode, $maxStatusCode
 	) {
 		foreach ($this->uploadResponses as $response) {
-			PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+			PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
 				$minStatusCode,
 				$response->getStatusCode(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
 			);
-			PHPUnit_Framework_Assert::assertLessThanOrEqual(
+			PHPUnit\Framework\Assert::assertLessThanOrEqual(
 				$maxStatusCode,
 				$response->getStatusCode(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
@@ -1554,7 +1554,7 @@ trait WebDav {
 	public function userUploadsAFileToOfBytes($user, $destination, $bytes) {
 		$filename = "filespecificSize.txt";
 		$this->createLocalFileOfSpecificSize($filename, $bytes);
-		PHPUnit_Framework_Assert::assertFileExists($this->workStorageDirLocation() . $filename);
+		PHPUnit\Framework\Assert::assertFileExists($this->workStorageDirLocation() . $filename);
 		$this->userUploadsAFileTo(
 			$user,
 			$this->temporaryStorageSubfolderName() . "/$filename",
@@ -2077,7 +2077,7 @@ trait WebDav {
 			$headerValue = $this->response->getHeader($headerName);
 			//Note: according to the documentation of getHeader it must return null
 			//if the header does not exist, but its returning an empty string
-			PHPUnit_Framework_Assert::assertEmpty(
+			PHPUnit\Framework\Assert::assertEmpty(
 				$headerValue,
 				"header $headerName should not exist " .
 				"but does and is set to $headerValue"
@@ -2102,7 +2102,7 @@ trait WebDav {
 			);
 			
 			$returnedHeader = $this->response->getHeader($headerName);
-			PHPUnit_Framework_Assert::assertNotFalse(
+			PHPUnit\Framework\Assert::assertNotFalse(
 				(bool)\preg_match($expectedHeaderValue, $returnedHeader),
 				"'$expectedHeaderValue' does not match '$returnedHeader'"
 			);
@@ -2172,7 +2172,7 @@ trait WebDav {
 	 */
 	public function userFileShouldHaveStoredId($user, $path) {
 		$currentFileID = $this->getFileIdForPath($user, $path);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$currentFileID, $this->storedFileID
 		);
 	}
@@ -2211,12 +2211,12 @@ trait WebDav {
 				$expectedFile[0]
 			);
 			if ($should) {
-				PHPUnit_Framework_Assert::assertNotEmpty(
+				PHPUnit\Framework\Assert::assertNotEmpty(
 					$fileFound,
 					"response does not contain the entry '$expectedFile[0]'"
 				);
 			} else {
-				PHPUnit_Framework_Assert::assertFalse(
+				PHPUnit\Framework\Assert::assertFalse(
 					$fileFound,
 					"response does contain the entry '$expectedFile[0]' but should not"
 				);
@@ -2243,7 +2243,7 @@ trait WebDav {
 		if ($multistatusResults === null) {
 			$multistatusResults = [];
 		}
-		PHPUnit_Framework_Assert::assertEquals((int)$numFiles, \count($multistatusResults));
+		PHPUnit\Framework\Assert::assertEquals((int)$numFiles, \count($multistatusResults));
 	}
 
 	/**
@@ -2261,7 +2261,7 @@ trait WebDav {
 		$elementRows = $expectedFiles->getRowsHash();
 		$resultEntries = $this->findEntryFromPropfindResponse();
 		foreach ($resultEntries as $resultEntry) {
-			PHPUnit_Framework_Assert::assertArrayHasKey($resultEntry, $elementRows);
+			PHPUnit\Framework\Assert::assertArrayHasKey($resultEntry, $elementRows);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -102,7 +102,7 @@ class WebDavLockingContext implements Context {
 			$this->tokenOfLastLock[$user][$file] = (string)$xmlPart[0];
 		} else {
 			if ($expectToSucceed === true) {
-				PHPUnit_Framework_Assert::fail("could not find lock token");
+				PHPUnit\Framework\Assert::fail("could not find lock token");
 			}
 		}
 	}
@@ -440,7 +440,7 @@ class WebDavLockingContext implements Context {
 		$responseXml = $this->featureContext->getResponseXml($response);
 		$responseXml->registerXPathNamespace('d', 'DAV:');
 		$xmlPart = $responseXml->xpath("//d:response//d:lockdiscovery/d:activelock");
-		PHPUnit_Framework_Assert::assertCount(
+		PHPUnit\Framework\Assert::assertCount(
 			(int)$count, $xmlPart,
 			"expected $count lock(s) for '$file' but found " . \count($xmlPart)
 		);

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -198,10 +198,10 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $responseXmlObject->xpath(
 			"//d:prop/" . "$nameSpacePrefix:$propertyName"
 		);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			0, $xmlPart, "Cannot find property \"$propertyName\""
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$propertyValue, $xmlPart[0]->__toString(),
 			"\"$propertyName\" has a value \"" .
 			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected"
@@ -224,7 +224,7 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$property/$childProperty"
 		);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find property \"$property/$childProperty\""
 		);
 	}
@@ -262,7 +262,7 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$key"
 		);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find property \"$key\""
 		);
 		$value = $xmlPart[0]->__toString();
@@ -274,7 +274,7 @@ class WebDavPropertiesContext implements Context {
 		if (\preg_match($expectedValue, $value) !== 1
 			&& \preg_match($altExpectedValue, $value) !== 1
 		) {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				"Property \"$key\" found with value \"$value\", " .
 				"expected \"$expectedValue\" or \"$altExpectedValue\""
 			);
@@ -292,14 +292,14 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function assertValueOfItemInResponseIs($xpath, $expectedValue) {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find item with xpath \"$xpath\""
 		);
 		$value = $xmlPart[0]->__toString();
 		$expectedValue = $this->featureContext->substituteInLineCodes(
 			$expectedValue
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedValue, $value,
 			"item \"$xpath\" found with value \"$value\", " .
 			"expected \"$expectedValue\""
@@ -317,14 +317,14 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function assertValueOfItemInResponseRegExp($xpath, $pattern) {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find item with xpath \"$xpath\""
 		);
 		$value = $xmlPart[0]->__toString();
 		$pattern = $this->featureContext->substituteInLineCodes(
 			$pattern
 		);
-		PHPUnit_Framework_Assert::assertRegExp(
+		PHPUnit\Framework\Assert::assertRegExp(
 			$pattern, $value,
 			"item \"$xpath\" found with value \"$value\", " .
 			"expected to match regex pattern: \"$pattern\""
@@ -386,11 +386,11 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$key"
 		);
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find property \"$key\""
 		);
 		$value = $xmlPart[0]->__toString();
-		PHPUnit_Framework_Assert::assertRegExp(
+		PHPUnit\Framework\Assert::assertRegExp(
 			$regex, $value,
 			"Property \"$key\" found with value \"$value\", expected \"$regex\""
 		);
@@ -422,10 +422,10 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$property"
 		);
-		PHPUnit_Framework_Assert::assertCount(
+		PHPUnit\Framework\Assert::assertCount(
 			1, $xmlPart, "Cannot find property \"$property\""
 		);
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$xmlPart[0], "Property \"$property\" is not empty"
 		);
 	}
@@ -475,7 +475,7 @@ class WebDavPropertiesContext implements Context {
 		$this->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->storedETAG[$user][$path],
 			$this->featureContext->getEtagFromResponseXmlObject()
 		);
@@ -494,7 +494,7 @@ class WebDavPropertiesContext implements Context {
 		$this->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
-		PHPUnit_Framework_Assert::assertNotEquals(
+		PHPUnit\Framework\Assert::assertNotEquals(
 			$this->storedETAG[$user][$path],
 			$this->featureContext->getEtagFromResponseXmlObject()
 		);

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -210,7 +210,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	public function theVersionOfOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
 		$actualVersion = $this->adminGeneralSettingsPage->getOwncloudVersion();
 		$expectedVersion = $this->featureContext->getSystemConfigValue('version');
-		PHPUnit_Framework_Assert::assertEquals(\trim($expectedVersion), $actualVersion);
+		PHPUnit\Framework\Assert::assertEquals(\trim($expectedVersion), $actualVersion);
 	}
 
 	/**
@@ -221,7 +221,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	public function theVersionStringOfTheOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
 		$actualVersion =  $this->adminGeneralSettingsPage->getOwncloudVersionString();
 		$expectedVersion = SetupHelper::runOcc(['-V'])['stdOut'];
-		PHPUnit_Framework_Assert::assertStringEndsWith($actualVersion, \trim($expectedVersion));
+		PHPUnit\Framework\Assert::assertStringEndsWith($actualVersion, \trim($expectedVersion));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -175,11 +175,11 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 		);
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$result, "Last created mount was expected to be present but was not"
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$result, "Last created mount was not expected to be present but was"
 			);
 		}
@@ -192,7 +192,7 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	 */
 	public function theExternalStorageFormShouldBeOnTheStorageSettingsPage() {
 		$isDisplayed = $this->adminStorageSettingsPage->externalStorageFormVisible();
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$isDisplayed, "External storage is expected to be visible but is not"
 		);
 	}
@@ -204,7 +204,7 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	 */
 	public function theExternalStorageFormShouldNotBeOnTheStorageSettingsPage() {
 		$isDisplayed = $this->adminStorageSettingsPage->externalStorageFormVisible();
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$isDisplayed, "External storage is not expected to be visible but is"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -283,16 +283,16 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theThumbnailShouldBeVisibleInTheDetailsPanel() {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
 		$thumbnail = $detailsDialog->findThumbnail();
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$thumbnail->isVisible(),
 			"thumbnail is not visible"
 		);
 		$style = $thumbnail->getAttribute("style");
-		PHPUnit_Framework_Assert::assertNotNull(
+		PHPUnit\Framework\Assert::assertNotNull(
 			$style,
 			'style attribute of details thumbnail is null'
 		);
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			$this->getCurrentFolderFilePath(),
 			$style
 		);
@@ -307,7 +307,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theTabNameDetailsPanelShouldBeVisible($tabName) {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$detailsDialog->isDetailsPanelVisible($tabName),
 			"the $tabName panel is not visible in the details panel"
 		);
@@ -321,7 +321,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theShareWithFieldShouldBeVisibleInTheDetailsPanel() {
 		$sharingDialog = $this->filesPage->getSharingDialog();
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$sharingDialog->isShareWithFieldVisible(),
 			'the share-with field is not visible in the details panel'
 		);
@@ -335,7 +335,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theShareWithFieldShouldNotBeVisibleInTheDetailsPanel() {
 		$sharingDialog = $this->filesPage->getSharingDialog();
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$sharingDialog->isShareWithFieldVisible(),
 			'the share-with field is visible in the details panel'
 		);
@@ -537,7 +537,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function thereShouldBeNoFilesFoldersListedOnTheWebUI() {
 		$pageObject = $this->getCurrentPageObject();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			0,
 			$pageObject->getSizeOfFileFolderList()
 		);
@@ -554,7 +554,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function thereShouldBeCountFilesFoldersListedOnTheWebUI($count) {
 		$pageObject = $this->getCurrentPageObject();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$count,
 			$pageObject->getSizeOfFileFolderList()
 		);
@@ -1264,12 +1264,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$folderIsEmpty = $pageObject->isFolderEmpty($this->getSession());
 
 		if ($should) {
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$folderIsEmpty,
 				"folder contains items but should be empty"
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$folderIsEmpty,
 				"folder is empty but should contain items"
 			);
@@ -1417,11 +1417,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		}
 
 		if ($should) {
-			PHPUnit_Framework_Assert::assertNotNull(
+			PHPUnit\Framework\Assert::assertNotNull(
 				$fileRow,
 				"could not find $fileLocationText when it should be listed"
 			);
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$fileRow->isVisible(),
 				"file row of $fileLocationText is not visible but should"
 			);
@@ -1430,13 +1430,13 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$name = \implode($name);
 			}
 			if ($fileRow === null) {
-				PHPUnit_Framework_Assert::assertContains(
+				PHPUnit\Framework\Assert::assertContains(
 					"could not find file with the name '$name'",
 					$exceptionMessage,
 					"found $fileLocationText when it should not be listed"
 				);
 			} else {
-				PHPUnit_Framework_Assert::assertFalse(
+				PHPUnit\Framework\Assert::assertFalse(
 					$fileRow->isVisible(),
 					"file row of $fileLocationText is visible but should not"
 				);
@@ -1514,7 +1514,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$fileNameParts[] = $namePartsRow['name-parts'];
 			}
 		} else {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				'no table of file name parts passed to theFollowingFileFolderShouldBeListed'
 			);
 		}
@@ -1545,7 +1545,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$name,
 		$toolTipText
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$toolTipText,
 			$this->getCurrentPageObject()->getTooltipOfFile($name, $this->getSession())
 		);
@@ -1575,7 +1575,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$tooltiptext
 	) {
 		$createFolderTooltip = $this->getCurrentPageObject()->getCreateFolderTooltip();
-		PHPUnit_Framework_Assert::assertSame($tooltiptext, $createFolderTooltip);
+		PHPUnit\Framework\Assert::assertSame($tooltiptext, $createFolderTooltip);
 	}
 
 	/**
@@ -1590,7 +1590,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		try {
 			$this->deleteTheFileUsingTheWebUI($name, false);
 		} catch (ElementNotFoundException $e) {
-			PHPUnit_Framework_Assert::assertContains(
+			PHPUnit\Framework\Assert::assertContains(
 				"could not find button 'Delete' in action Menu",
 				$e->getMessage()
 			);
@@ -1629,7 +1629,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$currentTime = \microtime(true);
 			}
 			
-			PHPUnit_Framework_Assert::assertLessThanOrEqual(
+			PHPUnit\Framework\Assert::assertLessThanOrEqual(
 				$windowHeight, $deleteBtnCoordinates ["top"]
 			);
 			//this will close the menu again
@@ -1909,7 +1909,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserShouldSeeFileActionTranslatedToInTheWebui($action_label, $translated_label) {
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			$translated_label,
 			$this->openedFileActionMenu->getActionLabelLocalized($action_label)
 		);
@@ -1949,7 +1949,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theDetailsDialogShouldBeVisibleInTheWebui() {
-		PHPUnit_Framework_Assert::assertTrue($this->filesPage->getDetailsDialog()->isDialogVisible());
+		PHPUnit\Framework\Assert::assertTrue($this->filesPage->getDetailsDialog()->isDialogVisible());
 	}
 
 	/**
@@ -2007,12 +2007,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$detailsDialog = $this->getCurrentPageObject()->getDetailsDialog();
 		$detailsDialog->waitTillPageIsLoaded($this->getSession());
 		if ($should) {
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$detailsDialog->isCommentOnUI($text),
 				"Failed to find comment with text $text in the webUI"
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$detailsDialog->isCommentOnUI($text),
 				"The comment with text $text exists in the webUI"
 			);
@@ -2049,7 +2049,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theVersionsListShouldContainEntries($num) {
 		$versionsList = $this->filesPage->getDetailsDialog()->getVersionsList();
 		$versionsCount = \count($versionsList->findAll("xpath", "//li"));
-		PHPUnit_Framework_Assert::assertEquals($num, $versionsCount);
+		PHPUnit\Framework\Assert::assertEquals($num, $versionsCount);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -256,7 +256,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		);
 		$matches = [];
 		\preg_match($regexSearch, $content, $matches);
-		PHPUnit_Framework_Assert::assertArrayHasKey(1, $matches, $errorMessage);
+		PHPUnit\Framework\Assert::assertArrayHasKey(1, $matches, $errorMessage);
 		return $matches[1];
 	}
 
@@ -284,7 +284,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function noNotificationShouldBeDisplayedOnTheWebUI() {
 		try {
 			$notificationText = $this->owncloudPage->getNotificationText();
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit\Framework\Assert::assertEquals(
 				'',
 				$notificationText,
 				"Expecting no notifications but got $notificationText"
@@ -304,7 +304,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function aNotificationShouldBeDisplayedOnTheWebUIWithTheText(
 		$notificationText
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$notificationText, $this->owncloudPage->getNotificationText()
 		);
 	}
@@ -327,7 +327,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$expectedNotifications = $table->getRows();
 		$numExpectedNotifications = \count($expectedNotifications);
 
-		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
 			$numExpectedNotifications,
 			$numActualNotifications,
 			"expected at least $numExpectedNotifications notifications but only found $numActualNotifications"
@@ -344,7 +344,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 					);
 				}
 			} else {
-				PHPUnit_Framework_Assert::assertEquals(
+				PHPUnit\Framework\Assert::assertEquals(
 					$expectedNotificationText,
 					$actualNotificationText
 				);
@@ -380,7 +380,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				$currentTime = \microtime(true);
 				$dialogs = $this->owncloudPage->getOcDialogs();
 			}
-			PHPUnit_Framework_Assert::assertEquals($count, \count($dialogs));
+			PHPUnit\Framework\Assert::assertEquals($count, \count($dialogs));
 		}
 		if ($table !== null) {
 			$expectedDialogs = $table->getHash();
@@ -402,7 +402,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				}
 			}
 			foreach ($expectedDialogs as $expectedDialog) {
-				PHPUnit_Framework_Assert::assertArrayHasKey(
+				PHPUnit\Framework\Assert::assertArrayHasKey(
 					"found",
 					$expectedDialog,
 					"could not find dialog with title '{$expectedDialog['title']}' "
@@ -424,7 +424,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$this->owncloudPage->waitForOutstandingAjaxCalls($this->getSession());
 		// Just check that the actual title starts with the expected title.
 		// Theming can have other text following.
-		PHPUnit_Framework_Assert::assertStringStartsWith(
+		PHPUnit\Framework\Assert::assertStringStartsWith(
 			$title, $this->owncloudPage->getPageTitle()
 		);
 	}
@@ -441,7 +441,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$this->generalErrorPage->waitTillPageIsLoaded($this->getSession());
 		// Just check that the actual title starts with the expected title.
 		// Theming can have other text following.
-		PHPUnit_Framework_Assert::assertStringStartsWith(
+		PHPUnit\Framework\Assert::assertStringStartsWith(
 			$title, $this->generalErrorPage->getPageTitle()
 		);
 	}
@@ -454,7 +454,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function anErrorShouldBeDisplayedOnTheGeneralErrorPage($error) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$error, $this->generalErrorPage->getErrorMessage()
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -132,7 +132,7 @@ class WebUIHelpAndTipsContext extends RawMinkContext implements Context {
 	public function theLinkForShouldBeValid($linkTitle) {
 		$linkUrl = $this->generateHelpLinks($this->getLinkID($linkTitle));
 		$linkOnUI = $this->helpAndTipsPage->getLinkUrlByTitle($linkTitle);
-		PHPUnit_Framework_Assert::assertSame($linkUrl, $linkOnUI);
+		PHPUnit\Framework\Assert::assertSame($linkUrl, $linkOnUI);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -403,7 +403,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	public function thisMessageShouldBeDisplayed(PyStringNode $string) {
 		$expectedString = $string->getRaw();
 		$passwordRecoveryMessage = $this->loginPage->getLostPasswordMessage();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedString, $passwordRecoveryMessage
 		);
 	}
@@ -420,7 +420,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	) {
 		$expectedString = $string->getRaw();
 		$setPasswordErrorMessage = $this->loginPage->getSetPasswordErrorMessage();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedString, $setPasswordErrorMessage
 		);
 	}
@@ -437,7 +437,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	) {
 		$expectedString = $string->getRaw();
 		$resetPasswordErrorMessage = $this->loginPage->getLostPasswordResetErrorMessage();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedString, $resetPasswordErrorMessage
 		);
 	}
@@ -451,7 +451,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	public function theImprintUrlOnTheLoginPageShouldLinkTo($expectedImprintUrl) {
 		$actualImprintUrl = $this->loginPage->getLegalUrl("Imprint");
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedImprintUrl,
 			$actualImprintUrl
 		);
@@ -466,7 +466,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	public function thePrivacyPolicyUrlOnTheLoginPageShouldLinkTo($expectedPrivacyPolicyUrl) {
 		$actualPrivacyPolicyUrl = $this->loginPage->getLegalUrl("Privacy Policy");
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedPrivacyPolicyUrl,
 			$actualPrivacyPolicyUrl
 		);
@@ -581,7 +581,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	public function theUserResetConfirmPasswordErrorMessage(PyStringNode $string) {
 		$expectedString = $string->getRaw();
 		$passwordMismatchMessage = $this->loginPage->getRestPasswordConfirmError();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$expectedString, $passwordMismatchMessage
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
@@ -62,7 +62,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 	) {
 		$notificationsDialog = $this->openNotificationsDialog($this->getSession());
 		$notifications = $notificationsDialog->getAllNotifications();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$number,
 			\count($notifications),
 			"expected $number notifications, found " . \count($notifications)
@@ -84,7 +84,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 				}
 			}
 			if (!$found) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"could not find expected notification: " .
 					\print_r($expectedNotification, true) .
 					" in viewed notifications: " .

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -176,7 +176,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function theOwncloudVersionShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui() {
-		PHPUnit_Framework_Assert::assertTrue($this->personalGeneralSettingsPage->isVersionDisplayed());
+		PHPUnit\Framework\Assert::assertTrue($this->personalGeneralSettingsPage->isVersionDisplayed());
 	}
 
 	/**
@@ -188,7 +188,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theFederatedCloudIdForUserShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($user) {
 		$userFederatedCloudId = $user . "@" . $this->featureContext->getLocalBaseUrlWithoutScheme();
-		PHPUnit_Framework_Assert::assertEquals($this->personalGeneralSettingsPage->getFederatedCloudID(), $userFederatedCloudId);
+		PHPUnit\Framework\Assert::assertEquals($this->personalGeneralSettingsPage->getFederatedCloudID(), $userFederatedCloudId);
 	}
 
 	/**
@@ -199,7 +199,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function groupShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($groupName) {
-		PHPUnit_Framework_Assert::assertTrue($this->personalGeneralSettingsPage->isGroupNameDisplayed($groupName));
+		PHPUnit\Framework\Assert::assertTrue($this->personalGeneralSettingsPage->isGroupNameDisplayed($groupName));
 	}
 
 	/**
@@ -220,7 +220,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 			'/Use the following link to confirm your changes to the email address: (http.*)/',
 			$content, $matches
 		);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		PHPUnit\Framework\Assert::assertArrayHasKey(
 			1, $matches,
 			"Couldn't find confirmation link in the email"
 		);
@@ -237,7 +237,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	public function aPasswordErrorMessageShouldBeDisplayedOnTheWebUIWithTheText(
 		$wrongPasswordMessageText
 	) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$wrongPasswordMessageText,
 			$this->personalGeneralSettingsPage->getWrongPasswordMessageText()
 		);
@@ -275,11 +275,11 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function thePreviewOfTheProfilePictureShouldBeShownInTheWebui($shouldOrNot) {
 		if ($shouldOrNot !== "not") {
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
 			);
 		}
@@ -303,7 +303,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theUserHasDeletedAnyExistingProfilePicture() {
 		$this->theUserDeletesTheExistingProfilePicture();
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
 		);
 	}
@@ -339,11 +339,11 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theUserShouldBeAbleToUploadTheFileAsTheProfilePicture($shouldOrNot) {
 		if ($shouldOrNot !== "not") {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$this->personalGeneralSettingsPage->isFileUploadErrorMsgVisible()
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$this->personalGeneralSettingsPage->isFileUploadErrorMsgVisible()
 			);
 		}

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
@@ -91,10 +91,10 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 		$appTr = $this->personalSecuritySettingsPage->getLinkedAppByName(
 			$this->appName
 		);
-		PHPUnit_Framework_Assert::assertNotEmpty($appTr);
+		PHPUnit\Framework\Assert::assertNotEmpty($appTr);
 		$disconnectButton
 			= $this->personalSecuritySettingsPage->getDisconnectButton($appTr);
-		PHPUnit_Framework_Assert::assertNotEmpty($disconnectButton);
+		PHPUnit\Framework\Assert::assertNotEmpty($disconnectButton);
 	}
 
 	/**
@@ -104,12 +104,12 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 	 */
 	public function theUserDisplayNameAndAppPasswordShouldBeDisplayedOnTheWebUI() {
 		$result = $this->personalSecuritySettingsPage->getAppPasswordResult();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$this->featureContext->getCurrentUser(),
 			$result[0]->getValue()
 		);
 
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			1, \preg_match(
 				'/(([A-Z]){5}-){3}([A-Z]){5}/', $result[1]->getValue()
 			)

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -87,7 +87,7 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function autoAcceptingCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageInTheWebui() {
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAutoAcceptLocalSharesCheckboxDisplayed()
 		);
 	}
@@ -98,7 +98,7 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function autoAcceptingFederatedCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageInTheWebui() {
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAutoAcceptFederatedSharesCheckboxDisplayed()
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -476,7 +476,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$expectedWarningMessage
 	) {
 		$warningMessage = $this->publicShareTab->getWarningMessage();
-		PHPUnit_Framework_Assert::assertEquals($expectedWarningMessage, $warningMessage);
+		PHPUnit\Framework\Assert::assertEquals($expectedWarningMessage, $warningMessage);
 	}
 
 	/**
@@ -488,7 +488,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		try {
 			$this->publicShareTab->getLinkUrl($this->linkName);
 		} catch (Exception $e) {
-			PHPUnit_Framework_Assert::assertContains(
+			PHPUnit\Framework\Assert::assertContains(
 				"could not find link entry with the given name",
 				$e->getMessage()
 			);
@@ -783,12 +783,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function thePublicShouldNotGetAccessToPublicShareFile() {
 		$warningMessage = $this->publicLinkFilesPage->getWarningMessage();
-		PHPUnit_Framework_Assert::assertEquals('The password is wrong. Try again.', $warningMessage);
+		PHPUnit\Framework\Assert::assertEquals('The password is wrong. Try again.', $warningMessage);
 
 		$lastCreatedLink = \end($this->createdPublicLinks);
 		$lastSharePath = $lastCreatedLink['url'] . '/authenticate';
 		$currentPath = $this->getSession()->getCurrentUrl();
-		PHPUnit_Framework_Assert::assertEquals($lastSharePath, $currentPath);
+		PHPUnit\Framework\Assert::assertEquals($lastSharePath, $currentPath);
 	}
 
 	/**
@@ -802,12 +802,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$userOrGroupName
 	) {
 		$autocompleteItems = $this->sharingDialog->getAutocompleteItemsList();
-		PHPUnit_Framework_Assert::assertCount(
+		PHPUnit\Framework\Assert::assertCount(
 			1,
 			$autocompleteItems,
 			"expected 1 autocomplete item but there are " . \count($autocompleteItems)
 		);
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			$userOrGroupName,
 			$autocompleteItems,
 			"'$userOrGroupName' not in autocomplete list"
@@ -862,7 +862,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 					&& ($displayName !== $this->featureContext->getCurrentUser())
 					&& ($displayName !== $this->featureContext->getCurrentUserDisplayName())
 				) {
-					PHPUnit_Framework_Assert::assertContains(
+					PHPUnit\Framework\Assert::assertContains(
 						$displayName,
 						$autocompleteItems,
 						"'$displayName' not in autocomplete list"
@@ -872,13 +872,13 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			}
 		}
 
-		PHPUnit_Framework_Assert::assertCount(
+		PHPUnit\Framework\Assert::assertCount(
 			$numExpectedItems,
 			$autocompleteItems,
 			"expected $numExpectedItems in autocomplete list but there are " . \count($autocompleteItems)
 		);
 
-		PHPUnit_Framework_Assert::assertNotContains(
+		PHPUnit\Framework\Assert::assertNotContains(
 			$notToBeListed,
 			$this->sharingDialog->getAutocompleteItemsList()
 		);
@@ -890,7 +890,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUsersOwnNameShouldNotBeListedInTheAutocompleteList() {
-		PHPUnit_Framework_Assert::assertNotContains(
+		PHPUnit\Framework\Assert::assertNotContains(
 			$this->filesPage->getMyDisplayname(),
 			$this->sharingDialog->getAutocompleteItemsList()
 		);
@@ -904,7 +904,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function aTooltipWithTheTextShouldBeShownNearTheShareWithField($text) {
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			$text,
 			$this->sharingDialog->getShareWithTooltip()
 		);
@@ -916,7 +916,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAutocompleteListShouldNotBeDisplayed() {
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$this->sharingDialog->getAutocompleteItemsList()
 		);
 	}
@@ -929,7 +929,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserShouldNotBeInShareWithUserList($username) {
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$this->sharingDialog->isUserPresentInShareWithList($username),
 			"user $username is present in the list"
 		);
@@ -959,28 +959,28 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		
 		$row = $this->filesPage->findFileRowByName($itemName, $this->getSession());
 		$sharingBtn = $row->findSharingButton();
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			$sharerName, $this->filesPage->getTrimmedText($sharingBtn)
 		);
 		$sharingDialog = $this->filesPage->openSharingDialog(
 			$itemName, $this->getSession()
 		);
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			$sharerName, $sharingDialog->getSharerName()
 		);
 		if ($fileOrFolder === "folder") {
-			PHPUnit_Framework_Assert::assertContains(
+			PHPUnit\Framework\Assert::assertContains(
 				"folder-shared.svg",
 				$row->findThumbnail()->getAttribute("style")
 			);
 			$detailsDialog = $this->filesPage->getDetailsDialog();
-			PHPUnit_Framework_Assert::assertContains(
+			PHPUnit\Framework\Assert::assertContains(
 				"folder-shared.svg",
 				$detailsDialog->findThumbnail()->getAttribute("style")
 			);
 		}
 		if ($sharedWithGroup !== "") {
-			PHPUnit_Framework_Assert::assertSame(
+			PHPUnit\Framework\Assert::assertSame(
 				$sharedWithGroup,
 				$sharingDialog->getSharedWithGroupName()
 			);
@@ -1000,7 +1000,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$fileRow = $this->sharedWithYouPage->findFileRowByName(
 			$item, $this->getSession()
 		);
-		PHPUnit_Framework_Assert::assertSame($state, $fileRow->getShareState());
+		PHPUnit\Framework\Assert::assertSame($state, $fileRow->getShareState());
 	}
 
 	/**
@@ -1026,10 +1026,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				break;
 			}
 		}
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$found, "could not find item called $item shared by $sharedBy"
 		);
-		PHPUnit_Framework_Assert::assertSame($state, $currentState);
+		PHPUnit\Framework\Assert::assertSame($state, $currentState);
 	}
 
 	/**
@@ -1131,7 +1131,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->generalErrorPage->setPagePath($path);
 		$this->generalErrorPage->open();
 		$actualErrorMsg = $this->generalErrorPage->getErrorMessage();
-		PHPUnit_Framework_Assert::assertContains($errorMsg, $actualErrorMsg);
+		PHPUnit\Framework\Assert::assertContains($errorMsg, $actualErrorMsg);
 	}
 
 	/**
@@ -1194,7 +1194,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				$settingsArray ['personalMessage']
 			);
 			if ($settingsArray['name'] !== null) {
-				PHPUnit_Framework_Assert::assertSame(
+				PHPUnit\Framework\Assert::assertSame(
 					$settingsArray ['name'], $linkName,
 					"set and retrieved public link names are not the same"
 				);
@@ -1214,7 +1214,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theTextPreviewOfThePublicLinkShouldContain($content) {
 		$previewText = $this->publicLinkFilesPage->getPreviewText();
-		PHPUnit_Framework_Assert::assertContains(
+		PHPUnit\Framework\Assert::assertContains(
 			$content, $previewText,
 			__METHOD__ . " file preview does not contain expected content"
 		);
@@ -1229,7 +1229,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theContentOfTheFileSharedByLastPublicLinkShouldBeTheSameAs($originalFile) {
 		$response = $this->thePublicDownloadsTheLastCreatedFileUsingTheWebui();
-		PHPUnit_Framework_Assert::assertEquals(200, $response->getStatusCode());
+		PHPUnit\Framework\Assert::assertEquals(200, $response->getStatusCode());
 		$body = $response->getBody()->getContents();
 
 		$user = $this->featureContext->getCurrentUser();
@@ -1238,7 +1238,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->featureContext->downloadFileAsUserUsingPassword($user, $originalFile, $password);
 		$originalContent = $this->featureContext->getResponse()->getBody()->getContents();
 
-		PHPUnit_Framework_Assert::assertSame($originalContent, $body);
+		PHPUnit\Framework\Assert::assertSame($originalContent, $body);
 	}
 
 	/**
@@ -1264,7 +1264,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			$address
 		);
 		$lastCreatedPublicLink = \end($this->createdPublicLinks);
-		PHPUnit_Framework_Assert::assertContains($lastCreatedPublicLink["url"], $content);
+		PHPUnit\Framework\Assert::assertContains($lastCreatedPublicLink["url"], $content);
 	}
 
 	/**
@@ -1279,7 +1279,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$actualMessage = $sharingDialog->getNoSharingMessage(
 			$this->getSession()
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $actualMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $actualMessage);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUITagsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUITagsContext.php
@@ -114,7 +114,7 @@ class WebUITagsContext extends RawMinkContext implements Context {
 	public function allTheTagsStartingWithInTheirNameShouldBeListedInTheDropdownListOnTheWebUI($value) {
 		$results = $this->filesPage->getDetailsDialog()->getDropDownTagsSuggestionResults();
 		foreach ($results as $tagResult) {
-			PHPUnit_Framework_Assert::assertStringStartsWith($value, $tagResult->getText());
+			PHPUnit\Framework\Assert::assertStringStartsWith($value, $tagResult->getText());
 		}
 
 		// check also that all tags that have been created and starts with $value

--- a/tests/acceptance/features/bootstrap/WebUIUserContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUserContext.php
@@ -56,7 +56,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	 */
 	public function displayNameOfTheCurrentUserOnTheWebUiShouldBe($displayname) {
 		$actualUserName = $this->owncloudPage->getMyDisplayname();
-		PHPUnit_Framework_Assert::assertSame(
+		PHPUnit\Framework\Assert::assertSame(
 			$displayname, $actualUserName,
 			"displayed username should be '$displayname' but it is '$actualUserName'"
 		);
@@ -74,12 +74,12 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	) {
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$this->owncloudPage->isDisplaynameVisible(),
 				"displayname should be visible, but is not"
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$this->owncloudPage->isDisplaynameVisible(),
 				"displayname should not be visible, but is"
 			);
@@ -96,12 +96,12 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	public function avatarShouldBeShownOnTheWebUI($shouldOrNot) {
 		$should = ($shouldOrNot !== "no");
 		if ($should) {
-			PHPUnit_Framework_Assert::assertTrue(
+			PHPUnit\Framework\Assert::assertTrue(
 				$this->owncloudPage->isAvatarVisible(),
 				"avatar should be visible, but is not"
 			);
 		} else {
-			PHPUnit_Framework_Assert::assertFalse(
+			PHPUnit\Framework\Assert::assertFalse(
 				$this->owncloudPage->isAvatarVisible(),
 				"avatar should not be visible, but is"
 			);

--- a/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
@@ -94,7 +94,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 		$this->closeDetailsDialog();
 		$pageObject = $this->webUIGeneralContext->getCurrentPageObject();
 		$fileRow = $pageObject->findFileRowByName($file, $this->getSession());
-		PHPUnit_Framework_Assert::assertTrue(
+		PHPUnit\Framework\Assert::assertTrue(
 			$fileRow->getLockState(),
 			"'$file' should be marked as locked, but its not"
 		);
@@ -111,7 +111,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 		$this->closeDetailsDialog();
 		$pageObject = $this->webUIGeneralContext->getCurrentPageObject();
 		$fileRow = $pageObject->findFileRowByName($file, $this->getSession());
-		PHPUnit_Framework_Assert::assertFalse(
+		PHPUnit\Framework\Assert::assertFalse(
 			$fileRow->getLockState(),
 			"'$file' should not be marked as locked, but it is"
 		);
@@ -137,7 +137,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 			$lockDialog = $fileRow->openLockDialog();
 		} catch (ElementNotFoundException $e) {
 			if ($should) {
-				PHPUnit_Framework_Assert::fail(
+				PHPUnit\Framework\Assert::fail(
 					"looking for a lock set by $lockedBy but no lock dialog exists"
 				);
 			} else {
@@ -153,14 +153,14 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 				if ($should) {
 					return true;
 				} else {
-					PHPUnit_Framework_Assert::fail(
+					PHPUnit\Framework\Assert::fail(
 						"found a lock set by $lockedBy that should not be listed"
 					);
 				}
 			}
 		}
 		if ($should) {
-			PHPUnit_Framework_Assert::fail("cannot find a lock set by $lockedBy");
+			PHPUnit\Framework\Assert::fail("cannot find a lock set by $lockedBy");
 		} else {
 			return true;
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,6 @@ if (\OCP\Util::needUpgrade()) {
 // load all enabled apps
 \OC_App::loadApps();
 
-PHPUnit_Framework_Error_Deprecated::$enabled = false;
+PHPUnit\Framework\Error\Deprecated::$enabled = false;
 
 OC_Hook::clear();

--- a/tests/lib/Activity/ManagerTest.php
+++ b/tests/lib/Activity/ManagerTest.php
@@ -17,13 +17,13 @@ class ManagerTest extends TestCase {
 	/** @var \OC\Activity\Manager */
 	private $activityManager;
 
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
 	protected function setUp() {

--- a/tests/lib/Activity/NullSession/ManagerTest.php
+++ b/tests/lib/Activity/NullSession/ManagerTest.php
@@ -22,9 +22,9 @@ class ManagerTest extends TestCase {
 
 	/** @var \OC\Activity\Manager */
 	private $activityManager;
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
 	protected function setUp() {

--- a/tests/lib/App/CodeChecker/InfoCheckerTest.php
+++ b/tests/lib/App/CodeChecker/InfoCheckerTest.php
@@ -29,7 +29,7 @@ use Test\TestCase;
 
 class InfoCheckerTest extends TestCase {
 
-	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $appManager;
 
 	protected function setUp() {

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -32,27 +32,27 @@ use org\bovigo\vfs\vfsStream;
  */
 class ManagerTest extends TestCase {
 
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 	/** @var IAppConfig */
 	protected $appConfig;
-	/** @var ICache | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICache | \PHPUnit\Framework\MockObject\MockObject */
 	protected $cache;
-	/** @var ICacheFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICacheFactory | \PHPUnit\Framework\MockObject\MockObject */
 	protected $cacheFactory;
 	/** @var IAppManager */
 	protected $manager;
-	/** @var  EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject */
 	protected $eventDispatcher;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var Platform | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Platform | \PHPUnit\Framework\MockObject\MockObject */
 	private $platform;
 
 	/**
-	 * @return IAppConfig | \PHPUnit_Framework_MockObject_MockObject
+	 * @return IAppConfig | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getAppConfig() {
 		$appConfig = [];
@@ -133,7 +133,7 @@ class ManagerTest extends TestCase {
 	 */
 	public function testEnableSecondAppTheme(): void {
 		$appThemeName = 'theme-one';
-		/** @var AppManager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setMethods(['isTheme', 'getAppInfo', 'getAppPath'])
 			->setConstructorArgs([$this->userSession, $this->appConfig,
@@ -242,7 +242,7 @@ class ManagerTest extends TestCase {
 		];
 		$this->expectClearCache();
 
-		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager|\PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([
 				$this->userSession, $this->appConfig, $this->groupManager,
@@ -287,7 +287,7 @@ class ManagerTest extends TestCase {
 			new Group('group2', [], null, $this->eventDispatcher)
 		];
 
-		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager|\PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([
 				$this->userSession, $this->appConfig, $this->groupManager,

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -108,19 +108,19 @@ class EntityTest extends \Test\TestCase {
 	}
 
 	public function testCallShouldOnlyWorkForGetterSetter() {
-		$this->setExpectedException('\BadFunctionCallException');
+		$this->expectException('\BadFunctionCallException');
 
 		$this->entity->something();
 	}
 
 	public function testGetterShouldFailIfAttributeNotDefined() {
-		$this->setExpectedException('\BadFunctionCallException');
+		$this->expectException('\BadFunctionCallException');
 
 		$this->entity->getTest();
 	}
 
 	public function testSetterShouldFailIfAttributeNotDefined() {
-		$this->setExpectedException('\BadFunctionCallException');
+		$this->expectException('\BadFunctionCallException');
 
 		$this->entity->setTest();
 	}

--- a/tests/lib/AppFramework/Db/MapperTest.php
+++ b/tests/lib/AppFramework/Db/MapperTest.php
@@ -102,7 +102,7 @@ class MapperTest extends MapperTestUtility {
 		$params = ['jo'];
 		$rows = [];
 		$this->setMapperResult($sql, $params, $rows);
-		$this->setExpectedException(
+		$this->expectException(
 			'\OCP\AppFramework\Db\DoesNotExistException');
 		$this->mapper->find($sql, $params);
 	}
@@ -112,7 +112,7 @@ class MapperTest extends MapperTestUtility {
 		$params = ['jo'];
 		$rows = [];
 		$this->setMapperResult($sql, $params, $rows, null, null, true);
-		$this->setExpectedException(
+		$this->expectException(
 			'\OCP\AppFramework\Db\DoesNotExistException');
 		$this->mapper->findOneEntity($sql, $params);
 	}
@@ -124,7 +124,7 @@ class MapperTest extends MapperTestUtility {
 			['jo'], ['ho']
 		];
 		$this->setMapperResult($sql, $params, $rows, null, null, true);
-		$this->setExpectedException(
+		$this->expectException(
 			'\OCP\AppFramework\Db\MultipleObjectsReturnedException');
 		$this->mapper->find($sql, $params);
 	}
@@ -136,7 +136,7 @@ class MapperTest extends MapperTestUtility {
 			['jo'], ['ho']
 		];
 		$this->setMapperResult($sql, $params, $rows, null, null, true);
-		$this->setExpectedException(
+		$this->expectException(
 			'\OCP\AppFramework\Db\MultipleObjectsReturnedException');
 		$this->mapper->findOneEntity($sql, $params);
 	}
@@ -224,7 +224,7 @@ class MapperTest extends MapperTestUtility {
 		$entity->setPreName($params[0]);
 		$entity->setEmail($params[1]);
 
-		$this->setExpectedException('InvalidArgumentException');
+		$this->expectException('InvalidArgumentException');
 
 		$this->mapper->update($entity);
 	}

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -71,21 +71,21 @@ class TestController extends Controller {
 }
 
 class DispatcherTest extends \Test\TestCase {
-	/** @var MiddlewareDispatcher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var MiddlewareDispatcher | \PHPUnit\Framework\MockObject\MockObject */
 	private $middlewareDispatcher;
-	/** @var Dispatcher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Dispatcher | \PHPUnit\Framework\MockObject\MockObject */
 	private $dispatcher;
 	private $controllerMethod;
-	/** @var Response | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Response | \PHPUnit\Framework\MockObject\MockObject */
 	private $response;
 	private $request;
 	private $lastModified;
 	private $etag;
-	/** @var Http | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Http | \PHPUnit\Framework\MockObject\MockObject */
 	private $http;
 	private $reflector;
 
-	/** @var Controller | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Controller | \PHPUnit\Framework\MockObject\MockObject */
 	private $controller;
 
 	protected function setUp() {

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -26,11 +26,11 @@ use Test\TestCase;
 class RequestTest extends TestCase {
 	/** @var string */
 	protected $stream = 'fakeinput://data';
-	/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISecureRandom | \PHPUnit\Framework\MockObject\MockObject */
 	protected $secureRandom;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var CsrfTokenManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var CsrfTokenManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $csrfTokenManager;
 
 	protected function setUp() {
@@ -1395,7 +1395,7 @@ class RequestTest extends TestCase {
 			->with('overwritecondaddr')
 			->will($this->returnValue($overwriteCondAddr));
 
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
 			->setMethods(['getScriptName'])
 			->setConstructorArgs([

--- a/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
@@ -167,7 +167,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 		$this->dispatcher->registerMiddleware($m1);
 		$this->dispatcher->registerMiddleware($m2);
 
-		$this->setExpectedException('\Exception');
+		$this->expectException('\Exception');
 		$this->dispatcher->beforeController($this->controller, $this->method);
 		$this->dispatcher->afterException($this->controller, $this->method, $this->exception);
 	}
@@ -193,7 +193,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	public function testAfterExceptionCorrectArguments() {
 		$m1 = $this->getMiddleware();
 
-		$this->setExpectedException('\Exception');
+		$this->expectException('\Exception');
 
 		$this->dispatcher->beforeController($this->controller, $this->method);
 		$this->dispatcher->afterException($this->controller, $this->method, $this->exception);
@@ -237,7 +237,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 		$m1 = $this->getMiddleware();
 		$m2 = $this->getMiddleware();
 
-		$this->setExpectedException('\Exception');
+		$this->expectException('\Exception');
 		$this->dispatcher->beforeController($this->controller, $this->method);
 		$this->dispatcher->afterException($this->controller, $this->method, $this->exception);
 

--- a/tests/lib/AppFramework/Middleware/MiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareTest.php
@@ -74,7 +74,7 @@ class MiddlewareTest extends \Test\TestCase {
 	}
 
 	public function testAfterExceptionRaiseAgainWhenUnhandled() {
-		$this->setExpectedException('Exception');
+		$this->expectException('Exception');
 		$afterEx = $this->middleware->afterException($this->controller, null, $this->exception);
 	}
 

--- a/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
@@ -31,7 +31,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	private $reflector;
 	/** @var Session */
 	private $session;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject*/
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject*/
 	private $config;
 	/** @var IUserSession */
 	private $fakeSession;

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -53,23 +53,23 @@ class SecurityMiddlewareTest extends TestCase {
 
 	/** @var SecurityMiddleware */
 	private $middleware;
-	/** @var Controller | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Controller | \PHPUnit\Framework\MockObject\MockObject */
 	private $controller;
 	private $secException;
 	private $secAjaxException;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var ControllerMethodReflector | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ControllerMethodReflector | \PHPUnit\Framework\MockObject\MockObject */
 	private $reader;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
-	/** @var INavigationManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var INavigationManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $navigationManager;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
-	/** @var ContentSecurityPolicyManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ContentSecurityPolicyManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $contentSecurityPolicyManager;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
 
 	protected function setUp() {
@@ -522,7 +522,7 @@ class SecurityMiddlewareTest extends TestCase {
 	}
 
 	public function testAfterController() {
-		/** @var Response | \PHPUnit_Framework_MockObject_MockObject $response */
+		/** @var Response | \PHPUnit\Framework\MockObject\MockObject $response */
 		$response = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->getMock();
 		$defaultPolicy = new ContentSecurityPolicy();
 		$defaultPolicy->addAllowedImageDomain('defaultpolicy');

--- a/tests/lib/AppFramework/Routing/RoutingTest.php
+++ b/tests/lib/AppFramework/Routing/RoutingTest.php
@@ -189,7 +189,7 @@ class RoutingTest extends \Test\TestCase {
 	 * @param string $actionName
 	 * @param array $requirements
 	 * @param array $defaults
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function mockRoute(
 		DIContainer $container,

--- a/tests/lib/Authentication/AccountModule/ManagerTest.php
+++ b/tests/lib/Authentication/AccountModule/ManagerTest.php
@@ -33,16 +33,16 @@ use Test\TestCase;
 
 class ManagerTest extends TestCase {
 
-	/** @var IUser|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
 	private $user;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
-	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
-	/** @var IServiceLoader|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IServiceLoader|\PHPUnit\Framework\MockObject\MockObject */
 	private $serviceLoader;
 
 	/** @var Manager */

--- a/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
@@ -161,7 +161,7 @@ class DefaultTokenMapperTest extends TestCase {
 	}
 
 	public function testGetTokenByUserNotFound() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock('\OCP\IUser');
 		$user->expects($this->once())
 			->method('getUID')
@@ -171,7 +171,7 @@ class DefaultTokenMapperTest extends TestCase {
 	}
 
 	public function testDeleteById() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock('\OCP\IUser');
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('id')
@@ -188,7 +188,7 @@ class DefaultTokenMapperTest extends TestCase {
 	}
 
 	public function testDeleteByIdWrongUser() {
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock('\OCP\IUser');
 		$id = 33;
 		$user->expects($this->once())

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -27,22 +27,22 @@ use Test\TestCase;
 
 class ManagerTest extends TestCase {
 
-	/** @var \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject */
 	private $user;
 
-	/** @var \OC\App\AppManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\App\AppManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $appManager;
 
-	/** @var \OCP\ISession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\ISession|\PHPUnit\Framework\MockObject\MockObject */
 	private $session;
 
 	/** @var Manager */
 	private $manager;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
-	/** @var \OCP\Authentication\TwoFactorAuth\IProvider|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Authentication\TwoFactorAuth\IProvider|\PHPUnit\Framework\MockObject\MockObject */
 	private $fakeProvider;
 
 	protected function setUp() {

--- a/tests/lib/AvatarManagerTest.php
+++ b/tests/lib/AvatarManagerTest.php
@@ -40,25 +40,25 @@ use Test\Traits\MountProviderTrait;
 class AvatarManagerTest extends TestCase {
 	use MountProviderTrait;
 
-	/** @var AvatarManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AvatarManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $avatarManager;
 
 	/** @var \OC\Files\Storage\Temporary */
 	private $storage;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 
 	/** @var Folder */
 	private $folder;
 
-	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject */
 	private $rootFolder;
 
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $l10n;
 
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	public function setUp() {

--- a/tests/lib/AvatarTest.php
+++ b/tests/lib/AvatarTest.php
@@ -18,20 +18,20 @@ use OCP\IL10N;
 use OCP\ILogger;
 
 class AvatarTest extends \Test\TestCase {
-	/** @var IStorage | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IStorage | \PHPUnit\Framework\MockObject\MockObject */
 	private $storage;
 
 	/** @var \OC\Avatar */
 	private $avatar;
 
-	/** @var \OC\User\User | \PHPUnit_Framework_MockObject_MockObject $user */
+	/** @var \OC\User\User | \PHPUnit\Framework\MockObject\MockObject $user */
 	private $user;
 
 	public function setUp() {
 		parent::setUp();
 
 		$this->storage = $this->createMock(IStorage::class);
-		/** @var \OCP\IL10N | \PHPUnit_Framework_MockObject_MockObject $l */
+		/** @var \OCP\IL10N | \PHPUnit\Framework\MockObject\MockObject $l */
 		$l = $this->createMock(IL10N::class);
 		$l->method('t')->will($this->returnArgument(0));
 		$this->user = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -26,13 +26,13 @@ class JobListTest extends TestCase {
 	/** @var \OCP\IDBConnection */
 	protected $connection;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCP\AppFramework\Utility\ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\AppFramework\Utility\ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $timeFactory;
 
-	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
 
 	protected function setUp() {

--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -43,18 +43,18 @@ use Test\TestCase;
 
 class SyncBackendTest extends TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
-	/** @var AccountMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AccountMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $mapper;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 	/** @var SyncBackend */
 	private $command;
 
-	/** @var UserInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var UserInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $dummyBackend;
 
 	public function setUp() {

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -174,7 +174,7 @@ class AdapterTest extends \Test\TestCase {
 		$ex = $this->createMock(AbstractDriverException::class);
 		$ex->expects($this->exactly(1))->method('getErrorCode')->willReturn(1214);
 		// Wrap the exception in a doctrine exception
-		/** @var  DriverException|\PHPUnit_Framework_MockObject_MockObject $ex */
+		/** @var  DriverException|\PHPUnit\Framework\MockObject\MockObject $ex */
 		$e = new \Doctrine\DBAL\Exception\DriverException('1214', $ex);
 		// Should be called 5 times for maxTry then kick out the exception
 		$qb->expects($this->exactly(1))->method('execute')->willThrowException($e);

--- a/tests/lib/DB/LegacyDBTest.php
+++ b/tests/lib/DB/LegacyDBTest.php
@@ -280,7 +280,7 @@ class LegacyDBTest extends \Test\TestCase {
 	 * Insert, select and delete decimal(12,2) values
 	 * @dataProvider decimalData
 	 */
-	public function testDecimal($insert, $expect) {
+	public function testDecimal($insert, $expect1, $expect2 = null) {
 		$table = "*PREFIX*" . $this->table4;
 		$rowname = 'decimaltest';
 
@@ -292,7 +292,17 @@ class LegacyDBTest extends \Test\TestCase {
 		$this->assertTrue((bool)$result);
 		$row = $result->fetchRow();
 		$this->assertArrayHasKey($rowname, $row);
-		$this->assertEquals($expect, $row[$rowname]);
+		if ($expect2 === null) {
+			$this->assertEquals($expect1, $row[$rowname]);
+		} else {
+			$this->assertThat(
+				$row[$rowname],
+				$this->logicalOr(
+					$this->equalTo($expect1),
+					$this->equalTo($expect2)
+				)
+			);
+		}
 		$query = OC_DB::prepare('DELETE FROM `' . $table . '`');
 		$result = $query->execute();
 		$this->assertTrue((bool)$result);
@@ -301,7 +311,7 @@ class LegacyDBTest extends \Test\TestCase {
 	public function decimalData() {
 		return [
 			['1337133713.37', '1337133713.37'],
-			['1234567890', '1234567890.00'],
+			['1234567890', '1234567890.00', '1234567890'],
 		];
 	}
 

--- a/tests/lib/DB/MDB2SchemaReaderTest.php
+++ b/tests/lib/DB/MDB2SchemaReaderTest.php
@@ -32,7 +32,7 @@ class MDB2SchemaReaderTest extends TestCase {
 	 * @return IConfig
 	 */
 	protected function getConfig() {
-		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+		/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject $config */
 		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -23,9 +23,9 @@ use OCP\Migration\ISqlMigration;
  */
 class MigrationsTest extends \Test\TestCase {
 
-	/** @var MigrationService | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var MigrationService | \PHPUnit\Framework\MockObject\MockObject */
 	private $migrationService;
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IDBConnection $db */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IDBConnection $db */
 	private $db;
 
 	public function setUp() {

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -59,25 +59,25 @@ use Test\Traits\UserTrait;
  */
 class DecryptAllTest extends TestCase {
 	use UserTrait;
-	/** @var \PHPUnit_Framework_MockObject_MockObject | IUserManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | IUserManager */
 	protected $userManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | Manager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | Manager */
 	protected $encryptionManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | View */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | View */
 	protected $view;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | ILogger */
 	protected $logger;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | \Symfony\Component\Console\Input\InputInterface */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Input\InputInterface */
 	protected $inputInterface;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | \Symfony\Component\Console\Output\OutputInterface */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Output\OutputInterface */
 	protected $outputInterface;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OCP\UserInterface */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | \OCP\UserInterface */
 	protected $userInterface;
 
 	/** @var  DecryptAll */
@@ -111,7 +111,7 @@ class DecryptAllTest extends TestCase {
 	}
 
 	public function testDecryptAllFailsToDecrypt() {
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject |  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -154,7 +154,7 @@ class DecryptAllTest extends TestCase {
 		} else {
 			$this->userManager->expects($this->never())->method('userExists');
 		}
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject |  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -242,7 +242,7 @@ class DecryptAllTest extends TestCase {
 
 	public function testNoUsersSeen() {
 		$this->createUser('user1', 'user1');
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject |  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -275,7 +275,7 @@ class DecryptAllTest extends TestCase {
 	 */
 	public function testDecryptAllUsersFiles($user) {
 
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject |  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -418,7 +418,7 @@ class DecryptAllTest extends TestCase {
 
 		$userManager = new \OC\User\Manager($iConfig, $this->logger, $accountMapper, $syncService, $utilSearch);
 		$user = '';
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject |  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -475,7 +475,7 @@ class DecryptAllTest extends TestCase {
 				return ($storage instanceof $className);
 			}));
 
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -540,7 +540,7 @@ class DecryptAllTest extends TestCase {
 	public function testDecryptFile() {
 		$path = 'test.txt';
 
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -595,7 +595,7 @@ class DecryptAllTest extends TestCase {
 
 		$path = '/user1/files/test.txt';
 
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[
@@ -622,7 +622,7 @@ class DecryptAllTest extends TestCase {
 	public function testDecryptFileFailure() {
 		$path = 'test.txt';
 
-		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject  $instance */
+		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
 			->setConstructorArgs(
 				[

--- a/tests/lib/Encryption/EncryptionWrapperTest.php
+++ b/tests/lib/Encryption/EncryptionWrapperTest.php
@@ -29,13 +29,13 @@ class EncryptionWrapperTest extends TestCase {
 	/** @var  EncryptionWrapper */
 	private $instance;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OCP\ILogger */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | \OCP\ILogger */
 	private $logger;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OC\Encryption\Manager */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | \OC\Encryption\Manager */
 	private $manager;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OC\Memcache\ArrayCache */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | \OC\Memcache\ArrayCache */
 	private $arrayCache;
 
 	public function setUp() {

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -44,13 +44,13 @@ class StorageTest extends TestCase {
 	/** @var Storage */
 	protected $storage;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | Util */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | Util */
 	protected $util;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject | View */
+	/** @var \PHPUnit\Framework\MockObject\MockObject | View */
 	protected $view;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
 	public function setUp() {
@@ -72,7 +72,7 @@ class StorageTest extends TestCase {
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user1');
-		/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession->method('getUser')->willReturn($user);
 

--- a/tests/lib/Encryption/ManagerTest.php
+++ b/tests/lib/Encryption/ManagerTest.php
@@ -10,22 +10,22 @@ class ManagerTest extends TestCase {
 	/** @var Manager */
 	private $manager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	private $l10n;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	private $view;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	private $util;
 	
-	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OC\Memcache\ArrayCache */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | \OC\Memcache\ArrayCache */
 	private $arrayCache;
 
 	public function setUp() {

--- a/tests/lib/Encryption/UpdateTest.php
+++ b/tests/lib/Encryption/UpdateTest.php
@@ -32,22 +32,22 @@ class UpdateTest extends TestCase {
 	/** @var string */
 	private $uid;
 
-	/** @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject */
 	private $view;
 
-	/** @var \OC\Encryption\Util | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Encryption\Util | \PHPUnit\Framework\MockObject\MockObject */
 	private $util;
 
-	/** @var \OC\Files\Mount\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Files\Mount\Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $mountManager;
 
-	/** @var \OC\Encryption\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Encryption\Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $encryptionManager;
 
-	/** @var \OCP\Encryption\IEncryptionModule | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Encryption\IEncryptionModule | \PHPUnit\Framework\MockObject\MockObject */
 	private $encryptionModule;
 
-	/** @var \OC\Encryption\File | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Encryption\File | \PHPUnit\Framework\MockObject\MockObject */
 	private $fileHelper;
 
 	protected function setUp() {
@@ -209,7 +209,7 @@ class UpdateTest extends TestCase {
 	 * create mock of the update method
 	 *
 	 * @param array$methods methods which should be set
-	 * @return \OC\Encryption\Update | \PHPUnit_Framework_MockObject_MockObject
+	 * @return \OC\Encryption\Update | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getUpdateMock($methods) {
 		return  $this->getMockBuilder('\OC\Encryption\Update')

--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -14,16 +14,16 @@ class UtilTest extends TestCase {
 	 */
 	protected $headerSize = 8192;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $view;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
 	/** @var  \OC\Encryption\Util */

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -492,7 +492,7 @@ class CacheTest extends TestCase {
 		$folderWith0308 = "\x53\x63\x68\x6f\xcc\x88\x6e";
 
 		/**
-		 * @var Cache | \PHPUnit_Framework_MockObject_MockObject $cacheMock
+		 * @var Cache | \PHPUnit\Framework\MockObject\MockObject $cacheMock
 		 */
 		$cacheMock = $this->getMockBuilder('\OC\Files\Cache\Cache')
 			->setMethods(['normalize'])

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -387,7 +387,7 @@ class ScannerTest extends \Test\TestCase {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function testUnLockInCaseOfExceptionInScanFile() {
-		/** @var Storage | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Storage | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->createMock(Storage::class);
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
@@ -412,7 +412,7 @@ class ScannerTest extends \Test\TestCase {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function testUnLockInCaseOfExceptionInScan() {
-		/** @var Storage | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Storage | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->createMock(Storage::class);
 		$storage->expects($this->any())
 			->method('instanceOfStorage')

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -60,7 +60,7 @@ class UserMountCacheTest extends TestCase {
 
 		/** @var IConfig $config */
 		$config = $this->createMock(IConfig::class);
-		/** @var AccountMapper | \PHPUnit_Framework_MockObject_MockObject $accountMapper */
+		/** @var AccountMapper | \PHPUnit\Framework\MockObject\MockObject $accountMapper */
 		$accountMapper = $this->createMock(AccountMapper::class);
 		$a1 = new Account();
 		$a1->setId(1);

--- a/tests/lib/Files/External/Auth/Password/SessionCredentialsTest.php
+++ b/tests/lib/Files/External/Auth/Password/SessionCredentialsTest.php
@@ -29,13 +29,13 @@ use OCP\IUser;
 
 class SessionCredentialsTest extends \Test\TestCase {
 
-	/** @var SessionCredentials | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var SessionCredentials | \PHPUnit\Framework\MockObject\MockObject */
 	private $authMech;
 
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
 
-	/** @var ICrypto | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICrypto | \PHPUnit\Framework\MockObject\MockObject */
 	private $crypto;
 
 	public function setUp() {

--- a/tests/lib/Files/External/ConfigAdapterTest.php
+++ b/tests/lib/Files/External/ConfigAdapterTest.php
@@ -37,7 +37,7 @@ use OC\Files\External\StorageConfig;
 
 class ConfigAdapterTest extends \Test\TestCase {
 
-	/** @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
 	/** @var IUserStoragesService */
@@ -46,10 +46,10 @@ class ConfigAdapterTest extends \Test\TestCase {
 	/** @var IUserGlobalStoragesService */
 	private $userGlobalStoragesService;
 
-	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject **/
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject **/
 	private $user;
 
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject **/
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject **/
 	private $session;
 
 	/** @var int */

--- a/tests/lib/Files/External/Service/StoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/StoragesServiceTest.php
@@ -65,7 +65,7 @@ abstract class StoragesServiceTest extends TestCase {
 	protected static $hookCalls;
 
 	/**
-	 * @var \PHPUnit_Framework_MockObject_MockObject | \OCP\Files\Config\IUserMountCache
+	 * @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Files\Config\IUserMountCache
 	 */
 	protected $mountCache;
 

--- a/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
@@ -37,7 +37,7 @@ use Test\Traits\UserTrait;
 class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 	use UserTrait;
 
-	/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject groupManager */
+	/** @var \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject groupManager */
 	protected $groupManager;
 
 	/**
@@ -62,7 +62,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		$this->globalStoragesService = $this->service;
 
 		$this->user = $this->createUser(self::USER_ID, self::USER_ID);
-		/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock('\OCP\IUserSession');
 		$userSession
 			->expects($this->any())

--- a/tests/lib/Files/External/Service/UserStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserStoragesServiceTest.php
@@ -59,7 +59,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 		$this->userId = $this->getUniqueID('user_');
 		$this->user = $this->createUser($this->userId, $this->userId);
 
-		/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock('\OCP\IUserSession');
 		$userSession
 			->expects($this->any())

--- a/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
+++ b/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
@@ -12,13 +12,13 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 	/** @var ObjectHomeMountProvider */
 	protected $provider;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var IUser|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
 	protected $user;
 
-	/** @var IStorageFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IStorageFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $loader;
 
 	public function setUp() {

--- a/tests/lib/Files/Node/AbstractFileTest.php
+++ b/tests/lib/Files/Node/AbstractFileTest.php
@@ -27,7 +27,7 @@ use Test\TestCase;
 
 class AbstractFileTest extends TestCase {
 	public function testMime() {
-		/** @var AbstractFile | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var AbstractFile | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = new AbstractFile();
 		$this->assertEquals('application/octet-stream', $node->getMimetype());
 		$this->assertEquals('application', $node->getMimePart());
@@ -39,7 +39,7 @@ class AbstractFileTest extends TestCase {
 	 * @dataProvider providesOperations
 	 */
 	public function testOperations($operation) {
-		/** @var AbstractFile | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var AbstractFile | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockForAbstractClass(AbstractFile::class);
 		$node->$operation('');
 	}

--- a/tests/lib/Files/Node/AbstractFolderTest.php
+++ b/tests/lib/Files/Node/AbstractFolderTest.php
@@ -27,7 +27,7 @@ use Test\TestCase;
 
 class AbstractFolderTest extends TestCase {
 	public function testMimeAndGetType() {
-		/** @var AbstractFolder | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var AbstractFolder | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockForAbstractClass(AbstractFolder::class);
 		$this->assertEquals('httpd/unix-directory', $node->getMimetype());
 		$this->assertEquals('httpd', $node->getMimePart());
@@ -39,7 +39,7 @@ class AbstractFolderTest extends TestCase {
 	 * @dataProvider providesOperations
 	 */
 	public function testOperations($operation) {
-		/** @var AbstractFolder | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var AbstractFolder | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockForAbstractClass(AbstractFolder::class);
 		$node->$operation('', '');
 	}

--- a/tests/lib/Files/Node/AbstractNodeTest.php
+++ b/tests/lib/Files/Node/AbstractNodeTest.php
@@ -26,7 +26,7 @@ use Test\TestCase;
 
 class AbstractNodeTest extends TestCase {
 	public function testMime() {
-		/** @var AbstractNode | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var AbstractNode | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockForAbstractClass(AbstractNode::class);
 		$node->expects($this->any())->method('getMimetype')->willReturn('foo/bar');
 		$this->assertEquals('foo/bar', $node->getMimetype());
@@ -38,7 +38,7 @@ class AbstractNodeTest extends TestCase {
 	 * @dataProvider providesOperations
 	 */
 	public function testOperations($operation) {
-		/** @var AbstractNode | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var AbstractNode | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockForAbstractClass(AbstractNode::class);
 		$node->$operation('');
 	}

--- a/tests/lib/Files/Node/FileTest.php
+++ b/tests/lib/Files/Node/FileTest.php
@@ -35,7 +35,7 @@ class FileTest extends NodeTest {
 		/** @var Manager $manager */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new Root($manager, $view, $this->user);
@@ -65,9 +65,9 @@ class FileTest extends NodeTest {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testGetContentNotPermitted() {
-		/** @var View | \PHPUnit_Framework_MockObject_MockObject $view */
+		/** @var View | \PHPUnit\Framework\MockObject\MockObject $view */
 		$view = $this->createMock(View::class);
-		/** @var Root | \PHPUnit_Framework_MockObject_MockObject $root */
+		/** @var Root | \PHPUnit\Framework\MockObject\MockObject $root */
 		$root = $this->createMock(Root::class);
 
 		$root->expects($this->any())
@@ -84,9 +84,9 @@ class FileTest extends NodeTest {
 	}
 
 	public function testPutContent() {
-		/** @var View | \PHPUnit_Framework_MockObject_MockObject $view */
+		/** @var View | \PHPUnit\Framework\MockObject\MockObject $view */
 		$view = $this->createMock(View::class);
-		/** @var Root | \PHPUnit_Framework_MockObject_MockObject $root */
+		/** @var Root | \PHPUnit\Framework\MockObject\MockObject $root */
 		$root = $this->createMock(Root::class);
 
 		$root->expects($this->any())
@@ -111,9 +111,9 @@ class FileTest extends NodeTest {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testPutContentNotPermitted() {
-		/** @var View | \PHPUnit_Framework_MockObject_MockObject $view */
+		/** @var View | \PHPUnit\Framework\MockObject\MockObject $view */
 		$view = $this->createMock(View::class);
-		/** @var Root | \PHPUnit_Framework_MockObject_MockObject $root */
+		/** @var Root | \PHPUnit\Framework\MockObject\MockObject $root */
 		$root = $this->createMock(Root::class);
 
 		$view->expects($this->once())
@@ -126,9 +126,9 @@ class FileTest extends NodeTest {
 	}
 
 	public function testGetMimeType() {
-		/** @var View | \PHPUnit_Framework_MockObject_MockObject $view */
+		/** @var View | \PHPUnit\Framework\MockObject\MockObject $view */
 		$view = $this->createMock(View::class);
-		/** @var Root | \PHPUnit_Framework_MockObject_MockObject $root */
+		/** @var Root | \PHPUnit\Framework\MockObject\MockObject $root */
 		$root = $this->createMock(Root::class);
 
 		$view->expects($this->once())
@@ -150,7 +150,7 @@ class FileTest extends NodeTest {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new Root($manager, $view, $this->user);
@@ -186,7 +186,7 @@ class FileTest extends NodeTest {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new Root($manager, new $view, $this->user);
@@ -227,7 +227,7 @@ class FileTest extends NodeTest {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new Root($manager, $view, $this->user);
@@ -254,7 +254,7 @@ class FileTest extends NodeTest {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new Root($manager, $view, $this->user);
@@ -281,7 +281,7 @@ class FileTest extends NodeTest {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new Root($manager, new $view, $this->user);
@@ -303,7 +303,7 @@ class FileTest extends NodeTest {
 		/** @var Manager $manager */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new Root($manager, $view, $this->user);

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -35,7 +35,7 @@ class FolderTest extends NodeTest {
 	public function testGetDirectoryContent() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -67,7 +67,7 @@ class FolderTest extends NodeTest {
 	public function testGet() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -88,7 +88,7 @@ class FolderTest extends NodeTest {
 	public function testNodeExists() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -112,7 +112,7 @@ class FolderTest extends NodeTest {
 	public function testNodeExistsNotExists() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -134,7 +134,7 @@ class FolderTest extends NodeTest {
 	public function testNewFolder() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -166,7 +166,7 @@ class FolderTest extends NodeTest {
 	public function testNewFolderNotPermitted() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -188,7 +188,7 @@ class FolderTest extends NodeTest {
 	public function testNewFile() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -220,7 +220,7 @@ class FolderTest extends NodeTest {
 	public function testNewFileNotPermitted() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -242,7 +242,7 @@ class FolderTest extends NodeTest {
 	public function testGetFreeSpace() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -264,7 +264,7 @@ class FolderTest extends NodeTest {
 	public function testSearch() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -316,7 +316,7 @@ class FolderTest extends NodeTest {
 	public function testSearchInRoot() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -370,7 +370,7 @@ class FolderTest extends NodeTest {
 	public function testSearchInStorageRoot() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -420,7 +420,7 @@ class FolderTest extends NodeTest {
 	public function testSearchByTag() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -471,7 +471,7 @@ class FolderTest extends NodeTest {
 	public function testSearchSubStorages() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -553,7 +553,7 @@ class FolderTest extends NodeTest {
 	public function testGetById() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -600,7 +600,7 @@ class FolderTest extends NodeTest {
 	public function testGetByIdOutsideFolder() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -641,7 +641,7 @@ class FolderTest extends NodeTest {
 	public function testGetByIdMultipleStorages() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -702,7 +702,7 @@ class FolderTest extends NodeTest {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		$folderPath = '/bar/foo';
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')

--- a/tests/lib/Files/Node/NodeTest.php
+++ b/tests/lib/Files/Node/NodeTest.php
@@ -49,7 +49,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testDelete() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 
@@ -106,7 +106,7 @@ abstract class NodeTest extends TestCase {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
@@ -138,7 +138,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testDeleteNotPermitted() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -158,7 +158,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testStat() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -185,7 +185,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetId() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -211,7 +211,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetSize() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -237,7 +237,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetEtag() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -263,7 +263,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetMTime() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -289,7 +289,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetStorage() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -297,7 +297,7 @@ abstract class NodeTest extends TestCase {
 			->method('getUser')
 			->will($this->returnValue($this->user));
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit_Framework_MockObject_MockObject $storage
+		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->createMock(Storage::class);
 
@@ -312,7 +312,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetPath() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -326,7 +326,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetInternalPath() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -334,7 +334,7 @@ abstract class NodeTest extends TestCase {
 			->method('getUser')
 			->will($this->returnValue($this->user));
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit_Framework_MockObject_MockObject $storage
+		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->createMock(Storage::class);
 
@@ -349,7 +349,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testGetName() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -363,7 +363,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testTouchSetMTime() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -412,7 +412,7 @@ abstract class NodeTest extends TestCase {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
@@ -444,7 +444,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testTouchNotPermitted() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -466,7 +466,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testInvalidPath() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -477,7 +477,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testCopySameStorage() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -512,12 +512,12 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testCopyNotPermitted() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit_Framework_MockObject_MockObject $storage
+		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->createMock(Storage::class);
 
@@ -548,7 +548,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testCopyNoParent() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -571,7 +571,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testCopyParentIsFile() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -593,7 +593,7 @@ abstract class NodeTest extends TestCase {
 
 	public function testMoveSameStorage() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -638,7 +638,7 @@ abstract class NodeTest extends TestCase {
 		 */
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->getMockBuilder(Root::class)
@@ -719,7 +719,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testMoveNotPermitted() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -747,12 +747,12 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testMoveNoParent() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit_Framework_MockObject_MockObject $storage
+		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->createMock(Storage::class);
 
@@ -775,7 +775,7 @@ abstract class NodeTest extends TestCase {
 	public function testMoveParentIsFile() {
 		/**
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -799,7 +799,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testMoveFailed() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);
@@ -828,7 +828,7 @@ abstract class NodeTest extends TestCase {
 	 */
 	public function testCopyFailed() {
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->createMock(Root::class);

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -38,7 +38,7 @@ class RootTest extends TestCase {
 		 */
 		$storage = $this->createMock('\OC\Files\Storage\Storage');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
@@ -64,7 +64,7 @@ class RootTest extends TestCase {
 		 */
 		$storage = $this->createMock('\OC\Files\Storage\Storage');
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
@@ -84,7 +84,7 @@ class RootTest extends TestCase {
 	public function testGetInvalidPath() {
 		$manager = new Manager();
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
@@ -98,7 +98,7 @@ class RootTest extends TestCase {
 	public function testGetNoStorages() {
 		$manager = new Manager();
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
@@ -113,7 +113,7 @@ class RootTest extends TestCase {
 		$this->logout();
 		$manager = new Manager();
 		/**
-		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$view = new \OC\Files\View();
 

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -40,9 +40,9 @@ use Test\TestCase;
  */
 class ObjectStoreTest extends TestCase {
 
-	/** @var IObjectStore | IVersionedObjectStorage | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IObjectStore | IVersionedObjectStorage | \PHPUnit\Framework\MockObject\MockObject */
 	private $impl;
-	/** @var ObjectStoreStorage | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ObjectStoreStorage | \PHPUnit\Framework\MockObject\MockObject */
 	private $objectStore;
 
 	public function setUp() {

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -85,7 +85,9 @@ class PathVerificationTest extends \Test\TestCase {
 			$this->expectException(InvalidPathException::class);
 			$this->expectExceptionMessage('4-byte characters are not supported in file names');
 		}
-		$this->view->verifyPath('', $fileName);
+		$this->assertNull(
+			$this->view->verifyPath('', $fileName)
+		);
 	}
 
 	public function providesAstralPlane() {

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -50,37 +50,37 @@ use Test\TestCase;
 class DavTest extends TestCase {
 
 	/**
-	 * @var DAV | \PHPUnit_Framework_MockObject_MockObject
+	 * @var DAV | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $instance;
 
 	/**
-	 * @var IClientService | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IClientService | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $httpClientService;
 
 	/**
-	 * @var IWebDavClientService | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IWebDavClientService | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $webDavClientService;
 
 	/**
-	 * @var Client | \PHPUnit_Framework_MockObject_MockObject
+	 * @var Client | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $davClient;
 
 	/**
-	 * @var IClient | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IClient | \PHPUnit\Framework\MockObject\MockObject
 	 **/
 	private $httpClient;
 
 	/**
-	 * @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject
+	 * @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $timeFactory;
 
 	/**
-	 * @var Cache | \PHPUnit_Framework_MockObject_MockObject
+	 * @var Cache | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $cache;
 

--- a/tests/lib/Files/Storage/FileTest.php
+++ b/tests/lib/Files/Storage/FileTest.php
@@ -31,7 +31,7 @@ use OCP\Files\Storage\IStorage;
 class FileTest extends NodeTest {
 	/**
 	 * @param $path
-	 * @param IStorage|\PHPUnit_Framework_MockObject_MockObject|null $storage
+	 * @param IStorage|\PHPUnit\Framework\MockObject\MockObject|null $storage
 	 * @return File
 	 */
 	protected function createTestNode($path, IStorage $storage = null) {

--- a/tests/lib/Files/Storage/FolderTest.php
+++ b/tests/lib/Files/Storage/FolderTest.php
@@ -34,7 +34,7 @@ class FolderTest extends NodeTest {
 
 	/**
 	 * @param $path
-	 * @param IStorage|\PHPUnit_Framework_MockObject_MockObject|null $storage
+	 * @param IStorage|\PHPUnit\Framework\MockObject\MockObject|null $storage
 	 * @return Folder
 	 */
 	protected function createTestNode($path, IStorage $storage = null) {

--- a/tests/lib/Files/Storage/NodeTest.php
+++ b/tests/lib/Files/Storage/NodeTest.php
@@ -35,7 +35,7 @@ abstract class NodeTest extends TestCase {
 	protected $viewDeleteMethod = 'unlink';
 	protected $user;
 	/**
-	 * @var IStorage|\PHPUnit_Framework_MockObject_MockObject
+	 * @var IStorage|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected $storage;
 

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -34,71 +34,71 @@ class EncryptionTest extends Storage {
 	private $sourceStorage;
 
 	/**
-	 * @var \OC\Files\Storage\Wrapper\Encryption | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Files\Storage\Wrapper\Encryption | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected $instance;
 
 	/**
-	 * @var \OC\Encryption\Keys\Storage | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Encryption\Keys\Storage | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $keyStore;
 
 	/**
-	 * @var \OC\Encryption\Util | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Encryption\Util | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $util;
 
 	/**
-	 * @var \OC\Encryption\Manager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Encryption\Manager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $encryptionManager;
 
 	/**
-	 * @var \OCP\Encryption\IEncryptionModule | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OCP\Encryption\IEncryptionModule | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $encryptionModule;
 
 	/**
-	 * @var \OC\Encryption\Update | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Encryption\Update | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $update;
 
 	/**
-	 * @var \OC\Files\Cache\Cache | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Files\Cache\Cache | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $cache;
 
 	/**
-	 * @var \OC\Log | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Log | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $logger;
 
 	/**
-	 * @var \OC\Encryption\File | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Encryption\File | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $file;
 
 	/**
-	 * @var \OC\Files\Mount\MountPoint | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Files\Mount\MountPoint | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $mount;
 
 	/**
-	 * @var \OC\Files\Mount\Manager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Files\Mount\Manager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $mountManager;
 
 	/**
-	 * @var \OC\Group\Manager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OC\Group\Manager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $groupManager;
 
 	/**
-	 * @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject
+	 * @var \OCP\IConfig | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $config;
 
-	/** @var  \OC\Memcache\ArrayCache | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  \OC\Memcache\ArrayCache | \PHPUnit\Framework\MockObject\MockObject */
 	private $arrayCache;
 
 	/** @var  integer dummy unencrypted size */
@@ -209,7 +209,7 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function buildMockModule() {
 		$this->encryptionModule = $this->getMockBuilder(IEncryptionModule::class)
@@ -841,7 +841,7 @@ class EncryptionTest extends Storage {
 
 		$mountPoint = '/mountPoint';
 
-		/** @var \OC\Files\Storage\Wrapper\Encryption |\PHPUnit_Framework_MockObject_MockObject  $instance */
+		/** @var \OC\Files\Storage\Wrapper\Encryption |\PHPUnit\Framework\MockObject\MockObject  $instance */
 		$instance = $this->getMockBuilder(Encryption::class)
 			->setConstructorArgs(
 				[

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -76,7 +76,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 	}
 
 	public function testFreeSpaceWithUnknownDiskSpace() {
-		/** @var Local | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Local | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Local::class)
 			->setMethods(['free_space'])
 			->setConstructorArgs([['datadir' => $this->tmpDir]])

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -8,7 +8,7 @@ use Test\TestCase;
 
 class EncryptionTest extends TestCase {
 
-	/** @var  \OCP\Encryption\IEncryptionModule | \PHPUnit_Framework_MockObject_MockObject  */
+	/** @var  \OCP\Encryption\IEncryptionModule | \PHPUnit\Framework\MockObject\MockObject  */
 	private $encryptionModule;
 
 	/**
@@ -305,7 +305,7 @@ class EncryptionTest extends TestCase {
 	}
 
 	/**
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function buildMockModule() {
 		$encryptionModule = $this->getMockBuilder('\OCP\Encryption\IEncryptionModule')

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1197,7 +1197,7 @@ class ViewTest extends TestCase {
 
 	private function doTestCopyRenameFail($operation) {
 		$storage1 = new Temporary([]);
-		/** @var \PHPUnit_Framework_MockObject_MockObject | Temporary $storage2 */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | Temporary $storage2 */
 		$storage2 = $this->getMockBuilder(TemporaryNoCross::class)
 			->setConstructorArgs([[]])
 			->setMethods(['fopen'])
@@ -1206,7 +1206,7 @@ class ViewTest extends TestCase {
 		$storage2->expects($this->any())
 			->method('fopen')
 			->will($this->returnCallback(function ($path, $mode) use ($storage2) {
-				/** @var \PHPUnit_Framework_MockObject_MockObject | Temporary $storage2 */
+				/** @var \PHPUnit\Framework\MockObject\MockObject | Temporary $storage2 */
 				$source = \fopen($storage2->getSourcePath($path), $mode);
 				return \OC\Files\Stream\Quota::wrap($source, 9);
 			}));
@@ -1249,7 +1249,7 @@ class ViewTest extends TestCase {
 
 	public function testDeleteFailKeepCache() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | Temporary $storage
+		 * @var \PHPUnit\Framework\MockObject\MockObject | Temporary $storage
 		 */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setConstructorArgs([[]])
@@ -1850,7 +1850,7 @@ class ViewTest extends TestCase {
 	) {
 		$view = new View('/' . $this->user . '/files/');
 
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation])
 			->getMock();
@@ -1906,7 +1906,7 @@ class ViewTest extends TestCase {
 		$view = new View('/' . $this->user . '/files/');
 
 		$path = 'test_file_put_contents.txt';
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['fopen'])
 			->getMock();
@@ -1938,7 +1938,7 @@ class ViewTest extends TestCase {
 		$view = new View('/' . $this->user . '/files/');
 
 		$path = 'test_file_put_contents.txt';
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['fopen'])
 			->getMock();
@@ -1997,7 +1997,7 @@ class ViewTest extends TestCase {
 		$view = new View('/' . $this->user . '/files/');
 
 		$path = 'test_file_put_contents.txt';
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['fopen'])
 			->getMock();
@@ -2049,7 +2049,7 @@ class ViewTest extends TestCase {
 	) {
 		$view = new View('/' . $this->user . '/files/');
 
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation])
 			->getMock();
@@ -2103,7 +2103,7 @@ class ViewTest extends TestCase {
 	) {
 		$view = new View('/' . $this->user . '/files/');
 
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation])
 			->getMock();
@@ -2142,7 +2142,7 @@ class ViewTest extends TestCase {
 	public function testLockFileRename($operation, $expectedLockTypeSourceDuring) {
 		$view = new View('/' . $this->user . '/files/');
 
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation, 'filemtime'])
 			->getMock();
@@ -2198,7 +2198,7 @@ class ViewTest extends TestCase {
 	public function testLockFileCopyException() {
 		$view = new View('/' . $this->user . '/files/');
 
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['copy'])
 			->getMock();
@@ -2317,11 +2317,11 @@ class ViewTest extends TestCase {
 	public function testLockFileRenameCrossStorage($viewOperation, $storageOperation, $expectedLockTypeSourceDuring) {
 		$view = new View('/' . $this->user . '/files/');
 
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$storageOperation])
 			->getMock();
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage2 */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage2 */
 		$storage2 = $this->getMockBuilder(Temporary::class)
 			->setMethods([$storageOperation, 'filemtime'])
 			->getMock();
@@ -2657,7 +2657,7 @@ class ViewTest extends TestCase {
 		// since stream wrappers influence the streams,
 		// this test makes sure that all stream wrappers properly return a failure
 		// to the caller instead of wrapping the boolean
-		/** @var Temporary | \PHPUnit_Framework_MockObject_MockObject $storage */
+		/** @var Temporary | \PHPUnit\Framework\MockObject\MockObject $storage */
 		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['fopen'])
 			->getMock();

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -146,7 +146,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGet() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
@@ -167,7 +167,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetNotExists() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
@@ -193,7 +193,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetMultipleBackends() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend1
 		 */
 		$backend1 = $this->getTestBackend();
 		$backend1->expects($this->any())
@@ -202,7 +202,7 @@ class ManagerTest extends \Test\TestCase {
 			->will($this->returnValue(false));
 
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
 		 */
 		$backend2 = $this->getTestBackend();
 		$backend2->expects($this->any())
@@ -220,7 +220,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testCreate() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backendGroupCreated = false;
 		$backend = $this->getTestBackend();
@@ -245,7 +245,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testCreateWithDispatcher() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backendGroupCreated = false;
 		$backend = $this->getTestBackend();
@@ -285,7 +285,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testCreateExists() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
@@ -303,7 +303,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testCreateExistsWithDispatcher() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
@@ -333,7 +333,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testSearch() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
@@ -355,7 +355,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testSearchMultipleBackends() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend1
 		 */
 		$backend1 = $this->getTestBackend();
 		$backend1->expects($this->once())
@@ -367,7 +367,7 @@ class ManagerTest extends \Test\TestCase {
 			->will($this->returnValue(true));
 
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
 		 */
 		$backend2 = $this->getTestBackend();
 		$backend2->expects($this->once())
@@ -391,7 +391,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testSearchMultipleBackendsLimitAndOffset() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend1
 		 */
 		$backend1 = $this->getTestBackend();
 		$backend1->expects($this->once())
@@ -403,7 +403,7 @@ class ManagerTest extends \Test\TestCase {
 			->will($this->returnValue(true));
 
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
 		 */
 		$backend2 = $this->getTestBackend();
 		$backend2->expects($this->once())
@@ -427,7 +427,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testSearchResultExistsButGroupDoesNot() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->createMock(Database::class);
 		$backend->expects($this->once())
@@ -450,7 +450,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testSearchBackendsForScope() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend1
 		 */
 		$backend1 = $this->getTestBackend();
 		$backend1->expects($this->any())
@@ -462,7 +462,7 @@ class ManagerTest extends \Test\TestCase {
 			->will($this->returnValue(true));
 
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
 		 */
 		$backend2 = $this->getTestBackend(null, [
 			[null, false],
@@ -496,7 +496,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetUserGroups() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
@@ -517,7 +517,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testGetUserGroupIds() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Group\Manager $manager */
+		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Group\Manager $manager */
 		$manager = $this->getMockBuilder('OC\Group\Manager')
 			->disableOriginalConstructor()
 			->setMethods(['getUserGroups'])
@@ -544,7 +544,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetUserGroupsWithDeletedGroup() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->createMock(Database::class);
 		$backend->expects($this->once())
@@ -568,7 +568,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetUserGroupsWithScope() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend(null, [
 			[null, false],
@@ -596,7 +596,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testIsInGroup() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
@@ -614,7 +614,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testInGroup() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
@@ -641,7 +641,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testNotInGroup() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
@@ -668,7 +668,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testIsAdmin() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
@@ -686,7 +686,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testNotAdmin() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
@@ -704,7 +704,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetUserGroupsMultipleBackends() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend1
 		 */
 		$backend1 = $this->getTestBackend();
 		$backend1->expects($this->once())
@@ -716,7 +716,7 @@ class ManagerTest extends \Test\TestCase {
 			->will($this->returnValue(true));
 
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
 		 */
 		$backend2 = $this->getTestBackend();
 		$backend2->expects($this->once())
@@ -740,7 +740,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDisplayNamesInGroupWithOneUserBackend() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -797,7 +797,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDisplayNamesInGroupWithOneUserBackendWithLimitSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -857,7 +857,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDisplayNamesInGroupWithOneUserBackendWithLimitAndOffsetSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -920,7 +920,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDisplayNamesInGroupWithOneUserBackendAndSearchEmpty() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -958,7 +958,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDisplayNamesInGroupWithOneUserBackendAndSearchEmptyAndLimitSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -996,7 +996,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDisplayNamesInGroupWithOneUserBackendAndSearchEmptyAndLimitAndOffsetSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -1034,7 +1034,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetUserGroupsWithAddUser() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$expectedGroups = [];
@@ -1070,7 +1070,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetUserGroupsWithRemoveUser() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$expectedGroups = ['group1'];
@@ -1112,7 +1112,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetUserIdGroups() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
@@ -1128,7 +1128,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGroupDisplayName() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend(
 			GroupInterface::ADD_TO_GROUP |
@@ -1162,7 +1162,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testFindUsersInGroupWithOneUserBackend() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -1219,7 +1219,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testFindUsersInGroupWithOneUserBackendWithLimitSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -1279,7 +1279,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testFindUsersInGroupWithOneUserBackendWithLimitAndOffsetSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -1342,7 +1342,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testFindUsersInGroupWithOneUserBackendAndSearchEmpty() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -1380,7 +1380,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testFindUsersInGroupWithOneUserBackendAndSearchEmptyAndLimitSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))
@@ -1418,7 +1418,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testFindUsersInGroupWithOneUserBackendAndSearchEmptyAndLimitAndOffsetSpecified() {
 		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->exactly(1))

--- a/tests/lib/Image/BmpToResourceTest.php
+++ b/tests/lib/Image/BmpToResourceTest.php
@@ -142,7 +142,7 @@ class BmpToResourceTest extends TestCase {
 
 		$instanceMock->method('readFile')
 			->will(
-				new \PHPUnit_Framework_MockObject_Stub_ConsecutiveCalls($values)
+				new \PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls($values)
 			)
 		;
 

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -44,19 +44,19 @@ use Test\TestCase;
  * - Then grab the signature file from "apps/SomeApp/appinfo/signature.json" and copy it into the hard-coded strings.
  */
 class CheckerTest extends TestCase {
-	/** @var EnvironmentHelper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EnvironmentHelper | \PHPUnit\Framework\MockObject\MockObject */
 	private $environmentHelper;
-	/** @var AppLocator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AppLocator | \PHPUnit\Framework\MockObject\MockObject */
 	private $appLocator;
 	/** @var Checker */
 	private $checker;
-	/** @var FileAccessHelper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var FileAccessHelper | \PHPUnit\Framework\MockObject\MockObject */
 	private $fileAccessHelper;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ICacheFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICacheFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $cacheFactory;
-	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $appManager;
 
 	public function setUp() {

--- a/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
+++ b/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
@@ -25,7 +25,7 @@ use OC\IntegrityCheck\Iterator\ExcludeFileByNameFilterIterator;
 use Test\TestCase;
 
 class ExcludeFileByNameFilterIteratorTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockBuilder */
+	/** @var \PHPUnit\Framework\MockObject\Mockbuilder */
 	protected $filter;
 
 	public function setUp() {

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -20,16 +20,16 @@ use Test\TestCase;
  */
 class FactoryTest extends TestCase {
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
 
-	/** @var IThemeService|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IThemeService|\PHPUnit\Framework\MockObject\MockObject */
 	protected $themeService;
 
 	/** @var string */
@@ -60,7 +60,7 @@ class FactoryTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return Factory|\PHPUnit_Framework_MockObject_MockObject
+	 * @return Factory|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getFactory(array $methods = []) {
 		if (!empty($methods)) {

--- a/tests/lib/Lock/Persistent/LockManagerTest.php
+++ b/tests/lib/Lock/Persistent/LockManagerTest.php
@@ -37,13 +37,13 @@ use Test\TestCase;
  * @group DB
  */
 class LockManagerTest extends TestCase {
-	/** @var LockMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var LockMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $lockMapper;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
 	/** @var LockManager */
 	private $manager;
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
 
 	public function setUp() {

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -21,10 +21,10 @@ class LoggerTest extends TestCase {
 	private $logger;
 	private static $logs = [];
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
-	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $eventDispatcher;
 
 	protected function setUp() {

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -16,11 +16,11 @@ use Test\TestCase;
 use OC\Mail\Message;
 
 class MailerTest extends TestCase {
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 	/** @var OC_Defaults */
 	private $defaults;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 	/** @var Mailer */
 	private $mailer;
@@ -80,7 +80,7 @@ class MailerTest extends TestCase {
 	 * @expectedException \Exception
 	 */
 	public function testSendInvalidMailException(): void {
-		/** @var Message | \PHPUnit_Framework_MockObject_MockObject $message */
+		/** @var Message | \PHPUnit\Framework\MockObject\MockObject $message */
 		$message = $this->getMockBuilder(Message::class)
 			->disableOriginalConstructor()->getMock();
 		$message->expects($this->once())
@@ -120,7 +120,7 @@ class MailerTest extends TestCase {
 
 		$this->mailer->method('getInstance')->willReturn($this->createMock(\Swift_SendmailTransport::class));
 
-		/** @var Message | \PHPUnit_Framework_MockObject_MockObject $message */
+		/** @var Message | \PHPUnit\Framework\MockObject\MockObject $message */
 		$message = $this->getMockBuilder(Message::class)
 			->disableOriginalConstructor()->getMock();
 		$message->expects($this->once())

--- a/tests/lib/Migration/BackgroundRepairTest.php
+++ b/tests/lib/Migration/BackgroundRepairTest.php
@@ -56,13 +56,13 @@ class TestRepairStep implements IRepairStep {
 
 class BackgroundRepairTest extends TestCase {
 
-	/** @var \OC\BackgroundJob\JobList | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\BackgroundJob\JobList | \PHPUnit\Framework\MockObject\MockObject */
 	private $jobList;
 
-	/** @var BackgroundRepair | \PHPUnit_Framework_MockObject_MockObject  */
+	/** @var BackgroundRepair | \PHPUnit\Framework\MockObject\MockObject  */
 	private $job;
 
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	public function setUp() {
@@ -105,7 +105,7 @@ class BackgroundRepairTest extends TestCase {
 	}
 
 	public function testWorkingStep() {
-		/** @var EventDispatcher | \PHPUnit_Framework_MockObject_MockObject $dispatcher */
+		/** @var EventDispatcher | \PHPUnit\Framework\MockObject\MockObject $dispatcher */
 		$dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcher');
 		$dispatcher->expects($this->once())->method('dispatch')
 			->with('\OC\Repair::step', new GenericEvent('\OC\Repair::step', ['A test repair step']));

--- a/tests/lib/Notification/ManagerTest.php
+++ b/tests/lib/Notification/ManagerTest.php
@@ -411,7 +411,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testNotify() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -419,7 +419,7 @@ class ManagerTest extends TestCase {
 			->method('isValid')
 			->willReturn(true);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $app */
 		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -427,7 +427,7 @@ class ManagerTest extends TestCase {
 			->method('notify')
 			->with($notification);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $app2 */
 		$app2 = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -449,7 +449,7 @@ class ManagerTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testNotifyInvalid() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -461,14 +461,14 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testPrepare() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->once())
 			->method('isValidParsed')
 			->willReturn(true);
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification2 */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification2 */
 		$notification2 = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -476,7 +476,7 @@ class ManagerTest extends TestCase {
 			->method('isValidParsed')
 			->willReturn(true);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $notifier */
 		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -485,7 +485,7 @@ class ManagerTest extends TestCase {
 			->with($notification, 'en')
 			->willReturnArgument(0);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier2 */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $notifier2 */
 		$notifier2 = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -512,7 +512,7 @@ class ManagerTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testPrepareInvalid() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -520,7 +520,7 @@ class ManagerTest extends TestCase {
 			->method('isValidParsed')
 			->willReturn(false);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $notifier */
 		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -539,7 +539,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testPrepareNotifierThrows() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -547,7 +547,7 @@ class ManagerTest extends TestCase {
 			->method('isValidParsed')
 			->willReturn(true);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $notifier */
 		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -569,7 +569,7 @@ class ManagerTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testPrepareNoNotifier() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -581,12 +581,12 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testMarkProcessed() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $app */
 		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -594,7 +594,7 @@ class ManagerTest extends TestCase {
 			->method('markProcessed')
 			->with($notification);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $app2 */
 		$app2 = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -613,12 +613,12 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetCount() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $app */
 		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -627,7 +627,7 @@ class ManagerTest extends TestCase {
 			->with($notification)
 			->willReturn(21);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
+		/** @var \OCP\Notification\IApp|\PHPUnit\Framework\MockObject\MockObject $app2 */
 		$app2 = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Notification/NotificationTest.php
+++ b/tests/lib/Notification/NotificationTest.php
@@ -391,7 +391,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddAction() {
-		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->getMockBuilder('OCP\Notification\IAction')
 			->disableOriginalConstructor()
 			->getMock();
@@ -411,7 +411,7 @@ class NotificationTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testAddActionInvalid() {
-		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->getMockBuilder('OCP\Notification\IAction')
 			->disableOriginalConstructor()
 			->getMock();
@@ -425,7 +425,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddActionSecondPrimary() {
-		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->getMockBuilder('OCP\Notification\IAction')
 			->disableOriginalConstructor()
 			->getMock();
@@ -443,7 +443,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddParsedAction() {
-		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->getMockBuilder('OCP\Notification\IAction')
 			->disableOriginalConstructor()
 			->getMock();
@@ -463,7 +463,7 @@ class NotificationTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testAddParsedActionInvalid() {
-		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->getMockBuilder('OCP\Notification\IAction')
 			->disableOriginalConstructor()
 			->getMock();
@@ -477,7 +477,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddActionSecondParsedPrimary() {
-		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->getMockBuilder('OCP\Notification\IAction')
 			->disableOriginalConstructor()
 			->getMock();
@@ -511,7 +511,7 @@ class NotificationTest extends TestCase {
 	 * @param bool $expected
 	 */
 	public function testIsValid($isValidCommon, $subject, $expected) {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder('\OC\Notification\Notification')
 			->setMethods([
 				'isValidCommon',
@@ -543,7 +543,7 @@ class NotificationTest extends TestCase {
 	 * @param bool $expected
 	 */
 	public function testIsParsedValid($isValidCommon, $subject, $expected) {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder('\OC\Notification\Notification')
 			->setMethods([
 				'isValidCommon',
@@ -589,7 +589,7 @@ class NotificationTest extends TestCase {
 	 * @param bool $expected
 	 */
 	public function testIsValidCommon($app, $user, $timestamp, $objectType, $objectId, $expected) {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
+		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder('\OC\Notification\Notification')
 			->setMethods([
 				'getApp',

--- a/tests/lib/Notification/NotificationTest.php
+++ b/tests/lib/Notification/NotificationTest.php
@@ -438,7 +438,7 @@ class NotificationTest extends TestCase {
 
 		$this->assertSame($this->notification, $this->notification->addAction($action));
 
-		$this->setExpectedException('\InvalidArgumentException');
+		$this->expectException('\InvalidArgumentException');
 		$this->notification->addAction($action);
 	}
 
@@ -490,7 +490,7 @@ class NotificationTest extends TestCase {
 
 		$this->assertSame($this->notification, $this->notification->addParsedAction($action));
 
-		$this->setExpectedException('\InvalidArgumentException');
+		$this->expectException('\InvalidArgumentException');
 		$this->notification->addParsedAction($action);
 	}
 

--- a/tests/lib/PreviewManagerTest.php
+++ b/tests/lib/PreviewManagerTest.php
@@ -52,7 +52,7 @@ class PreviewManagerTest extends TestCase {
 	private $user;
 	/** @var View */
 	private $rootView;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 	/** @var IPreview */
 	private $previewManager;
@@ -75,7 +75,7 @@ class PreviewManagerTest extends TestCase {
 		$this->rootView->file_put_contents($imgPath, $imgData);
 		$this->config = $this->createMock(IConfig::class);
 
-		/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession->method('getUser')->willReturn($this->user);
 
@@ -94,7 +94,7 @@ class PreviewManagerTest extends TestCase {
 		// return defaults
 		$this->config->method('getSystemValue')->will($this->returnArgument(1));
 
-		/** @var FileInfo | \PHPUnit_Framework_MockObject_MockObject $file */
+		/** @var FileInfo | \PHPUnit\Framework\MockObject\MockObject $file */
 		$file = $this->createMock(FileInfo::class);
 		$file->expects($this->atLeastOnce())
 			->method('getMimetype')
@@ -107,7 +107,7 @@ class PreviewManagerTest extends TestCase {
 		// return defaults
 		$this->config->method('getSystemValue')->with('enable_previews', true)->willReturn(false);
 
-		/** @var FileInfo | \PHPUnit_Framework_MockObject_MockObject $file */
+		/** @var FileInfo | \PHPUnit\Framework\MockObject\MockObject $file */
 		$file = $this->createMock(FileInfo::class);
 		$file->expects($this->never())->method('getMimetype');
 
@@ -118,7 +118,7 @@ class PreviewManagerTest extends TestCase {
 		// return defaults
 		$this->config->method('getSystemValue')->will($this->returnArgument(1));
 
-		/** @var FileInfo | \PHPUnit_Framework_MockObject_MockObject $file */
+		/** @var FileInfo | \PHPUnit\Framework\MockObject\MockObject $file */
 		$file = $this->createMock(FileInfo::class);
 		$file->expects($this->atLeastOnce())
 			->method('getMimetype')

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -34,15 +34,15 @@ use Test\TestCase;
  */
 class AppsTest extends TestCase {
 
-	/** @var Apps | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Apps | \PHPUnit\Framework\MockObject\MockObject */
 	protected $repair;
-	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $appManager;
-	/** @var  EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject */
 	protected $eventDispatcher;
-	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject*/
+	/** @var  IConfig | \PHPUnit\Framework\MockObject\MockObject*/
 	protected $config;
-	/** @var \OC_Defaults | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC_Defaults | \PHPUnit\Framework\MockObject\MockObject */
 	private $defaults;
 
 	protected function setUp() {

--- a/tests/lib/Repair/CleanTagsTest.php
+++ b/tests/lib/Repair/CleanTagsTest.php
@@ -25,7 +25,7 @@ class CleanTagsTest extends \Test\TestCase {
 	/** @var \OCP\IDBConnection */
 	protected $connection;
 
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
 	/** @var int */

--- a/tests/lib/Repair/DisableExtraThemesTest.php
+++ b/tests/lib/Repair/DisableExtraThemesTest.php
@@ -20,16 +20,16 @@ use Test\TestCase;
  */
 class DisableExtraThemesTest extends TestCase {
 
-	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $appManager;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var IAppConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $appConfig;
 
-	/** @var IOutput|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IOutput|\PHPUnit\Framework\MockObject\MockObject */
 	protected $output;
 
 	protected function setUp() {

--- a/tests/lib/Repair/DropOldJobsTest.php
+++ b/tests/lib/Repair/DropOldJobsTest.php
@@ -34,7 +34,7 @@ class DropOldJobsTest extends \Test\TestCase {
 		$this->assertTrue($this->jobList->has('OC\Cache\FileGlobalGC', null), 'Asserting that the job OC\Cache\FileGlobalGC exists before repairing');
 		$this->assertTrue($this->jobList->has('OC_Cache_FileGlobalGC', null), 'Asserting that the job OC_Cache_FileGlobalGC exists before repairing');
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/DropOldTablesTest.php
+++ b/tests/lib/Repair/DropOldTablesTest.php
@@ -32,7 +32,7 @@ class DropOldTablesTest extends \Test\TestCase {
 		$this->assertFalse($this->connection->tableExists('sharing'), 'Asserting that the table oc_sharing does not exist before repairing');
 		$this->assertTrue($this->connection->tableExists('permissions'), 'Asserting that the table oc_permissions does exist before repairing');
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/OldGroupMembershipSharesTest.php
+++ b/tests/lib/Repair/OldGroupMembershipSharesTest.php
@@ -27,13 +27,13 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 	/** @var \OCP\IDBConnection */
 	protected $connection;
 
-	/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
 	protected function setUp() {
 		parent::setUp();
 
-		/** \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+		/** \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 		$this->groupManager = $this->getMockBuilder('OCP\IGroupManager')
 			->disableOriginalConstructor()
 			->getMock();
@@ -83,7 +83,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member], ['id' => $notAMember]], $rows);
 		$result->closeCursor();
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RemoveGetETagEntriesTest.php
+++ b/tests/lib/Repair/RemoveGetETagEntriesTest.php
@@ -64,7 +64,7 @@ class RemoveGetETagEntriesTest extends TestCase {
 			$this->assertContains($entry, $data, 'Asserts that the entries are the ones from the test data set');
 		}
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RepairCollationTest.php
+++ b/tests/lib/Repair/RepairCollationTest.php
@@ -80,7 +80,7 @@ class RepairCollationTest extends TestCase {
 		$tables = $this->repair->getAllNonUTF8BinTables($this->connection);
 		$this->assertGreaterThanOrEqual(1, \count($tables));
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RepairInnoDBTest.php
+++ b/tests/lib/Repair/RepairInnoDBTest.php
@@ -51,7 +51,7 @@ class RepairInnoDBTest extends \Test\TestCase {
 		$result = $this->countMyIsamTables();
 		$this->assertEquals(1, $result);
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RepairInvalidSharesTest.php
+++ b/tests/lib/Repair/RepairInvalidSharesTest.php
@@ -99,7 +99,7 @@ class RepairInvalidSharesTest extends TestCase {
 				'token' => $qb->expr()->literal('abcdefg')
 			])->execute();
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();
@@ -184,7 +184,7 @@ class RepairInvalidSharesTest extends TestCase {
 
 		$keepThisShareId2 = $this->getLastShareId();
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();
@@ -260,7 +260,7 @@ class RepairInvalidSharesTest extends TestCase {
 		$this->assertEquals([['id' => $parent], ['id' => $validChild], ['id' => $invalidChild]], $rows);
 		$result->closeCursor();
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();
@@ -323,7 +323,7 @@ class RepairInvalidSharesTest extends TestCase {
 
 		$shareId = $this->getLastShareId();
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RepairMimeTypesTest.php
+++ b/tests/lib/Repair/RepairMimeTypesTest.php
@@ -38,7 +38,7 @@ class RepairMimeTypesTest extends \Test\TestCase {
 		$this->savedMimetypeLoader = \OC::$server->getMimeTypeLoader();
 		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
 
-		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+		/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject $config */
 		$config = $this->getMockBuilder('OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
@@ -106,7 +106,7 @@ class RepairMimeTypesTest extends \Test\TestCase {
 	private function renameMimeTypes($currentMimeTypes, $fixedMimeTypes) {
 		$this->addEntries($currentMimeTypes);
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -44,7 +44,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 				['httpd/unix-directory', 2],
 			]));
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger $logger */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | ILogger $logger */
 		$logger = $this->createMock(ILogger::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader, $logger, $this->config);

--- a/tests/lib/Repair/RepairSharePropagationTest.php
+++ b/tests/lib/Repair/RepairSharePropagationTest.php
@@ -26,7 +26,7 @@ class RepairSharePropagationTest extends \Test\TestCase {
 	 * @param array $expectedRemovedKeys
 	 */
 	public function testRemovePropagationEntries(array $startKeys, array $expectedRemovedKeys) {
-		/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\IConfig $config */
+		/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\IConfig $config */
 		$config = $this->createMock('\OCP\IConfig');
 		$config->expects($this->once())
 			->method('getAppKeys')
@@ -41,7 +41,7 @@ class RepairSharePropagationTest extends \Test\TestCase {
 				$removedKeys[] = $key;
 			}));
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RepairSqliteAutoincrementTest.php
+++ b/tests/lib/Repair/RepairSqliteAutoincrementTest.php
@@ -77,7 +77,7 @@ class RepairSqliteAutoincrementTest extends \Test\TestCase {
 	public function testConvertIdColumn() {
 		$this->assertFalse($this->checkAutoincrement());
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Repair/RepairUnmergedSharesTest.php
+++ b/tests/lib/Repair/RepairUnmergedSharesTest.php
@@ -580,7 +580,7 @@ class RepairUnmergedSharesTest extends TestCase {
 			$shareIds[] = $this->createShare($share[0], $share[1], $share[2], $share[3], $share[4], $share[5]);
 		}
 
-		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -27,7 +27,7 @@ use OCP\Session\Exceptions\SessionNotAvailableException;
 use OC\Session\Memory;
 
 class CryptoSessionDataTest extends Session {
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\Security\ICrypto */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\Security\ICrypto */
 	protected $crypto;
 
 	/** @var \OCP\ISession */
@@ -58,7 +58,7 @@ class CryptoSessionDataTest extends Session {
 	 * Thrown exception during session destruct/close should be handled silently
 	 */
 	public function testDestructExceptionCatching() {
-		/** @var Memory | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var Memory | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->getMockBuilder(Memory::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Session/CryptoWrappingTest.php
+++ b/tests/lib/Session/CryptoWrappingTest.php
@@ -25,10 +25,10 @@ use OC\Session\CryptoSessionData;
 use Test\TestCase;
 
 class CryptoWrappingTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\Security\ICrypto */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\Security\ICrypto */
 	protected $crypto;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\ISession */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\ISession */
 	protected $wrappedSession;
 
 	/** @var \OC\Session\CryptoSessionData */

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -12,19 +12,19 @@ use OCP\IConfig;
 
 class SetupTest extends \Test\TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
-	/** @var \bantu\IniGetWrapper\IniGetWrapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \bantu\IniGetWrapper\IniGetWrapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $iniWrapper;
-	/** @var \OCP\IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $l10n;
-	/** @var \OC_Defaults | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC_Defaults | \PHPUnit\Framework\MockObject\MockObject */
 	private $defaults;
-	/** @var \OC\Setup | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Setup | \PHPUnit\Framework\MockObject\MockObject */
 	protected $setupClass;
-	/** @var \OCP\ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var \OCP\Security\ISecureRandom | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Security\ISecureRandom | \PHPUnit\Framework\MockObject\MockObject */
 	protected $random;
 
 	protected function setUp() {

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -43,21 +43,21 @@ use Test\TestCase;
  * @group DB
  */
 class MailNotificationsTest extends TestCase {
-	/** @var IManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $shareManager;
 	/** @var IL10N */
 	private $l10n;
-	/** @var IMailer | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IMailer | \PHPUnit\Framework\MockObject\MockObject */
 	private $mailer;
 	/** @var ILogger */
 	private $logger;
 	/** @var IConfig */
 	private $config;
-	/** @var Defaults | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Defaults | \PHPUnit\Framework\MockObject\MockObject */
 	private $defaults;
-	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
 	private $user;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 	private $eventDispatcher;
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -47,13 +47,13 @@ class DefaultShareProviderTest extends TestCase {
 	/** @var IDBConnection */
 	protected $dbConn;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
-	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject */
 	protected $rootFolder;
 
 	/** @var DefaultShareProvider */

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -65,7 +65,7 @@ class ManagerTest extends \Test\TestCase {
 
 	/** @var Manager */
 	protected $manager;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
 	/** @var IConfig */
 	protected $config;
@@ -73,25 +73,25 @@ class ManagerTest extends \Test\TestCase {
 	protected $secureRandom;
 	/** @var IHasher */
 	protected $hasher;
-	/** @var IShareProvider | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IShareProvider | \PHPUnit\Framework\MockObject\MockObject */
 	protected $defaultProvider;
 	/** @var  IMountManager */
 	protected $mountManager;
 	/** @var  IGroupManager */
 	protected $groupManager;
-	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 	/** @var DummyFactory */
 	protected $factory;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
-	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject */
 	protected $rootFolder;
 	/** @var EventDispatcher */
 	protected $eventDispatcher;
-	/** @var  View | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  View | \PHPUnit\Framework\MockObject\MockObject */
 	protected $view;
-	/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject */
 	protected $connection;
 
 	public function setUp() {
@@ -147,7 +147,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @return Manager | \PHPUnit_Framework_MockObject_MockBuilder
+	 * @return Manager | \PHPUnit\Framework\MockObject\Mockbuilder
 	 */
 	private function createManagerMock() {
 		return 	$this->getMockBuilder(Manager::class)

--- a/tests/lib/Share20/ShareTest.php
+++ b/tests/lib/Share20/ShareTest.php
@@ -29,7 +29,7 @@ use OCP\Files\IRootFolder;
  */
 class ShareTest extends \Test\TestCase {
 
-	/** @var IRootFolder|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRootFolder|\PHPUnit\Framework\MockObject\MockObject */
 	protected $rootFolder;
 	/** @var \OCP\Share\IShare */
 	protected $share;

--- a/tests/lib/Template/BaseTest.php
+++ b/tests/lib/Template/BaseTest.php
@@ -13,7 +13,7 @@ use OCP\Theme\ITheme;
 
 class BaseTest extends \Test\TestCase {
 
-	/** @var ITheme|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITheme|\PHPUnit\Framework\MockObject\MockObject */
 	protected $theme;
 
 	/** @var string */

--- a/tests/lib/Template/CSSResourceLocatorTest.php
+++ b/tests/lib/Template/CSSResourceLocatorTest.php
@@ -15,9 +15,9 @@ use OCP\ILogger;
 use Test\TestCase;
 
 class CSSResourceLocatorTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $appManager;
 	protected $serverRoot = '/var/www/owncloud';
 	protected $appRoot = '/var/www/apps';
@@ -32,7 +32,7 @@ class CSSResourceLocatorTest extends TestCase {
 	 * @param string $theme
 	 * @param array $core_map
 	 * @param array $appsRoots
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getResourceLocator($theme, $core_map, $appsRoots) {
 		$themeInstance = $this->createMock(Theme::class);

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -15,9 +15,9 @@ use OCP\ILogger;
 use Test\TestCase;
 
 class JSResourceLocatorTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $appManager;
 	protected $serverRoot = '/var/www/owncloud';
 	protected $appRoot = '/var/www/apps';
@@ -32,7 +32,7 @@ class JSResourceLocatorTest extends TestCase {
 	 * @param string $theme
 	 * @param array $core_map
 	 * @param array $appsRoots
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getResourceLocator($theme, $core_map, $appsRoots) {
 		$themeInstance = $this->createMock(Theme::class);

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -14,7 +14,7 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 
 class ResourceLocatorTest extends \Test\TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
 	protected $root;
 	
@@ -42,7 +42,7 @@ class ResourceLocatorTest extends \Test\TestCase {
 	 * @param string $theme
 	 * @param array $core_map
 	 * @param array $appsRoots
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getResourceLocator($theme, $core_map, $appsRoots) {
 		$themeInstance = $this->createMock('OC\Theme\Theme');

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -475,7 +475,7 @@ abstract class TestCase extends BaseTestCase {
 
 		$requestToken = 12345;
 		$theme = new OC_Defaults();
-		/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject $l10n */
+		/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->getMockBuilder('\OCP\IL10N')
 			->disableOriginalConstructor()->getMock();
 		$l10n

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -8,12 +8,12 @@ use OCP\App\IAppManager;
 
 class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 	/**
-	 * @var IAppManager | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IAppManager | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $appManager;
 
 	/**
-	 * @var EnvironmentHelper |  \PHPUnit_Framework_MockObject_MockObject
+	 * @var EnvironmentHelper |  \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $environmentHelper;
 

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -28,9 +28,9 @@ use OCP\Util;
 use Test\TestCase;
 
 class VersionCheckTest extends TestCase {
-	/** @var IConfig| \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig| \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var VersionCheck | \PHPUnit_Framework_MockObject_MockObject*/
+	/** @var VersionCheck | \PHPUnit\Framework\MockObject\MockObject*/
 	private $updater;
 
 	public function setUp() {

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -28,13 +28,13 @@ use OCP\IConfig;
 use OCP\ILogger;
 
 class UpdaterTest extends TestCase {
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 	/** @var Updater */
 	private $updater;
-	/** @var Checker | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Checker | \PHPUnit\Framework\MockObject\MockObject */
 	private $checker;
 
 	public function setUp() {

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -21,10 +21,10 @@ class UrlGeneratorTest extends TestCase {
 
 	/** @var IURLGenerator */
 	private $urlGenerator;
-	/** @var IRouter | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRouter | \PHPUnit\Framework\MockObject\MockObject */
 	private $router;
 
-	/** @var EnvironmentHelper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EnvironmentHelper | \PHPUnit\Framework\MockObject\MockObject */
 	private $environmentHelper;
 
 	public function setUp() {

--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -37,7 +37,7 @@ use Test\TestCase;
  */
 class AccountMapperTest extends TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
 	/** @var IDBConnection */

--- a/tests/lib/User/BasicAuthModuleTest.php
+++ b/tests/lib/User/BasicAuthModuleTest.php
@@ -34,19 +34,19 @@ use Test\TestCase;
 
 class BasicAuthModuleTest extends TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $manager;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
-	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
 	private $user;
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
 
 	public function setUp() {

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -36,9 +36,9 @@ class ManagerTest extends TestCase {
 
 	/** @var Manager */
 	private $manager;
-	/** @var AccountMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AccountMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $accountMapper;
-	/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var SyncService | \PHPUnit\Framework\MockObject\MockObject */
 	private $syncService;
 
 	/**
@@ -50,9 +50,9 @@ class ManagerTest extends TestCase {
 		parent::setUp();
 
 		$this->overwriteService('EventDispatcher', new EventDispatcher());
-		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+		/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject $config */
 		$config = $this->createMock(IConfig::class);
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+		/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject $logger */
 		$logger = $this->createMock(ILogger::class);
 		$this->accountMapper = $this->createMock(AccountMapper::class);
 		$this->syncService = $this->createMock(SyncService::class);
@@ -69,12 +69,12 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetBackends() {
-		/** @var Backend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var Backend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock(Backend::class);
 		$this->manager->registerBackend($backend);
 		$this->assertEquals([$backend], $this->manager->getBackends());
 
-		/** @var Backend | \PHPUnit_Framework_MockObject_MockObject $dummyDatabaseBackend */
+		/** @var Backend | \PHPUnit\Framework\MockObject\MockObject $dummyDatabaseBackend */
 		$dummyDatabaseBackend = $this->createMock(Database::class);
 		$this->manager->registerBackend($dummyDatabaseBackend);
 		$this->assertEquals([$backend, $dummyDatabaseBackend], $this->manager->getBackends());
@@ -93,7 +93,7 @@ class ManagerTest extends TestCase {
 
 	public function testCheckPassword() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var \OC\User\Backend | \PHPUnit\Framework\MockObject\MockObject $backend
 		 */
 		$backend = $this->createMock(Database::class);
 		$backend->expects($this->once())
@@ -126,7 +126,7 @@ class ManagerTest extends TestCase {
 
 	public function testCheckPasswordNotSupported() {
 		/**
-		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 * @var \OC\User\Backend | \PHPUnit\Framework\MockObject\MockObject $backend
 		 */
 		$backend = $this->createMock(Database::class);
 		$backend->expects($this->never())

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -44,15 +44,15 @@ use OCP\UserInterface;
  */
 class SessionTest extends TestCase {
 
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
 
-	/** @var DefaultTokenProvider | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var DefaultTokenProvider | \PHPUnit\Framework\MockObject\MockObject */
 	protected $tokenProvider;
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 	/** @var IServiceLoader */
 	private $serviceLoader;
@@ -81,12 +81,12 @@ class SessionTest extends TestCase {
 		$token->setLoginName('User123');
 		$token->setLastCheck(200);
 
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $expectedUser */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $expectedUser */
 		$expectedUser = $this->createMock(IUser::class);
 		$expectedUser->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('user123'));
-		/** @var Memory | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var Memory | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->at(0))
 			->method('get')
@@ -94,7 +94,7 @@ class SessionTest extends TestCase {
 			->will($this->returnValue($expectedUser->getUID()));
 		$sessionId = 'abcdef12345';
 
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->getMockBuilder(Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -157,7 +157,7 @@ class SessionTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \PHPUnit_Framework_MockObject_MockObject | Session $userSession */
+		/** @var \PHPUnit\Framework\MockObject\MockObject | Session $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods([
@@ -173,7 +173,7 @@ class SessionTest extends TestCase {
 	}
 
 	public function testSetUser() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->once())
 			->method('set')
@@ -182,7 +182,7 @@ class SessionTest extends TestCase {
 		/** @var Manager $manager */
 		$manager = $this->createMock(Manager::class);
 
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('getUID')
@@ -246,9 +246,9 @@ class SessionTest extends TestCase {
 			->with('foo', 'bar')
 			->will($this->returnValue($user));
 
-		/** @var $eventDispatcher | \PHPUnit_Framework_MockObject_MockObject */
+		/** @var $eventDispatcher | \PHPUnit\Framework\MockObject\MockObject */
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $eventDispatcher])
 			->setMethods([
@@ -278,7 +278,7 @@ class SessionTest extends TestCase {
 	 * @expectedException \OC\User\LoginException
 	 */
 	public function testLoginValidPasswordDisabled() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->never())
 			->method('set');
@@ -289,7 +289,7 @@ class SessionTest extends TestCase {
 			->with('bar')
 			->will($this->throwException(new InvalidTokenException()));
 
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 
 		$user = $this->createMock(IUser::class);
@@ -311,9 +311,9 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLoginInvalidPassword() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
 			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -344,9 +344,9 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLoginNonExisting() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
 			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -374,9 +374,9 @@ class SessionTest extends TestCase {
 	 * when generating the token on the browser.
 	 */
 	public function testLoginWithDifferentTokenLoginName() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
 			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -410,11 +410,11 @@ class SessionTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$session = $this->createMock(ISession::class);
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 		$request->method('getRemoteAddress')->willReturn('12.34.56.78');
 
-		/** @var EventDispatcher | \PHPUnit_Framework_MockObject_MockObject $eventDispatcher */
+		/** @var EventDispatcher | \PHPUnit\Framework\MockObject\MockObject $eventDispatcher */
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 
 		/** @var Session $userSession */
@@ -442,7 +442,7 @@ class SessionTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$session = $this->createMock(ISession::class);
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 
 		/** @var Session $userSession */
@@ -471,10 +471,10 @@ class SessionTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$session = $this->createMock(ISession::class);
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods(['isTokenPassword', 'login', 'supportsCookies', 'createSessionToken', 'getUser'])
@@ -503,14 +503,14 @@ class SessionTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$session = $this->createMock(ISession::class);
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 		$request->method('getRemoteAddress')->willReturn('12.34.56.78');
 
-		/** @var EventDispatcher | \PHPUnit_Framework_MockObject_MockObject $eventDispatcher */
+		/** @var EventDispatcher | \PHPUnit\Framework\MockObject\MockObject $eventDispatcher */
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $eventDispatcher])
 			->setMethods(['login', 'isTwoFactorEnforced'])
@@ -567,7 +567,7 @@ class SessionTest extends TestCase {
 		$token = 'goodToken';
 		\OC::$server->getConfig()->setUserValue('foo', 'login_token', $token, \time());
 
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			//override, otherwise tests will fail because of setcookie()
 			->setMethods(['setMagicInCookie'])
@@ -581,14 +581,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testRememberLoginInvalidToken() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->never())
 			->method('set');
 		$session->expects($this->once())
 			->method('regenerateId');
 
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
@@ -627,14 +627,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testRememberLoginInvalidUser() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->never())
 			->method('set');
 		$session->expects($this->once())
 			->method('regenerateId');
 
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$user = $this->createMock(IUser::class);
 
@@ -680,7 +680,7 @@ class SessionTest extends TestCase {
 
 		$session = new Memory('');
 		$session->set('user_id', 'foo');
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods([
@@ -699,9 +699,9 @@ class SessionTest extends TestCase {
 	}
 
 	public function testCreateSessionToken() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->createMock(Manager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
 		$user = $this->createMock(IUser::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
@@ -744,13 +744,13 @@ class SessionTest extends TestCase {
 	}
 
 	public function testCreateSessionTokenWithTokenPassword() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->getMockBuilder(Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var IToken | \PHPUnit_Framework_MockObject_MockObject $token */
+		/** @var IToken | \PHPUnit\Framework\MockObject\MockObject $token */
 		$token = $this->createMock(IToken::class);
 		$user = $this->createMock(IUser::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
@@ -798,11 +798,11 @@ class SessionTest extends TestCase {
 	}
 
 	public function testCreateSessionTokenWithNonExistentUser() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $manager */
 		$manager = $this->getMockBuilder(Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
 			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -835,12 +835,12 @@ class SessionTest extends TestCase {
 		$token->setUid('fritz0');
 		$token->setLastCheck(100); // Needs check
 		$user = $this->createMock(IUser::class);
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setMethods(['logout'])
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->getMock();
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
 
 		$request->expects($this->once())
@@ -868,13 +868,13 @@ class SessionTest extends TestCase {
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$tokenProvider = $this->createMock(IProvider::class);
 
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods(['logout'])
 			->getMock();
 
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$token = new DefaultToken();
 		$token->setLoginName('susan');
@@ -917,13 +917,13 @@ class SessionTest extends TestCase {
 		$session = $this->createMock(ISession::class);
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$tokenProvider = $this->createMock(IProvider::class);
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods(['logout'])
 			->getMock();
 
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('isEnabled')
@@ -957,13 +957,13 @@ class SessionTest extends TestCase {
 	}
 
 	public function testUpdateSessionTokenPassword() {
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
 			$tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -988,13 +988,13 @@ class SessionTest extends TestCase {
 	}
 
 	public function testUpdateSessionTokenPasswordNoSessionAvailable() {
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
 			$tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -1008,13 +1008,13 @@ class SessionTest extends TestCase {
 	}
 
 	public function testUpdateSessionTokenPasswordInvalidTokenException() {
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
 			$tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -1040,7 +1040,7 @@ class SessionTest extends TestCase {
 	}
 
 	public function testCancelLogout() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->once())
 			->method('set')
@@ -1049,7 +1049,7 @@ class SessionTest extends TestCase {
 		/** @var Manager $manager */
 		$manager = $this->createMock(Manager::class);
 
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('getUID')
@@ -1082,7 +1082,7 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLogout() {
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->once())
 			->method('set')
@@ -1091,13 +1091,13 @@ class SessionTest extends TestCase {
 		/** @var Manager $manager */
 		$manager = $this->createMock(Manager::class);
 
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('foo'));
 
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods(['getAuthModules', 'unsetMagicInCookie'])
@@ -1127,13 +1127,13 @@ class SessionTest extends TestCase {
 	}
 
 	public function testApacheLogin() {
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1155,14 +1155,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testFailedLoginWithApache() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1187,14 +1187,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLoginWithApache() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1231,15 +1231,15 @@ class SessionTest extends TestCase {
 	}
 
 	public function testFailedLoginWithPassword() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
 		$userManager->expects($this->once())->method('checkPassword')->willReturn(false);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1262,14 +1262,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLoginWithPassword() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 
@@ -1305,14 +1305,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLoginFailedWithToken() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1346,14 +1346,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLoginWithToken() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1432,18 +1432,18 @@ class SessionTest extends TestCase {
 	 * @param null $loggedInUser
 	 */
 	public function testVerifyAuthHeaders($expectedReturn, array $modules, $loggedInUser = null) {
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods(['getAuthModules', 'logout', 'isLoggedIn', 'getUser'])
@@ -1481,18 +1481,18 @@ class SessionTest extends TestCase {
 	 * @throws \Exception
 	 */
 	public function testTryAuthModuleLogin($expectedReturn, array $modules) {
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 
-		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService, $this->eventDispatcher])
 			->setMethods(['getAuthModules', 'createSessionToken', 'loginUser', 'getUser'])
@@ -1511,14 +1511,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testFailedLoginUser() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1536,14 +1536,14 @@ class SessionTest extends TestCase {
 	}
 
 	public function testLoginUser() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
 			$tokenProvider, $this->config, $this->logger, $this->serviceLoader,
@@ -1565,14 +1565,14 @@ class SessionTest extends TestCase {
 	 * @expectedExceptionMessage User disabled
 	 */
 	public function testFailedLoginUserDisabled() {
-		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var Manager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(Manager::class);
 		$userManager->expects($this->any())->method('emit')->willReturn(null);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | \PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject $timeFactory */
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$eventDispatcher = $this->createMock(EventDispatcher::class);
 		$userSession = new Session($userManager, $session, $timeFactory,

--- a/tests/lib/User/Sync/AllUsersIteratorTest.php
+++ b/tests/lib/User/Sync/AllUsersIteratorTest.php
@@ -34,7 +34,7 @@ use Test\TestCase;
 class AllUsersIteratorTest extends TestCase {
 
 	/**
-	 * @var UserInterface|\PHPUnit_Framework_MockObject_MockObject
+	 * @var UserInterface|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $backend;
 	/**

--- a/tests/lib/User/Sync/SeenUsersIteratorTest.php
+++ b/tests/lib/User/Sync/SeenUsersIteratorTest.php
@@ -35,7 +35,7 @@ use Test\TestCase;
 class SeenUsersIteratorTest extends TestCase {
 
 	/**
-	 * @var AccountMapper|\PHPUnit_Framework_MockObject_MockObject
+	 * @var AccountMapper|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $mapper;
 	/**

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -40,11 +40,11 @@ use Test\TestCase;
 
 class SyncServiceTest extends TestCase {
 
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
-	/** @var AccountMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AccountMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $mapper;
 
 	protected function setUp() {
@@ -56,7 +56,7 @@ class SyncServiceTest extends TestCase {
 	}
 
 	public function testSetupAccount() {
-		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock(UserInterface::class);
 
 		$this->config->expects($this->any())->method('getUserKeys')->willReturnMap([
@@ -81,7 +81,7 @@ class SyncServiceTest extends TestCase {
 	 * Pass in a backend that has new users anc check that they accounts are inserted
 	 */
 	public function testSetupNewAccount() {
-		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock(UserInterface::class);
 		$account = $this->createMock(Account::class);
 
@@ -118,7 +118,7 @@ class SyncServiceTest extends TestCase {
 	 * Pass in a backend that has new users anc check that they accounts are inserted
 	 */
 	public function testSetupNewAccountLogsErrorOnException() {
-		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock(UserInterface::class);
 
 		$backendUids = ['thisuserhasntbeenseenbefore'];
@@ -138,7 +138,7 @@ class SyncServiceTest extends TestCase {
 
 	public function testSyncHomeLogsWhenBackendDiffersFromExisting() {
 
-		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock([UserInterface::class, IProvidesHomeBackend::class]);
 		$a = $this->getMockBuilder(Account::class)->setMethods(['getHome'])->getMock();
 
@@ -193,11 +193,11 @@ class SyncServiceTest extends TestCase {
 	 */
 	public function testSyncQuota($backendProvidesQuota, $backendQuota, $preferencesQuota, $expectedQuota) {
 
-		/** @var UserInterface | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var UserInterface | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$a = $this->getMockBuilder(Account::class)->setMethods(['setQuota'])->getMock();
 
 		if ($backendProvidesQuota) {
-			/** @var UserInterface | IProvidesQuotaBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+			/** @var UserInterface | IProvidesQuotaBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 			$backend = $this->createMock([UserInterface::class, IProvidesQuotaBackend::class]);
 			$backend->expects($this->exactly(1))->method('getQuota')->willReturn($backendQuota);
 		} else {
@@ -227,7 +227,7 @@ class SyncServiceTest extends TestCase {
 		$a = $this->createMock(Account::class);
 		$a->method('__call')->with('getUserId')->willReturn('user1');
 
-		/** @var UserInterface | IProvidesUserNameBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		/** @var UserInterface | IProvidesUserNameBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock([UserInterface::class, IProvidesUserNameBackend::class]);
 		$backend->expects($this->once())
 			->method('getUserName')

--- a/tests/lib/User/TokenAuthModuleTest.php
+++ b/tests/lib/User/TokenAuthModuleTest.php
@@ -34,15 +34,15 @@ use Test\TestCase;
 
 class TokenAuthModuleTest extends TestCase {
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $manager;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
 	private $user;
-	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | \PHPUnit\Framework\MockObject\MockObject */
 	private $session;
-	/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IProvider | \PHPUnit\Framework\MockObject\MockObject */
 	private $tokenProvider;
 
 	public function setUp() {

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -34,25 +34,25 @@ use Test\Traits\PasswordTrait;
  * @package Test\User
  */
 class UserTest extends TestCase {
-	/** @var AccountMapper | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var AccountMapper | \PHPUnit\Framework\MockObject\MockObject */
 	private $accountMapper;
 	/** @var Account */
 	private $account;
 	/** @var User */
 	private $user;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 	/** @var PublicEmitter */
 	private $emitter;
-	/** @var EventDispatcher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var EventDispatcher | \PHPUnit\Framework\MockObject\MockObject */
 	private $eventDispatcher;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
-	/** @var  Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  Manager | \PHPUnit\Framework\MockObject\MockObject */
 	private $groupManager;
-	/** @var  SubAdmin | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  SubAdmin | \PHPUnit\Framework\MockObject\MockObject */
 	private $subAdmin;
-	/** @var  Session | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  Session | \PHPUnit\Framework\MockObject\MockObject */
 	private $sessionUser;
 
 	public function setUp() {
@@ -142,7 +142,7 @@ class UserTest extends TestCase {
 			$calledEvents['user.aftersetpassword'] = $event;
 		});
 		$backend = $this->createMock(IChangePasswordBackend::class);
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->createMock(Account::class);
 		$account->expects($this->any())->method('getBackendInstance')->willReturn($backend);
 		$account->expects($this->any())->method('__call')->with('getUserId')->willReturn('foo');
@@ -192,7 +192,7 @@ class UserTest extends TestCase {
 			->with('foo', 'owncloud', 'lostpassword');
 
 		$backend = $this->createMock(IChangePasswordBackend::class);
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->createMock(Account::class);
 		$account->expects($this->any())->method('getBackendInstance')->willReturn($backend);
 		$account->expects($this->any())->method('__call')->with('getUserId')->willReturn('foo');
@@ -225,7 +225,7 @@ class UserTest extends TestCase {
 			->getMock();
 		$backend->expects($this->any())->method('canChangeAvatar')->willReturn($canChange);
 
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->createMock(Account::class);
 		$account->expects($this->any())->method('getBackendInstance')->willReturn($backend);
 		$account->expects($this->any())->method('__call')->with('getUserId')->willReturn('foo');
@@ -304,7 +304,7 @@ class UserTest extends TestCase {
 			->setMethods(['implementsActions'])
 			->getMock();
 
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->getMockBuilder(Account::class)
 			->setMethods(['getBackendInstance', 'getDisplayName', 'setDisplayName'])
 			->getMock();
@@ -334,7 +334,7 @@ class UserTest extends TestCase {
 			->setMethods(['implementsActions'])
 			->getMock();
 
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->getMockBuilder(Account::class)
 			->setMethods(['getBackendInstance', 'getDisplayName', 'setDisplayName'])
 			->getMock();
@@ -384,7 +384,7 @@ class UserTest extends TestCase {
 			->setMethods(['implementsActions'])
 			->getMock();
 
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->getMockBuilder(Account::class)
 			->setMethods(['getBackendInstance', 'getDisplayName', 'setDisplayName'])
 			->getMock();
@@ -416,7 +416,7 @@ class UserTest extends TestCase {
 			->setMethods(['implementsActions'])
 			->getMock();
 
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->createMock(Account::class);
 		$account->expects($this->any())->method('getBackendInstance')->willReturn($backend);
 		$account->expects($this->any())->method('__call')->with('getDisplayName')->willReturn('foo');
@@ -451,7 +451,7 @@ class UserTest extends TestCase {
 		$emitter->listen('\OC\User', 'postSetPassword', $hook);
 
 		$backend = $this->createMock(IChangePasswordBackend::class);
-		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		/** @var Account | \PHPUnit\Framework\MockObject\MockObject $account */
 		$account = $this->createMock(Account::class);
 		$account->expects($this->any())->method('getBackendInstance')->willReturn($backend);
 		$account->expects($this->any())->method('__call')->with('getUserId')->willReturn('foo');

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -18,7 +18,7 @@ class UtilCheckServerTest extends TestCase {
 
 	/**
 	 * @param array $systemOptions
-	 * @return \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\IConfig | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getConfig($systemOptions) {
 		$systemOptions['datadirectory'] = $this->datadir;

--- a/tests/lib/legacy/DefaultsTest.php
+++ b/tests/lib/legacy/DefaultsTest.php
@@ -24,7 +24,7 @@ use Test\TestCase;
 
 class DefaultsTest extends TestCase {
 	/**
-	 * @var OC_Defaults | \PHPUnit_Framework_MockObject_MockObject
+	 * @var OC_Defaults | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected $defaults;
 

--- a/tests/lib/legacy/DefaultsTest.php
+++ b/tests/lib/legacy/DefaultsTest.php
@@ -32,11 +32,8 @@ class DefaultsTest extends TestCase {
 		$imprintUrl = 'http://example.org/imprint';
 		$privacyPolicyUrl = 'http://example.org/privacy';
 		$defaults = $this->getDefaultsMock(
-			['themeExist', 'getImprintUrl', 'getPrivacyPolicyUrl']
+			['getImprintUrl', 'getPrivacyPolicyUrl']
 		);
-		$defaults->expects($this->any())
-			->method('themeExist')
-			->willReturn(false);
 		$defaults->expects($this->exactly(2))
 			->method('getImprintUrl')
 			->willReturn($imprintUrl);
@@ -55,12 +52,7 @@ class DefaultsTest extends TestCase {
 		$config->expects($this->any())
 			->method('getAppValue')
 			->willThrowException(new \Exception());
-		$defaults = $this->getDefaultsMock(
-			['themeExist']
-		);
-		$defaults->expects($this->any())
-			->method('themeExist')
-			->willReturn(false);
+		$defaults = new OC_Defaults();
 		$defaults->setConfig($config);
 
 		$footer = $defaults->getShortFooter();

--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -9,26 +9,26 @@
 /**
  * Starts a new session before each test execution
  */
-class StartSessionListener implements PHPUnit_Framework_TestListener {
-	public function addError(PHPUnit_Framework_Test $test, Exception $e, $time) {
+class StartSessionListener implements PHPUnit\Framework\TestListener {
+	public function addError(PHPUnit\Framework\Test $test, Exception $e, $time) {
 	}
 
-	public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time) {
+	public function addFailure(PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, $time) {
 	}
 
-	public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	public function addIncompleteTest(PHPUnit\Framework\Test $test, Exception $e, $time) {
 	}
 
-	public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	public function addRiskyTest(PHPUnit\Framework\Test $test, Exception $e, $time) {
 	}
 
-	public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	public function addSkippedTest(PHPUnit\Framework\Test $test, Exception $e, $time) {
 	}
 
-	public function startTest(PHPUnit_Framework_Test $test) {
+	public function startTest(PHPUnit\Framework\Test $test) {
 	}
 
-	public function endTest(PHPUnit_Framework_Test $test, $time) {
+	public function endTest(PHPUnit\Framework\Test $test, $time) {
 		// reopen the session - only allowed for memory session
 		if (\OC::$server->getSession() instanceof \OC\Session\Memory) {
 			/** @var $session \OC\Session\Memory */
@@ -37,12 +37,12 @@ class StartSessionListener implements PHPUnit_Framework_TestListener {
 		}
 	}
 
-	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
+	public function startTestSuite(PHPUnit\Framework\TestSuite $suite) {
 	}
 
-	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
+	public function endTestSuite(PHPUnit\Framework\TestSuite $suite) {
 	}
 
-	public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time) {
+	public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, $time) {
 	}
 }

--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -10,39 +10,39 @@
  * Starts a new session before each test execution
  */
 class StartSessionListener implements PHPUnit\Framework\TestListener {
-	public function addError(PHPUnit\Framework\Test $test, Exception $e, $time) {
+	public function addError(PHPUnit\Framework\Test $test, \Throwable $t, float $time): void {
 	}
 
-	public function addFailure(PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, $time) {
+	public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, float $time): void {
 	}
 
-	public function addIncompleteTest(PHPUnit\Framework\Test $test, Exception $e, $time) {
+	public function addFailure(PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, float $time): void {
 	}
 
-	public function addRiskyTest(PHPUnit\Framework\Test $test, Exception $e, $time) {
+	public function addIncompleteTest(PHPUnit\Framework\Test $test, \Throwable $t, float $time): void {
 	}
 
-	public function addSkippedTest(PHPUnit\Framework\Test $test, Exception $e, $time) {
+	public function addRiskyTest(PHPUnit\Framework\Test $test, \Throwable $t, float $time): void {
 	}
 
-	public function startTest(PHPUnit\Framework\Test $test) {
+	public function addSkippedTest(PHPUnit\Framework\Test $test, \Throwable $t, float $time): void {
 	}
 
-	public function endTest(PHPUnit\Framework\Test $test, $time) {
+	public function startTestSuite(PHPUnit\Framework\TestSuite $suite): void {
+	}
+
+	public function endTestSuite(PHPUnit\Framework\TestSuite $suite): void {
+	}
+
+	public function startTest(PHPUnit\Framework\Test $test): void {
+	}
+
+	public function endTest(PHPUnit\Framework\Test $test, float $time): void {
 		// reopen the session - only allowed for memory session
 		if (\OC::$server->getSession() instanceof \OC\Session\Memory) {
 			/** @var $session \OC\Session\Memory */
 			$session = \OC::$server->getSession();
 			$session->reopen();
 		}
-	}
-
-	public function startTestSuite(PHPUnit\Framework\TestSuite $suite) {
-	}
-
-	public function endTestSuite(PHPUnit\Framework\TestSuite $suite) {
-	}
-
-	public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, $time) {
 	}
 }


### PR DESCRIPTION
## Description
See what happens, and then if it might help #34858

Note: PHPUnit7 requires PHP7.1, so it cannot help in `stable10` while it still supports PHP7.0.

## Related Issue
maybe can help #34858

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
