### PR TITLE
[stable10] Backport of Add encryption version fix command

### DIFF
--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -33,6 +33,7 @@
 		<command>OCA\Encryption\Command\RecreateMasterKey</command>
 		<command>OCA\Encryption\Command\MigrateKeys</command>
 		<command>OCA\Encryption\Command\HSMDaemon</command>
+		<command>OCA\Encryption\Command\FixEncryptedVersion</command>
 	</commands>
 	<settings>
 		<admin>OCA\Encryption\Panels\Admin</admin>

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Command;
+
+use OC\Files\Cache\Cache;
+use OC\Files\View;
+use OC\HintException;
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixEncryptedVersion extends Command {
+	/** @var IRootFolder  */
+	private $rootFolder;
+
+	/** @var IUserManager  */
+	private $userManager;
+
+	/** @var View  */
+	private $view;
+
+	public function __construct(IRootFolder $rootFolder, IUserManager $userManager, View $view) {
+		$this->rootFolder = $rootFolder;
+		$this->userManager = $userManager;
+		$this->view = $view;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('encryption:fixencryptedversion')
+			->setDescription('Fix the encrypted version if the encrypted file(s) are not downloadable.')
+			->addArgument(
+				'user',
+				InputArgument::REQUIRED,
+				'The user id whose files needs fix'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$user = $input->getArgument('user');
+
+		if ($user === null) {
+			$output->writeln("<error>No user provided.</error>\n");
+		}
+
+		if ($this->userManager->get($user) === null) {
+			$output->writeln("<error>User $user does not exist. Please provide a valid user id</error>");
+			return 1;
+		}
+		$this->walkUserFolder($user, $output);
+	}
+
+	/**
+	 * @param string $user
+	 * @param OutputInterface $output
+	 */
+	private function walkUserFolder($user, OutputInterface $output) {
+		$this->setupUserFs($user);
+		$directories = [];
+		$directories[] = '/' . $user . '/files';
+		while ($root = \array_pop($directories)) {
+			$directoryContent = $this->view->getDirectoryContent($root);
+			foreach ($directoryContent as $file) {
+				$path = $root . '/' . $file['name'];
+				if ($this->view->is_dir($path)) {
+					$directories[] = $path;
+				} else {
+					$output->writeln("Verifying the content of file $path");
+					$this->verifyFileContent($path, $output);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param OutputInterface $output
+	 * @param bool $ignoreCorrectEncVersionCall, setting this variable to false avoids recursion
+	 */
+	private function verifyFileContent($path, OutputInterface $output, $ignoreCorrectEncVersionCall = true) {
+		try {
+			/**
+			 * In encryption, the files are read in a block size of 8192 bytes
+			 * Read block size of 8192 and a bit more (808 bytes)
+			 * If there is any problem, the first block should throw the signature
+			 * mismatch error. Which as of now, is enough to proceed ahead to
+			 * correct the encrypted version.
+			 */
+			if ($this->view->readfilePart($path, 0, 9000) !== false) {
+				$output->writeln("<info>The file $path is: OK</info>");
+			}
+			return true;
+		} catch (HintException $e) {
+			\OC::$server->getLogger()->warning("Issue: " . $e->getMessage());
+			//If allowOnce is set to false, this becomes recursive.
+			if ($ignoreCorrectEncVersionCall === true) {
+				//Lets rectify the file by correcting encrypted version
+				$output->writeln("<info>Attempting to fix the path: $path</info>");
+				return $this->correctEncryptedVersion($path, $output);
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param OutputInterface $output
+	 */
+	private function correctEncryptedVersion($path, OutputInterface $output) {
+		$fileInfo = $this->view->getFileInfo($path);
+		$fileId = $fileInfo->getId();
+		$encryptedVersion = $fileInfo->getEncryptedVersion();
+		$wrongEncryptedVersion = $encryptedVersion;
+
+		$storage = $fileInfo->getStorage();
+
+		$cache = $storage->getCache();
+		$fileCache = $cache->get($fileId);
+
+		if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+			$output->writeln("<info>The file: $path is a share. Hence kindly fix this by running the script under the owner of share</info>");
+			return true;
+		}
+
+		if ($encryptedVersion >= 0) {
+			//test by decrementing the value till 1 and if nothing works try incrementing
+			$encryptedVersion--;
+			while ($encryptedVersion > 0) {
+				$cacheInfo = ['encryptedVersion' => $encryptedVersion, 'encrypted' => $encryptedVersion];
+				$cache->put($fileCache->getPath(), $cacheInfo);
+				$output->writeln("<info>Decrement the encrypted version to $encryptedVersion</info>");
+				if ($this->verifyFileContent($path, $output, false) === true) {
+					$output->writeln("<info>Fixed the file $path with version " . $encryptedVersion . "</info>");
+					return true;
+				}
+				$encryptedVersion--;
+			}
+
+			//So decrementing did not worked. Now lets increment. Max increment is till 5
+			$increment = 1;
+			while ($increment <= 5) {
+				/**
+				 * The wrongEncryptedVersion would not be incremented so nothing to worry here.
+				 * Only the newEncryptedVersion is incremented.
+				 * For example if the wrong encrypted version is 4 then
+				 * cycle1 -> newEncryptedVersion = 5 ( 4 + 1)
+				 * cycle2 -> newEncryptedVersion = 6 ( 4 + 2)
+				 * cycle3 -> newEncryptedVersion = 7 ( 4 + 3)
+				 */
+				$newEncryptedVersion = $wrongEncryptedVersion + $increment;
+
+				$cacheInfo = ['encryptedVersion' => $newEncryptedVersion, 'encrypted' => $newEncryptedVersion];
+				$cache->put($fileCache->getPath(), $cacheInfo);
+				$output->writeln("<info>Increment the encrypted version to $newEncryptedVersion</info>");
+				if ($this->verifyFileContent($path, $output, false) === true) {
+					$output->writeln("<info>Fixed the file $path with version " . $newEncryptedVersion . "</info>");
+					return true;
+				}
+				$increment++;
+			}
+		}
+	}
+
+	/**
+	 * Setup user file system
+	 * @param string $uid
+	 */
+	private function setupUserFs($uid) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($uid);
+	}
+}

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -52,12 +52,12 @@ class FixEncryptedVersion extends Command {
 		parent::configure();
 
 		$this
-			->setName('encryption:fixencryptedversion')
+			->setName('encryption:fix-encrypted-version')
 			->setDescription('Fix the encrypted version if the encrypted file(s) are not downloadable.')
 			->addArgument(
 				'user',
 				InputArgument::REQUIRED,
-				'The user id whose files needs fix'
+				'The id of the user whose files need fixing'
 			);
 	}
 
@@ -65,11 +65,11 @@ class FixEncryptedVersion extends Command {
 		$user = $input->getArgument('user');
 
 		if ($user === null) {
-			$output->writeln("<error>No user provided.</error>\n");
+			$output->writeln("<error>No user id provided.</error>\n");
 		}
 
 		if ($this->userManager->get($user) === null) {
-			$output->writeln("<error>User $user does not exist. Please provide a valid user id</error>");
+			$output->writeln("<error>User id $user does not exist. Please provide a valid user id</error>");
 			return 1;
 		}
 		$this->walkUserFolder($user, $output);
@@ -143,7 +143,7 @@ class FixEncryptedVersion extends Command {
 		$fileCache = $cache->get($fileId);
 
 		if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
-			$output->writeln("<info>The file: $path is a share. Hence kindly fix this by running the script under the owner of share</info>");
+			$output->writeln("<info>The file: $path is a share. Hence kindly fix this by running the script for the owner of share</info>");
 			return true;
 		}
 
@@ -155,17 +155,17 @@ class FixEncryptedVersion extends Command {
 				$cache->put($fileCache->getPath(), $cacheInfo);
 				$output->writeln("<info>Decrement the encrypted version to $encryptedVersion</info>");
 				if ($this->verifyFileContent($path, $output, false) === true) {
-					$output->writeln("<info>Fixed the file $path with version " . $encryptedVersion . "</info>");
+					$output->writeln("<info>Fixed the file: $path with version " . $encryptedVersion . "</info>");
 					return true;
 				}
 				$encryptedVersion--;
 			}
 
-			//So decrementing did not worked. Now lets increment. Max increment is till 5
+			//So decrementing did not work. Now lets increment. Max increment is till 5
 			$increment = 1;
 			while ($increment <= 5) {
 				/**
-				 * The wrongEncryptedVersion would not be incremented so nothing to worry here.
+				 * The wrongEncryptedVersion would not be incremented so nothing to worry about here.
 				 * Only the newEncryptedVersion is incremented.
 				 * For example if the wrong encrypted version is 4 then
 				 * cycle1 -> newEncryptedVersion = 5 ( 4 + 1)
@@ -178,7 +178,7 @@ class FixEncryptedVersion extends Command {
 				$cache->put($fileCache->getPath(), $cacheInfo);
 				$output->writeln("<info>Increment the encrypted version to $newEncryptedVersion</info>");
 				if ($this->verifyFileContent($path, $output, false) === true) {
-					$output->writeln("<info>Fixed the file $path with version " . $newEncryptedVersion . "</info>");
+					$output->writeln("<info>Fixed the file: $path with version " . $newEncryptedVersion . "</info>");
 					return true;
 				}
 				$increment++;

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Encryption\Tests\Command;
 
+use OC\Files\Cache\Cache;
 use OC\Files\Filesystem;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\View;
@@ -121,7 +122,7 @@ class FixEncryptedVersionTest extends TestCase {
 	 * In this test the encrypted version is set to zero whereas it should have been
 	 * set to a positive non zero number.
 	 */
-	public function testEncryptedVersionZero() {
+	public function testEncryptedVersionIsNotZero() {
 		$this->markTestSkippedIfFilesPrimary();
 		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
 		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
@@ -150,7 +151,7 @@ class FixEncryptedVersionTest extends TestCase {
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Increment the encrypted version to 1
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 1
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 1
 Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 The file /test_enc_version_affected_user1/files/world.txt is: OK
 ", $output);
@@ -219,7 +220,7 @@ Increment the encrypted version to 4
 Increment the encrypted version to 5
 Increment the encrypted version to 6
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 6
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 6
 Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
 Increment the encrypted version to 2
@@ -227,7 +228,7 @@ Increment the encrypted version to 3
 Increment the encrypted version to 4
 Increment the encrypted version to 5
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/world.txt with version 5
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
@@ -293,7 +294,7 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 9
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 9
 Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
 Decrement the encrypted version to 14
@@ -303,7 +304,7 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/world.txt with version 9
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -156,7 +156,7 @@ The file /test_enc_version_affected_user1/files/world.txt is: OK
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
 		 * where as the ob_get_level is found to be zero.
 		 */
 		\ob_start();
@@ -231,7 +231,7 @@ Fixed the file /test_enc_version_affected_user1/files/world.txt with version 5
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
 		 * where as the ob_get_level is found to be zero.
 		 */
 		\ob_start();
@@ -307,7 +307,7 @@ Fixed the file /test_enc_version_affected_user1/files/world.txt with version 9
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
 		 * where as the ob_get_level is found to be zero.
 		 */
 		\ob_start();

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -1,0 +1,315 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Tests\Command;
+
+use OC\Files\Filesystem;
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OC\Files\View;
+use OCA\Encryption\AppInfo\Application;
+use OCA\Encryption\Command\FixEncryptedVersion;
+use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\KeyManager;
+use OCA\Encryption\Session;
+use OCA\Encryption\Util;
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use Symfony\Component\Console\Tester\CommandTester;
+use OCA\Encryption\Users\Setup;
+use Test\TestCase;
+
+/**
+ * Class FixEncryptedVersionTest
+ *
+ * @group DB
+ * @package OCA\Encryption\Tests\Command
+ */
+class FixEncryptedVersionTest extends TestCase {
+	const TEST_ENCRYPTION_VERSION_AFFECTED_USER = 'test_enc_version_affected_user1';
+
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var View */
+	private $view;
+
+	/** @var FixEncryptedVersion */
+	private $fixEncryptedVersion;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		//Enable encryption app
+		\OC_App::enable("encryption");
+		//Enable encryption
+		\OC::$server->getConfig()->setAppValue('core', 'encryption_enabled', 'yes');
+		//Enable Masterkey
+		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '1');
+		//Setup Storage
+		\OC::$server->getEncryptionManager()->setupStorage();
+		$crypt = new Crypt(\OC::$server->getLogger(), \OC::$server->getUserSession(), \OC::$server->getConfig(), \OC::$server->getL10N('encryption'));
+		$encryptionSession = new Session(\OC::$server->getSession());
+		$view = new View("/");
+		$encryptionUtil = new Util($view, $crypt, \OC::$server->getLogger(), \OC::$server->getUserSession(), \OC::$server->getConfig(), \OC::$server->getUserManager());
+		$keyManager = new KeyManager(\OC::$server->getEncryptionKeyStorage(),
+			$crypt, \OC::$server->getConfig(), \OC::$server->getUserSession(),
+			$encryptionSession, \OC::$server->getLogger(), $encryptionUtil);
+		$userSetup = new Setup(\OC::$server->getLogger(), \OC::$server->getUserSession(), $crypt, $keyManager);
+		$userSetup->setupSystem();
+		\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(false);
+		$app = new Application([], true);
+		$app->registerHooks();
+		\OC::$server->getUserManager()->createUser(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		$user = \OC::$server->getUserManager()->get(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER);
+		if ($user !== null) {
+			$user->delete();
+		}
+		\OC_App::disable('encryption');
+		\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(true);
+		\OC::$server->getConfig()->deleteAppValue('core', 'encryption_enabled');
+		\OC::$server->getConfig()->deleteAppValue('core', 'default_encryption_module');
+		\OC::$server->getConfig()->deleteAppValues('encryption');
+		Filesystem::getLoader()->removeStorageWrapper("oc_encryption");
+	}
+
+	public function setUp() {
+		parent::setUp();
+		$this->rootFolder = \OC::$server->getRootFolder();
+		$this->userManager = \OC::$server->getUserManager();
+		$this->view = new View("/");
+		$this->fixEncryptedVersion = new FixEncryptedVersion($this->rootFolder, $this->userManager, $this->view);
+		$this->commandTester = new CommandTester($this->fixEncryptedVersion);
+	}
+
+	public function markTestSkippedIfFilesPrimary() {
+		$view = new View("/");
+		$path = "/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER;
+		list($storage, $internalPath) = $view->resolvePath($path);
+		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
+			$this->markTestSkipped("Skipping this test because fseek issue was hit.");
+		}
+	}
+
+	/**
+	 * In this test the encrypted version is set to zero whereas it should have been
+	 * set to a positive non zero number.
+	 */
+	public function testEncryptedVersionZero() {
+		$this->markTestSkippedIfFilesPrimary();
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('world.txt', 'a test string for world');
+
+		$fileInfo = $view->getFileInfo('hello.txt');
+
+		$storage = $fileInfo->getStorage();
+		$cache = $storage->getCache();
+		$fileCache = $cache->get($fileInfo->getId());
+
+		//Now change the encrypted version to zero
+		$cacheInfo = ['encryptedVersion' => 0, 'encrypted' => 0];
+		$cache->put($fileCache->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Increment the encrypted version to 1
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 1
+Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+", $output);
+		/**
+		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * where as the ob_get_level is found to be zero.
+		 */
+		\ob_start();
+	}
+
+	/**
+	 * In this test the encrypted version of the file is less than the original value
+	 * but greater than zero
+	 */
+	public function testEncryptedVersionLessThanOriginalValue() {
+		$this->markTestSkippedIfFilesPrimary();
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->touch('foo.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('hello.txt', 'Yet another value');
+		$view->file_put_contents('hello.txt', 'Lets modify again1');
+		$view->file_put_contents('hello.txt', 'Lets modify again2');
+		$view->file_put_contents('hello.txt', 'Lets modify again3');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('foo.txt', 'a foo test');
+
+		$fileInfo1 = $view->getFileInfo('hello.txt');
+
+		$storage1 = $fileInfo1->getStorage();
+		$cache1 = $storage1->getCache();
+		$fileCache1 = $cache1->get($fileInfo1->getId());
+
+		//Now change the encrypted version to two
+		$cacheInfo = ['encryptedVersion' => 2, 'encrypted' => 2];
+		$cache1->put($fileCache1->getPath(), $cacheInfo);
+
+		$fileInfo2 = $view->getFileInfo('world.txt');
+		$storage2 = $fileInfo2->getStorage();
+		$cache2 = $storage2->getCache();
+		$filecache2 = $cache2->get($fileInfo2->getId());
+
+		//Now change the encrypted version to 1
+		$cacheInfo = ['encryptedVersion' => 1, 'encrypted' => 1];
+		$cache2->put($filecache2->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Decrement the encrypted version to 1
+Increment the encrypted version to 3
+Increment the encrypted version to 4
+Increment the encrypted version to 5
+Increment the encrypted version to 6
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 6
+Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
+Increment the encrypted version to 2
+Increment the encrypted version to 3
+Increment the encrypted version to 4
+Increment the encrypted version to 5
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/world.txt with version 5
+", $output);
+		/**
+		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * where as the ob_get_level is found to be zero.
+		 */
+		\ob_start();
+	}
+
+	/**
+	 * In this test the encrypted version of the file is greater than the original value
+	 * but greater than zero
+	 */
+	public function testEncryptedVersionGreaterThanOriginalValue() {
+		$this->markTestSkippedIfFilesPrimary();
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->touch('foo.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('hello.txt', 'Lets modify again2');
+		$view->file_put_contents('hello.txt', 'Lets modify again3');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('foo.txt', 'a foo test');
+
+		$fileInfo1 = $view->getFileInfo('hello.txt');
+
+		$storage1 = $fileInfo1->getStorage();
+		$cache1 = $storage1->getCache();
+		$fileCache1 = $cache1->get($fileInfo1->getId());
+
+		//Now change the encrypted version to fifteem
+		$cacheInfo = ['encryptedVersion' => 15, 'encrypted' => 15];
+		$cache1->put($fileCache1->getPath(), $cacheInfo);
+
+		$fileInfo2 = $view->getFileInfo('world.txt');
+		$storage2 = $fileInfo2->getStorage();
+		$cache2 = $storage2->getCache();
+		$filecache2 = $cache2->get($fileInfo2->getId());
+
+		//Now change the encrypted version to 1
+		$cacheInfo = ['encryptedVersion' => 15, 'encrypted' => 15];
+		$cache2->put($filecache2->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Decrement the encrypted version to 14
+Decrement the encrypted version to 13
+Decrement the encrypted version to 12
+Decrement the encrypted version to 11
+Decrement the encrypted version to 10
+Decrement the encrypted version to 9
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 9
+Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
+Decrement the encrypted version to 14
+Decrement the encrypted version to 13
+Decrement the encrypted version to 12
+Decrement the encrypted version to 11
+Decrement the encrypted version to 10
+Decrement the encrypted version to 9
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/world.txt with version 9
+", $output);
+		/**
+		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * where as the ob_get_level is found to be zero.
+		 */
+		\ob_start();
+	}
+}


### PR DESCRIPTION
Backport of `encryption` app PR https://github.com/owncloud/encryption/pull/115

Add a new command to fix the encryption
version. This would help the admin to
fix the issues related to encryption version
mismatch for the files.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The `encryption:fixencryptedversion` command becomes handy when the encrypted version in the filecache becomes inconsistent. It helps to fix the encrypted version, so that user doesn't hit with `Bad Signature` errors while trying to view or download the file from oC UI.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `encryption:fixencryptedversion` command becomes handy when the encrypted version in the filecache becomes inconsistent. It helps to fix the encrypted version, so that user doesn't hit with `Bad Signature` errors while trying to view or download the file from oC UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
