### PR TITLE
[stable10] Backport of Renaming and adding new options for public link

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -843,16 +843,6 @@ OC.Uploader.prototype = _.extend({
 					upload
 				]);
 				return false;
-			} else {
-				/**
-				 * The public link with view-download-upload option. Here we would
-				 * not overwrite the files. Instead create new file by autorenaming,
-				 * if the file already exists.
-				 *
-				 */
-				if (fileInfo) {
-					callbacks.onAutoRenameForPublicLink(upload);
-				}
 			}
 			return true;
 		});
@@ -1111,9 +1101,6 @@ OC.Uploader.prototype = _.extend({
 
 							onNoConflicts: function (selection) {
 								self.submitUploads(selection.uploads);
-							},
-							onAutoRenameForPublicLink: function(upload) {
-								self.onAutorename(upload);
 							},
 							onSkipConflicts: function (selection) {
 								//TODO mark conflicting files as toskip

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -455,8 +455,9 @@ class Share20OcsController extends OCSController {
 					Constants::PERMISSION_UPDATE |
 					Constants::PERMISSION_DELETE
 				);
-			} elseif ($permissions === Constants::PERMISSION_CREATE ||
-				$permissions === (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE)) {
+			} elseif ($permissions === \OCP\Constants::PERMISSION_CREATE ||
+				$permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) ||
+				$permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE)) {
 				$share->setPermissions($permissions);
 			} else {
 				// because when "publicUpload" is passed usually no permissions are set,

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -365,6 +365,7 @@ class ShareController extends Controller {
 		}
 
 		$shareTmpl['canDownload'] = !!($share->getPermissions() & \OCP\Constants::PERMISSION_READ > 0);
+		$shareTmpl['sharePermission'] = $share->getPermissions();
 		$shareTmpl['downloadURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.downloadShare', ['token' => $token]);
 		$shareTmpl['shareUrl'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $token]);
 		$shareTmpl['maxSizeAnimateGif'] = $this->config->getSystemValue('max_filesize_animated_gifs_public_sharing', 10);

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -50,6 +50,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 <input type="hidden" name="mimetypeIcon" value="<?php p(\OC::$server->getMimeTypeDetector()->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
 <input type="hidden" name="filesize" value="<?php p($_['nonHumanFileSize']); ?>" id="filesize">
 <input type="hidden" name="maxSizeAnimateGif" value="<?php p($_['maxSizeAnimateGif']); ?>" id="maxSizeAnimateGif">
+<input type="hidden" name="sharePermission" value="<?php p($_['sharePermission']); ?>" id="sharePermission">
 
 <header>
 	<div id="header" class="<?php p((isset($_['folder']) ? 'share-folder' : 'share-file')) ?>" data-protected="<?php p($_['protected']) ?>"

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -424,6 +424,7 @@ class ShareControllerTest extends \Test\TestCase {
 			'shareUrl' => null,
 			'previewImage' => null,
 			'canDownload' => true,
+			'sharePermission' => true
 		];
 
 		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -27,11 +27,16 @@
 				'<label class="bold" for="sharingDialogAllowPublicRead-{{cid}}">{{publicReadLabel}}</label>' +
 				'<p><em>{{publicReadDescription}}</em></p>' +
 			'</div>' +
-			'{{#if publicUploadPossible}}' +
-			'<div id="allowPublicReadWrite-{{cid}}" class="public-link-modal--item">' +
+			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
 				'<p><em>{{publicReadWriteDescription}}</em></p>' +
+			'</div>' +
+			'{{#if publicUploadPossible}}' +
+			'<div id="allowpublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="{{publicUploadWriteValue}}" name="publicPermissions" id="sharingDialogAllowpublicUploadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowpublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +
+				'<p><em>{{publicUploadWriteDescription}}</em></p>' +
 			'</div>' +
 			'<div id="allowPublicUploadWrapper-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadValue}}" name="publicPermissions" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadSelected}}checked{{/if}} />' +
@@ -258,8 +263,13 @@
 				publicReadValue            : OC.PERMISSION_READ,
 				publicReadSelected         : this.model.get('permissions') === OC.PERMISSION_READ,
 
-				publicReadWriteLabel       : t('core', 'Download / View / Upload'),
-				publicReadWriteDescription : t('core', 'Recipients can view, download, edit, delete and upload contents.'),
+				publicUploadWriteLabel       : t('core', 'Download / View / Upload'),
+				publicUploadWriteDescription : t('core', 'Recipients can view, download and upload contents.'),
+				publicUploadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE,
+				publicUploadWriteSelected    : this.model.get('permissions') === (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE),
+
+				publicReadWriteLabel       : t('core', 'Download / View / Edit'),
+				publicReadWriteDescription : t('core', 'Recipients can view, download and edit contents.'),
 				publicReadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE,
 				publicReadWriteSelected    : this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE),
 

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -208,7 +208,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 					permissions: OC.PERMISSION_READ | OC.PERMISSION_CREATE
 				});
 				view.render();
