### PR TITLE
phpunit6 enable failOnRisky

### DIFF
--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -85,7 +85,7 @@ class PathVerificationTest extends \Test\TestCase {
 			$this->expectException(InvalidPathException::class);
 			$this->expectExceptionMessage('4-byte characters are not supported in file names');
 		}
-		$this->view->verifyPath('', $fileName);
+		$this->assertNull($this->view->verifyPath('', $fileName));
 	}
 
 	public function providesAstralPlane() {

--- a/tests/phpunit-autotest-external.xml
+++ b/tests/phpunit-autotest-external.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="bootstrap.php"
 		 verbose="true"
+		 failOnRisky="true"
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -3,6 +3,7 @@
 		 verbose="true"
 		 backupGlobals="false"
 		 backupStaticAttributes="false"
+		 failOnRisky="true"
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"


### PR DESCRIPTION
## Description
In `phpunit` enable `failOnRisky` so we know about tests that `phpunit`  thinks are "a bit odd"

## Related Issue
- while looking into #34858 we bumped PHPUnit to v6, and this is a flow-on setting

## Motivation and Context
We did this already in apps. Be consistent and do it in core.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
