### PR TITLE
[stable10] Point to current installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/10.1/admin_manual/installation/
+https://doc.owncloud.org/server/latest/admin_manual/installation/
 
 ## Contribution Guidelines
 https://owncloud.org/contribute/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/10.1/developer_manual/app/index.html
+https://doc.owncloud.org/server/10.1/admin_manual/installation/
 
 ## Contribution Guidelines
 https://owncloud.org/contribute/


### PR DESCRIPTION
Backport #35036

Note: I including the 2nd commit from the `master` PR because it seems reasonable to just keep the README in `stable10` pointing to the latest docs. Otherwise we have to remember to bump this with every minor version release. And actually people will anyway mostly use this link from the `master` branch on the default GitHub UI page.