### PR TITLE
[stable10] Fix public link share default expiration behavior

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -327,20 +327,6 @@ class Manager implements IManager {
 			}
 		}
 
-		// If expiredate is empty set a default one if there is a default
-		$fullId = null;
-		try {
-			$fullId = $share->getFullId();
-		} catch (\UnexpectedValueException $e) {
-			// This is a new share
-		}
-
-		if ($fullId === null && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
-			$expirationDate = new \DateTime();
-			$expirationDate->setTime(0, 0, 0);
-			$expirationDate->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));
-		}
-
 		// If we enforce the expiration date check that is does not exceed
 		if ($this->shareApiLinkDefaultExpireDateEnforced()) {
 			if ($expirationDate === null) {

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -56,19 +56,31 @@
 	print_unescaped('checked="checked"');
 } ?> />
 		<label for="shareapiDefaultExpireDate"><?php p($l->t('Set default expiration date'));?></label><br/>
+		<span id="setDefaultExpireDate" class="indent <?php if ($_['allowLinks'] !== 'yes' || $_['shareDefaultExpireDateSet'] === 'no' || $_['shareAPIEnabled'] === 'no') {
+	p('hidden');
+}?>">
+			<?php p($l->t('Expire after ')); ?>
+			<input type="text" name='shareapi_expire_after_n_days' id="shareapiExpireAfterNDays" placeholder="<?php p('7')?>"
+				   value='<?php p($_['shareExpireAfterNDays']) ?>' />
+			<?php p($l->t('days')); ?><br/>
+			<?php if ($_['shareEnforceExpireDate'] === 'yes'): ?>
+				<input type="checkbox" name="shareapi_enforce_expire_date" id="shareapiEnforceExpireDate" class="checkbox" value="1" checked="checked" />
+			<?php else: ?>
+				<input type="checkbox" name="shareapi_enforce_expire_date" id="shareapiEnforceExpireDate" class="checkbox" value="1" />
+			<?php endif; ?>
+			<label class="indent" for="shareapiEnforceExpireDate"><?php p($l->t('Enforce expiration date'));?></label><br/>
+		</span>
 
 		<input type="checkbox" name="shareapi_allow_public_notification" id="allowPublicMailNotification" class="checkbox"
 			   value="1" <?php if ($_['allowPublicMailNotification'] == 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
 		<label for="allowPublicMailNotification"><?php p($l->t('Allow users to send mail notification for shared files'));?></label><br/>
-	<span id="publicMailNotificationLang" <?php if ($_['allowPublicMailNotification'] == 'no') {
-	print_unescaped('class="hidden"');
-} ?>>
-		<label><?php p($l->t('Language used for public mail notifications for shared files'));?></label>
-		<?php print_unescaped($_['publicMailNotificationLang']); ?>
-		<br>
-	</span>
+		<span id="publicMailNotificationLang" class="indent <?php if ($_['allowPublicMailNotification'] == 'no'): ?>hidden<?php endif; ?>">
+			<label><?php p($l->t('Language used for public mail notifications for shared files'));?></label>
+			<?php print_unescaped($_['publicMailNotificationLang']); ?>
+			<br>
+		</span>
 
 
 		<input type="checkbox" name="shareapi_allow_social_share" id="allowSocialShare" class="checkbox"
@@ -77,19 +89,6 @@
 } ?> />
 		<label for="allowSocialShare"><?php p($l->t('Allow users to share file via social media'));?></label><br/>
 
-	</p>
-	<p id="setDefaultExpireDate" class="double-indent <?php if ($_['allowLinks'] !== 'yes' || $_['shareDefaultExpireDateSet'] === 'no' || $_['shareAPIEnabled'] === 'no') {
-	p('hidden');
-}?>">
-		<?php p($l->t('Expire after ')); ?>
-		<input type="text" name='shareapi_expire_after_n_days' id="shareapiExpireAfterNDays" placeholder="<?php p('7')?>"
-			   value='<?php p($_['shareExpireAfterNDays']) ?>' />
-		<?php p($l->t('days')); ?>
-		<input type="checkbox" name="shareapi_enforce_expire_date" id="shareapiEnforceExpireDate" class="checkbox"
-			   value="1" <?php if ($_['shareEnforceExpireDate'] === 'yes') {
-	print_unescaped('checked="checked"');
-} ?> />
-		<label for="shareapiEnforceExpireDate"><?php p($l->t('Enforce expiration date'));?></label><br/>
 	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') {
 	p('hidden');

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -934,7 +934,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException  \InvalidArgumentException
+	 * @expectedException \InvalidArgumentException
 	 */
 	public function testvalidateExpirationDateEnforceButNotSetNewShare() {
 		$share = $this->manager->newShare();

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -933,24 +933,19 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($share->getExpirationDate());
 	}
 
+	/**
+	 * @expectedException  \InvalidArgumentException
+	 */
 	public function testvalidateExpirationDateEnforceButNotSetNewShare() {
 		$share = $this->manager->newShare();
 
 		$this->config->method('getAppValue')
 			->will($this->returnValueMap([
-				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
-				['core', 'shareapi_expire_after_n_days', '7', '3'],
 				['core', 'shareapi_default_expire_date', 'no', 'yes'],
+				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 			]));
 
-		$expected = new \DateTime();
-		$expected->setTime(0, 0, 0);
-		$expected->add(new \DateInterval('P3D'));
-
 		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
-
-		$this->assertNotNull($share->getExpirationDate());
-		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
 	public function testvalidateExpirationDateEnforceToFarIntoFuture() {
@@ -963,6 +958,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->config->method('getAppValue')
 			->will($this->returnValueMap([
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
 				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
 			]));


### PR DESCRIPTION
Backport of #34960
## Description
- "default link expiration" sub-entry location problem fixed. Now, it is under "Set expiration date".

- Currently, when the expiration date enabled and not enforced,  the default expiration date is set even though the user deleted it on share creation. With this PR, if the user removes the expiration date on share creation, no expiration date will be set as discussed in here: https://github.com/owncloud/enterprise/issues/3204#issuecomment-478657949

## Related Issue
Closes https://github.com/owncloud/enterprise/issues/3204

## Motivation and Context
Fixing bugs.

## How Has This Been Tested?
Unit tests are adjusted. Also, manually tested with following steps:
- Activate, "Set expiration date" from admin sharing settings. The expiration date sub-entry should be listed under "Set expiration date" input.

To test share creation behavior;
- Activate, "Set expiration date" but not enforce.
- Click share a file via public link and remove default expiration date from its input field. The share should be created without an expiration date.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 