### PR TITLE
Adjust OC_VersionCanBeUpgradedFrom spacing to match stable10

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@ $OC_Version = [11, 0, 0, 0];
 // The human readable string
 $OC_VersionString = '11.0.0 prealpha';
 
-$OC_VersionCanBeUpgradedFrom = [[8,2,11], [9, 0, 9],[9, 1],[10, 0],[10, 1]];
+$OC_VersionCanBeUpgradedFrom = [[8, 2, 11], [9, 0, 9],[9, 1],[10, 0],[10, 1]];
 
 // The ownCloud channel
 $OC_Channel = 'git';


### PR DESCRIPTION
## Description
PR #30934 added 8.2.11 to `OC_VersionCanBeUpgradedFrom` but the format/spacing was done a bit differently than in `stable10` 

Make it the same, to reduce diffs between master and stable10.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
