### PR TITLE
Type::JSON not supported in current Doctrine

### DIFF
--- a/core/Migrations/Version20181220085457.php
+++ b/core/Migrations/Version20181220085457.php
@@ -38,7 +38,7 @@ class Version20181220085457 implements ISchemaMigration {
 			if (!$shareTable->hasColumn('attributes')) {
 				$shareTable->addColumn(
 					'attributes',
-					Type::JSON,
+					Type::TEXT,
 					[
 						'default' => null,
 						'notnull' => false


### PR DESCRIPTION
Doctrine/dbal 2.5 doesn't have json, so using text instead for now to avoid migration troubles.

Had to apply this on stable10 here https://github.com/owncloud/core/pull/34951