### PR TITLE
Wait for form to load when following password reset link

### DIFF
--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -44,6 +44,7 @@ class LoginPage extends OwncloudPage {
 	protected $lostPasswordId = "lost-password";
 	protected $setPasswordErrorMessageId = "error-message";
 
+	protected $setPasswordFormXpath = "//form[@id='reset-password' or @id='set-password']";
 	protected $lostPasswordResetErrorXpath = "//li[contains(@class,'error')]";
 	protected $imprintUrlXpath = "//a[contains(text(),'Imprint')]";
 	protected $privacyPolicyXpath = "//a[contains(text(),'Privacy Policy')]";
@@ -204,6 +205,14 @@ class LoginPage extends OwncloudPage {
 	 * @return void
 	 */
 	public function resetThePassword($newPassword, $confirmNewPassword, Session $session) {
+		$form = $this->waitTillElementIsNotNull($this->setPasswordFormXpath);
+		$this->assertElementNotNull(
+			$form,
+			__METHOD__ .
+			" xpath $this->setPasswordFormXpath " .
+			'could not find set password form.'
+		);
+
 		$this->fillField($this->passwordInputId, $newPassword);
 		$this->fillField($this->confirmPasswordInputId, $confirmNewPassword);
 		$this->findById($this->submitLoginId)->click();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This adds a wait for the form in the `password reset` page. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes [drone error](https://drone.owncloud.com/owncloud/core/17030/903)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally and :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [] Backport (if applicable set "backport-request" label and remove when the backport was done)
