### PR TITLE
Filter unavailable users and remove unavailable shares  on polling

### DIFF
--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -164,8 +164,10 @@ class Application extends App {
 			function ($c) use ($server) {
 				if ($server->getAppManager()->isEnabledForUser('files_sharing')) {
 					$sharingApp = new \OCA\Files_Sharing\AppInfo\Application();
+					$externalManager = $sharingApp->getContainer()->query('ExternalManager');
 					$externalMountProvider = $sharingApp->getContainer()->query('ExternalMountProvider');
 				} else {
+					$externalManager = null;
 					$externalMountProvider = null;
 				}
 
@@ -173,6 +175,7 @@ class Application extends App {
 					$server->getDatabaseConnection(),
 					$server->getUserManager(),
 					\OC\Files\Filesystem::getLoader(),
+					$externalManager,
 					$externalMountProvider
 				);
 			}

--- a/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
+++ b/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
@@ -82,6 +82,13 @@ class PollIncomingShares extends Command {
 		$cursor = $this->getCursor();
 		while ($data = $cursor->fetch()) {
 			$user = $this->userManager->get($data['user']);
+			if ($user === null) {
+				$output->writeln(
+					"Skipping user \"{$data['user']}\". Reason: user manager was unable to resolve the uid into the user object"
+				);
+				continue;
+			}
+
 			$userMounts = $this->externalMountProvider->getMountsForUser($user, $this->loader);
 			/** @var \OCA\Files_Sharing\External\Mount $mount */
 			foreach ($userMounts as $mount) {

--- a/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
+++ b/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
@@ -22,9 +22,12 @@
 namespace OCA\FederatedFileSharing\Tests\Command;
 
 use Doctrine\DBAL\Driver\Statement;
+use OC\User\NoUserException;
 use OCA\FederatedFileSharing\Tests\TestCase;
 use OCA\FederatedFileSharing\Command\PollIncomingShares;
+use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\External\MountProvider;
+use OCA\Files_Sharing\External\Storage;
 use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Storage\IStorageFactory;
@@ -32,6 +35,7 @@ use OCP\Files\StorageNotAvailableException;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -44,25 +48,31 @@ class PollIncomingSharesTest extends TestCase {
 	/** @var CommandTester */
 	private $commandTester;
 
-	/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IDBConnection | MockObject */
 	private $dbConnection;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager | MockObject */
 	private $userManager;
 
-	/** @var MountProvider | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var MountProvider | MockObject */
 	private $externalMountProvider;
 
-	/** @var IStorageFactory | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IStorageFactory | MockObject */
 	private $loader;
+
+	/**
+	 * @var Manager | MockObject
+	 */
+	private $externalManager;
 
 	protected function setUp() {
 		parent::setUp();
 		$this->dbConnection = $this->createMock(IDBConnection::class);
 		$this->userManager = $this->createMock(IUserManager::class);
-		$this->externalMountProvider = $this->createMock(MountProvider::class);
 		$this->loader = $this->createMock(IStorageFactory::class);
-		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->loader, $this->externalMountProvider);
+		$this->externalManager = $this->createMock(Manager::class);
+		$this->externalMountProvider = $this->createMock(MountProvider::class);
+		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->loader, $this->externalManager, $this->externalMountProvider);
 		$this->commandTester = new CommandTester($command);
 	}
 
@@ -92,7 +102,7 @@ class PollIncomingSharesTest extends TestCase {
 	}
 
 	public function testWithFilesSharingDisabled() {
-		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->loader, null);
+		$command = new PollIncomingShares($this->dbConnection, $this->userManager, $this->loader, $this->externalManager, null);
 		$this->commandTester = new CommandTester($command);
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();
@@ -103,8 +113,13 @@ class PollIncomingSharesTest extends TestCase {
 		$uid = 'foo';
 		$exprBuilder = $this->createMock(IExpressionBuilder::class);
 		$statementMock = $this->createMock(Statement::class);
-		$statementMock->method('fetch')->willReturnOnConsecutiveCalls(['user' => $uid], false);
+		$statementMock->method('fetch')->willReturnOnConsecutiveCalls(
+			['user' => $uid],
+			['id' => 50, 'remote' => 'example.org'],
+			false
+		);
 		$qbMock = $this->createMock(IQueryBuilder::class);
+		$qbMock->method('select')->willReturnSelf();
 		$qbMock->method('selectDistinct')->willReturnSelf();
 		$qbMock->method('from')->willReturnSelf();
 		$qbMock->method('where')->willReturnSelf();
@@ -115,7 +130,7 @@ class PollIncomingSharesTest extends TestCase {
 		$this->userManager->expects($this->once())->method('get')
 			->with($uid)->willReturn($userMock);
 
-		$storage = $this->createMock(\OCA\Files_Sharing\External\Storage::class);
+		$storage = $this->createMock(Storage::class);
 		$storage->method('hasUpdated')->willThrowException(new StorageNotAvailableException('Ooops'));
 		$storage->method('getRemote')->willReturn('example.org');
 
@@ -129,7 +144,7 @@ class PollIncomingSharesTest extends TestCase {
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();
 		$this->assertContains(
-			'Skipping external share with id "0" from remote "example.org". Reason: "Ooops"',
+			'Skipping external share with id "50" from remote "example.org". Reason: "Ooops"',
 			$output
 		);
 	}
@@ -153,6 +168,47 @@ class PollIncomingSharesTest extends TestCase {
 		$output = $this->commandTester->getDisplay();
 		$this->assertContains(
 			'Skipping user "foo". Reason: user manager was unable to resolve the uid into the user object',
+			$output
+		);
+	}
+
+	public function testPollingUnsharedMount() {
+		$uid = 'foo';
+		$exprBuilder = $this->createMock(IExpressionBuilder::class);
+		$statementMock = $this->createMock(Statement::class);
+		$statementMock->method('fetch')->willReturnOnConsecutiveCalls(
+			['user' => $uid],
+			['id' => 50, 'remote' => 'example.org'],
+			false
+		);
+		$qbMock = $this->createMock(IQueryBuilder::class);
+		$qbMock->method('select')->willReturnSelf();
+		$qbMock->method('selectDistinct')->willReturnSelf();
+		$qbMock->method('from')->willReturnSelf();
+		$qbMock->method('where')->willReturnSelf();
+		$qbMock->method('expr')->willReturn($exprBuilder);
+		$qbMock->method('execute')->willReturn($statementMock);
+
+		$userMock = $this->createMock(IUser::class);
+		$this->userManager->expects($this->once())->method('get')
+			->with($uid)->willReturn($userMock);
+
+		$this->externalManager->expects($this->once())->method('removeShare');
+
+		$storage = $this->createMock(Storage::class);
+		$storage->method('hasUpdated')->willThrowException(new NoUserException('Ooops'));
+
+		$mount = $this->createMock(\OCA\Files_Sharing\External\Mount::class);
+		$mount->method('getStorage')->willReturn($storage);
+		$mount->method('getMountPoint')->willReturn("/$uid/files/point");
+		$this->externalMountProvider->expects($this->once())->method('getMountsForUser')
+			->willReturn([$mount]);
+
+		$this->dbConnection->method('getQueryBuilder')->willReturn($qbMock);
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains(
+			'Remote "example.org" reports that external share with id "50" no longer exists. Removing it..',
 			$output
 		);
 	}

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -30,6 +30,7 @@
 namespace OCA\Files_Sharing\External;
 
 use OC\Files\Filesystem;
+use OC\User\NoUserException;
 use OCP\Files;
 use OCP\Notification\IManager;
 use OCP\Share\Events\AcceptShare;
@@ -257,7 +258,7 @@ class Manager {
 	 * @return string
 	 */
 	protected function stripPath($path) {
-		$prefix = '/' . $this->uid . '/files';
+		$prefix = "/{$this->uid}/files";
 		return \rtrim(\substr($path, \strlen($prefix)), '/');
 	}
 
@@ -308,7 +309,27 @@ class Manager {
 		return $result;
 	}
 
+	/**
+	 * Explicitly set uid when the shares are managed in CLI
+	 *
+	 * @param string|null $uid
+	 */
+	public function setUid($uid) {
+		// FIXME: External manager should not depend on uid
+		$this->uid = $uid;
+	}
+
+	/**
+	 * @param $mountPoint
+	 * @return bool
+	 *
+	 * @throws NoUserException
+	 */
 	public function removeShare($mountPoint) {
+		if ($this->uid === null) {
+			throw new NoUserException();
+		}
+
 		$mountPointObj = $this->mountManager->find($mountPoint);
 		$id = $mountPointObj->getStorage()->getCache()->getId('');
 


### PR DESCRIPTION
## Description
Protect polling from exploding on unavailable users

## Motivation and Context
`An unhandled exception has been thrown:
TypeError: Argument 1 passed to OCA\Files_Sharing\External\MountProvider::getMountsForUser() must implement interface OCP\IUser, null given,` when UserManager knows nothing about a userId

## How Has This Been Tested?
1. Create and accept a federated share
2.  Execute `update oc_share_external set user="Iwouldliketobreakthepolling" limit 1;`

### Expected
Polling goes through all entries with no termination

### Actual
Polling  terminates with `TypeError: Argument 1 passed to OCA\Files_Sharing\External\MountProvider::getMountsForUser() must implement interface OCP\IUser, null given`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
