### PR TITLE
Use consistent app name in writeLog() calls

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -126,13 +126,13 @@ class RequestHandlerController extends OCSController {
 				);
 			}
 			// FIXME this should be a method in the user management instead
-			\OCP\Util::writeLog('files_sharing', 'shareWith before, ' . $shareWith, \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('federatedfilesharing', 'shareWith before, ' . $shareWith, \OCP\Util::DEBUG);
 			\OCP\Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',
 				['uid' => &$shareWith]
 			);
-			\OCP\Util::writeLog('files_sharing', 'shareWith after, ' . $shareWith, \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('federatedfilesharing', 'shareWith after, ' . $shareWith, \OCP\Util::DEBUG);
 			if (!$this->userManager->userExists($shareWith)) {
 				throw new BadRequestException('User does not exist');
 			}
@@ -164,7 +164,7 @@ class RequestHandlerController extends OCSController {
 			);
 		} catch (\Exception $e) {
 			\OCP\Util::writeLog(
-				'files_sharing',
+				'federatedfilesharing',
 				'server can not add remote share, ' . $e->getMessage(),
 				\OCP\Util::ERROR
 			);

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -77,14 +77,14 @@ class Helper {
 		try {
 			$path = Filesystem::getPath($linkItem['file_source']);
 		} catch (NotFoundException $e) {
-			\OCP\Util::writeLog('share', 'could not resolve linkItem', \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('files_sharing', 'could not resolve linkItem', \OCP\Util::DEBUG);
 			\OC_Response::setStatus(404);
 			\OCP\JSON::error(['success' => false]);
 			exit();
 		}
 
 		if (!isset($linkItem['item_type'])) {
-			\OCP\Util::writeLog('share', 'No item type set for share id: ' . $linkItem['id'], \OCP\Util::ERROR);
+			\OCP\Util::writeLog('files_sharing', 'No item type set for share id: ' . $linkItem['id'], \OCP\Util::ERROR);
 			\OC_Response::setStatus(404);
 			\OCP\JSON::error(['success' => false]);
 			exit();
@@ -144,7 +144,7 @@ class Helper {
 					return false;
 				}
 			} else {
-				\OCP\Util::writeLog('share', 'Unknown share type '.$linkItem['share_type']
+				\OCP\Util::writeLog('files_sharing', 'Unknown share type '.$linkItem['share_type']
 					.' for share id '.$linkItem['id'], \OCP\Util::ERROR);
 				return false;
 			}
@@ -176,7 +176,7 @@ class Helper {
 			if ($info instanceof \OC\Files\FileInfo) {
 				$ids[] = $info['fileid'];
 			} else {
-				\OCP\Util::writeLog('sharing', 'No fileinfo available for: ' . $path, \OCP\Util::WARN);
+				\OCP\Util::writeLog('files_sharing', 'No fileinfo available for: ' . $path, \OCP\Util::WARN);
 			}
 			$path = \dirname($path);
 		}

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -163,7 +163,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 
 		// it is not a file relative to data/user/files
 		if (\count($split) < 3 || $split[1] !== 'files') {
-			\OCP\Util::writeLog('file sharing',
+			\OCP\Util::writeLog('files_sharing',
 				'Can not strip userid and "files/" from path: ' . $path,
 				\OCP\Util::ERROR);
 			throw new \OCA\Files_Sharing\Exceptions\BrokenPath('Path does not start with /user/files', 10);
@@ -206,7 +206,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 
 			foreach ($shares as $share) {
 				if ($this->user === $share->getShareOwner()) {
-					\OCP\Util::writeLog('files',
+					\OCP\Util::writeLog('files_sharing',
 						'It is not allowed to move one mount point into a shared folder',
 						\OCP\Util::DEBUG);
 					return false;
@@ -240,7 +240,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 			$this->setMountPoint($target);
 			$this->storage->setMountPoint($relTargetPath);
 		} catch (\Exception $e) {
-			\OCP\Util::writeLog('file sharing',
+			\OCP\Util::writeLog('files_sharing',
 				'Could not rename mount point for shared folder "' . $this->getMountPoint() . '" to "' . $target . '"',
 				\OCP\Util::ERROR);
 		}

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -65,7 +65,7 @@ foreach ($list as $file) {
 	OCA\Files_Trashbin\Trashbin::delete($filename, \OCP\User::getUser(), $timestamp);
 	if (OCA\Files_Trashbin\Trashbin::file_exists($filename, $timestamp)) {
 		$error[] = $filename;
-		\OCP\Util::writeLog('trashbin', 'can\'t delete ' . $filename . ' permanently.', \OCP\Util::ERROR);
+		\OCP\Util::writeLog('files_trashbin', 'can\'t delete ' . $filename . ' permanently.', \OCP\Util::ERROR);
 	}
 	// only list deleted files if not deleting everything
 	elseif (!$deleteAll) {

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -73,7 +73,7 @@ foreach ($list as $file) {
 
 	if (!OCA\Files_Trashbin\Trashbin::restore($path, $filename, $timestamp)) {
 		$error[] = $filename;
-		\OCP\Util::writeLog('trashbin', 'can\'t restore ' . $filename, \OCP\Util::DEBUG);
+		\OCP\Util::writeLog('files_trashbin', 'can\'t restore ' . $filename, \OCP\Util::DEBUG);
 	} else {
 		$success[$i]['filename'] = $file;
 		$success[$i]['timestamp'] = $timestamp;


### PR DESCRIPTION
## Description
Adjust `writeLog()` calls so they consistently use the name of the relevant "built in" app.

## Motivation and Context
While looking at PR #35041 I noticed that some of the `writeLog()` calls had "varied" values for the app name parameter.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
