### PR TITLE
substitute ocs path in feature files

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -493,6 +493,18 @@ trait BasicStructure {
 	}
 
 	/**
+	 * returns the OCS path
+	 * the path is without a slash at the end and without a slash at the beginning
+	 *
+	 * @param string $ocsApiVersion
+	 *
+	 * @return string
+	 */
+	public function getOCSPath($ocsApiVersion) {
+		return \ltrim($this->getBasePath() . "/ocs/v{$ocsApiVersion}.php", "/");
+	}
+
+	/**
 	 * returns the base URL but without "http(s)://" in front of it
 	 *
 	 * @return string
@@ -1896,6 +1908,22 @@ trait BasicStructure {
 					"getBasePath"
 				],
 				"parameter" => []
+			],
+			[
+				"code" => "%ocs_path_v1%",
+				"function" => [
+					$this,
+					"getOCSPath"
+				],
+				"parameter" => [1]
+			],
+			[
+				"code" => "%ocs_path_v2%",
+				"function" => [
+					$this,
+					"getOCSPath"
+				],
+				"parameter" => [2]
 			],
 			[
 				"code" => "%productname%",


### PR DESCRIPTION
## Description
possibility to substitute the complete OCS path in a feature file 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
