### PR TITLE
run federation tests also with OCSV v2 API

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -2,15 +2,15 @@
 Feature: federated
 
   Background:
-    Given using OCS API version "1"
-    And using server "REMOTE"
+    Given using server "REMOTE"
     And user "user0" has been created with default attributes
     And using server "LOCAL"
     And user "user1" has been created with default attributes
 
-  Scenario: Federate share a file with another server
+  Scenario Outline: Federate share a file with another server
+    Given using OCS API version "<ocs-api-version>"
     When user "user1" from server "LOCAL" shares "/textfile0.txt" with user "user0" from server "REMOTE" using the sharing API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the share fields of the last share should include
       | id                     | A_NUMBER       |
@@ -28,10 +28,15 @@ Feature: federated
       | displayname_owner      | User One       |
       | share_with             | user0@REMOTE   |
       | share_with_displayname | user0@REMOTE   |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Federate share a file with local server
+  Scenario Outline: Federate share a file with local server
+    Given using OCS API version "<ocs-api-version>"
     When user "user0" from server "REMOTE" shares "/textfile0.txt" with user "user1" from server "LOCAL" using the sharing API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the share fields of the last share should include
       | id                     | A_NUMBER       |
@@ -49,11 +54,16 @@ Feature: federated
       | displayname_owner      | User Zero      |
       | share_with             | user1@LOCAL    |
       | share_with_displayname | user1@LOCAL    |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Remote sharee can see the pending share
+  Scenario Outline: Remote sharee can see the pending share
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" gets the list of pending federated cloud shares using the sharing API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
       | id          | A_NUMBER                                   |
@@ -65,12 +75,17 @@ Feature: federated
       | user        | user1                                      |
       | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
       | accepted    | 0                                          |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Remote sharee requests information of only one share
+  Scenario Outline: Remote sharee requests information of only one share
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
     When user "user1" retrieves the information of the last federated cloud share using the sharing API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
       | id          | A_NUMBER           |
@@ -84,10 +99,15 @@ Feature: federated
       | accepted    | 1                  |
       | type        | file               |
       | permissions | 27                 |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
   @issue-34636
-  Scenario: Remote sharee requests information of only one share before accepting it
+  Scenario Outline: Remote sharee requests information of only one share before accepting it
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" retrieves the information of the last pending federated cloud share using the sharing API
     Then the HTTP status code should be "200" or "500"
     And the body of the response should be empty
@@ -103,34 +123,54 @@ Feature: federated
     #  | user        | user1                                      |
     #  | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
     #  | accepted    | 0                                          |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: sending a GET request to a pending remote share is not valid
+  Scenario Outline: sending a GET request to a pending remote share is not valid
+    Given using OCS API version "<ocs-api-version>"
     When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending/12"
     Then the HTTP status code should be "405"
     And the body of the response should be empty
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: sending a GET request to a not existing remote share
+  Scenario Outline: sending a GET request to a not existing remote share
+    Given using OCS API version "<ocs-api-version>"
     When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/9999999999"
-    Then the OCS status code should be "404"
-    And the HTTP status code should be "200"
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 404        | 200         |
+      | 2               | 404        | 404         |
 
-  Scenario: accept a pending remote share
+  Scenario Outline: accept a pending remote share
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Reshare a federated shared file
+  Scenario Outline: Reshare a federated shared file
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
     And user "user2" has been created with default attributes
+    And using OCS API version "<ocs-api-version>"
     When user "user1" creates a share using the sharing API with settings
       | path        | /textfile0 (2).txt |
       | shareType   | 0                  |
       | shareWith   | user2              |
       | permissions | 19                 |
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the share fields of the last share should include
       | id                     | A_NUMBER           |
@@ -148,40 +188,65 @@ Feature: federated
       | displayname_owner      | User One           |
       | share_with             | user2              |
       | share_with_displayname | User Two           |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Overwrite a federated shared file as recipient - local server shares - remote server receives
