### PR TITLE
[stable10] substitute complete dav path in acceptance test steps

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -505,6 +505,15 @@ trait BasicStructure {
 	}
 
 	/**
+	 * returns the complete DAV path including the base path e.g. owncloud-core/remote.php/dav
+
+	 * @return string
+	 */
+	public function getDAVPathIncludingBasePath() {
+		return \ltrim($this->getBasePath() . "/" . $this->getDavPath(), "/");
+	}
+
+	/**
 	 * returns the base URL but without "http(s)://" in front of it
 	 *
 	 * @return string
@@ -1906,6 +1915,14 @@ trait BasicStructure {
 				"function" => [
 					$this,
 					"getBasePath"
+				],
+				"parameter" => []
+			],
+			[
+				"code" => "%dav_path%",
+				"function" => [
+					$this,
+					"getDAVPathIncludingBasePath"
 				],
 				"parameter" => []
 			],


### PR DESCRIPTION
## Description
a new substitution for the complete dav path

## Related Issue
needed for owncloud/admin_audit#79

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] port to master (if applicable set "backport-request" label and remove when the backport was done)
