### PR TITLE
[10.2.0] add new capability privateLinksDetailsParam

### DIFF
--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -58,6 +58,7 @@ class Capabilities implements ICapability {
 			],
 			'files' => [
 				'privateLinks' => true,
+				'privateLinksDetailsParam' => true,
 				'bigfilechunking' => true,
 				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
 			],

--- a/apps/files/tests/CapabilitiesTest.php
+++ b/apps/files/tests/CapabilitiesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OCA\Files;
+
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+class CapabilitiesTest extends TestCase {
+
+	/** @var IConfig| MockObject */
+	protected $config;
+
+	/** @var Capabilities */
+	protected $capabilities;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->capabilities = new Capabilities($this->config);
+	}
+
+	public function testGetCapabilities() {
+		$result = $this->capabilities->getCapabilities();
+		$this->assertArrayHasKey('checksums', $result);
+		$this->assertArrayHasKey('files', $result);
+		$this->assertArrayHasKey('privateLinksDetailsParam', $result['files']);
+		$this->assertTrue($result['files']['privateLinksDetailsParam']);
+	}
+}


### PR DESCRIPTION
Backport of #35101
## Description
add capability entry for this feature: owncloud/core#32152

## Related Issue
- Fixes https://github.com/owncloud/docs/issues/265

## Motivation and Context
Show clients whether this feature #32152 is supported or not.

## How Has This Been Tested?
Unit tests added, also tested via ocs rest api for capabilities.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
