### PR TITLE
[stable10] delete newly created core config parameters after scenario

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -393,6 +393,12 @@ trait AppConfiguration {
 			if (($server === 'LOCAL') || $this->federatedServerExists()) {
 				$this->usingServer($server);
 				$this->resetAppConfigs();
+				$this->coreConfigs[$server] = AppConfigHelper::getAppConfigs(
+					$this->getBaseUrl(),
+					$this->getAdminUsername(),
+					$this->getAdminPassword(),
+					'core'
+				);
 			}
 		}
 		$this->usingServer($previousServer);
@@ -414,6 +420,28 @@ trait AppConfiguration {
 				$this->usingServer($server);
 				if (\key_exists($this->getBaseUrl(), $this->savedCapabilitiesChanges)) {
 					$this->modifyAppConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+				}
+				$currentCoreConfigs = AppConfigHelper::getAppConfigs(
+					$this->getBaseUrl(),
+					$this->getAdminUsername(),
+					$this->getAdminPassword(),
+					'core'
+				);
+				foreach ($currentCoreConfigs as $config) {
+					$found = false;
+					foreach ($this->coreConfigs[$server] as $originalConfig) {
+						if ($config['configkey'] === $originalConfig['configkey']) {
+							$found = true;
+							break;
+						}
+					}
+					if ($found === false) {
+						AppConfigHelper::deleteAppConfig(
+							$this->getBaseUrl(),
+							$this->getAdminUsername(),
+							$this->getAdminPassword(), 'core', $config['configkey']
+						);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description
if parameters were newly creates e.g. with `When the administrator sets parameter "brand-new-config" of app "core" to "no"` delete them at the end of the scenario again

## Related Issue
needed for https://github.com/owncloud/admin_audit/issues/79

## How Has This Been Tested?
created tests that create new parameters and see if they are gone after the test run

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Forwardport to master
