### PR TITLE
read files from skeleton folder by providing absolute path

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,7 @@ pipeline:
   install-fed-server:
     image: owncloudci/core
     pull: true
+    exclude: apps/testing
     version: ${FEDERATION_OC_VERSION}
     core_path: /drone/fed-server
     when:


### PR DESCRIPTION
## Description
get the absolute path and read the file
needs https://github.com/owncloud/testing/pull/94

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/615

## Motivation and Context
less complexity, less magic

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
