### PR TITLE
Use creator of invitation as From field in invitation mails

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -122,6 +122,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		$message = $this->mailer->createMessage();
 
 		$message->setReplyTo([$sender => $senderName])
+			->setFrom([$sender => $senderName])
 			->setTo([$recipient => $recipientName])
 			->setSubject($subject)
 			->setBody($iTipMessage->message->serialize(), $contentType);


### PR DESCRIPTION
## Motivation and Context

Invitations to events are send by people and not the technical email address. Invitees expect to get an invitation from another person, not a service.

## How Has This Been Tested?

Manually tested in our environment and by other users here: https://github.com/owncloud/core/issues/25470#issuecomment-460729618


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
