### PR TITLE
OCM Convert providerId/remoteId into string

### DIFF
--- a/apps/federatedfilesharing/appinfo/Migrations/Version20190410160725.php
+++ b/apps/federatedfilesharing/appinfo/Migrations/Version20190410160725.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OCA\FederatedFileSharing\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+/** Updates remote_id to be string if required */
+class Version20190410160725 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+
+		if ($schema->hasTable("${prefix}federated_reshares")) {
+			$table = $schema->getTable("{$prefix}federated_reshares");
+			$remoteIdColumn = $table->getColumn('remote_id');
+			if ($remoteIdColumn && $remoteIdColumn->getType()->getName() !== Type::STRING) {
+				$remoteIdColumn->setType(Type::getType(Type::STRING));
+				$remoteIdColumn->setOptions(['length' => 255]);
+			}
+		}
+
+		if ($schema->hasTable("${prefix}share_external")) {
+			$table = $schema->getTable("{$prefix}share_external");
+			$remoteIdColumn = $table->getColumn('remote_id');
+			if ($remoteIdColumn && $remoteIdColumn->getType()->getName() !== Type::STRING) {
+				$remoteIdColumn->setType(Type::getType(Type::STRING));
+				$remoteIdColumn->setOptions(['length' => 255]);
+			}
+		}
+	}
+}

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -5,7 +5,7 @@
     <description>Provide federated file sharing across ownCloud servers</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle, Roeland Jago Douma</author>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <namespace>FederatedFileSharing</namespace>
     <use-migrations>true</use-migrations>
     <category>other</category>

