### PR TITLE
[10.1.1] Set proper value when upgrading app patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Set the correct value when upgrading app patch version in DB - [#34859](https://github.com/owncloud/core/pull/34859)
+- Set the correct value when upgrading app patch version in DB - [#34878](https://github.com/owncloud/core/pull/34878)
 
 ## [10.1.0] - 2019-02-06
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -914,7 +914,7 @@ class OC_App {
 				return true;
 			}
 			// update app version in db
-			\OC::$server->getConfig()->setAppValue($app, 'installed_version', $versions[$app]);
+			\OC::$server->getConfig()->setAppValue($app, 'installed_version', $currentVersion);
 		}
 		return false;
 	}


### PR DESCRIPTION
Adjusted fix from https://github.com/owncloud/core/pull/34859 for the code on top of v10.1.0

:warning: this is not the exact same fix as the variables were different on v10.1.0 vs stable10.

