### PR TITLE
[stable10] Backport of Remove share permission check from the file upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -829,11 +829,7 @@ OC.Uploader.prototype = _.extend({
 				return true;
 			}
 			var fileInfo = fileList.findFile(file.name);
-			var sharePermission = $("#sharePermission").val();
-			if (sharePermission !== undefined) {
-				sharePermission &= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE);
-			}
-			if (fileInfo && (sharePermission !== (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE))) {
+			if (fileInfo) {
 				conflicts.push([
 					// original
 					_.extend(fileInfo, {

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1003,6 +1003,23 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user uploads file :name and clicks :label button :number_of times using webUI
+	 *
+	 * @param string $name
+	 * @param string $label
+	 * @param int $number_of
+	 *
+	 * @return void
+	 */
+	public function theUserClicksUploadAndCancelMultipleTimes($name, $label, $number_of) {
+		for ($i = 0; $i < $number_of; $i++) {
+			$this->theUserUploadsFileUsingTheWebUI($name);
+			$this->theUserChoosesToInTheUploadDialog($label);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+		}
+	}
+
+	/**
 	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed on the webUI$/
 	 *
 	 * @param string $shouldOrNot

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -371,6 +371,7 @@ Feature: Share by public link
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
+    Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user edits the permission of an already existing public link from read-write to upload-write-without-overwrite
     Given the user has created a new public link for folder "simple-folder" using the webUI with
@@ -380,3 +381,14 @@ Feature: Share by public link
     When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem (2).txt" should be listed on the webUI
+
+  Scenario: user creates public link with view download and upload feature and uploads and cancels same file multiple times to verify the conflict dialog exits after clicking cancel button
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | upload-write-without-modify |
+    And the public accesses the last created public link using the webUI
+    When the user uploads file "lorem.txt" and clicks "Cancel" button 10 times using webUI
+    Then no dialog should be displayed on the webUI
+    And no notification should be displayed on the webUI
+    And file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should not have changed
+    And file "lorem (2).txt" should not be listed on the webUI


### PR DESCRIPTION
Backport #35060 
so that stable10 QA tarball is more up-to-date

Note: has also been backported to release-10.2.0 in PR #35082 