### PR TITLE
escape substitutions when comparing by regex

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -68,10 +68,17 @@ trait Logging {
 			}
 
 			foreach (\array_keys($expectedLogEntry) as $attribute) {
-				$expectedLogEntry[$attribute]
-					= $this->featureContext->substituteInLineCodes(
-						$expectedLogEntry[$attribute]
-					);
+				if ($comparingMode === 'matching') {
+					$expectedLogEntry[$attribute]
+						= $this->featureContext->substituteInLineCodes(
+							$expectedLogEntry[$attribute], ['preg_quote' => ['/'] ]
+						);
+				} else {
+					$expectedLogEntry[$attribute]
+						= $this->featureContext->substituteInLineCodes(
+							$expectedLogEntry[$attribute]
+						);
+				}
 
 				if ($expectedLogEntry[$attribute] !== "") {
 					PHPUnit_Framework_Assert::assertArrayHasKey(
@@ -238,15 +245,20 @@ trait Logging {
 					if (!\is_string($logEntry[$attribute])) {
 						$logEntry[$attribute] = \json_encode($logEntry[$attribute]);
 					}
-					$expectedLogEntry[$attribute]
-						= $this->featureContext->substituteInLineCodes(
-							$expectedLogEntry[$attribute]
-						);
+
 					if ($regexCompare === true) {
+						$expectedLogEntry[$attribute]
+							= $this->featureContext->substituteInLineCodes(
+								$expectedLogEntry[$attribute], ['preg_quote' => ['/'] ]
+							);
 						$matchAttribute = \preg_match(
 							$expectedLogEntry[$attribute], $logEntry[$attribute]
 						);
 					} else {
+						$expectedLogEntry[$attribute]
+							= $this->featureContext->substituteInLineCodes(
+								$expectedLogEntry[$attribute]
+							);
 						$matchAttribute
 							= ($expectedLogEntry[$attribute] === $logEntry[$attribute]);
 					}


### PR DESCRIPTION
## Description
the substitution comes by default without any escaping, that is a problem for regex comparisons when  its e.g. an url `http://localhost`

## Related Issue
needed for https://github.com/owncloud/admin_audit/issues/79

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
