### PR TITLE
Limiting the maximum width of .fileName in #app-sidebar

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -90,7 +90,7 @@
 }
 
 #app-sidebar .fileName h3 {
-	max-width: 300px;
+	max-width: 280px;
 	display: inline-block;
 	padding: 5px 0;
 	margin: -5px 0;
@@ -116,9 +116,9 @@
 
 #app-sidebar .close {
 	position: absolute;
-	top: 0;
-	right: 0;
-	padding: 15px;
+	top: 5px;
+	right: 5px;
+	padding: 5px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
 }


### PR DESCRIPTION
## Description
This fixes a problem mainly affects the resolution of 1680px wide as it is widely used on MacBook with 13-inch retina display. When creating private links it happens to 90% that you close the dialog.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/34997

## Motivation and Context
`#app-sidebar .close` is overlapping, this leads to accidential hit the close button instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on Firefox and Chrome

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/33026403/55837633-39e78280-5b22-11e9-95c4-d2da5a10c845.png)

After:
![image](https://user-images.githubusercontent.com/33026403/55839599-bbdaaa00-5b28-11e9-9dbf-c893289d00e0.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
