### PR TITLE
do not escape slashes when json encoding no-strings values in log file analysis

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -87,7 +87,9 @@ trait Logging {
 					);
 					$message = "log entry:\n{$logLines[$lineNo]}\n";
 					if (!\is_string($logEntry[$attribute])) {
-						$logEntry[$attribute] = \json_encode($logEntry[$attribute]);
+						$logEntry[$attribute] = \json_encode(
+							$logEntry[$attribute], JSON_UNESCAPED_SLASHES
+						);
 					}
 					if ($comparingMode === 'with') {
 						PHPUnit_Framework_Assert::assertEquals(
@@ -243,7 +245,9 @@ trait Logging {
 						break;
 					}
 					if (!\is_string($logEntry[$attribute])) {
-						$logEntry[$attribute] = \json_encode($logEntry[$attribute]);
+						$logEntry[$attribute] = \json_encode(
+							$logEntry[$attribute], JSON_UNESCAPED_SLASHES
+						);
 					}
 
 					if ($regexCompare === true) {


### PR DESCRIPTION
## Description
do not escape `/` so that we can easily compare against path and URL variables

## Related Issue
 owncloud/admin_audit#79

## Motivation and Context
e.g. needed when regex comparing against `%remote_server%` we add one layer of escaping for regex in https://github.com/owncloud/core/pull/34910 too hard to think about an other layer for JSON

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
