### PR TITLE
[10.2.0] Respect 'writable' appdir flag on update

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -222,16 +222,18 @@ class Installer {
 		$info = self::checkAppsIntegrity($info, $extractDir, $path, $isShipped);
 
 		$currentDir = OC_App::getAppPath($info['id']);
+		if (\is_dir("$currentDir/.git")) {
+			throw new AppAlreadyInstalledException("App <{$info['id']}> is a git clone - it will not be updated.");
+		}
+
 		$basedir  = OC_App::getInstallPath();
 		$basedir .= '/';
 		$basedir .= $info['id'];
 
-		if ($currentDir !== false && \is_writable($currentDir)) {
+		if ($currentDir !== false && OC_App::isAppDirWritable($info['id'])) {
 			$basedir = $currentDir;
 		}
-		if (\is_dir("$basedir/.git")) {
-			throw new AppAlreadyInstalledException("App <{$info['id']}> is a git clone - it will not be updated.");
-		}
+
 		if (\is_dir($basedir)) {
 			OC_Helper::rmdirr($basedir);
 		}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -568,6 +568,20 @@ class OC_App {
 	 */
 	public static function isAppDirWritable($appId) {
 		$path = self::getAppPath($appId);
+		// Check if the parent directory is marked as writable in config.php
+		if ($path !== false) {
+			$appDir = \substr($path, 0, -\strlen("/$appId"));
+			foreach (OC::$APPSROOTS as $dir) {
+				if ($dir['path'] !== $appDir) {
+					continue;
+				}
+				if (!isset($dir['writable'])
+					|| $dir['writable'] !== true
+				) {
+					return false;
+				}
+			}
+		}
 		return ($path !== false) ? \is_writable($path) : false;
 	}
 
@@ -942,6 +956,7 @@ class OC_App {
 	 * @return bool
 	 */
 	public static function updateApp($appId) {
+		\OC::$server->getAppManager()->clearAppsCache();
 		$appPath = self::getAppPath($appId);
 		if ($appPath === false) {
 			return false;
@@ -958,7 +973,6 @@ class OC_App {
 		}
 		self::executeRepairSteps($appId, $appData['repair-steps']['post-migration']);
 		self::setupLiveMigrations($appId, $appData['repair-steps']['live-migration']);
-		\OC::$server->getAppManager()->clearAppsCache();
 		// run upgrade code
 		if (\file_exists($appPath . '/appinfo/update.php')) {
 			self::loadApp($appId, false);


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/35072
## Description
Check if the current appdir is marked as writable before updating the app

## Related Issue
- Fixes #35031

## Motivation and Context
Fix App is updated inside the directory that is marked as not writable.

## How Has This Been Tested?
see #35031

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

