### PR TITLE
[stable10] fix multi gdrive external storage bug

### DIFF
--- a/apps/files_external/js/gdrive.js
+++ b/apps/files_external/js/gdrive.js
@@ -22,38 +22,37 @@ $(document).ready(function() {
 			});
 			el.tooltip({placement: 'top'});
 			backendEl.append(el);
+
+			/**
+			 * ------- OAUTH2 Events ----------
+			 *
+			 * The files_external_{backendId} app's CUSTOM JS should handle the OAuth2 events itself
+			 * instead on relying on the core for the implemention. These two functions
+			 * [1] OCA.External.Settings.OAuth2.getAuthUrl, [2] OCA.External.Settings.OAuth2.verifyCode
+			 * abstract away the details of sending the request to backend for getting the AuthURL or
+			 * verifying the code, mounting the storage config etc
+			 */
+			$tr.find('.configuration').on('oauth_step1', function (event, data) {
+				if (data['backend_id'] !== backendId) {
+					return;	// means the trigger is not for this storage adapter
+				}
+
+				// Redirects the User on success else displays an alert (with error message sent by backend)
+				OCA.External.Settings.OAuth2.getAuthUrl(backendUrl, data);
+			});
+
+			$tr.find('.configuration').on('oauth_step2', function (event, data) {
+				if (data['backend_id'] !== backendId || data['code'] === undefined) {
+					return;		// means the trigger is not for this OAuth2 grant
+				}
+
+				OCA.External.Settings.OAuth2.verifyCode(backendUrl, data)
+					.fail(function (message) {
+						OC.dialogs.alert(message,
+							t('files_external', 'Error verifying OAuth2 Code for ' + backendId)
+						);
+					});
+			});
 		}
 	});
-
-	/**
-	 * ------- OAUTH2 Events ----------
-	 * 
-	 * The files_external_{backendId} app's CUSTOM JS should handle the OAuth2 events itself
-	 * instead on relying on the core for the implemention. These two functions
-	 * [1] OCA.External.Settings.OAuth2.getAuthUrl, [2] OCA.External.Settings.OAuth2.verifyCode
-	 * abstract away the details of sending the request to backend for getting the AuthURL or
-	 * verifying the code, mounting the storage config etc
-	 */
-	$('.configuration').on('oauth_step1', function (event, data) {
-		if (data['backend_id'] !== backendId) {
-			return;	// means the trigger is not for this storage adapter
-		}
-
-		// Redirects the User on success else displays an alert (with error message sent by backend)
-		OCA.External.Settings.OAuth2.getAuthUrl(backendUrl, data);
-	});
-
-	$('.configuration').on('oauth_step2', function (event, data) {
-		if (data['backend_id'] !== backendId || data['code'] === undefined) {
-			return;		// means the trigger is not for this OAuth2 grant
-		}
-
-		OCA.External.Settings.OAuth2.verifyCode(backendUrl, data)
-		.fail(function (message) {
-			OC.dialogs.alert(message,
-				t('files_external', 'Error verifying OAuth2 Code for ' + backendId)
-			);
-		})
-	});
-
 });


### PR DESCRIPTION
## Description
- Fixes bug on multiple gdrive account addition
- As @Lirein explained in https://github.com/owncloud/core/issues/31497#issue-325256774. currently `oauth2_step1` and `oauth_step2` handlers are always registering for the first container in `gdrive.js`. I moved them inside of `whenSelectBackend` event and registered each of them separately.

@op6sie, @Lirein please test if you available.

## Related Issue
fixes #31154 , fixes #31497

## Motivation and Context
Fixing bugs.

## How Has This Been Tested?
Try to add multiple gdrive external storage. It should work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open Tasks:
- [x] Port to files_external_gdrive app