### PR TITLE
[stable10] User\\Session::loginUser(): password can be null

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -977,7 +977,7 @@ class Session implements IUserSession, Emitter {
 	 * @return boolean True if the user can be authenticated, false otherwise
 	 * @throws LoginException if an app canceled the login process or the user is not enabled
 	 */
-	public function loginUser(IUser $user = null, $password) {
+	public function loginUser(IUser $user = null, $password = null) {
 		$uid = $user === null ? '' : $user->getUID();
 		return $this->emittingCall(function () use (&$user, &$password) {
 			if ($user === null) {


### PR DESCRIPTION
## Description
The argument $password of User\\Session::loginUser() can be null. If not properly documents/defined tools like phpstan will :boom:

## Related Issue
none

## How Has This Been Tested?
- running phpstan on code which used loginUser

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] port to master branch is necessary
