### PR TITLE
[stable10] Have a real controller handling cron requests

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -32,6 +32,7 @@ use OC\AppFramework\Utility\SimpleContainer;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Core\Controller\AvatarController;
 use OC\Core\Controller\CloudController;
+use OC\Core\Controller\CronController;
 use OC\Core\Controller\LoginController;
 use OC\Core\Controller\LostController;
 use OC\Core\Controller\TokenController;
@@ -39,6 +40,9 @@ use OC\Core\Controller\TwoFactorChallengeController;
 use OC\Core\Controller\UserController;
 use OC_Defaults;
 use OCP\AppFramework\App;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\Util;
 
@@ -136,6 +140,15 @@ class Application extends App {
 			return new CloudController(
 				$c->query('AppName'),
 				$c->query('Request')
+			);
+		});
+		$container->registerService('CronController', function (SimpleContainer $c) {
+			return new CronController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query(IConfig::class),
+				$c->query(ILogger::class),
+				$c->query(IJobList::class)
 			);
 		});
 

--- a/core/Command/System/Cron.php
+++ b/core/Command/System/Cron.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\System;
+
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\ITempManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Cron extends Command {
+
+	/** @var \OCP\BackgroundJob\IJobList */
+	private $jobList;
+	/** @var IConfig */
+	private $config;
+	/** @var ILogger */
+	private $logger;
+	/** @var ITempManager */
+	private $tempManager;
+
+	/**
+	 * Cron constructor.
+	 *
+	 * @param IJobList $jobList
+	 * @param IConfig $config
+	 * @param ILogger $logger
+	 * @param ITempManager $tempManager
+	 */
+	public function __construct(IJobList $jobList,
+								IConfig $config,
+								ILogger $logger,
+								ITempManager $tempManager) {
+		$this->jobList = $jobList;
+		$this->config = $config;
+		$this->logger = $logger;
+		$this->tempManager = $tempManager;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('system:cron')
+			->setDescription('Execute background jobs as cron');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		if (\OCP\Util::needUpgrade()) {
+			$output->writeln('Update required, skipping cron');
+			return 1;
+		}
+		if ($this->config->getSystemValue('maintenance', false)) {
+			$output->writeln('We are in maintenance mode, skipping cron');
+			return 1;
+		}
+		if ($this->config->getSystemValue('singleuser', false)) {
+			$output->writeln('We are in admin only mode, skipping cron');
+			return 1;
+		}
+
+		// clean the temp folder
+		$this->tempManager->cleanOld();
+
+		// Exit if background jobs are disabled!
+		$appMode = $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax');
+		if ($appMode === 'none') {
+			$output->writeln('Background Jobs are disabled!');
+			return 1;
+		}
+
+		// We call ownCloud from the CLI (aka cron)
+		if ($appMode !== 'cron') {
+			$this->config->setAppValue('core', 'backgroundjobs_mode', 'cron');
+		}
+
+		$progress = new ProgressBar($output);
+
+		// We only ask for jobs for 14 minutes, because after 15 minutes the next
+		// system cron task should spawn.
+		$endTime = \time() + 14 * 60;
+
+		$executedJobs = [];
+		while ($job = $this->jobList->getNext()) {
+			if (isset($executedJobs[$job->getId()])) {
+				$this->jobList->unlockJob($job);
+				break;
+			}
+			$progress->advance();
+			$jobName = \get_class($job);
+			$progress->setMessage("Executing: {$job->getId()} - {$jobName}");
+
+			$job->execute($this->jobList, $this->logger);
+
+			// clean up after unclean jobs
+			\OC_Util::tearDownFS();
+
+			$this->jobList->setLastJob($job);
+			$executedJobs[$job->getId()] = true;
+			unset($job);
+
+			if (\time() > $endTime) {
+				break;
+			}
+		}
+
+		// Log the successful cron execution
+		if ($this->config->getSystemValue('cron_log', true)) {
+			$this->config->setAppValue('core', 'lastcron', \time());
+		}
+		$output->writeln('');
+
+		return 0;
+	}
+}

