### PR TITLE
Fix missing progress bar in files drop view

### DIFF
--- a/apps/files_sharing/js/PublicUploadView.js
+++ b/apps/files_sharing/js/PublicUploadView.js
@@ -152,9 +152,10 @@
 		var view = new OCA.Sharing.PublicUploadView({
 			shareToken: $('#sharingToken').val()
 		});
+		$('#preview .uploadForm').append(view.$el);
+
 		view.render();
 
-		$('#preview .uploadForm').append(view.$el);
 		$('#uploadprogresswrapper .stop').on('click', function () {
 			view.onUploadCancel();
 		});


### PR DESCRIPTION
## Description
The uploader is expecting the progress bar element to be in the DOM when
created. This fix makes sure to append the PublicUploadView's element to
the DOM before rendering it.

## Related Issue
https://github.com/owncloud/enterprise/issues/3281

Regression introduced through https://github.com/owncloud/core/pull/32170 where the progress bar stops working.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] backport to release-10.2.0
