### PR TITLE
[stable10] Tests cannot be executed if instance is in maintenance mode or needs upgrade

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,14 @@ if ($configDir) {
 
 require_once __DIR__ . '/../lib/base.php';
 
+// if instance is in maintenance mode tests cannot be executed
+if (\OC::$server->getSystemConfig()->getValue('maintenance', false)) {
+	throw new LogicException('Instance is in maintenance mode. Tests cannot be executed.');
+}
+if (\OCP\Util::needUpgrade()) {
+	throw new LogicException('Upgrade is required. Tests cannot be executed.');
+}
+
 // especially with code coverage it will require some more time
 \set_time_limit(0);
 


### PR DESCRIPTION
Backport #30934

Note: just 1 commit to backport. The other commit is for `version.php` which already has the changes in `stable10`