### PR TITLE
Remove func_get_args() from ExpressionBuilder andX orX

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -58,14 +58,13 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 *     // (u.type = ?) AND (u.role = ?)
 	 *     $expr->andX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
-	 *                 at least one defined when converting to string.
+	 * @param mixed $clauses Optional clause(s). Defaults = null, but requires
+	 *                       at least one defined when converting to string.
 	 *
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
-	public function andX($x = null) {
-		$arguments = \func_get_args();
-		$compositeExpression = \call_user_func_array([$this->expressionBuilder, 'andX'], $arguments);
+	public function andX(...$clauses) {
+		$compositeExpression = \call_user_func_array([$this->expressionBuilder, 'andX'], $clauses);
 		return new CompositeExpression($compositeExpression);
 	}
 
@@ -78,14 +77,13 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 *     // (u.type = ?) OR (u.role = ?)
 	 *     $qb->where($qb->expr()->orX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
-	 *                 at least one defined when converting to string.
+	 * @param array $clauses Optional clause(s). Defaults = null, but requires
+	 *                       at least one defined when converting to string.
 	 *
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
-	public function orX($x = null) {
-		$arguments = \func_get_args();
-		$compositeExpression = \call_user_func_array([$this->expressionBuilder, 'orX'], $arguments);
+	public function orX(...$clauses) {
+		$compositeExpression = \call_user_func_array([$this->expressionBuilder, 'orX'], $clauses);
 		return new CompositeExpression($compositeExpression);
 	}
 

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -306,12 +306,16 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->leftJoin('u', 'phonenumbers', 'p', 'u.id = p.user_id');
 	 * </code>
 	 *
-	 * @param mixed $select The selection expressions.
+	 * @param mixed $select The first selection expression or an array of expressions.
+	 * @param array ...$otherExpressions Any other expressions as a variable-length argument list
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function select($select = null) {
-		$selects = \is_array($select) ? $select : \func_get_args();
+	public function select($select = null, ...$otherExpressions) {
+		if (!\is_array($select)) {
+			$select = [$select];
+		}
+		$selects = \array_merge($select, $otherExpressions);
 
 		$this->queryBuilder->select(
 			$this->helper->quoteColumnNames($selects)

--- a/lib/public/DB/QueryBuilder/IExpressionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IExpressionBuilder.php
@@ -64,13 +64,12 @@ interface IExpressionBuilder {
 	 *     // (u.type = ?) AND (u.role = ?)
 	 *     $expr->andX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
-	 *                 at least one defined when converting to string.
-	 *
+	 * @param array $clauses Optional clause(s). Defaults = null, but requires
+	 *                       at least one defined when converting to string.
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 * @since 8.2.0
 	 */
-	public function andX($x = null);
+	public function andX(...$clauses);
 
 	/**
 	 * Creates a disjunction of the given boolean expressions.
@@ -81,13 +80,13 @@ interface IExpressionBuilder {
 	 *     // (u.type = ?) OR (u.role = ?)
 	 *     $qb->where($qb->expr()->orX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
-	 *                 at least one defined when converting to string.
+	 * @param array $clauses Optional clause(s). Defaults = null, but requires
+	 *                       at least one defined when converting to string.
 	 *
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 * @since 8.2.0
 	 */
-	public function orX($x = null);
+	public function orX(...$clauses);
 
 	/**
 	 * Creates a comparison expression.


### PR DESCRIPTION
## Description
While investigating some unit tests, I noticed that the PHPdoc for ExpressionBuilder andX orX methods was not "correct". That is because it was difficult to sort out exactly what to write in PHPdoc for Variable-length argument lists. In this case, for example, the parameter `$x` is not used anywhere in the code. The code does `func_get_args()` to get the variable-length argument list.

These days (since PHP5.6) there is the `...$args` syntax for this, so we can remove the "old" `func_get_args()` calls and use the "new" `...$args` syntax to get an array of the variable arguments.

https://www.php.net/manual/en/functions.arguments.php "Variable-length argument lists" section.

This demonstrates adjusting some calls. Someone can decide if we want to do this refactoring some day on more `func_get_args()` calls.

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
