### PR TITLE
[stable10] Update backported code from 33302 33859 now we have PHP7

### DIFF
--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -87,8 +87,8 @@ class Listener {
 			$owner = $mount->getUser()->getUID();
 			$ownerFolder = $this->rootFolder->getUserFolder($owner);
 			$nodes = $ownerFolder->getById($event->getComment()->getObjectId(), true);
-			if (!empty($nodes)) {
-				$node = $nodes[0];
+			$node = $nodes[0] ?? null;
+			if ($node) {
 				$path = $node->getPath();
 				if (\strpos($path, '/' . $owner . '/files/') === 0) {
 					$path = \substr($path, \strlen('/' . $owner . '/files'));

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -361,7 +361,8 @@ class FilesReportPlugin extends ServerPlugin {
 		$results = [];
 		foreach ($fileIds as $fileId) {
 			$entries = $folder->getById($fileId, true);
-			if (!empty($entries)) {
+			$entry = $entries[0] ?? null;
+			if ($entry) {
 				$entry = $entries[0];
 				$node = $this->makeSabreNode($entry);
 				if ($node) {

--- a/apps/files/lib/ActivityHelper.php
+++ b/apps/files/lib/ActivityHelper.php
@@ -60,8 +60,8 @@ class ActivityHelper {
 		$folders = $items = [];
 		foreach ($favorites as $favorite) {
 			$nodes = $rootFolder->getById($favorite, true);
-			if (!empty($nodes)) {
-				$node = $nodes[0];
+			$node = $nodes[0] ?? null;
+			if ($node) {
 				$path = \substr($node->getPath(), \strlen($user . '/files/'));
 
 				$items[] = $path;

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -169,7 +169,8 @@ class Share20OcsController extends OCSController {
 		}
 
 		$nodes = $userFolder->getById($share->getNodeId(), true);
-		if (empty($nodes)) {
+		$node = $nodes[0] ?? null;
+		if ($node === null) {
 			throw new NotFoundException();
 		}
 		$node = $nodes[0];
@@ -965,8 +966,8 @@ class Share20OcsController extends OCSController {
 	 */
 	public function notifyRecipientsDisabled($itemSource, $shareType, $recipient) {
 		$userFolder = $this->rootFolder->getUserFolder($this->currentUser->getUID());
-		$nodes = $userFolder->getById($itemSource);
-		$node = $nodes[0];
+		$nodes = $userFolder->getById($itemSource, true);
+		$node = $nodes[0] ?? null;
 
 		$items = $this->shareManager->getSharedWith($recipient, $shareType, $node);
 		if (\count($items) > 0) {

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -194,10 +194,10 @@ class SharedMount extends MountPoint implements MoveableMount {
 		}
 
 		$targetNodes = \OC::$server->getRootFolder()->getById($fileId, true);
-		if (empty($targetNodes)) {
+		$targetNode = $targetNodes[0] ?? null;
+		if ($targetNode === null) {
 			return false;
 		}
-		$targetNode = $targetNodes[0];
 
 		$shareManager = \OC::$server->getShareManager();
 		// FIXME: make it stop earlier in '/$userId/files'

--- a/apps/systemtags/lib/Activity/Listener.php
+++ b/apps/systemtags/lib/Activity/Listener.php
@@ -160,8 +160,8 @@ class Listener {
 			$owner = $mount->getUser()->getUID();
 			$ownerFolder = $this->rootFolder->getUserFolder($owner);
 			$nodes = $ownerFolder->getById($event->getObjectId(), true);
-			if (!empty($nodes)) {
-				$node = $nodes[0];
+			$node = $nodes[0] ?? null;
+			if ($node) {
 				$path = $node->getPath();
 				if (\strpos($path, '/' . $owner . '/files/') === 0) {
 					$path = \substr($path, \strlen('/' . $owner . '/files'));

--- a/lib/private/Files/Config/CachedMountInfo.php
+++ b/lib/private/Files/Config/CachedMountInfo.php
@@ -92,10 +92,7 @@ class CachedMountInfo implements ICachedMountInfo {
 		Filesystem::initMountPoints($this->getUser()->getUID());
 		$userNode = \OC::$server->getUserFolder($this->getUser()->getUID());
 		$nodes = $userNode->getParent()->getById($this->getRootId(), true);
-		if (empty($nodes)) {
-			return null;
-		}
-		return $nodes[0];
+		return $nodes[0] ?? null;
 	}
 
 	/**

--- a/lib/private/Files/Meta/MetaFileIdNode.php
+++ b/lib/private/Files/Meta/MetaFileIdNode.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/private/Files/Meta/MetaFileVersionNode.php
+++ b/lib/private/Files/Meta/MetaFileVersionNode.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -65,7 +65,7 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 	 */
 	public function __construct(MetaVersionCollection $parent,
 								IRootFolder $root,
-								array $version, Storage $storage, $internalPath) {
+								array $version, Storage\IStorage $storage, $internalPath) {
 		$this->parent = $parent;
 		$this->versionId = $version['version'];
 		$this->versionInfo = $version;

--- a/lib/private/Files/Meta/MetaRootNode.php
+++ b/lib/private/Files/Meta/MetaRootNode.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/private/Files/Meta/MetaVersionCollection.php
+++ b/lib/private/Files/Meta/MetaVersionCollection.php
@@ -3,7 +3,7 @@
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/private/Files/Node/AbstractFolder.php
+++ b/lib/private/Files/Node/AbstractFolder.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/lib/Files/MetaFilesTest.php
+++ b/tests/lib/Files/MetaFilesTest.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/lib/Files/MetaVersionCollectionTest.php
+++ b/tests/lib/Files/MetaVersionCollectionTest.php
@@ -62,7 +62,7 @@ class MetaVersionCollectionTest extends TestCase {
 
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->node = $this->createMock(Node::class);
-		$this->storage = $this->createMock([Storage::class, IVersionedStorage::class]);
+		$this->storage = $this->createMock([IStorage::class, IVersionedStorage::class]);
 		$this->node->method('getStorage')->willReturn($this->storage);
 		$this->collection = new MetaVersionCollection($this->rootFolder, $this->node);
 	}


### PR DESCRIPTION
## Description
PR #33302 used some PHP7 specific code, e.g. "null coalescing operator" https://www.php.net/manual/en/migration70.new-features.php

So that had to be backported differently in `stable10` PR #33859

This PR applies the "null coalescing operator" changes to `stable10` to make these files the same in `stable10` and `master`

## Related Issue
Aligning core master and stable10

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
