### PR TITLE
Remove share permission check from the file upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -829,11 +829,7 @@ OC.Uploader.prototype = _.extend({
 				return true;
 			}
 			var fileInfo = fileList.findFile(file.name);
-			var sharePermission = $("#sharePermission").val();
-			if (sharePermission !== undefined) {
-				sharePermission &= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE);
-			}
-			if (fileInfo && (sharePermission !== (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE))) {
+			if (fileInfo) {
 				conflicts.push([
 					// original
 					_.extend(fileInfo, {

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1003,6 +1003,23 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user uploads file :name and clicks :label button :number_of times using webUI
+	 *
+	 * @param string $name
+	 * @param string $label
+	 * @param int $number_of
+	 *
+	 * @return void
+	 */
+	public function theUserClicksUploadAndCancelMultipleTimes($name, $label, $number_of) {
+		for ($i = 0; $i < $number_of; $i++) {
+			$this->theUserUploadsFileUsingTheWebUI($name);
+			$this->theUserChoosesToInTheUploadDialog($label);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+		}
+	}
+
+	/**
 	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed on the webUI$/
 	 *
 	 * @param string $shouldOrNot

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -371,6 +371,7 @@ Feature: Share by public link
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user edits the permission of an already existing public link from read-write to upload-write-without-overwrite
     Given the user has created a new public link for folder "simple-folder" using the webUI with
@@ -380,3 +381,14 @@ Feature: Share by public link
     When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem (2).txt" should be listed on the webUI
+
+  Scenario: user creates public link with view download and upload feature and uploads and cancels same file multiple times to verify the conflict dialog exits after clicking cancel button
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | upload-write-without-modify |
+    And the public accesses the last created public link using the webUI
+    When the user uploads file "lorem.txt" and clicks "Cancel" button 10 times using webUI
+    Then no dialog should be displayed on the webUI
+    And no notification should be displayed on the webUI
+    And file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should not have changed
+    And file "lorem (2).txt" should not be listed on the webUI


### PR DESCRIPTION
Remove share permission check from the file upload
js file.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Remove `sharePermission` checks from the file-upload.js file. We are no where using it and there is a problem in the code due to this. When we know its a file, we just have to check the fileinfo ( in the if condition ). The problem this PR tries to address is, when files are uploaded, the file information should be shown. Instead of this, the directory information was shown. 

This also fixes the cancel button problem in the conflict dialog. The cancel button clicked once cancels the conflict dialog.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35056
- Fixes https://github.com/owncloud/core/issues/35057

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove `sharePermission` checks from the file-upload.js file. This solves 2 problems:
1. The file which has conflict will show the file information in the conflict dialog popup and not the directory info.
2. Cancel button of the conflict dialog pop up will work with one click, instead of multiple click issue mentioned at https://github.com/owncloud/core/issues/35057.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  Kindly see the screen share 
![granularPermission](https://user-images.githubusercontent.com/3600427/56344792-ee953a00-61db-11e9-9fa1-1460ac814785.gif)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