-				expect(view.$('.publicPermissions').length).toEqual(3);
+				expect(view.$('.publicPermissions').length).toEqual(4);
 			});
 			it('renders checkbox disabled when public upload is disallowed by user', function() {
 				publicUploadConfigStub.returns(true);

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -50,6 +50,7 @@ class SharingHelper {
 	 *                                                    1 = read; 2 = update; 4 = create;
 	 *                                                    8 = delete; 16 = share; 31 = all
 	 *                                                    15 = change
+	 *                                                    7 = uploadwriteonly
 	 *                                                    (default: 31, for public shares: 1)
 	 *                                                    Pass either the (total) number,
 	 *                                                    or the keyword,
@@ -170,6 +171,7 @@ class SharingHelper {
 					'read' => 1,
 					'update' => 2,
 					'create' => 4,
+					'uploadwriteonly' => 7,
 					'delete' => 8,
 					'change' => 15,
 					'share' => 16,

--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -197,6 +197,24 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @public_link_share-feature-required
+  Scenario Outline: Creating a link share with upload permissions keeps it
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created folder "/afolder"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | /afolder |
+      | permissions | 7        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the share fields of the last share should include
+      | id          | A_NUMBER |
+      | share_type  | 3        |
+      | permissions | 7        |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
   Scenario Outline: Share of folder and sub-folder to same user - core#20645
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -311,3 +311,25 @@ Feature: sharing
       | 1 | hallo |
       | 2 | welt  |
     Then the HTTP status code should be "403"
+
+  @smokeTest @public_link_share-feature-required
+  Scenario: Uploading to a public upload-read-write and no edit and no overwrite share
+    Given as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER          |
+      | permissions | uploadwriteonly |
+    When the public uploads file "test.txt" with content "test" using the public WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+
+  @smokeTest @public_link_share-feature-required
+  Scenario: Uploading same file to a public upload-read-write and no edit and no overwrite share multiple times
+    Given as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER          |
+      | permissions | uploadwriteonly |
+    When the public uploads file "test.txt" with content "test" using the public WebDAV API
+    And the public uploads file "test.txt" with content "test2" with autorename mode using the public WebDAV API
+    And the public uploads file "test.txt" with content "test3" with autorename mode using the public WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+    And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
+    And the content of file "/FOLDER/test (3).txt" for user "user0" should be "test3"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -115,6 +115,7 @@ trait Sharing {
 	 *       |                 |     1 = read; 2 = update; 4 = create;               |
 	 *       |                 |     8 = delete; 16 = share; 31 = all                |
 	 *       |                 |     15 = change                                     |
+	 *       |                 |     7 = uploadwriteonly                             |
 	 *       |                 |     (default: 31, for public shares: 1)             |
 	 *       |                 |     Pass either the (total) number,                 |
 	 *       |                 |     or the keyword,                                 |
@@ -292,8 +293,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
-	 * @Given /^user "([^"]*)" has created a public link share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^user "([^"]*)" creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|uploadwriteonly|share|all) permission(?:s|)$/
+	 * @Given /^user "([^"]*)" has created a public link share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|uploadwriteonly|share|all) permission(?:s|)$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -308,8 +309,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
-	 * @Given /^the user has created a public link share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^the user creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|uploadwriteonly|share|all) permission(?:s|)$/
+	 * @Given /^the user has created a public link share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|uploadwriteonly|share|all) permission(?:s|)$/
 	 *
 	 * @param string $path
 	 * @param string|int|string[]|int[]|null $permissions

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -50,6 +50,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	private $permissionLabelXpath = [
 		'read' => ".//label[contains(@for, 'sharingDialogAllowPublicRead')]",
 		'read-write' => ".//label[contains(@for, 'sharingDialogAllowPublicReadWrite')]",
+		'upload-write-without-modify' =>  ".//label[contains(@for, 'sharingDialogAllowpublicUploadWrite')]",
 		'upload' => ".//label[contains(@for, 'sharingDialogAllowPublicUpload')]"
 	];
 	private $popupCloseButton = "//a[@class='oc-dialog-close']";

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -366,3 +366,17 @@ Feature: Share by public link
     When the user removes the public link at position 3 of file "lorem.txt" using the webUI
     Then the public link with name "third-link" should not be in the public links list
     And the number of public links should be 2
+
+  Scenario: user creates public link with view and upload feature
+    When the user creates a new public link for folder "simple-folder" using the webUI with
+      | permission | upload-write-without-modify |
+    And the public accesses the last created public link using the webUI
+
+  Scenario: user edits the permission of an already existing public link from read-write to upload-write-without-overwrite
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | read-write |
+    When the user changes the permission of the public link named "Public link" to "upload-write-without-modify"
+    And the public accesses the last created public link using the webUI
+    When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem (2).txt" should be listed on the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR renames and adds an option in the public link share dialog. The `View/Download/Upload` is now renamed to `View/Download/Edit`. So if the user wants to create a link which would let others to create, edit, upload and delete in the public link then `View/Download/Edit` should be selected.
The new option `View/Download/Upload` has lesser permission. When a public link with this option is created, the user could create folder(s), no delete option is available.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Renaming `View/Download/Upload` to `View/Download/Edit` in the public link share creation dialog.
- Created `View/Download/Upload` with minimal permission. Removed edit and delete option.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Done the testing same as done at https://github.com/owncloud/core/pull/34687#issue-258349867

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
