### PR TITLE
dont show notification if federated share autoaccepted

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -1053,7 +1053,7 @@ class FederatedShareProvider implements IShareProvider {
 	 *
 	 * @return bool
 	 */
-	protected function getAccepted($remote, $shareWith) {
+	public function getAccepted($remote, $shareWith) {
 		$event = $this->eventDispatcher->dispatch(
 			'remoteshare.received',
 			new GenericEvent('', ['remote' => $remote])

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -919,11 +919,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->with('remoteshare.received', $this->anything())
 			->willReturn($event);
 
-		$shouldAutoAccept = $this->invokePrivate(
-			$this->provider,
-			'getAccepted',
-			['remote', 'user@server.com']
-		);
+		$shouldAutoAccept = $this->provider->getAccepted('remote', 'user@server.com');
 
 		$this->assertEquals($expected, $shouldAutoAccept);
 	}


### PR DESCRIPTION
## Description
No need to show a notification if federated share auto-accepted.

## Related Issue
- Fixes #35067

## Motivation and Context
Fixing bug.

## How Has This Been Tested?
### Steps to reproduce
1. set up 2 servers
2. on server1 add server2 as trusted server
3. on server1 enable `Automatically accept remote shares from trusted servers `
4. share folder from server2 to server1
5. share should be accepted and no notification.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)