### PR TITLE
[10.2] Wrong translation file referenced for accept & decline share

### DIFF
--- a/apps/federatedfilesharing/js/public.js
+++ b/apps/federatedfilesharing/js/public.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 	$('#header #details').prepend(
 		'<span id="save">' +
-		'	<button id="save-button">'+t('files_sharing', 'Add to your ownCloud')+'</button>' +
+		'	<button id="save-button">'+t('federatedfilesharing', 'Add to your ownCloud')+'</button>' +
 		'	<form class="save-form hidden" action="#">' +
 		'		<input type="text" id="remote_address" placeholder="example.com/owncloud"/>' +
 		'		<button id="save-button-confirm" class="icon-confirm svg" disabled></button>' +

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -126,13 +126,13 @@ class RequestHandlerController extends OCSController {
 				);
 			}
 			// FIXME this should be a method in the user management instead
-			\OCP\Util::writeLog('files_sharing', 'shareWith before, ' . $shareWith, \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('federatedfilesharing', 'shareWith before, ' . $shareWith, \OCP\Util::DEBUG);
 			\OCP\Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',
 				['uid' => &$shareWith]
 			);
-			\OCP\Util::writeLog('files_sharing', 'shareWith after, ' . $shareWith, \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('federatedfilesharing', 'shareWith after, ' . $shareWith, \OCP\Util::DEBUG);
 			if (!$this->userManager->userExists($shareWith)) {
 				throw new BadRequestException('User does not exist');
 			}
@@ -164,7 +164,7 @@ class RequestHandlerController extends OCSController {
 			);
 		} catch (\Exception $e) {
 			\OCP\Util::writeLog(
-				'files_sharing',
+				'federatedfilesharing',
 				'server can not add remote share, ' . $e->getMessage(),
 				\OCP\Util::ERROR
 			);

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -219,7 +219,7 @@ OCA.Sharing.App = {
 			if(response.responseJSON && response.responseJSON.message) {
 				message = ': ' + response.responseJSON.message;
 			}
-			OC.Notification.show(t('files', 'An error occurred while updating share state: {message}', {message:  message}), {type: 'error'});
+			OC.Notification.show(t('files_sharing', 'An error occurred while updating share state: {message}', {message:  message}), {type: 'error'});
 		});
 		return xhr;
 	},