--- a/core/Controller/CronController.php
+++ b/core/Controller/CronController.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\ILogger;
+
+class CronController extends Controller {
+	
+	/** @var IConfig */
+	private $config;
+	/** @var ILogger */
+	private $logger;
+	/** @var IJobList */
+	private $jobList;
+
+	/**
+	 * CronController constructor.
+	 *
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IConfig $config
+	 * @param ILogger $logger
+	 * @param IJobList $jobList
+	 */
+	public function __construct($appName, IRequest $request,
+								IConfig $config,
+								ILogger $logger,
+								IJobList $jobList) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+		$this->logger = $logger;
+		$this->jobList = $jobList;
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * @return JSONResponse
+	 * @throws \Exception
+	 */
+	public function run(): JSONResponse {
+		// Exit if background jobs are disabled!
+		$appMode = $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax');
+		if ($appMode === 'none') {
+			return new JSONResponse(['data' => ['message' => 'Background jobs disabled!']]);
+		}
+
+		// We call cron.php from some website
+		if ($appMode === 'cron') {
+			return new JSONResponse(['data' => ['message' => 'Background jobs are using system cron!']]);
+		}
+
+		// Work and success :-)
+		$job = $this->jobList->getNext();
+		if ($job !== null) {
+			$job->execute($this->jobList, $this->logger);
+			$this->jobList->setLastJob($job);
+		}
+
+		// Log the successful cron execution
+		if ($this->config->getSystemValue('cron_log', true)) {
+			$this->config->setAppValue('core', 'lastcron', \time());
+		}
+
+		return new JSONResponse();
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -176,6 +176,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager(null)));
 	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager(null)));
 	$application->add(new OC\Core\Command\Security\ListRoutes(\OC::$server->getRouter()));
+	$application->add(new OC\Core\Command\System\Cron(\OC::$server->getJobList(), \OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->getTempManager()));
 } else {
 	$application->add(new OC\Core\Command\Maintenance\Install(\OC::$server->getConfig()));
 }

