### PR TITLE
Aborted uploads are not cleared properly

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -682,6 +682,7 @@ OC.Uploader.prototype = _.extend({
 		this.log('canceling uploads');
 		jQuery.each(this._uploads, function(i, upload) {
 			upload.abort();
+			upload.aborted = true;
 		});
 		this.clear();
 	},
@@ -691,7 +692,7 @@ OC.Uploader.prototype = _.extend({
 	clear: function() {
 		var remainingUploads = {};
 		_.each(this._uploads, function(upload, key) {
-			if (!upload.isDone) {
+			if (!upload.isDone && !upload.aborted) {
 				remainingUploads[key] = upload;
 			}
 		});

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -133,11 +133,13 @@ describe('OC.Upload tests', function() {
 		it('clear leaves pending uploads', function() {
 			uploader._uploads = {
 				'abc': {name: 'a job well done.txt', isDone: true},
-				'def': {name: 'whatevs.txt'}
+				'def': {name: 'whatevs.txt'},
+				'ghi': {name: 'aborted.txt', aborted: true}
 			};
 
 			uploader.clear();
 
+			//This does verify that aborted upload(s) will not be available in the _uploads
 			expect(uploader._uploads).toEqual({'def': {name: 'whatevs.txt'}});
 		});
 	});


### PR DESCRIPTION
File uploads should also be checked if they
are aborted or not. This would help to check
if the file is aborted or not. If aborted then
it would be cleared from the list.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When user uploads file and then aborts the upload ( the abort is done for the first time ), the global value of `this._uploads` is not updated properly. If the file is aborted, then as of now the state of `upload` is `pending`. And hence `this._uploads` will always have currently aborted upload. So when the user tries to upload a file next time ( say second time ), then the value in the `this_upload` mismatches. Because it has previous value. And the error could also be seen in the console. 

In this change set I have introduced an attribute `aborted` for the `upload`. When the upload is aborted, `aborted` attribute of `upload` is set to true. And hence while clearing the uploads, it checks whether the current aborted upload should be added to remaining uploads or not.

In simple terms its an issue of not clearing uploads list.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35086

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The aborted upload(s) should be cleared from the list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Here is how I have tested in my instance 
![upload-cancel](https://user-images.githubusercontent.com/3600427/56966955-cf07f500-6b7d-11e9-8d65-000899b324c1.gif)
- I have also tested without aborting/cancelling the upload. And it worked. The files were available in the UI. Was able to download them.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
