### PR TITLE
[stable10] Add a command to poll incoming federated shares for updates

### DIFF
--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -20,4 +20,7 @@
         <personal>OCA\FederatedFileSharing\Panels\GeneralPersonalPanel</personal>
         <personal>OCA\FederatedFileSharing\Panels\SharingPersonalPanel</personal>
     </settings>
+    <commands>
+        <command>OCA\FederatedFileSharing\Command\PollIncomingShares</command>
+    </commands>
 </info>

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -162,12 +162,18 @@ class Application extends App {
 		$container->registerService(
 			PollIncomingShares::class,
 			function ($c) use ($server) {
-				$sharingApp = new \OCA\Files_Sharing\AppInfo\Application();
+				if ($server->getAppManager()->isEnabledForUser('files_sharing')) {
+					$sharingApp = new \OCA\Files_Sharing\AppInfo\Application();
+					$externalMountProvider = $sharingApp->getContainer()->query('ExternalMountProvider');
+				} else {
+					$externalMountProvider = null;
+				}
+
 				return new PollIncomingShares(
 					$server->getDatabaseConnection(),
 					$server->getUserManager(),
-					$sharingApp->getContainer()->query('ExternalMountProvider'),
-					\OC\Files\Filesystem::getLoader()
+					\OC\Files\Filesystem::getLoader(),
+					$externalMountProvider
 				);
 			}
 		);

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -22,6 +22,7 @@
 namespace OCA\FederatedFileSharing\AppInfo;
 
 use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\Command\PollIncomingShares;
 use OCA\FederatedFileSharing\Controller\OcmController;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\FederatedShareProvider;
@@ -155,6 +156,19 @@ class Application extends App {
 			'Permissions',
 			function ($c) {
 				return new Permissions();
+			}
+		);
+
+		$container->registerService(
+			PollIncomingShares::class,
+			function ($c) use ($server) {
+				$sharingApp = new \OCA\Files_Sharing\AppInfo\Application();
+				return new PollIncomingShares(
+					$server->getDatabaseConnection(),
+					$server->getUserManager(),
+					$sharingApp->getContainer()->query('ExternalMountProvider'),
+					\OC\Files\Filesystem::getLoader()
+				);
 			}
 		);
 	}

--- a/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
+++ b/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Command;
+
+use OC\ServerNotAvailableException;
+use OCA\Files_Sharing\AppInfo\Application;
+use OCP\Files\Storage\IStorage;
+use OCP\Files\StorageInvalidException;
+use OCP\Files\StorageNotAvailableException;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\Lock\LockedException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PollIncomingShares extends Command {
+	/** @var IDBConnection */
+	private $dbConnection;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/**
+	 * PollIncomingShares constructor.
+	 *
+	 * @param IDBConnection $dbConnection
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(IDBConnection $dbConnection, IUserManager $userManager) {
+		parent::__construct();
+		$this->dbConnection = $dbConnection;
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this->setName('incoming-shares:poll')
+			->setDescription('Poll incoming federated shares manually to detect updates');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @return int|null|void
+	 */
+	public function execute(InputInterface $input, OutputInterface $output) {
+		$mountProvider = $this->getExternalMountProvider();
+		$loader = $this->getLoader();
+		$cursor = $this->getCursor();
+		while ($data = $cursor->fetch()) {
+			$user = $this->userManager->get($data['user']);
+			$userMounts = $mountProvider->getMountsForUser($user, $loader);
+			/** @var \OCA\Files_Sharing\External\Mount $mount */
+			foreach ($userMounts as $mount) {
+				/** @var Storage $storage */
+				$storage = $mount->getStorage();
+				$this->refreshStorageRoot($storage);
+			}
+		}
+		$cursor->closeCursor();
+	}
+
+	/**
+	 * @param IStorage $storage
+	 */
+	protected function refreshStorageRoot(IStorage $storage) {
+		try {
+			$localMtime = $storage->filemtime('');
+			/** @var \OCA\Files_Sharing\External\Storage $storage */
+			if ($storage->hasUpdated('', $localMtime)) {
+				try {
+					$storage->getScanner('')->scan('', false, 0);
+				} catch (LockedException $e) {
+					// it can be locked, let's skip it then
+				} catch (ServerNotAvailableException $e) {
+					// remote server hasn't responded
+				}
+			}
+		} catch (StorageNotAvailableException $e) {
+			// pass
+		} catch (StorageInvalidException $e) {
+			// pass
+		}
+	}
+
+	/**
+	 * @return \Doctrine\DBAL\Driver\Statement
+	 */
+	protected function getCursor() {
+		$qb = $this->dbConnection->getQueryBuilder();
+		$qb->selectDistinct('user')
+			->from('share_external')
+			->where($qb->expr()->eq('accepted', $qb->expr()->literal('1')));
+
+		return $qb->execute();
+	}
+
+	/**
+	 * @return \OCP\Files\Storage\IStorageFactory
+	 */
+	protected function getLoader() {
+		return \OC\Files\Filesystem::getLoader();
+	}
+
+	/**
+	 * @return \OCA\Files_Sharing\External\MountProvider
+	 */
+	protected function getExternalMountProvider() {
+		$app = new Application();
+		return $app->getContainer()->query('ExternalMountProvider');
+	}
+}

