### PR TITLE
Get translations from correct app

### DIFF
--- a/apps/federatedfilesharing/js/public.js
+++ b/apps/federatedfilesharing/js/public.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 	$('#header #details').prepend(
 		'<span id="save">' +
-		'	<button id="save-button">'+t('files_sharing', 'Add to your ownCloud')+'</button>' +
+		'	<button id="save-button">'+t('federatedfilesharing', 'Add to your ownCloud')+'</button>' +
 		'	<form class="save-form hidden" action="#">' +
 		'		<input type="text" id="remote_address" placeholder="example.com/owncloud"/>' +
 		'		<button id="save-button-confirm" class="icon-confirm svg" disabled></button>' +

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -219,7 +219,7 @@ OCA.Sharing.App = {
 			if(response.responseJSON && response.responseJSON.message) {
 				message = ': ' + response.responseJSON.message;
 			}
-			OC.Notification.show(t('files', 'An error occurred while updating share state: {message}', {message:  message}), {type: 'error'});
+			OC.Notification.show(t('files_sharing', 'An error occurred while updating share state: {message}', {message:  message}), {type: 'error'});
 		});
 		return xhr;
 	},
@@ -239,7 +239,7 @@ OCA.Sharing.App = {
 						path: OC.dirname(data.file_target)
 					});
 				} else {
-					OC.Notification.show(t('files', 'An error occurred while updating share state: {message}', {message: meta.message}), {type: 'error'});
+					OC.Notification.show(t('files_sharing', 'An error occurred while updating share state: {message}', {message: meta.message}), {type: 'error'});
 				}
 			}
 			context.fileList.showFileBusyState(context.$file, false);

--- a/apps/files_trashbin/js/app.js
+++ b/apps/files_trashbin/js/app.js
@@ -68,7 +68,7 @@ OCA.Trashbin.App = {
 
 		fileActions.registerAction({
 			name: 'Delete',
-			displayName: t('files', 'Delete'),
+			displayName: t('files_trashbin', 'Delete'),
 			mime: 'all',
 			permissions: OC.PERMISSION_READ,
 			iconClass: 'icon-delete',

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -350,7 +350,7 @@
 			if (result.status === 403) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show(t('files', 'This operation is forbidden'));
+				OC.Notification.show(t('files_trashbin', 'This operation is forbidden'));
 				return false;
 			}
 
@@ -358,7 +358,7 @@
 			if (result.status === 500) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show(t('files', 'This directory is unavailable, please check the logs or contact the administrator'));
+				OC.Notification.show(t('files_trashbin', 'This directory is unavailable, please check the logs or contact the administrator'));
 				return false;
 			}
 

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -132,7 +132,7 @@
 					fileInfoModel.trigger('busy', fileInfoModel, false);
 					self.$el.find('.versions').removeClass('hidden');
 					self._toggleLoading(false);
-					OC.Notification.show(t('files_version', 'Failed to revert {file} to revision {timestamp}.', 
+					OC.Notification.show(t('files_versions', 'Failed to revert {file} to revision {timestamp}.',
 						{
 							file: versionModel.getFullPath(),
 							timestamp: OC.Util.formatDate(versionModel.get('timestamp') * 1000)


### PR DESCRIPTION
## Description
Fixup the core apps so that they consistently lookup translations inside their "own" app.

## Related Issue
- Fixes #35040

## Motivation and Context
If people have gone to the effort of adding translations in Transifex, then use them ;)

## How Has This Been Tested?
Switch language to Deutsch and look on the UI for the "easy to make happen" text and confirm that it is translated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
