### PR TITLE
Adding id for auth message

### DIFF
--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -13,7 +13,7 @@ $template = $_['template'];
 
 <fieldset class="warning">
 		<legend><strong><?php p($provider->getDisplayName()); ?></strong></legend>
-		<p><?php p($l->t('Please authenticate using the selected factor.')) ?></p>
+		<p id="twoFactorAuthMessage"><?php p($l->t('Please authenticate using the selected factor.')) ?></p>
 </fieldset>
 <?php if ($error): ?>
 	<?php if ($error_message) {


### PR DESCRIPTION
## Description
This makes it possible to add a custom auth message

## Related Issue
- Fixes #34848

## Motivation and Context
2FA provider are now able to add custom messages, which makes 2FA apps more flexible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

