### PR TITLE
[stable10] Backport of Fixing encrypted version test

### DIFF
--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -147,14 +147,13 @@ class FixEncryptedVersionTest extends TestCase {
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Increment the encrypted version to 1
-The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 1
-Verifying the content of file /test_enc_version_affected_user1/files/world.txt
-The file /test_enc_version_affected_user1/files/world.txt is: OK
-", $output);
+The file /test_enc_version_affected_user1/files/hello.txt is: OK", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+The file /test_enc_version_affected_user1/files/world.txt is: OK", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
 		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
@@ -210,9 +209,10 @@ The file /test_enc_version_affected_user1/files/world.txt is: OK
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
-The file /test_enc_version_affected_user1/files/foo.txt is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Decrement the encrypted version to 1
 Increment the encrypted version to 3
@@ -220,16 +220,15 @@ Increment the encrypted version to 4
 Increment the encrypted version to 5
 Increment the encrypted version to 6
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 6
-Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 6", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
 Increment the encrypted version to 2
 Increment the encrypted version to 3
 Increment the encrypted version to 4
 Increment the encrypted version to 5
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5
-", $output);
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
 		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
@@ -283,9 +282,9 @@ Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
-The file /test_enc_version_affected_user1/files/foo.txt is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Decrement the encrypted version to 14
 Decrement the encrypted version to 13
@@ -294,8 +293,8 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 9
-Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 9", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
 Decrement the encrypted version to 14
 Decrement the encrypted version to 13
@@ -304,8 +303,7 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9
-", $output);
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
 		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1


### PR DESCRIPTION
Its better to verify if the command output contains specific
strings, instead of grabbing the whole command output
and comparing with string equal.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Adjust the unit test for fix-encrypted-version command so that it should not rely on the skeleton files. It should only rely on the output that we need to look into for the files which requires fixing in the tests. In general this PR makes the unit tests good, so that it tries to verify the results that it is supposed to and not rely on what are the files provided by the skeleton.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve the unit tests to grab the output of the fix-encrypted-version command and verify the output of command for the files which were found to be problematic. Lets not bother about the files which does not have problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  Ran unit test locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
