### PR TITLE
Pass admin username, password, base URL from readSkeletonFile to runOcc

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -496,7 +496,10 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		//find the absolute path of the currently set skeletondirectory
 		$occResponse = self::runOcc(
-			['config:system:get', 'skeletondirectory']
+			['config:system:get', 'skeletondirectory'],
+			$adminUsername,
+			$adminPassword,
+			$baseUrl
 		);
 		if ((int) $occResponse['code'] !== 0) {
 			throw new \Exception(


### PR DESCRIPTION
# Description
PR #34938 changed the code in `SetupHelper::readSkeletonFile()`

Fix it so that when calling down to `runOcc()` we pass down any specific admin username, password and base URL that the caller might have passed in.

This will get `oauth2` CI passing.

## Motivation and Context
In `oauth2` CI is failing when it tries to call core `SetupHelper::readSkeletonFile()` using an access token as the admin password. The access token is not being passed down to `runOcc` as the admin password - the original admin password is getting used, and that is not valid because token-auth is enforced in the test.

## How Has This Been Tested?
CI and analysing `oauth2` test fail.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
