### PR TITLE
[stable10] Remove skeletondirectory setting from preseed-config.php

### DIFF
--- a/tests/preseed-config.php
+++ b/tests/preseed-config.php
@@ -17,6 +17,3 @@ if (\is_dir(OC::$SERVERROOT.'/apps2')) {
 		'writable' => false,
 	];
 }
-if (\getenv("TC") === "selenium") {
-	$CONFIG['skeletondirectory'] = OC::$SERVERROOT . '/tests/ui/skeleton';
-}


### PR DESCRIPTION
## Description
These lines were removed in master PR #28603 and backport to stable10 #28610
They came back again accidentally in stable10 PR #28714

Remove them again - they are not in master and are not needed.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