@@ -239,7 +239,7 @@ OCA.Sharing.App = {
 						path: OC.dirname(data.file_target)
 					});
 				} else {
-					OC.Notification.show(t('files', 'An error occurred while updating share state: {message}', {message: meta.message}), {type: 'error'});
+					OC.Notification.show(t('files_sharing', 'An error occurred while updating share state: {message}', {message: meta.message}), {type: 'error'});
 				}
 			}
 			context.fileList.showFileBusyState(context.$file, false);

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -257,7 +257,7 @@ OCA.Sharing.App = {
 		fileActions.registerAction({
 			name: 'Accept',
 			type: OCA.Files.FileActions.TYPE_INLINE,
-			displayName: t('files', 'Accept Share'),
+			displayName: t('files_sharing', 'Accept Share'),
 			mime: 'all',
 			iconClass: 'icon-checkmark',
 			permissions: OC.PERMISSION_READ,
@@ -268,7 +268,7 @@ OCA.Sharing.App = {
 		fileActions.registerAction({
 			name: 'Reject',
 			type: OCA.Files.FileActions.TYPE_INLINE,
-			displayName: t('files', 'Decline Share'),
+			displayName: t('files_sharing', 'Decline Share'),
 			iconClass: 'icon-close',
 			mime: 'all',
 			permissions: OC.PERMISSION_READ,

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -77,14 +77,14 @@ class Helper {
 		try {
 			$path = Filesystem::getPath($linkItem['file_source']);
 		} catch (NotFoundException $e) {
-			\OCP\Util::writeLog('share', 'could not resolve linkItem', \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('files_sharing', 'could not resolve linkItem', \OCP\Util::DEBUG);
 			\OC_Response::setStatus(404);
 			\OCP\JSON::error(['success' => false]);
 			exit();
 		}
 
 		if (!isset($linkItem['item_type'])) {
-			\OCP\Util::writeLog('share', 'No item type set for share id: ' . $linkItem['id'], \OCP\Util::ERROR);
+			\OCP\Util::writeLog('files_sharing', 'No item type set for share id: ' . $linkItem['id'], \OCP\Util::ERROR);
 			\OC_Response::setStatus(404);
 			\OCP\JSON::error(['success' => false]);
 			exit();
@@ -146,7 +146,7 @@ class Helper {
 					return false;
 				}
 			} else {
-				\OCP\Util::writeLog('share', 'Unknown share type '.$linkItem['share_type']
+				\OCP\Util::writeLog('files_sharing', 'Unknown share type '.$linkItem['share_type']
 					.' for share id '.$linkItem['id'], \OCP\Util::ERROR);
 				return false;
 			}
@@ -178,7 +178,7 @@ class Helper {
 			if ($info instanceof \OC\Files\FileInfo) {
 				$ids[] = $info['fileid'];
 			} else {
-				\OCP\Util::writeLog('sharing', 'No fileinfo available for: ' . $path, \OCP\Util::WARN);
+				\OCP\Util::writeLog('files_sharing', 'No fileinfo available for: ' . $path, \OCP\Util::WARN);
 			}
 			$path = \dirname($path);
 		}

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -163,7 +163,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 
 		// it is not a file relative to data/user/files
 		if (\count($split) < 3 || $split[1] !== 'files') {
-			\OCP\Util::writeLog('file sharing',
+			\OCP\Util::writeLog('files_sharing',
 				'Can not strip userid and "files/" from path: ' . $path,
 				\OCP\Util::ERROR);
 			throw new \OCA\Files_Sharing\Exceptions\BrokenPath('Path does not start with /user/files', 10);
@@ -206,7 +206,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 
 			foreach ($shares as $share) {
 				if ($this->user === $share->getShareOwner()) {
-					\OCP\Util::writeLog('files',
+					\OCP\Util::writeLog('files_sharing',
 						'It is not allowed to move one mount point into a shared folder',
 						\OCP\Util::DEBUG);
 					return false;
@@ -240,7 +240,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 			$this->setMountPoint($target);
 			$this->storage->setMountPoint($relTargetPath);
 		} catch (\Exception $e) {
-			\OCP\Util::writeLog('file sharing',
+			\OCP\Util::writeLog('files_sharing',
 				'Could not rename mount point for shared folder "' . $this->getMountPoint() . '" to "' . $target . '"',
 				\OCP\Util::ERROR);
 		}

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -65,7 +65,7 @@ foreach ($list as $file) {
 	OCA\Files_Trashbin\Trashbin::delete($filename, \OCP\User::getUser(), $timestamp);
 	if (OCA\Files_Trashbin\Trashbin::file_exists($filename, $timestamp)) {
 		$error[] = $filename;
-		\OCP\Util::writeLog('trashbin', 'can\'t delete ' . $filename . ' permanently.', \OCP\Util::ERROR);
+		\OCP\Util::writeLog('files_trashbin', 'can\'t delete ' . $filename . ' permanently.', \OCP\Util::ERROR);
 	}
 	// only list deleted files if not deleting everything
 	elseif (!$deleteAll) {

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -71,7 +71,7 @@ foreach ($list as $file) {
 
 	if (!OCA\Files_Trashbin\Trashbin::restore($path, $filename, $timestamp)) {
 		$error[] = $filename;
-		\OCP\Util::writeLog('trashbin', 'can\'t restore ' . $filename, \OCP\Util::DEBUG);
+		\OCP\Util::writeLog('files_trashbin', 'can\'t restore ' . $filename, \OCP\Util::DEBUG);
 	} else {
 		$success[$i]['filename'] = $file;
 		$success[$i]['timestamp'] = $timestamp;

--- a/apps/files_trashbin/js/app.js
+++ b/apps/files_trashbin/js/app.js
@@ -68,7 +68,7 @@ OCA.Trashbin.App = {
 
 		fileActions.registerAction({
 			name: 'Delete',
-			displayName: t('files', 'Delete'),
+			displayName: t('files_trashbin', 'Delete'),
 			mime: 'all',
 			permissions: OC.PERMISSION_READ,
 			iconClass: 'icon-delete',

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -350,7 +350,7 @@
 			if (result.status === 403) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show(t('files', 'This operation is forbidden'));
+				OC.Notification.show(t('files_trashbin', 'This operation is forbidden'));
 				return false;
 			}
 
@@ -358,7 +358,7 @@
 			if (result.status === 500) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show(t('files', 'This directory is unavailable, please check the logs or contact the administrator'));
+				OC.Notification.show(t('files_trashbin', 'This directory is unavailable, please check the logs or contact the administrator'));
 				return false;
 			}
 

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -132,7 +132,7 @@
 					fileInfoModel.trigger('busy', fileInfoModel, false);
 					self.$el.find('.versions').removeClass('hidden');
 					self._toggleLoading(false);
-					OC.Notification.show(t('files_version', 'Failed to revert {file} to revision {timestamp}.', 
+					OC.Notification.show(t('files_versions', 'Failed to revert {file} to revision {timestamp}.',
 						{
 							file: versionModel.getFullPath(),
 							timestamp: OC.Util.formatDate(versionModel.get('timestamp') * 1000)


### PR DESCRIPTION
## Description
Backport into 10.2 release:
PR #35045 Wrong translation file referenced for accept & decline share
PR #35043 Get translations from correct app
PR #35049 Use consistent app name in writeLog() calls

## How Has This Been Tested?
Observing some translations in the webUI
