### PR TITLE
Avoid headers set twice in some situations

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,22 +15,30 @@
 
   <IfModule mod_env.c>
     # Add security and privacy related headers
+    Header      unset X-Content-Type-Options
     Header always set X-Content-Type-Options "nosniff"
+    Header      unset X-XSS-Protection
     Header always set X-XSS-Protection "1; mode=block"
+    Header      unset X-Robots-Tag
     Header always set X-Robots-Tag "none"
+    Header      unset X-Frame-Options
     Header always set X-Frame-Options "SAMEORIGIN"
+    Header      unset X-Download-Options
     Header always set X-Download-Options "noopen"
+    Header      unset X-Permitted-Cross-Domain-Policies
     Header always set X-Permitted-Cross-Domain-Policies "none"
     SetEnv modHeadersAvailable true
   </IfModule>
 
   # Let browsers cache CSS, JS files for half a year
   <FilesMatch "\.(css|js)$">
+    Header      unset Cache-Control
     Header always set Cache-Control "max-age=15778463"
   </FilesMatch>
   
   # Let browsers cache WOFF files for a week
   <FilesMatch "\.woff$">
+    Header      unset Cache-Control
     Header always set Cache-Control "max-age=604800"
   </FilesMatch>
 </IfModule>
@@ -84,4 +92,3 @@ Options -Indexes
 <IfModule pagespeed_module>
   ModPagespeed Off
 </IfModule>
-


### PR DESCRIPTION
Hi,

This PR follows #31231, and solves behavior discussed in #35093.
We are then sure headers are set only one time, whatever the table, `onsuccess` or `always`, Apache configuration uses to set its headers.

Thank you 👍 