### PR TITLE
Add new exceptions for objectstore

### DIFF
--- a/lib/public/Files/ObjectStore/ObjectStoreException.php
+++ b/lib/public/Files/ObjectStore/ObjectStoreException.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\ObjectStore;
+
+/**
+ * Exception to handle object storage failures
+ * Class ObjectStoreException
+ *
+ * @package OCP\Files\ObjectStore
+ * @since 10.3.0
+ */
+class ObjectStoreException extends \Exception {
+	/**
+	 * ObjectStoreException constructor.
+	 *
+	 * @param string $message
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 10.3.0
+	 */
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/lib/public/Files/ObjectStore/ObjectStoreOperationException.php
+++ b/lib/public/Files/ObjectStore/ObjectStoreOperationException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\ObjectStore;
+
+/**
+ * Exception to handle read, write and delete to object storage
+ * Class ObjectStoreOperationException
+ *
+ * @package OCP\Files\ObjectStore
+ * @since 10.3.0
+ */
+class ObjectStoreOperationException extends ObjectStoreException {
+	/**
+	 * ObjectStoreOperationException constructor.
+	 *
+	 * @param string $message
+	 * @param int $statusCode
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 10.3.0
+	 */
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/lib/public/Files/ObjectStore/ObjectStoreWriteException.php
+++ b/lib/public/Files/ObjectStore/ObjectStoreWriteException.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\ObjectStore;
+
+/**
+ * Exception when file upload to object store fails
+ * Class ObjectStoreWriteException
+ *
+ * @package OCP\Files\ObjectStore
+ * @since 10.3.0
+ */
+class ObjectStoreWriteException extends ObjectStoreOperationException {
+	/** @var int  */
+	private $statusCode;
+
+	/**
+	 * ObjectStoreWriteException constructor.
+	 *
+	 * @param string $message
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 10.3.0
+	 */
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}


### PR DESCRIPTION
Add new exceptions for objectstore.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Introducing new exception(s) to objectstorage. The idea of having new exception is because the interface `IObjectStore` relies on exception.
So we have an exception heirarchy as shown below:
![ObjectStoreWriteException](https://user-images.githubusercontent.com/3600427/57142583-826d2580-6dda-11e9-8af3-60fea1ef242a.png)


The idea is any operation specific exceptions ( like `readObject`, `writeObject` and `deleteObject` ) will use exceptions like `ObjectStoreWriteException` ( for `writeObject` ) or `ObjectStoreReadException` ( for `readObject` ) or `ObjectStoreDeleteException` ( for `deleteObject` )  which inherits from `ObjectStoreOperationException`. The `ObjectStoreOperationException` inherits from `ObjectStoreException`.

This PR focuses only on the 3 exceptions shared above( i.e, ObjectSoreException, ObjectStoreOperationException and ObjectStoreWriteException ). So in future lets say we need to add exception for `readObject` then we could create new exception like `ObjectStoreReadException` which would inherit from `ObjectStoreOperationException` and so on.
But lets say if we need to have an exception for connection, then we have an option to create, say `ObjectStoreConnectionException` which can be inherited from `ObjectStoreException`


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Introduces new exception for objectstorage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Requires https://github.com/owncloud/files_primary_s3/pull/212
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
