### PR TITLE
[stable10] Wrong translation file referenced for accept & decline share

### DIFF
--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -257,7 +257,7 @@ OCA.Sharing.App = {
 		fileActions.registerAction({
 			name: 'Accept',
 			type: OCA.Files.FileActions.TYPE_INLINE,
-			displayName: t('files', 'Accept Share'),
+			displayName: t('files_sharing', 'Accept Share'),
 			mime: 'all',
 			iconClass: 'icon-checkmark',
 			permissions: OC.PERMISSION_READ,
@@ -268,7 +268,7 @@ OCA.Sharing.App = {
 		fileActions.registerAction({
 			name: 'Reject',
 			type: OCA.Files.FileActions.TYPE_INLINE,
-			displayName: t('files', 'Decline Share'),
+			displayName: t('files_sharing', 'Decline Share'),
 			iconClass: 'icon-close',
 			mime: 'all',
 			permissions: OC.PERMISSION_READ,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The strings for 'Accept Share' and 'Decline Share' are not translated.

These string live in apps/files_sharing/js/app.js
The translation for the strings is in apps/files_sharing/l10n/

However, in the code it says:
displayName: t('files', 'Decline Share')

So the string is searched for in the wrong file. Changed it to
displayName: t('files_sharing', 'Decline Share')

## Motivation and Context
See above

## How Has This Been Tested?
Tested on local installation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

