### PR TITLE
When resharing disallow changing share attributes

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -69,7 +69,7 @@
 			'<div class="shareAttributes"">' +
 			'{{#each shareAttributes}}' +
 			'<span class="shareOption">' +
-			'<input id="can-{{name}}-{{cid}}-{{shareWith}}" type="checkbox" name="{{name}}" class="attributes checkbox" {{#if enabled}}checked="checked"{{/if}} data-scope="{{scope}}" data-enabled="{{enabled}}""/>' +
+			'<input id="can-{{name}}-{{cid}}-{{shareWith}}" type="checkbox" name="{{name}}" class="attributes checkbox" {{#if isReshare}}disabled{{/if}} {{#if enabled}}checked="checked"{{/if}} data-scope="{{scope}}" data-enabled="{{enabled}}""/>' +
 			'<label for="can-{{name}}-{{cid}}-{{shareWith}}">{{label}}</label>' +
 			'</span>' +
 			'{{/each}}' +
@@ -129,6 +129,9 @@
 			var cid = this.cid;
 			var shareWith = model.getShareWith(shareIndex);
 
+			// Check if reshare, and if so disable the checkboxes
+			var isReshare = model.hasReshare();
+
 			// Returns OC.Share.Types.ShareAttribute[] which were set for this
 			// share (and stored in DB)
 			var attributes = model.getShareAttributes(shareIndex);
@@ -145,6 +148,7 @@
 				if (regAttr && regAttr.label) {
 					list.push({
 						cid: cid,
+						isReshare: isReshare,
 						shareWith: shareWith,
 						enabled: attribute.enabled,
 						scope: attribute.scope,

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -389,6 +389,64 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(listView.$el.find("input[name='test-attribute']").is(':checked')).toEqual(true);
 			expect(updateShareStub.calledOnce).toEqual(true);
 		});
+		
+		it('prevents checking/unchecking attribute when reshared', function () {
+			shareModel.registerShareAttribute({
+				scope: "test",
+				key: "test-attribute-checked",
+				default: true,
+				label: "test attribute checked",
+				shareType : [],
+				incompatiblePermissions: [],
+				requiredPermissions: [],
+				incompatibleAttributes: []
+			});
+			shareModel.registerShareAttribute({
+				scope: "test",
+				key: "test-attribute-unchecked",
+				default: false,
+				label: "test attribute unchecked",
+				shareType : [],
+				incompatiblePermissions: [],
+				requiredPermissions: [],
+				incompatibleAttributes: []
+			});
+
+			shareModel.set('reshare', {
+				uid_owner: 100
+			});
+			shareModel.set('shares', [
+				{
+					id: 100,
+					item_source: '123',
+					permissions: 1,
+					attributes: [{ scope: 'test', key: 'test-attribute-checked', enabled: true }],
+					share_type: OC.Share.SHARE_TYPE_USER,
+					share_with: 'user1',
+					share_with_displayname: 'User One'
+				},
+				{
+					id: 101,
+					item_source: '123',
+					permissions: 1,
+					attributes: [{ scope: 'test', key: 'test-attribute-unchecked', enabled: false }],
+					share_type: OC.Share.SHARE_TYPE_USER,
+					share_with: 'user2',
+					share_with_displayname: 'User Two'
+				}
+			]);
+
+			listView.render();
+
+			// Click should have no action
+			listView.$el.find("input[name='test-attribute-checked']").click();
+			expect(listView.$el.find("input[name='test-attribute-checked']").is(':checked')).toEqual(true);
+			listView.$el.find("input[name='test-attribute-unchecked']").click();
+			expect(listView.$el.find("input[name='test-attribute-unchecked']").is(':checked')).toEqual(false);
+
+			// Update never called when clicked
+			expect(updateShareStub.called).toEqual(false);
+		});
 	});
 
 });


### PR DESCRIPTION
When user receives a share, one should not be able to change assigned attributes when resharing further:
<img width="373" alt="Screenshot at Apr 27 13-10-09" src="https://user-images.githubusercontent.com/13368647/56848900-d0bb8980-68ed-11e9-900c-8da3776dd1f4.png">

