### PR TITLE
[stable10] Backport of Convert shareWith to lower case

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -386,6 +386,10 @@ class Share20OcsController extends OCSController {
 
 		$globalAutoAccept = $this->config->getAppValue('core', 'shareapi_auto_accept_share', 'yes') === 'yes';
 		if ($shareType === Share::SHARE_TYPE_USER) {
+			//Lower the case if the share type is user
+			if (($shareWith !== null) && ($shareWith !== '')) {
+				$shareWith = \strtolower($shareWith);
+			}
 			$userAutoAccept = false;
 			if ($globalAutoAccept) {
 				$userAutoAccept = $this->config->getUserValue($shareWith, 'files_sharing', 'auto_accept_share', 'yes') === 'yes';

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -903,7 +903,7 @@ class Share20OcsControllerTest extends TestCase {
 				->with('valid-path')
 				->willReturn($path);
 
-		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
+		$this->userManager->method('userExists')->with('validuser')->willReturn(true);
 
 		$path->expects($this->once())
 			->method('lock')
@@ -921,7 +921,7 @@ class Share20OcsControllerTest extends TestCase {
 						~\OCP\Constants::PERMISSION_CREATE
 					) &&
 					$share->getShareType() === Share::SHARE_TYPE_USER &&
-					$share->getSharedWith() === 'validUser' &&
+					$share->getSharedWith() === 'validuser' &&
 					$share->getSharedBy() === 'currentUser';
 			}))
 			->will($this->returnArgument(0));
@@ -1587,7 +1587,7 @@ class Share20OcsControllerTest extends TestCase {
 			->with('valid-path')
 			->willReturn($path);
 
-		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
+		$this->userManager->method('userExists')->with('validuser')->willReturn(true);
 
 		$this->shareManager
 			->expects($this->once())


### PR DESCRIPTION
Convert shareWith to lower case when share is created.
This would help to make it consistent across oC.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Convert `shareWith` to lower case. The share API does not convert it to lower case, and as a result, it would cause inconsistency: if the API is used by passing `shareWith` with a mix of upper and lower case. The share would be inaccessible. This was found with guest user.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Convert `shareWith` to lower case in the Share20OcsController::createShare(). If its not converted the share might be inaccessible to the user. This was found with guest user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- - Create guest user with email address having upper and lower case
- Set the guest user password by accessing the link from email
- The guest share is accessible from the webUI by logging in as the guest user.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
