### PR TITLE
[stable10] use array_key_exists and not isset for the case the value is NULL

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -230,7 +230,7 @@ trait Logging {
 						//don't check empty table entries
 						continue;
 					}
-					if (!isset($logEntry[$attribute])) {
+					if (!\array_key_exists($attribute, $logEntry)) {
 						//this line does not have the attribute we are looking for
 						$foundLine = false;
 						break;


### PR DESCRIPTION
backport of #34893