### PR TITLE
[10.2.0] Backport of dont show notification if federated share auto…

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -1053,7 +1053,7 @@ class FederatedShareProvider implements IShareProvider {
 	 *
 	 * @return bool
 	 */
-	protected function getAccepted($remote, $shareWith) {
+	public function getAccepted($remote, $shareWith) {
 		$event = $this->eventDispatcher->dispatch(
 			'remoteshare.received',
 			new GenericEvent('', ['remote' => $remote])

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -916,11 +916,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->with('remoteshare.received', $this->anything())
 			->willReturn($event);
 
-		$shouldAutoAccept = $this->invokePrivate(
-			$this->provider,
-			'getAccepted',
-			['remote', 'user@server.com']
-		);
+		$shouldAutoAccept = $this->provider->getAccepted('remote', 'user@server.com');
 
 		$this->assertEquals($expected, $shouldAutoAccept);
 	}


### PR DESCRIPTION
…accepted

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
No need to show a notification if federated share auto-accepted.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35067

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No need to show a notification if federated share auto-accepted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested according to the same steps mentioned at https://github.com/owncloud/core/pull/35132#issue-274864384

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
