### PR TITLE
[stable10] Also run drone on release branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /drone
   path: src
 
-branches: [master, stable10, stable9.1, stable9]
+branches: [master, stable10, release*]
 
 clone:
   git:


### PR DESCRIPTION
Backport #34896 

even if this makes no real difference to what happens with drone jobs in `stable10`, it is nice to have minimal diffs between `master` and `stable10` branches.