### PR TITLE
Extend SharingApi test context to test uppercase to lowercase conversion

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -875,6 +875,28 @@ trait Sharing {
 	}
 
 	/**
+	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with user with uppercase letters "([^"]*)"(?: with permissions (.*))?$/
+	 *
+	 * @param string $user1
+	 * @param string $filepath
+	 * @param string $user2
+	 * @param int $permissions
+	 *
+	 * @return void
+	 */
+	public function userHasSharedFileWithUserWithUppercaseLettersUsingTheSharingApi(
+		$user1, $filepath, $user2, $permissions = null
+	) {
+		$this->userSharesFileWithUserUsingTheSharingApi(
+			$user1, $filepath, $user2, $permissions
+		);
+		PHPUnit\Framework\Assert::assertTrue(
+			$this->isUserOrGroupInSharedData(\strtolower($user2), $permissions),
+			"User $user1 failed to share $filepath with user $user2"
+		);
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with the administrator(?: with permissions (.*))?$/
 	 *
 	 * @param string $sharer


### PR DESCRIPTION
## Description
Extend Acceptance Test Suite

## Related Issue
- Needed for https://github.com/owncloud/guests/pull/325

## Motivation and Context
We need to test the stability of the SharingAPI even if we feed it with uppercase/lowercase differences to the correctn UID

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
