### PR TITLE
use array_key_exists and not isset for the case the value is NULL

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -230,7 +230,7 @@ trait Logging {
 						//don't check empty table entries
 						continue;
 					}
-					if (!isset($logEntry[$attribute])) {
+					if (!\array_key_exists($attribute, $logEntry)) {
 						//this line does not have the attribute we are looking for
 						$foundLine = false;
 						break;


### PR DESCRIPTION
## Description
if the value of the checked key is `NULL` `isset` does return `false`.
so to be able to test `NULL` values in the logfile we need to check by `array_key_exists`

## Related Issue
needed for https://github.com/owncloud/admin_audit/issues/79

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