--- a/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
+++ b/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
@@ -24,8 +24,10 @@ namespace OCA\FederatedFileSharing\Tests\Command;
 use Doctrine\DBAL\Driver\Statement;
 use OCA\FederatedFileSharing\Tests\TestCase;
 use OCA\FederatedFileSharing\Command\PollIncomingShares;
+use OCA\Files_Sharing\External\MountProvider;
 use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Storage\IStorageFactory;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -47,11 +49,19 @@ class PollIncomingSharesTest extends TestCase {
 	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $userManager;
 
+	/** @var MountProvider | \PHPUnit_Framework_MockObject_MockObject */
+	private $externalMountProvider;
+
+	/** @var IStorageFactory | \PHPUnit_Framework_MockObject_MockObject */
+	private $loader;
+
 	protected function setUp() {
 		parent::setUp();
 		$this->dbConnection = $this->createMock(IDBConnection::class);
 		$this->userManager = $this->createMock(IUserManager::class);
-		$command = new PollIncomingShares($this->dbConnection, $this->userManager);
+		$this->externalMountProvider = $this->createMock(MountProvider::class);
+		$this->loader = $this->createMock(IStorageFactory::class);
+		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->externalMountProvider, $this->loader);
 		$this->commandTester = new CommandTester($command);
 	}
 
@@ -70,6 +80,9 @@ class PollIncomingSharesTest extends TestCase {
 		$userMock = $this->createMock(IUser::class);
 		$this->userManager->expects($this->once())->method('get')
 			->with($uid)->willReturn($userMock);
+
+		$this->externalMountProvider->expects($this->once())->method('getMountsForUser')
+			->willReturn([]);
 
 		$this->dbConnection->method('getQueryBuilder')->willReturn($qbMock);
 		$this->commandTester->execute([]);

--- a/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
+++ b/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
@@ -61,7 +61,7 @@ class PollIncomingSharesTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->externalMountProvider = $this->createMock(MountProvider::class);
 		$this->loader = $this->createMock(IStorageFactory::class);
-		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->externalMountProvider, $this->loader);
+		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->loader, $this->externalMountProvider);
 		$this->commandTester = new CommandTester($command);
 	}
 
@@ -88,5 +88,13 @@ class PollIncomingSharesTest extends TestCase {
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();
 		$this->assertEmpty($output);
+	}
+
+	public function testWithFilesSharingDisabled() {
+		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->loader, null);
+		$this->commandTester = new CommandTester($command);
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains("Polling is not possible when files_sharing app is disabled. Please enable it with 'occ app:enable files_sharing'", $output);
 	}
 }

--- a/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
+++ b/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Tests\Command;
+
+use Doctrine\DBAL\Driver\Statement;
+use OCA\FederatedFileSharing\Tests\TestCase;
+use OCA\FederatedFileSharing\Command\PollIncomingShares;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class PollIncomingSharesTest
+ *
+ * @group DB
+ * @package OCA\FederatedFileSharing\Tests\Command
+ */
+class PollIncomingSharesTest extends TestCase {
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject */
+	private $dbConnection;
+
+	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dbConnection = $this->createMock(IDBConnection::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$command = new PollIncomingShares($this->dbConnection, $this->userManager);
+		$this->commandTester = new CommandTester($command);
+	}
+
+	public function testNoSharesPoll() {
+		$uid = 'foo';
+		$exprBuilder = $this->createMock(IExpressionBuilder::class);
+		$statementMock = $this->createMock(Statement::class);
+		$statementMock->method('fetch')->willReturnOnConsecutiveCalls(['user' => $uid], false);
+		$qbMock = $this->createMock(IQueryBuilder::class);
+		$qbMock->method('selectDistinct')->willReturnSelf();
+		$qbMock->method('from')->willReturnSelf();
+		$qbMock->method('where')->willReturnSelf();
+		$qbMock->method('expr')->willReturn($exprBuilder);
+		$qbMock->method('execute')->willReturn($statementMock);
+
+		$userMock = $this->createMock(IUser::class);
+		$this->userManager->expects($this->once())->method('get')
+			->with($uid)->willReturn($userMock);
+
+		$this->dbConnection->method('getQueryBuilder')->willReturn($qbMock);
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertEmpty($output);
+	}
+}


### PR DESCRIPTION
## Description
Backport of https://github.com/owncloud/core/pull/34903

Allow manually poll federated share updates and update the storage root 
to help the sync client properly detect federated share updates

## Related Issue

- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. setup two OC instances oc1 and oc2
2. create a federated share from user@oc1 to user@oc2 with a deep nested folder structure
3. Accept the share by user@oc2
4. Setup a desktop client for user@oc2, let  it sync the data
5. update the share by user@oc1 (e.g by uploading something into /really/deeply/nested/folder)
6. wait for the client - nothing is synced
7. run `php occ incomingShares:sync`
8. wait a bit - the changes is synced


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

