### PR TITLE
Add acceptance test for checking changing sharing permissions

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1656,6 +1656,60 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then it should be possible to delete file/folder :name using the webUI
+	 *
+	 * @param string $name
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function itShouldBePossibleToDeleteFileFolderUsingTheWebUI($name) {
+		$this->deleteTheFileUsingTheWebUI($name, true);
+	}
+
+	/**
+	 * @Then /^the option to (delete|rename|download)\s?(?:file|folder) "([^"]*)" should (not|)\s?be available in the webUI$/
+	 *
+	 * @param string $action
+	 * @param string $name
+	 * @param string $shouldOrNot
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function optionShouldNotBeAvailable($action, $name, $shouldOrNot) {
+		$visible = $shouldOrNot !== "not";
+		$pageObject = $this->getCurrentPageObject();
+		$session = $this->getSession();
+		$pageObject->waitTillPageIsLoaded($session);
+		$fileRow = $pageObject->findFileRowByName($name, $session);
+		$action = \ucfirst($action);
+		if ($visible) {
+			PHPUnit\Framework\Assert::assertTrue($fileRow->isActionLabelAvailable($action, $session));
+		} else {
+			PHPUnit\Framework\Assert::assertFalse($fileRow->isActionLabelAvailable($action, $session));
+		}
+		$fileRow->clickFileActionButton();
+	}
+
+	/**
+	 * @Then /^the option to upload file should (not|)\s?be available in the webUI$/
+	 *
+	 * @param string $shouldOrNot
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function uploadButtonShouldNotBeVisible($shouldOrNot) {
+		$visible = $shouldOrNot !== "not";
+		if ($visible) {
+			PHPUnit\Framework\Assert::assertTrue($this->getCurrentPageObject()->isUploadButtonAvailable());
+		} else {
+			PHPUnit\Framework\Assert::assertFalse($this->getCurrentPageObject()->isUploadButtonAvailable());
+		}
+	}
+
+	/**
 	 * @Then the files action menu should be completely visible after opening it using the webUI
 	 *
 	 * @return void

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -51,6 +51,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	protected $appSettingsContentId = "app-settings-content";
 	protected $styleOfCheckboxWhenVisible = "display: block;";
 	protected $detailsDialogXpath = "//*[contains(@id, 'app-sidebar') and not(contains(@class, 'disappear'))]";
+	protected $newFileFolderButtonXpath = './/*[@id="controls"]//a[@class="button new"]';
 
 	/**
 	 * @return string
@@ -648,5 +649,18 @@ abstract class FilesPageBasic extends OwncloudPage {
 			"could not find the field for show hidden files checkbox"
 		);
 		$showHiddenFilesCheckBox->click();
+	}
+
+	/**
+	 * Return is New File/folder button is available in the webUI
+	 *
+	 * @return boolean
+	 */
+	public function isUploadButtonAvailable() {
+		$btn = $this->find("xpath", $this->newFileFolderButtonXpath);
+		if ($btn === null) {
+			return false;
+		}
+		return $btn->isVisible();
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -416,6 +416,9 @@ class FilesPageCRUD extends FilesPageBasic {
 			$message = "INFORMATION: retried to delete file '$name' $counter times";
 			echo $message;
 			\error_log($message);
+			if ($counter === $maxRetries) {
+				throw new \Exception($message);
+			}
 		}
 	}
 

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -218,4 +218,24 @@ class FileActionsMenu extends OwncloudPage {
 	public function getActionLabelLocalized($action) {
 		return $this->findButton($action)->getText();
 	}
+
+	/**
+	 * return if the Action label is visible
+	 *
+	 * @param string $action ("Delete"|"Rename"|"Details")
+	 *
+	 * @return boolean
+	 */
+	public function isActionLabelVisible($action) {
+		$xpathLocator = \sprintf($this->fileActionXpath, $action);
+		$this->waitTillElementIsNotNull($xpathLocator);
+		$button = $this->menuElement->find(
+			"xpath",
+			$xpathLocator
+		);
+		if (!$button) {
+			return false;
+		}
+		return $button->isVisible();
+	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -572,4 +572,17 @@ class FileRow extends OwncloudPage {
 		);
 		return $element;
 	}
+
+	/**
+	 * Returns if action menu is Available in the fileRow
+	 *
+	 * @param string $actionLabel
+	 * @param Session $session
+	 *
+	 * @return boolean
+	 */
+	public function isActionLabelAvailable($actionLabel, Session $session) {
+		$actionMenu = $this->openFileActionsMenu($session);
+		return $actionMenu->isActionLabelVisible($actionLabel);
+	}
 }

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -424,3 +424,60 @@ Feature: Share by public link
       #Then the following folder should be listed on the webUI
         #| newfolder |
         #| newfolder |
+
+  Scenario: Permissions work correctly on public link share with upload-write-without-modify
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | upload-write-without-modify |
+    When the public accesses the last created public link using the webUI
+    Then the option to rename file "lorem.txt" should not be available in the webUI
+    And the option to delete file "lorem.txt" should not be available in the webUI
+    And the option to upload file should be available in the webUI
+
+  Scenario: Permissions work correctly on public link share with read-write
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | read-write |
+    When the public accesses the last created public link using the webUI
+    Then the option to rename file "lorem.txt" should be available in the webUI
+    And the option to delete file "lorem.txt" should be available in the webUI
+    And the option to upload file should be available in the webUI
+
+  Scenario: User tries to upload existing file in public link share with permissions upload-write-without-modify
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | upload-write-without-modify |
+    And the public accesses the last created public link using the webUI
+    When the user uploads file "lorem.txt" using the webUI
+    Then a notification should be displayed on the webUI with the text "The file lorem.txt already exists"
+    And file "lorem.txt" should be listed on the webUI
+    And file "lorem (2).txt" should not be listed on the webUI
+
+  Scenario: User tries to upload existing file in public link share with permissions read-write
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And file "lorem (2).txt" should be listed on the webUI
+
+  Scenario: Editing the permission on a existing share from read-write to upload-write-without-modify works correctly
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    Then it should be possible to delete file "lorem.txt" using the webUI
+    When the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder"
+    And the user opens the public link share tab
+    And the user changes the permission of the public link named "Public link" to "upload-write-without-modify"
+    And the public accesses the last created public link using the webUI
+    Then the option to delete file "lorem-big.txt" should not be available in the webUI
+
+  Scenario: Editing the permission on a existing share from upload-write-without-modify to read-write works correctly
+    Given the user has created a new public link for folder "simple-folder" using the webUI with
+      | permission | upload-write-without-modify |
+    And the public accesses the last created public link using the webUI
+    Then the option to delete file "lorem.txt" should not be available in the webUI
+    When the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder"
+    And the user opens the public link share tab
+    And the user changes the permission of the public link named "Public link" to "read-write"
+    And the public accesses the last created public link using the webUI
+    Then it should be possible to delete file "lorem-big.txt" using the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add acceptance test for checking changing sharing permissions from 
1. read-write to upload-write-without-modify
2. upload-write-without-modify to read-write

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Test for issue #35155

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
