### PR TITLE
Also run drone on release branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /drone
   path: src
 
-branches: [master, stable10, stable9.1, stable9]
+branches: [master, stable10, release*]
 
 clone:
   git:


### PR DESCRIPTION
I need this to run tests on release-10.1.1 branch to confirm all is fine for the patch release.

Also will be needed in the future when we switch to release branches for core.

Will this need a backport or does drone only read the config from master ?