### PR TITLE
Add the requiredPermissions property for extra share attributes

### DIFF
--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -74,6 +74,7 @@
 	 * @property {number[]} shareType
 	 * @property {number[]} incompatiblePermissions
 	 * @property {OC.Share.Types.ShareAttribute[]} incompatibleAttributes
+	 * @property {number[]} requiredPermissions
 	 */
 
 	/**
@@ -882,6 +883,11 @@
 				var attr = this._registeredAttributes[i];
 				for(var ii in attr.incompatiblePermissions) {
 					if (this._hasPermission(permissions, attr.incompatiblePermissions[ii])) {
+						compatible = false;
+					}
+				}
+				for(var ii in attr.requiredPermissions) {
+					if (!this._hasPermission(permissions, attr.requiredPermissions[ii])) {
 						compatible = false;
 					}
 				}


### PR DESCRIPTION
Related Issue: https://github.com/owncloud/core/pull/33994#issuecomment-481226241

When adding extra share attributes, the ability to specify not only incompatible permissions (`incompatibleAttributes`), but also mandatory permissions is required (`requiredPermissions`).

For example, a new option is available only if there are rights to edit and is hidden if there are no rights to edit.

With these changes in "shareitemmodel.js" I was able to implement the new opening modes of the ONLYOFFICE editor.
These are limited editing modes when the user has the right to save the file, but limited features are available in the editor (only reviewing, only filling forms, or only commenting).

ONLYOFFICE code:
https://github.com/ONLYOFFICE/onlyoffice-owncloud/blob/71db430e1e5b28b81cf0ef55819b7c3acca53c51/js/main.js#L281

![My Video Gif(1)](https://user-images.githubusercontent.com/8580527/55863714-c4ac9980-5b83-11e9-8fbc-e4809b783b0e.gif)

@mrow4a @DeepDiver1975 @pmaier1 @ibnpetr