### PR TITLE
Always provide return status for functions

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -391,11 +391,16 @@ class ObjectStoreStorage extends Common {
 		$fileId = $this->getCache()->put($path, $stat);
 		try {
 			//upload to object storage
-			$this->objectStore->writeObject($this->getURN($fileId), \fopen($tmpFile, 'r'));
+			$status = $this->objectStore->writeObject($this->getURN($fileId), \fopen($tmpFile, 'r'));
 		} catch (\Exception $ex) {
 			$this->getCache()->remove($path);
 			\OCP\Util::writeLog('objectstore', 'Could not create object: ' . $ex->getMessage(), \OCP\Util::ERROR);
 			throw $ex; // make this bubble up
+		}
+		if ($status !== true) {
+			$this->getCache()->remove($path);
+			\OCP\Util::writeLog('objectstore', 'Could not create object: kindly contact your administrator.', \OCP\Util::ERROR);
+			return false;
 		}
 	}
 

--- a/lib/public/Files/ObjectStore/IObjectStore.php
+++ b/lib/public/Files/ObjectStore/IObjectStore.php
@@ -47,6 +47,7 @@ interface IObjectStore {
 	 * @param string $urn the unified resource name used to identify the object
 	 * @param resource $stream stream with the data to write
 	 * @throws \Exception when something goes wrong, message will be logged
+	 * @return null|bool
 	 * @since 7.0.0
 	 */
 	public function writeObject($urn, $stream);

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -76,14 +76,34 @@ class ObjectStoreTest extends TestCase {
 		$this->assertFalse($this->objectStore->file_exists('test'));
 	}
 
-	public function testGetAndPutContents() {
-		$this->impl->expects($this->once())->method('writeObject');
+	public function providesGetAndPutContents() {
+		return [
+			['123456', true],
+			['123456', false]
+		];
+	}
+
+	/**
+	 * @dataProvider providesGetAndPutContents
+	 * @param string $streamContent
+	 * @param bool $expectedResult
+	 */
+	public function testGetAndPutContents($streamContent, $expectedResult) {
+		$this->impl->expects($this->once())->method('writeObject')->willReturn($expectedResult);
 		$this->assertEquals(5, $this->objectStore->file_put_contents('test.txt', 'lorem'));
 
-		$stream = $this->createStreamFor('123456');
+		$stream = $this->createStreamFor($streamContent);
 
-		$this->impl->expects($this->once())->method('readObject')->willReturn($stream);
-		$this->assertEquals('123456', $this->objectStore->file_get_contents('test.txt'));
+		if ($expectedResult === true) {
+			$this->impl->expects($this->once())->method('readObject')->willReturn($stream);
+		}
+
+		if ($expectedResult === true) {
+			$result = '123456';
+		} else {
+			$result = false;
+		}
+		$this->assertEquals($result, $this->objectStore->file_get_contents('test.txt'));
 	}
 
 	public function testGetScanner() {


### PR DESCRIPTION
Provide return for functions. This would help
to know the status of methods called.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Functions should return values which would help to process whether the call to a method was successful or not. For instance in a scenario, where a file is uploaded in an objectstorage the filecache is updated but there is no clue if the file upload to the objectstorage is successful or not. Lets say if the file upload to objectorage fails and the system considers it as successful, then user will end up in a situation where:
- there is an entry in the filecache for the file
- there is no entry in the object storage
This PR addresses the issue.
Note: This PR is under development.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The methods/function should return the status of file upload to object storage. Say if the status is 200 return true. Else return false. This would also help to process the status of the method called for objectorage upload.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- At the end of `writeObject()` return false and then run curl command :
```
 ✘ sujith@sujith-ownCloud  /tmp  curl -u admin:admin -T file2.txt 'http://localhost/testing/remote.php/dav/files/admin/'
<!DOCTYPE html>
<html class="ng-csp" data-placeholder-focus="false" lang="en" >
        <head data-requesttoken="">
                <meta charset="utf-8">
                <title>
                ownCloud                </title>
                <meta http-equiv="X-UA-Compatible" content="IE=edge">
                <meta name="referrer" content="never">
                <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
                                        <meta name="apple-itunes-app" content="app-id=543672169">
                                <meta name="theme-color" content="#1d2d44">
                <link rel="icon" href="/testing/core/img/favicon.ico">
                <link rel="apple-touch-icon-precomposed" href="/testing/core/img/favicon-touch.png">
                <link rel="mask-icon" sizes="any" href="/testing/core/img/favicon-mask.svg" color="#1d2d44">
                                        <link rel="stylesheet" href="/testing/core/vendor/select2/select2.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/styles.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/inputs.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/header.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/icons.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/fonts.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/apps.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/global.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/fixes.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/multiselect.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/mobile.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/vendor/jquery-ui/themes/base/jquery-ui.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/jquery-ui-fixes.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/tooltip.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/apps/files_versions/css/versions.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/jquery.ocdialog.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                        <link rel="stylesheet" href="/testing/core/css/share.css?v=5cf6c400779c8af51639613f8d1fef7f">
                                                                        <script src="/testing/core/vendor/jquery/dist/jquery.min.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/jquery-ui/jquery-ui.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/underscore/underscore.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/moment/min/moment-with-locales.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/handlebars/handlebars.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/blueimp-md5/js/md5.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/bootstrap/js/tooltip.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/backbone/backbone.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/es6-promise/es6-promise.auto.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/davclient.js/lib/client.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/clipboard/dist/clipboard.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/bowser/src/bowser.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/jquery.ocdialog.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/oc-dialogs.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/js.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/l10n.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/octemplate.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/eventsource.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/config.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/search/js/search.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/oc-requesttoken.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/apps.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/mimetype.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/mimetypelist.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/snapjs/dist/latest/snap.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/vendor/select2/select2.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/oc-backbone.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/oc-backbone-webdav.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/placeholder.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/jquery.avatar.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/files/fileinfo.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/files/client.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/shareconfigmodel.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/shareitemmodel.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialogresharerinfoview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialoglinkshareview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialoglinksocialview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialogmailview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialogexpirationview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialogshareelistview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialogview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/share.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharemodel.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharescollection.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        <script src="/testing/core/js/sharedialoglinklistview.js?v=5cf6c400779c8af51639613f8d1fef7f"></script>
                                        </head>
        <body id="body-login">
                <noscript>
        <div id="nojavascript">
                <div>
                        This application requires JavaScript for correct operation. Please <a href="https://www.enable-javascript.com/" target="_blank" rel="noreferrer">enable JavaScript</a> and reload the page.          </div>
        </div>
</noscript>
                <div class="wrapper">
                        <div class="v-align">
                                                                        <header role="banner">
                                                <div id="header">
                                                        <div class="logo">
                                                                <h1 class="hidden-visually">
                                                                        ownCloud                                                                </h1>
                                                        </div>
                                                        <div id="logo-claim" style="display:none;"></div>
                                                </div>
                                        </header>
                                                                <span class="error error-wide">
        <h2><strong>Internal Server Error</strong></h2>
                <p>The server encountered an internal error and was unable to complete your request.</p>
                <p>Please contact the server administrator if this error reappears multiple times and include the technical details below in your report.</p>
                <p>More details can be found in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.org/server/11.0/go.php?to=admin-logfiles">server log</a>.</p>
        <br>

        <h2><strong>Technical details</strong></h2>
        <ul>
                <li>Remote Address: 127.0.0.1</li>
                <li>Request ID: SDDwScgu2JguOwzLeNmq</li>
                        </ul>

        </span>
                                <div class="push"></div><!-- for sticky footer -->
                        </div>
                </div>
                <footer role="contentinfo">
                        <p class="info">
                                <a href="https://owncloud.org" target="_blank" rel="noreferrer">ownCloud</a> &ndash; A safe home for all your data                      </p>
                </footer>
        </body>
</html>
 sujith@sujith-ownCloud  /tmp 
```
- Remove the changes made in the above step and re-run the curl command:
```
sujith@sujith-ownCloud  /tmp  curl -u admin:admin -T file2.txt 'http://localhost/testing/remote.php/dav/files/admin/'
 sujith@sujith-ownCloud  /tmp 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Required https://github.com/owncloud/files_primary_s3/pull/205
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