+  Scenario Outline: Overwrite a federated shared file as recipient - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "/textfile0.txt" with user "user0" from server "REMOTE"
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
+    And using OCS API version "<ocs-api-version>"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/textfile0.txt" for user "user1" on server "LOCAL" should be "BLABLABLA" plus end-of-line
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Overwrite a federated shared file as recipient - remote server shares - local server receives
+  Scenario Outline: Overwrite a federated shared file as recipient - remote server shares - local server receives
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
     When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/textfile0.txt" for user "user0" on server "REMOTE" should be "BLABLABLA" plus end-of-line
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
+  Scenario Outline: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
+    And using OCS API version "<ocs-api-version>"
     When user "user0" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/PARENT/textfile0.txt" for user "user1" on server "LOCAL" should be "BLABLABLA" plus end-of-line
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
+  Scenario Outline: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
     Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
     When user "user1" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/PARENT/textfile0.txt" for user "user0" on server "REMOTE" should be "BLABLABLA" plus end-of-line
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Overwrite a federated shared file as recipient using old chunking
+  Scenario Outline: Overwrite a federated shared file as recipient using old chunking
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
     When user "user1" uploads the following "3" chunks to "/textfile0 (2).txt" with old chunking and using the WebDAV API
       | 1 | AAAAA |
       | 2 | BBBBB |
@@ -189,10 +254,15 @@ Feature: federated
     Then the HTTP status code should be "201"
     And the content of file "/textfile0 (2).txt" for user "user1" should be "AAAAABBBBBCCCCC"
     And the content of file "/textfile0.txt" for user "user0" on server "REMOTE" should be "AAAAABBBBBCCCCC"
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Overwrite a file in a federated shared folder as recipient using old chunking
+  Scenario Outline: Overwrite a file in a federated shared folder as recipient using old chunking
     Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
     When user "user1" uploads the following "3" chunks to "/PARENT (2)/textfile0.txt" with old chunking and using the WebDAV API
       | 1 | AAAAA |
       | 2 | BBBBB |
@@ -200,12 +270,17 @@ Feature: federated
     Then the HTTP status code should be "201"
     And the content of file "/PARENT (2)/textfile0.txt" for user "user1" should be "AAAAABBBBBCCCCC"
     And the content of file "/PARENT/textfile0.txt" for user "user0" on server "REMOTE" should be "AAAAABBBBBCCCCC"
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Remote sharee deletes an accepted federated share
+  Scenario Outline: Remote sharee deletes an accepted federated share
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
     When user "user1" deletes the last federated cloud share using the sharing API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "user1" should not see the following elements
       | /textfile0%20(2).txt      |
@@ -213,10 +288,16 @@ Feature: federated
     Then the response should contain 0 entries
     When user "user1" gets the list of pending federated cloud shares using the sharing API
     Then the response should contain 0 entries
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Remote sharee tries to delete an accepted federated share sending wrong password
+  @issue-31276
+  Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
     When user "user1" deletes the last federated cloud share with password "invalid" using the sharing API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
@@ -237,11 +318,16 @@ Feature: federated
       | permissions | 27                 |
     When user "user1" gets the list of pending federated cloud shares using the sharing API
     Then the response should contain 0 entries
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
-  Scenario: Remote sharee deletes a pending federated share
+  Scenario Outline: Remote sharee deletes a pending federated share
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" deletes the last pending federated cloud share using the sharing API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "user1" should not see the following elements
       | /textfile0%20(2).txt      |
@@ -249,9 +335,15 @@ Feature: federated
     Then the response should contain 0 entries
     When user "user1" gets the list of pending federated cloud shares using the sharing API
     Then the response should contain 0 entries
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
 
-  Scenario: Remote sharee tries to delete a pending federated share sending wrong password
+  @issue-31276
+  Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" deletes the last pending federated cloud share with password "invalid" using the sharing API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
@@ -270,38 +362,62 @@ Feature: federated
       | accepted    | 0                                          |
     When user "user1" gets the list of federated cloud shares using the sharing API
     Then the response should contain 0 entries
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
-  Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
+  Scenario Outline: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
     Given using server "LOCAL"
-    And using OCS API version "2"
+    And using OCS API version "<ocs-api-version>"
     When user "UNAUTHORIZED_USER" requests shared secret using the federation API
-    Then the HTTP status code should be "403"
+    Then the HTTP status code should be "<http-status>"
+    Then the OCS status code should be "403"
+    Examples:
+      | ocs-api-version | http-status |
+      | 1               | 200         |
+      | 2               | 403         |
 
   @skipOnLDAP
