### PR TITLE
[10.2.0] Backport of Fix update share permissions for public link

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -796,9 +796,6 @@ class Share20OcsController extends OCSController {
 					$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 					return new Result(null, 400, $this->l->t('Public upload is only possible for publicly shared folders'));
 				}
-
-				// normalize to correct public upload permissions
-				$newPermissions = Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE;
 			}
 
 			// create-only (upload-only)

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -1773,9 +1773,15 @@ class Share20OcsControllerTest extends TestCase {
 
 		$this->shareManager->expects($this->once())->method('updateShare')->with(
 			$this->callback(function (\OCP\Share\IShare $share) {
-				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
-				$share->getPassword() === 'password' &&
-				$share->getExpirationDate() === null;
+				if ($share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE)) {
+					return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
+						$share->getPassword() === 'password' &&
+						$share->getExpirationDate() === null;
+				} else {
+					return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE) &&
+						$share->getPassword() === 'password' &&
+						$share->getExpirationDate() === null;
+				}
 			})
 		)->will($this->returnArgument(0));
 
@@ -2052,7 +2058,7 @@ class Share20OcsControllerTest extends TestCase {
 
 		$this->shareManager->expects($this->once())->method('updateShare')->with(
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
-				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
+				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE) &&
 				$share->getPassword() === 'password' &&
 				$share->getExpirationDate() === $date;
 			})

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -149,7 +149,7 @@ Feature: sharing
     When the user creates a public link share using the sharing API with settings
       | path | FOLDER |
     And the user updates the last share using the sharing API with
-      | permissions | 7 |
+      | permissions | 15 |
     And the user gets the info of the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -161,6 +161,39 @@ Feature: sharing
       | file_source       | A_NUMBER             |
       | file_target       | /FOLDER              |
       | permissions       | 15                   |
+      | stime             | A_NUMBER             |
+      | token             | A_TOKEN              |
+      | storage           | A_NUMBER             |
+      | mail_send         | 0                    |
+      | uid_owner         | user0                |
+      | file_parent       | A_NUMBER             |
+      | displayname_owner | User Zero            |
+      | url               | AN_URL               |
+      | mimetype          | httpd/unix-directory |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario Outline: Creating a new public link share, updating its permissions to view download and upload and getting its info
+    Given using OCS API version "<ocs_api_version>"
+    And as user "user0"
+    When the user creates a public link share using the sharing API with settings
+      | path | FOLDER |
+    And the user updates the last share using the sharing API with
+      | permissions | 7 |
+    And the user gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | id                | A_NUMBER             |
+      | item_type         | folder               |
+      | item_source       | A_NUMBER             |
+      | share_type        | 3                    |
+      | file_source       | A_NUMBER             |
+      | file_target       | /FOLDER              |
+      | permissions       | 7                    |
       | stime             | A_NUMBER             |
       | token             | A_TOKEN              |
       | storage           | A_NUMBER             |


### PR DESCRIPTION
When user tries to change the permission from
permission 15 to permission 7 ( i.e, View/Download/
Upload), the permissions are not updated properly.
The reason for this is due to the overwriting
of newpermission variable with permission 15.
This changeset removes the overwriting to newpermission
variable.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When user has opted to change the public link permission change from `Download/View/Edit` to `Download/View/Upload`, the value of `newPermissions` in the code is overwritten to `15` and does not use the real value obtained. This change set tries not to overwrite the value to `15` and use the real value obtained.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35155

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not overwrite the permissions, instead use the value obtained.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Testing similarly mentioned at https://github.com/owncloud/core/pull/35157#issue-276130844

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
