### PR TITLE
[10.2.0] Set mail_send via old share API

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -920,12 +920,13 @@ class Share20OcsController extends OCSController {
 	 * @NoAdminRequired
 	 *
 	 * @param int $itemSource
+	 * @param string $itemType
 	 * @param int $shareType
 	 * @param string $recipient
 	 *
 	 * @return Result
 	 */
-	public function notifyRecipients($itemSource, $shareType, $recipient) {
+	public function notifyRecipients($itemSource, $itemType, $shareType, $recipient) {
 		$recipientList = [];
 		if ($shareType === Share::SHARE_TYPE_USER) {
 			$recipientList[] = $this->userManager->get($recipient);
@@ -960,12 +961,8 @@ class Share20OcsController extends OCSController {
 		// if we were able to send to at least one recipient, mark as sent
 		// allowing the user to resend would spam users who already got a notification
 		if (\count($result) < \count($recipientList)) {
-			$items = $this->shareManager->getSharedWith($recipient, $shareType, $node);
-			if (\count($items) > 0) {
-				$share = $items[0];
-				$share->setMailSend(true);
-				$this->shareManager->updateShare($share);
-			}
+			// FIXME: migrate to a new share API
+			Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
 		}
 
 		$message = empty($result)
@@ -984,22 +981,15 @@ class Share20OcsController extends OCSController {
 	 * @NoAdminRequired
 	 *
 	 * @param int $itemSource
+	 * @param string $itemType
 	 * @param int $shareType
 	 * @param string $recipient
 	 *
 	 * @return Result
 	 */
-	public function notifyRecipientsDisabled($itemSource, $shareType, $recipient) {
-		$userFolder = $this->rootFolder->getUserFolder($this->currentUser->getUID());
-		$nodes = $userFolder->getById($itemSource, true);
-		$node = $nodes[0] ?? null;
-
-		$items = $this->shareManager->getSharedWith($recipient, $shareType, $node);
-		if (\count($items) > 0) {
-			$share = $items[0];
-			$share->setMailSend(true);
-			$this->shareManager->updateShare($share);
-		}
+	public function notifyRecipientsDisabled($itemSource, $itemType, $shareType, $recipient) {
+		// FIXME: migrate to a new share API
+		Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
 		return new Result();
 	}
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/35136

## Description
Partially reverts https://github.com/owncloud/core/pull/33180/commits/129d5e1563bbeafa0993da3c7c09cb1e9ec4a3da

## Related Issue
- Fixes #35089 

## Motivation and Context
It's possible to notify group about share multiple times

## How Has This Been Tested?
In accordance with #35089 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
