### PR TITLE
Point to current installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/10.1/admin_manual/installation/
+https://doc.owncloud.org/server/latest/admin_manual/installation/
 
 ## Contribution Guidelines
 https://owncloud.org/contribute/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/10.1/developer_manual/app/index.html
+https://doc.owncloud.org/server/10.1/admin_manual/installation/
 
 ## Contribution Guidelines
 https://owncloud.org/contribute/


### PR DESCRIPTION
## Description
Change link to installation instructions so that it goes to the admin manual, and not to a 404 in the developer manual.

## Related Issue
- Fixes #35035

## Motivation and Context

## How Has This Been Tested?
Click on the link and it works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
