### PR TITLE
Move share_external migration into the sharing app

### DIFF
--- a/apps/federatedfilesharing/tests/appinfo/Migrations/Version20190410160725Test.php
+++ b/apps/federatedfilesharing/tests/appinfo/Migrations/Version20190410160725Test.php
@@ -16,14 +16,10 @@ class Version20190410160725Test extends TestCase {
 		$migration = new Version20190410160725();
 		$table = $this->createMock(Table::class);
 		$schema = $this->createMock(Schema::class);
-		$schema->method('hasTable')->withConsecutive(
-			['pr_federated_reshares'],
-			['pr_share_external']
-		)->willReturn(true);
-		$schema->method('getTable')->withConsecutive(
-			['pr_federated_reshares'],
-			['pr_share_external']
-		)->willReturn($table);
+		$schema->method('hasTable')->with('pr_federated_reshares')
+			->willReturn(true);
+		$schema->method('getTable')->with('pr_federated_reshares')
+			->willReturn($table);
 
 		$this->assertNull($migration->changeSchema($schema, ['tablePrefix' => $tablePrefix]));
 	}

--- a/apps/files_sharing/appinfo/Migrations/Version20190426123324.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20190426123324.php
@@ -19,19 +19,18 @@
  *
  */
 
-namespace OCA\FederatedFileSharing\Migrations;
+namespace OCA\Files_Sharing\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use OCP\Migration\ISchemaMigration;
 
 /** Updates remote_id to be string if required */
-class Version20190410160725 implements ISchemaMigration {
+class Version20190426123324 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-
-		if ($schema->hasTable("${prefix}federated_reshares")) {
-			$table = $schema->getTable("{$prefix}federated_reshares");
+		if ($schema->hasTable("${prefix}share_external")) {
+			$table = $schema->getTable("{$prefix}share_external");
 			$remoteIdColumn = $table->getColumn('remote_id');
 			if ($remoteIdColumn && $remoteIdColumn->getType()->getName() !== Type::STRING) {
 				$remoteIdColumn->setType(Type::getType(Type::STRING));

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -10,7 +10,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<licence>AGPL</licence>
 	<author>Michael Gapczynski, Bjoern Schiessle</author>
 	<default_enable/>
-	<version>0.11.0</version>
+	<version>0.12.0</version>
 	<types>
 		<filesystem/>
 	</types>


### PR DESCRIPTION
## Description
Subj

## Related Issue
Fixes https://drone.owncloud.com/owncloud/update-testing/398/188

## Motivation and Context
Wrong  migration order for share_external table.

## How Has This Been Tested?
1. install from master@8f3d6c810677d061ac3bf85d482d1ed9a4d4c462
1.  git checkout fix-providerid-migration
1. php occ upgrade
1. describe oc_share_external;

Expected 
`remote_id       | varchar(255)`

Actual 
`remote_id       | bigint`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
