### PR TITLE
shareAutocompletion feature updated for not listing the user in autocomplete list in webui

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -897,6 +897,21 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then user :username should not be listed in the autocomplete list on the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userShouldNotBeListedInTheAutocompleteListOnTheWebui($username) {
+		$names = $this->sharingDialog->getAutocompleteItemsList();
+		if (\in_array($username, $names)) {
+			throw new Exception("$username found in autocomplete list but not expected");
+		}
+	}
+
+	/**
 	 * @Then a tooltip with the text :text should be shown near the share-with-field on the webUI
 	 *
 	 * @param string $text

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -36,6 +36,7 @@ Feature: Autocompletion of share-with names
     When the user types "us" in the share-with-field
     Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
+    And user "Four" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   @smokeTest
@@ -46,6 +47,7 @@ Feature: Autocompletion of share-with names
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
+    And user "other" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion for a pattern that does not match any user or group
     Given user "regularuser" has logged in using the webUI
@@ -66,6 +68,7 @@ Feature: Autocompletion of share-with names
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "Use" in the share-with-field
     Then only "Use" should be listed in the autocomplete list on the webUI
+    And user "User Two" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocomplete short group names when completely typed
@@ -78,6 +81,7 @@ Feature: Autocompletion of share-with names
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
     Then only "fi (group)" should be listed in the autocomplete list on the webUI
+    And user "finance1" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
@@ -107,6 +111,7 @@ Feature: Autocompletion of share-with names
     When the user types "use" in the share-with-field
     Then all users and groups that contain the string "use" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
+    And user "Four" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
@@ -117,6 +122,7 @@ Feature: Autocompletion of share-with names
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
     And the users own name should not be listed in the autocomplete list on the webUI
+    And user "Four" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
@@ -127,6 +133,7 @@ Feature: Autocompletion of share-with names
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
     And the users own name should not be listed in the autocomplete list on the webUI
+    And user "Four" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
@@ -137,6 +144,7 @@ Feature: Autocompletion of share-with names
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
     And the users own name should not be listed in the autocomplete list on the webUI
+    And user "Four" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
@@ -147,3 +155,24 @@ Feature: Autocompletion of share-with names
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
     And the users own name should not be listed in the autocomplete list on the webUI
+    And user "Four" should not be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: autocompletion of a pattern where the name of existing users contain the pattern somewhere in the middle
+    Given user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for folder "simple-folder"
+    When the user types "se" in the share-with-field
+    Then all users and groups that contain the string "se" in their name should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
+    And user "Four" should not be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: autocompletion of a pattern where the name of existing users contain the pattern at the end
+    Given user "usergrp" has logged in using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for folder "simple-folder"
+    When the user types "r3" in the share-with-field
+    Then all users and groups that contain the string "r3" in their name should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
+    And user "User One" should not be listed in the autocomplete list on the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
ShareAutocompletion feature updated so that the users whose name doesn't contain the text typed in "share-with-field" is not listed in autocomplete list in webUI.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
testing of medial search on group and user #34659
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
