### PR TITLE
feature test for share autocomplete list in webUI

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -419,6 +419,7 @@ default:
         - WebUILoginContext:
         - WebUISharingContext:
         - WebUIAdminSharingSettingsContext:
+        - WebUIPersonalSharingSettingsContext:
 
     webUISharingNotifications:
       paths:

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -82,6 +82,19 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
+	 * @When /^the user (disables|enables) allow finding you via autocomplete in share dialog$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 */
+	public function switchAllowFindingYouViaAutocompleteInShareDialog($action) {
+		$this->personalSharingSettingsPage->toggleFindingYouViaAutocomplete(
+			$this->getSession(), $action
+		);
+	}
+
+	/**
 	 * @Then User-based auto accepting checkbox should not be displayed on the personal sharing settings page in the webUI
 	 *
 	 * @return void
@@ -100,6 +113,17 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	public function autoAcceptingFederatedCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageInTheWebui() {
 		PHPUnit\Framework\Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAutoAcceptFederatedSharesCheckboxDisplayed()
+		);
+	}
+
+	/**
+	 * @Then allow finding you via autocomplete checkbox should not be displayed on the personal sharing settings page
+	 *
+	 * @return void
+	 */
+	public function allowFindingYouViaAutocompleteCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPage() {
+		PHPUnit\Framework\Assert::assertFalse(
+			$this->personalSharingSettingsPage->isAllowFindingYouViaAutocompleteCheckboxDisplayed()
 		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -897,6 +897,23 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then user :username should be listed in the autocomplete list on the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userShouldBeListedInTheAutocompleteListOnTheWebui($username) {
+		$names = $this->sharingDialog->getAutocompleteItemsList();
+		PHPUnit\Framework\Assert::assertContains(
+			$username,
+			$names,
+			"$username not found in autocomplete list"
+		);
+	}
+
+	/**
 	 * @Then user :username should not be listed in the autocomplete list on the webUI
 	 *
 	 * @param string $username

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -43,7 +43,10 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 		= '//label[@for="userAutoAcceptShareTrustedInput"]';
 	protected $autoAcceptFederatedSharesCheckboxXpathCheckboxId
 		= 'userAutoAcceptShareTrustedInput';
-
+	protected $allowFindingYouViaAutocompleteCheckboxXpath
+		= '//label[@for="allow_share_dialog_user_enumeration_input"]';
+	protected $allowFindingYouViaAutocompleteCheckboxXpathCheckboxId
+		= 'allow_share_dialog_user_enumeration_input';
 	/**
 	 *
 	 * @param Session $session
@@ -76,6 +79,21 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 		);
 	}
 
+	/**
+	 *
+	 * @param Session $session
+	 * @param string $action "enables|disables"
+	 *
+	 * @return void
+	 */
+	public function toggleFindingYouViaAutocomplete(Session $session, $action) {
+		$this->toggleCheckbox(
+			$session,
+			$action,
+			$this->allowFindingYouViaAutocompleteCheckboxXpath,
+			$this->allowFindingYouViaAutocompleteCheckboxXpathCheckboxId
+		);
+	}
 	/**
 	 * there is no reliable loading indicator on the personal sharing settings page,
 	 * so just wait for files_sharing personal panel div to be there and all Ajax calls to finish
@@ -115,6 +133,22 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 	 */
 	public function isAutoAcceptFederatedSharesCheckboxDisplayed() {
 		$localAutoAcceptCheckbox = $this->find('xpath', $this->autoAcceptFederatedSharesCheckboxXpath);
+		if ($localAutoAcceptCheckbox === null) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Check if the allow finding you via autocomplete checkbox is shown in the webui
+	 *
+	 * @return boolean
+	 */
+	public function isAllowFindingYouViaAutocompleteCheckboxDisplayed() {
+		$localAutoAcceptCheckbox = $this->find(
+			'xpath',
+			$this->allowFindingYouViaAutocompleteCheckboxXpath
+		);
 		if ($localAutoAcceptCheckbox === null) {
 			return false;
 		}

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -176,3 +176,95 @@ Feature: Autocompletion of share-with names
     Then all users and groups that contain the string "r3" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "User One" should not be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: allow user to disable autocomplete in sharing dialog
+    Given user "regularuser" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables allow finding you via autocomplete in share dialog
+    And the user re-logs in as "user1" using the webUI
+    And the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder"
+    And the user types "reg" in the share-with-field
+    Then user "Regular User" should not be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: user disables autocomplete in sharing dialog but the sharer types full username
+    Given user "regularuser" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables allow finding you via autocomplete in share dialog
+    And the user re-logs in as "user1" using the webUI
+    And the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder"
+    And the user types "regularuser" in the share-with-field
+    Then user "Regular User" should be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: user disables autocomplete in sharing dialog but the sharer types full display name
+    Given user "regularuser" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables allow finding you via autocomplete in share dialog
+    And the user re-logs in as "user1" using the webUI
+    And the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder"
+    And the user types "Regular User" in the share-with-field
+    Then user "Regular User" should be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: allow user to enable autocomplete in sharing dialog
+    Given user "regularuser" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user enables allow finding you via autocomplete in share dialog
+    And the user re-logs in as "user1" using the webUI
+    And the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder"
+    And the user types "reg" in the share-with-field
+    Then user "Regular User" should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: autocompletion of a pattern when admin disables username autocompletion in share dialog
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    And user "regularuser" has logged in using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for folder "simple-folder"
+    When the user types "user" in the share-with-field
+    Then a tooltip with the text "No users or groups found for user" should be shown near the share-with-field on the webUI
+    And the autocomplete list should not be displayed on the webUI
+
+  @skipOnLDAP
+  Scenario: admin disables share dialog user enumeration
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    And user "regularuser" has logged in using the webUI
+    When the user browses to the personal sharing settings page
+    Then allow finding you via autocomplete checkbox should not be displayed on the personal sharing settings page
+
+  @skipOnLDAP
+  Scenario: admin disables share dialog user enumeration and types full user name of user in sharing dialog
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    And user "regularuser" has logged in using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for folder "simple-folder"
+    When the user types "user1" in the share-with-field
+    Then user "User One" should be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: admin disables share dialog user enumeration and types full display name of user in sharing dialog
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    And user "regularuser" has logged in using the webUI
+    And the user has browsed to the files page
+    And the user has opened the share dialog for folder "simple-folder"
+    When the user types "User One" in the share-with-field
+    Then user "User One" should be listed in the autocomplete list on the webUI
+
+  @skipOnLDAP
+  Scenario: autocompletion of pattern when user disables and then enables autocompletion in sharing dialog
+    Given user "regularuser" has logged in using the webUI
+    And the user has browsed to the personal sharing settings page
+    When the user disables allow finding you via autocomplete in share dialog
+    And the user enables allow finding you via autocomplete in share dialog
+    And the user re-logs in as "user1" using the webUI
+    And the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder"
+    And the user types "reg" in the share-with-field
+    Then user "Regular User" should be listed in the autocomplete list on the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Test for autocompletion feature in share dialog using webUI.
Includes test for allowing user to opt-out of autocomplete in sharing dialog #34942
and admin disabling share dialog user enumeration
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