--- a/core/routes.php
+++ b/core/routes.php
@@ -51,6 +51,7 @@ $application->registerRoutes($this, [
 		['name' => 'TwoFactorChallenge#selectChallenge', 'url' => '/login/selectchallenge', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#showChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#solveChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'POST'],
+		['name' => 'Cron#run', 'url' => '/cron', 'verb' => 'GET'],
 	],
 	'ocs' => [
 		['root' => '/cloud', 'name' => 'Cloud#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],

--- a/cron.php
+++ b/cron.php
@@ -31,112 +31,13 @@
  *
  */
 
-try {
-	require_once __DIR__ . '/lib/base.php';
+require_once __DIR__ . '/lib/base.php';
 
-	if (!\OC::$CLI) {
-		$url = \OC::$server->getURLGenerator()->linkToRoute('core.Cron.run');
-		\header("Location: $url");
-		return;
-	}
-
-	if (\OCP\Util::needUpgrade()) {
-		\OCP\Util::writeLog('cron', 'Update required, skipping cron', \OCP\Util::DEBUG);
-		return;
-	}
-	if (\OC::$server->getSystemConfig()->getValue('maintenance', false)) {
-		\OCP\Util::writeLog('cron', 'We are in maintenance mode, skipping cron', \OCP\Util::DEBUG);
-		return;
-	}
-
-	if (\OC::$server->getSystemConfig()->getValue('singleuser', false)) {
-		\OCP\Util::writeLog('cron', 'We are in admin only mode, skipping cron', \OCP\Util::DEBUG);
-		return;
-	}
-
-	// load all apps to get all api routes properly setup
-	OC_App::loadApps();
-
-	\OC::$server->getSession()->close();
-
-	// initialize a dummy memory session
-	$session = new \OC\Session\Memory('');
-	$cryptoWrapper = \OC::$server->getSessionCryptoWrapper();
-	$session = $cryptoWrapper->wrapSession($session);
-	\OC::$server->setSession($session);
-
-	$logger = \OC::$server->getLogger();
-	$config = \OC::$server->getConfig();
-
-	// Don't do anything if ownCloud has not been installed
-	if (!$config->getSystemValue('installed', false)) {
-		exit(0);
-	}
-
-	\OC::$server->getTempManager()->cleanOld();
-
-	// Exit if background jobs are disabled!
-	$appMode = \OCP\BackgroundJob::getExecutionType();
-	if ($appMode == 'none') {
-		echo 'Background Jobs are disabled!' . PHP_EOL;
-		exit(1);
-	}
-
-	// set to run indefinitely if needed
-	\set_time_limit(0);
-
-	// the cron job must be executed with the right user
-	if (!\function_exists('posix_getuid')) {
-		echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
-		exit(0);
-	}
-	$user = \posix_getpwuid(\posix_getuid());
-	$configUser = \posix_getpwuid(\fileowner(OC::$SERVERROOT . '/config/config.php'));
-	if ($user['name'] !== $configUser['name']) {
-		echo "Console has to be executed with the same user as the web server is operated" . PHP_EOL;
-		echo "Current user: " . $user['name'] . PHP_EOL;
-		echo "Web server user: " . $configUser['name'] . PHP_EOL;
-		exit(0);
-	}
-
-	// We call ownCloud from the CLI (aka cron)
-	if ($appMode != 'cron') {
-		\OCP\BackgroundJob::setExecutionType('cron');
-	}
-
-	// Work
-	$jobList = \OC::$server->getJobList();
-
-	// We only ask for jobs for 14 minutes, because after 15 minutes the next
-	// system cron task should spawn.
-	$endTime = \time() + 14 * 60;
-
-	$executedJobs = [];
-	while ($job = $jobList->getNext()) {
-		if (isset($executedJobs[$job->getId()])) {
-			$jobList->unlockJob($job);
-			break;
-		}
-
-		$job->execute($jobList, $logger);
-		// clean up after unclean jobs
-		\OC_Util::tearDownFS();
-
-		$jobList->setLastJob($job);
-		$executedJobs[$job->getId()] = true;
-		unset($job);
-
-		if (\time() > $endTime) {
-			break;
-		}
-	}
-
-	// Log the successful cron execution
-	if (\OC::$server->getConfig()->getSystemValue('cron_log', true)) {
-		\OC::$server->getConfig()->setAppValue('core', 'lastcron', \time());
-	}
-} catch (Exception $ex) {
-	\OC::$server->getLogger()->logException($ex, [ 'app' => 'cron', 'level' => \OCP\Util::FATAL]);
-} catch (Error $ex) {
-	\OC::$server->getLogger()->logException($ex, [ 'app' => 'cron', 'level' => \OCP\Util::FATAL]);
+if (!\OC::$CLI) {
+	$url = \OC::$server->getURLGenerator()->linkToRoute('core.Cron.run');
+	\header("Location: $url");
+	return;
 }
+
+echo 'Please use ./occ system:cron' . PHP_EOL;
+exit(1);

--- a/lib/private/AppFramework/Routing/RouteActionHandler.php
+++ b/lib/private/AppFramework/Routing/RouteActionHandler.php
@@ -33,6 +33,7 @@ class RouteActionHandler {
 	private $container;
 
 	/**
+	 * @param DIContainer $container
 	 * @param string $controllerName
 	 * @param string $actionName
 	 */

--- a/tests/Core/Command/System/CronTest.php
+++ b/tests/Core/Command/System/CronTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\System;
+
+use OC\Core\Command\System\Cron;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\ITempManager;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * Class CronTest
+ *
+ * @group DB
+ */
+class CronTest extends TestCase {
+	use UserTrait;
+
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+	/** @var IJobList | \PHPUnit_Framework_MockObject_MockObject */
+	private $jobList;
+	/** @var ITempManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $tempManager;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->tempManager = $this->createMock(ITempManager::class);
+
+		$command = new Cron($this->jobList, $this->config, $this->logger, $this->tempManager);
+		$this->commandTester = new CommandTester($command);
+	}
+
+	public function testMaintenanceMode(): void {
+		$this->config->method('getSystemValue')->with('maintenance', false)->willReturn(true);
+
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains('We are in maintenance mode, skipping cron', $output);
+	}
+
+	public function testSingleuser(): void {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['maintenance', false, false],
+				['singleuser', false, true]
+			]);
+
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains('We are in admin only mode, skipping cron', $output);
+	}
+
+	public function testCronDisabled(): void {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['maintenance', false, false],
+				['singleuser', false, false]
+			]);
+		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('none');
+
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains('Background Jobs are disabled!', $output);
+	}
+
+	public function testCronRun(): void {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['maintenance', false, false],
+				['singleuser', false, false]
+			]);
+		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('ajax');
+		// assert that the mode is set to cron
+		$this->config->expects(self::once())->method('setAppValue')->with('core', 'backgroundjobs_mode', 'cron');
+
+		$job = $this->createMock(IJob::class);
+		$job->expects(self::once())->method('execute')->with($this->jobList, $this->logger);
+		$this->jobList->method('getNext')->willReturnOnConsecutiveCalls($job, null);
+		$this->jobList->expects(self::once())->method('setLastJob')->with($job);
+
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains('1 [->--------------------------]', $output);
+	}
+}

--- a/tests/Core/Command/System/CronTest.php
+++ b/tests/Core/Command/System/CronTest.php
@@ -63,7 +63,7 @@ class CronTest extends TestCase {
 		$this->commandTester = new CommandTester($command);
 	}
 
-	public function testMaintenanceMode(): void {
+	public function testMaintenanceMode() {
 		$this->config->method('getSystemValue')->with('maintenance', false)->willReturn(true);
 
 		$this->commandTester->execute([]);
@@ -71,7 +71,7 @@ class CronTest extends TestCase {
 		$this->assertContains('We are in maintenance mode, skipping cron', $output);
 	}
 
-	public function testSingleuser(): void {
+	public function testSingleuser() {
 		$this->config->method('getSystemValue')
 			->willReturnMap([
 				['maintenance', false, false],
@@ -83,7 +83,7 @@ class CronTest extends TestCase {
 		$this->assertContains('We are in admin only mode, skipping cron', $output);
 	}
 
-	public function testCronDisabled(): void {
+	public function testCronDisabled() {
 		$this->config->method('getSystemValue')
 			->willReturnMap([
 				['maintenance', false, false],
@@ -96,7 +96,7 @@ class CronTest extends TestCase {
 		$this->assertContains('Background Jobs are disabled!', $output);
 	}
 
-	public function testCronRun(): void {
+	public function testCronRun() {
 		$this->config->method('getSystemValue')
 			->willReturnMap([
 				['maintenance', false, false],

--- a/tests/Core/Controller/CronControllerTest.php
+++ b/tests/Core/Controller/CronControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Controller;
+
+use OC\Core\Controller\CronController;
+use OCP\AppFramework\Http;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IRequest;
+use Test\TestCase;
+
+/**
+ * Class CronControllerTest
+ *
+ * @package OC\Core\Controller
+ */
+class CronControllerTest extends TestCase {
+
+	/** @var CronController */
+	private $controller;
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+	/** @var IJobList | \PHPUnit_Framework_MockObject_MockObject */
+	private $jobList;
+	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	protected function setUp() {
+		$this->request = $this->createMock(IRequest::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->jobList = $this->createMock(IJobList::class);
+
+		$this->controller = new CronController('core', $this->request,
+			$this->config, $this->logger, $this->jobList);
+	}
+
+	public function testCronDisabled(): void {
+		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('none');
+		$response = $this->controller->run();
+		$this->assertEquals(new Http\JSONResponse(['data' => ['message' => 'Background jobs disabled!']]), $response);
+	}
+
+	public function testCronReal(): void {
+		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('cron');
+		$response = $this->controller->run();
+		$this->assertEquals(new Http\JSONResponse(['data' => ['message' => 'Background jobs are using system cron!']]), $response);
+	}
+
+	public function testCronRun(): void {
+		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('ajax');
+		$job = $this->createMock(IJob::class);
+		$job->expects(self::once())->method('execute')->with($this->jobList, $this->logger);
+		$this->jobList->expects(self::once())->method('getNext')->willReturn($job);
+		$this->jobList->expects(self::once())->method('setLastJob')->with($job);
+		$response = $this->controller->run();
+		$this->assertEquals(new Http\JSONResponse(), $response);
+	}
+}

--- a/tests/Core/Controller/CronControllerTest.php
+++ b/tests/Core/Controller/CronControllerTest.php
@@ -58,19 +58,19 @@ class CronControllerTest extends TestCase {
 			$this->config, $this->logger, $this->jobList);
 	}
 
-	public function testCronDisabled(): void {
+	public function testCronDisabled() {
 		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('none');
 		$response = $this->controller->run();
 		$this->assertEquals(new Http\JSONResponse(['data' => ['message' => 'Background jobs disabled!']]), $response);
 	}
 
-	public function testCronReal(): void {
+	public function testCronReal() {
 		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('cron');
 		$response = $this->controller->run();
 		$this->assertEquals(new Http\JSONResponse(['data' => ['message' => 'Background jobs are using system cron!']]), $response);
 	}
 
-	public function testCronRun(): void {
+	public function testCronRun() {
 		$this->config->method('getAppValue')->with('core', 'backgroundjobs_mode', 'ajax')->willReturn('ajax');
 		$job = $this->createMock(IJob::class);
 		$job->expects(self::once())->method('execute')->with($this->jobList, $this->logger);


### PR DESCRIPTION
Backport #31914 

The last commit removes some PHP7.1-only `: void` return declarations so that the unit tests pass here in `stable10` with PHP 7.0.

Note: since the PR in master, `cron.php` was modified by PR #32404 - that PR changed some exception logging https://github.com/owncloud/core/pull/32404/files

~~I did not see where to apply a similar "fix" to this new code with `CronController`. I think there is nothing needed. But someone please confirm that while reviewing.~~ - see comment below, this is OK.