### PR TITLE
Center the logo and login fields for setup page

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -943,31 +943,31 @@ div.crumb:active {
 
 /* Force constant vertical height for login box over all devices */
 #body-login .wrapper {
-    height: 100vh; /* fix IE11 */
-    display: -webkit-box !important;
-    -webkit-box-orient: horizontal !important;
-    -webkit-box-pack: center !important;
-    -webkit-box-align: center !important;
-    display: -webkit-flex !important;
-    -webkit-flex-direction: row !important;
-    -webkit-align-self: center !important;
-    -webkit-align-items: center !important;
-    display: -moz-box !important;
-    -moz-box-orient: horizontal !important;
-    -moz-box-pack: center !important;
-    -moz-box-align: center !important;
-    display: -ms-flexbox !important;
-    -ms-flex-direction: row !important;
-    -ms-flex-pack: center !important;
-    -ms-flex-align: center !important;
-    display: flex !important;
-    flex-direction: row !important;
-    align-self: center !important;
-    align-items: center !important;
+	min-height: 100vh; /* fix IE11 */
+	display: -webkit-box !important;
+	-webkit-box-orient: horizontal !important;
+	-webkit-box-pack: center !important;
+	-webkit-box-align: center !important;
+	display: -webkit-flex !important;
+	-webkit-flex-direction: row !important;
+	-webkit-align-self: center !important;
+	-webkit-align-items: center !important;
+	display: -moz-box !important;
+	-moz-box-orient: horizontal !important;
+	-moz-box-pack: center !important;
+	-moz-box-align: center !important;
+	display: -ms-flexbox !important;
+	-ms-flex-direction: row !important;
+	-ms-flex-pack: center !important;
+	-ms-flex-align: center !important;
+	display: flex !important;
+	flex-direction: row !important;
+	align-self: center !important;
+	align-items: center !important;
 }
 
 #body-login .v-align {
-    margin-top: -120px;
+	margin-top: -120px;
 }
 
 /* LEGACY FIX only - do not use fieldsets for settings */


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Bugfix
This is a bugfix for my PR https://github.com/owncloud/core/pull/33375 - During another test I noticed that this did not consider the setup (first setup of the server, setting an admin password).

## Description
Force constant vertical height for login box over all devices (also in setup page)

## Motivation and Context
I incorporate this function into almost every theme I create. The logo and credential fields are centered on each device. That's why I thought it would be great to integrate this improvement into our Core Theme.

## How Has This Been Tested?
Manual tested on Chrome, Firefox, Edge browser with different resolutions and also mobile resolutions

## Screenshots:
Before (Google Pixel2):
![image](https://user-images.githubusercontent.com/33026403/56326767-acd2a800-6177-11e9-8f20-e2ddd2b60bf3.png)

After (Google Pixel2):
![image](https://user-images.githubusercontent.com/33026403/56326853-03d87d00-6178-11e9-88fb-375c4d9a797d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
