### PR TITLE
Bump symfony (v3.4.25 => v3.4.26)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2502,7 +2502,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.25",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -2574,7 +2574,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.25",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -2630,7 +2630,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.25",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -3036,7 +3036,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.25",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -3085,7 +3085,7 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.25",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -3161,7 +3161,7 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.25",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",


### PR DESCRIPTION
## Description
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 6 updates, 0 removals
  - Updating symfony/debug (v3.4.25 => v3.4.26): Loading from cache
  - Updating symfony/console (v3.4.25 => v3.4.26): Loading from cache
  - Updating symfony/event-dispatcher (v3.4.25 => v3.4.26): Loading from cache
  - Updating symfony/routing (v3.4.25 => v3.4.26): Loading from cache
  - Updating symfony/process (v3.4.25 => v3.4.26): Loading from cache
  - Updating symfony/translation (v3.4.25 => v3.4.26): Loading from cache
```
https://symfony.com/blog/symfony-3-4-26-released

Those release notes list some CVEs that are fixed. So that needs a review to see if they impact ownCloud use of Symfony.

Note: `stable10` PR is #35048

## Motivation and Context
Be up-to-date.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
