### PR TITLE
[stable10] Allow configuring thumbnails path

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -777,6 +777,17 @@ $CONFIG = array(
 'enable_previews' => true,
 
 /**
+ * Location of the thumbnails folder, defaults to `data/$user/thumbnails` where
+ * `$user` is the current user. When specified, the format will change to
+ * `$previews_path/$user` where `$previews_path` is the configured previews base directory
+ * and `$user` will be substituted with the user id automatically.
+ *
+ * For example if `previews_path` is `/var/cache/owncloud/thumbnails` then for a logged in
+ * user `user1` the thumbnail path will be `/var/cache/owncloud/thumbnails/user1`.
+ */
+'previews_path' => '',
+
+/**
  * The maximum width, in pixels, of a preview. A value of `null` means there
  * is no limit.
  */

--- a/lib/private/Files/Mount/CacheMountProvider.php
+++ b/lib/private/Files/Mount/CacheMountProvider.php
@@ -36,7 +36,7 @@ class CacheMountProvider implements IMountProvider {
 	private $config;
 
 	/**
-	 * ObjectStoreHomeMountProvider constructor.
+	 * CacheMountProvider constructor.
 	 *
 	 * @param IConfig $config
 	 */
@@ -60,7 +60,7 @@ class CacheMountProvider implements IMountProvider {
 			}
 
 			return [
-				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/cache', ['datadir' => $cacheDir, $loader])
+				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/cache', ['datadir' => $cacheDir], $loader)
 			];
 		} else {
 			return [];

--- a/lib/private/Files/Mount/PreviewsMountProvider.php
+++ b/lib/private/Files/Mount/PreviewsMountProvider.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Mount;
+
+use OCP\Files\Config\IMountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IUser;
+
+/**
+ * Mount provider for custom preview storages
+ */
+class PreviewsMountProvider implements IMountProvider {
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	/**
+	 * PreviewsMountProvider constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Get the previews mount for a user
+	 *
+	 * @param IUser $user
+	 * @param IStorageFactory $loader
+	 * @return \OCP\Files\Mount\IMountPoint[]
+	 */
+	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
+		$previewsPath = $this->config->getSystemValue('previews_path', '');
+		if ($previewsPath !== '') {
+			$previewsDir = \rtrim($previewsPath, '/') . '/' . $user->getUID();
+			if (!\file_exists($previewsDir)) {
+				\mkdir($previewsDir, 0770, true);
+			}
+
+			return [
+				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/thumbnails', ['datadir' => $previewsDir], $loader)
+			];
+		} else {
+			return [];
+		}
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -51,6 +51,7 @@ use OC\Diagnostics\QueryLogger;
 use OC\Files\Config\UserMountCache;
 use OC\Files\Config\UserMountCacheListener;
 use OC\Files\Mount\CacheMountProvider;
+use OC\Files\Mount\PreviewsMountProvider;
 use OC\Files\Mount\LocalHomeMountProvider;
 use OC\Files\Mount\ObjectHomeMountProvider;
 use OC\Files\Node\HookConnector;
@@ -627,6 +628,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 
 			$config = $c->getConfig();
 			$manager->registerProvider(new CacheMountProvider($config));
+			$manager->registerProvider(new PreviewsMountProvider($config));
 			$manager->registerHomeProvider(new LocalHomeMountProvider());
 			$manager->registerHomeProvider(new ObjectHomeMountProvider($config));
 

--- a/tests/lib/Files/Mount/CacheMountProviderTest.php
+++ b/tests/lib/Files/Mount/CacheMountProviderTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Mount;
+
+use OC\Files\Mount\CacheMountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IUser;
+use OC\Files\Mount\MountPoint;
+
+class CacheMountProviderTest extends \Test\TestCase {
+
+	/** @var CacheMountPorivder */
+	protected $provider;
+
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	protected $config;
+
+	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
+	protected $user;
+
+	/** @var IStorageFactory|\PHPUnit\Framework\MockObject\MockObject */
+	protected $loader;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->user = $this->createMock(IUser::class);
+		$this->loader = $this->createMock(IStorageFactory::class);
+
+		$this->provider = new CacheMountProvider($this->config);
+	}
+
+	public function testConfiguredCachePath() {
+		$tempFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('cache_path', '')
+			->willReturn($tempFolder . '/cache');
+
+		$this->user->expects($this->any())->method('getUID')->willReturn('someuser');
+
+		$mounts = $this->provider->getMountsForUser($this->user, $this->loader);
+
+		$this->assertCount(1, $mounts);
+		$mount = $mounts[0];
+
+		$this->assertInstanceOf(MountPoint::class, $mount);
+		$this->assertEquals('/someuser/cache/', $mount->getMountPoint());
+
+		$this->assertTrue(\is_dir($tempFolder . '/cache/someuser'));
+
+		$storageArgs = ['datadir' => $tempFolder . '/cache/someuser'];
+
+		$this->loader->expects($this->once())
+			->method('getInstance')
+			->with($mount, '\OC\Files\Storage\Local', $storageArgs);
+
+		// trigger storage creation which will pass config args above
+		$mount->getStorage();
+
+		\rmdir($tempFolder . '/cache/someuser');
+		\rmdir($tempFolder . '/cache');
+	}
+}

--- a/tests/lib/Files/Mount/PreviewsMountProviderTest.php
+++ b/tests/lib/Files/Mount/PreviewsMountProviderTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Mount;
+
+use OC\Files\Mount\PreviewsMountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IUser;
+use OC\Files\Mount\MountPoint;
+
+class PreviewsMountProviderTest extends \Test\TestCase {
+
+	/** @var PreviewsMountPorivder */
+	protected $provider;
+
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	protected $config;
+
+	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
+	protected $user;
+
+	/** @var IStorageFactory|\PHPUnit\Framework\MockObject\MockObject */
+	protected $loader;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->user = $this->createMock(IUser::class);
+		$this->loader = $this->createMock(IStorageFactory::class);
+
+		$this->provider = new PreviewsMountProvider($this->config);
+	}
+
+	public function testConfiguredPreviewsPath() {
+		$tempFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('previews_path', '')
+			->willReturn($tempFolder . '/thumbnails');
+
+		$this->user->expects($this->any())->method('getUID')->willReturn('someuser');
+
+		$mounts = $this->provider->getMountsForUser($this->user, $this->loader);
+
+		$this->assertCount(1, $mounts);
+		$mount = $mounts[0];
+
+		$this->assertInstanceOf(MountPoint::class, $mount);
+		$this->assertEquals('/someuser/thumbnails/', $mount->getMountPoint());
+
+		$this->assertTrue(\is_dir($tempFolder . '/thumbnails/someuser'));
+
+		$storageArgs = ['datadir' => $tempFolder . '/thumbnails/someuser'];
+
+		$this->loader->expects($this->once())
+			->method('getInstance')
+			->with($mount, '\OC\Files\Storage\Local', $storageArgs);
+
+		// trigger storage creation which will pass config args above
+		$mount->getStorage();
+
+		\rmdir($tempFolder . '/thumbnails/someuser');
+		\rmdir($tempFolder . '/thumbnails');
+	}
+}


### PR DESCRIPTION
Similar to "cache_path" but for thumbnails.
This was quickly copied from the CacheMountProvider

Why ? Because I tried to set this up on my server with symlinks and it says "following symlinks not allowed".
