### PR TITLE
Respect 'writable' appdir flag on update

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -225,16 +225,18 @@ class Installer {
 		$info = self::checkAppsIntegrity($info, $extractDir, $path, $isShipped);
 
 		$currentDir = OC_App::getAppPath($info['id']);
+		if (\is_dir("$currentDir/.git")) {
+			throw new AppAlreadyInstalledException("App <{$info['id']}> is a git clone - it will not be updated.");
+		}
+
 		$basedir  = OC_App::getInstallPath();
 		$basedir .= '/';
 		$basedir .= $info['id'];
 
-		if ($currentDir !== false && \is_writable($currentDir)) {
+		if ($currentDir !== false && OC_App::isAppDirWritable($info['id'])) {
 			$basedir = $currentDir;
 		}
-		if (\is_dir("$basedir/.git")) {
-			throw new AppAlreadyInstalledException("App <{$info['id']}> is a git clone - it will not be updated.");
-		}
+
 		if (\is_dir($basedir)) {
 			OC_Helper::rmdirr($basedir);
 		}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
- Fixes #35031

## Motivation and Context
Fix App is updated inside the directory that is marked as not writable.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