-  Scenario: Upload file to received federated share while quota is set on home storage
+  Scenario Outline: Upload file to received federated share while quota is set on home storage
     Given user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
     And as user "user0" on server "REMOTE" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   @skipOnLDAP
-  Scenario: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives
+  Scenario Outline: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives
     Given using server "LOCAL"
     And the quota of user "user1" has been set to "20 B"
     And user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"
     And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
+    And using OCS API version "<ocs-api-version>"
     When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   @skipOnLDAP
-  Scenario: Upload file to received federated share while quota is set on remote storage - remote server shares - local server receives
+  Scenario Outline: Upload file to received federated share while quota is set on remote storage - remote server shares - local server receives
     Given using server "REMOTE"
     And the quota of user "user0" has been set to "20 B"
     And user "user0" from server "REMOTE" has shared "/PARENT" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -565,7 +565,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @return string
+	 * @return int
 	 */
 	public function getOcsApiVersion() {
 		return $this->ocsApiVersion;

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -110,8 +110,6 @@ class FederationContext implements Context {
 	public function userFromServerAcceptsLastPendingShareUsingTheSharingAPI($user, $server) {
 		$previous = $this->featureContext->usingServer($server);
 		$this->userGetsTheListOfPendingFederatedCloudShares($user);
-		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
@@ -148,8 +146,6 @@ class FederationContext implements Context {
 	 */
 	public function userRetrievesInformationOfLastFederatedShare($user) {
 		$this->userGetsTheListOfFederatedCloudShares($user);
-		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
@@ -170,8 +166,6 @@ class FederationContext implements Context {
 	 */
 	public function userRetrievesInformationOfLastPendingFederatedShare($user) {
 		$this->userGetsTheListOfPendingFederatedCloudShares($user);
-		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
@@ -232,8 +226,6 @@ class FederationContext implements Context {
 		} else {
 			$this->userGetsTheListOfFederatedCloudShares($user);
 		}
-		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->ocsContext->theOCSStatusCodeShouldBe('100');
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -90,12 +90,11 @@ class FederationContext implements Context {
 		$this->userFromServerSharesWithUserFromServerUsingTheSharingAPI(
 			$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->ocsContext->theOCSStatusCodeShouldBe(
-			'100', 'Could not share file/folder! message: "' .
-				$this->ocsContext->getOCSResponseStatusMessage(
-					$this->featureContext->getResponse()
-				) . '"'
+		$this->ocsContext->assertOCSResponseIndicatesSuccess(
+			'Could not share file/folder! message: "' .
+			$this->ocsContext->getOCSResponseStatusMessage(
+				$this->featureContext->getResponse()
+			) . '"'
 		);
 	}
 
@@ -133,8 +132,7 @@ class FederationContext implements Context {
 		$this->userFromServerAcceptsLastPendingShareUsingTheSharingAPI(
 			$user, $server
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBe('200');
-		$this->ocsContext->theOCSStatusCodeShouldBe('100');
+		$this->ocsContext->assertOCSResponseIndicatesSuccess();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -404,6 +404,22 @@ class OCSContext implements Context {
 	}
 
 	/**
+	 * check if the HTTP status code and the OCS status code indicate that the request was successful
+	 * this function is aware of the currently used OCS version
+	 *
+	 * @param string $message
+	 *
+	 * @return void
+	 */
+	public function assertOCSResponseIndicatesSuccess($message = "") {
+		$this->featureContext->theHTTPStatusCodeShouldBe('200', $message);
+		if ($this->featureContext->getOcsApiVersion() === 1) {
+			$this->theOCSStatusCodeShouldBe('100', $message);
+		} else {
+			$this->theOCSStatusCodeShouldBe('200', $message);
+		}
+	}
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *


### PR DESCRIPTION
## Description
noticed that we don't have any federation sharing tests running with ocs API v2
to be able to run this tests there were some changes to be made
mainly there are about that `When` statements used to check the result, `When` statements should not do that see: https://doc.owncloud.com/server/10.0/developer_manual/core/acceptance-tests.html#when-steps
Additionally the checks were only correct for ocs v1.

## Motivation and Context
this all is needed for https://github.com/owncloud/admin_audit/pull/153
ocs v2 tests fail there because this steps here are not correct

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