--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -116,7 +116,7 @@ class FedShareManager {
 	 * @param Address $ownerAddress
 	 * @param Address $sharedByAddress
 	 * @param string $shareWith
-	 * @param int $remoteId
+	 * @param string $remoteId
 	 * @param string $name
 	 * @param string $token
 	 *
@@ -181,7 +181,7 @@ class FedShareManager {
 
 	/**
 	 * @param IShare $share
-	 * @param int $remoteId
+	 * @param string $remoteId
 	 * @param string $shareWith
 	 * @param int|null $permissions - null for OCM 1.0-proposal1
 	 *

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -302,7 +302,7 @@ class FederatedShareProvider implements IShareProvider {
 			->andWhere($query->expr()->eq('mountpoint', $query->createNamedParameter($share->getTarget())));
 		$result = $query->execute()->fetchAll();
 
-		if (isset($result[0]) && (int)$result[0]['remote_id'] > 0) {
+		if (isset($result[0]) && $result[0]['remote_id'] !== "") {
 			return $result[0];
 		}
 
@@ -427,7 +427,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * get share ID on remote server for federated re-shares
 	 *
 	 * @param IShare $share
-	 * @return int
+	 * @return string
 	 * @throws ShareNotFound
 	 */
 	public function getRemoteId(IShare $share) {
@@ -440,7 +440,7 @@ class FederatedShareProvider implements IShareProvider {
 			throw new ShareNotFound();
 		}
 
-		return (int)$data['remote_id'];
+		return $data['remote_id'];
 	}
 
 	/**
@@ -975,7 +975,7 @@ class FederatedShareProvider implements IShareProvider {
 	}
 
 	/**
-	 * @param int $remoteId
+	 * @param string $remoteId
 	 * @param string $shareToken
 	 * @return mixed
 	 */

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -83,7 +83,7 @@ class Notifications {
 	 * @param Address $sharedByAddress
 	 * @param string $token
 	 * @param string $name
-	 * @param int $remote_id
+	 * @param string $remote_id
 	 *
 	 * @return bool
 	 *
@@ -148,7 +148,7 @@ class Notifications {
 			if (\is_array($response) && isset($response['sharedSecret'], $response['providerId'])) {
 				return [
 					$response['sharedSecret'],
-					(int) $response['providerId']
+					$response['providerId']
 				];
 			}
 			return true;
@@ -172,7 +172,7 @@ class Notifications {
 		if ($httpRequestSuccessful && $this->isOcsStatusOk($status) && $validToken && $validRemoteId) {
 			return [
 				$status['ocs']['data']['token'],
-				(int)$status['ocs']['data']['remoteId']
+				$status['ocs']['data']['remoteId']
 			];
 		}
 
@@ -207,7 +207,7 @@ class Notifications {
 	 * send notification to remote server if the permissions was changed
 	 *
 	 * @param string $remote
-	 * @param int $remoteId
+	 * @param string $remoteId
 	 * @param string $token
 	 * @param int $permissions
 	 * @return bool
@@ -220,7 +220,7 @@ class Notifications {
 	 * forward accept reShare to remote server
 	 *
 	 * @param string $remote
-	 * @param int $remoteId
+	 * @param string $remoteId
 	 * @param string $token
 	 */
 	public function sendAcceptShare($remote, $remoteId, $token) {
@@ -231,7 +231,7 @@ class Notifications {
 	 * forward decline reShare to remote server
 	 *
 	 * @param string $remote
-	 * @param int $remoteId
+	 * @param string $remoteId
 	 * @param string $token
 	 */
 	public function sendDeclineShare($remote, $remoteId, $token) {
@@ -242,7 +242,7 @@ class Notifications {
 	 * inform remote server whether server-to-server share was accepted/declined
 	 *
 	 * @param string $remote
-	 * @param int $remoteId Share id on the remote host
+	 * @param string $remoteId Share id on the remote host
 	 * @param string $token
 	 * @param string $action possible actions:
 	 * 	                     accept, decline, unshare, revoke, permissions
@@ -371,7 +371,7 @@ class Notifications {
 		$fields = [
 			'shareWith' => $shareWithAddress->getCloudId(),
 			'name' => $name,
-			'providerId' => $remote_id,
+			'providerId' => (string) $remote_id,
 			'owner' => $ownerAddress->getCloudId(),
 			'ownerDisplayName' => $ownerAddress->getDisplayName(),
 			'sender' => $sharedByAddress->getCloudId(),

--- a/apps/federatedfilesharing/tests/appinfo/Migrations/Version20190410160725Test.php
+++ b/apps/federatedfilesharing/tests/appinfo/Migrations/Version20190410160725Test.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OCA\FederatedFileSharing\Tests\appinfo\Migrations;
+
+// FIXME: autoloader fails to load migration
+require_once \dirname(\dirname(\dirname(__DIR__))) . "/appinfo/Migrations/Version20190410160725.php";
+
+use Doctrine\DBAL\Schema\Table;
+use OCA\FederatedFileSharing\Migrations\Version20190410160725;
+use Test\TestCase;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20190410160725Test extends TestCase {
+	public function testExecute() {
+		$tablePrefix = 'pr_';
+		$migration = new Version20190410160725();
+		$table = $this->createMock(Table::class);
+		$schema = $this->createMock(Schema::class);
+		$schema->method('hasTable')->withConsecutive(
+			['pr_federated_reshares'],
+			['pr_share_external']
+		)->willReturn(true);
+		$schema->method('getTable')->withConsecutive(
+			['pr_federated_reshares'],
+			['pr_share_external']
+		)->willReturn($table);
+
+		$this->assertNull($migration->changeSchema($schema, ['tablePrefix' => $tablePrefix]));
+	}
+}

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -103,7 +103,7 @@ class Manager {
 	 * @param string $owner
 	 * @param boolean $accepted
 	 * @param string $user
-	 * @param int $remoteId
+	 * @param string $remoteId
 	 * @return Mount|null
 	 */
 	public function addShare($remote, $token, $password, $name, $owner, $accepted=false, $user = null, $remoteId = -1) {

--- a/lib/public/Share/Events/ShareEvent.php
+++ b/lib/public/Share/Events/ShareEvent.php
@@ -62,11 +62,11 @@ class ShareEvent extends Event {
 	}
 
 	/**
-	 * @return int
+	 * @return string
 	 * @since 10.0.2
 	 */
 	public function getRemoteId() {
-		return (int)$this->share['remote_id'];
+		return $this->share['remote_id'];
 	}
 
 	/**


### PR DESCRIPTION
## Description
`providerId` that we are storing in `remoteId`  field should be a string according to the spec:
```
"providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
```

## Related Issue
- Fixes #34632

## Motivation and Context
Better OCM spec support

## How Has This Been Tested?
```
curl --header "Content-Type: application/json"   --request POST   --data \
'{"shareWith":"user@http:\/\/oc1","name":"\u0432\u0430\u0432\u0430.txt","providerId":"STRING","owner":"user2@http:\/\/oc2","ownerDisplayName":"manic","sender":"user2@http:\/\/oc2","senderDisplayName":"manic","shareType":"user","resourceType":"file","protocol":{"name":"webdav","options":{"sharedSecret":"pljNJU60e7ACFgW"}}}' \
http://oc1/index.php/apps/federatedfilesharing/shares
```
#### Before (internal server error)
```
{"message":"internal server error, was not able to add share from user2@http:\/\/oc2"}
```

#### After (share created)
```
[]
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
