### PR TITLE
[stable10] Remove wait for ajax calls

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -587,6 +587,16 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then the user should be redirected to the login page
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUserShouldBeRedirectedToTheLoginPage() {
+		$this->loginPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
 	 * @When /^the user follows the password set link received by "([^"]*)"(?: in Email number (\d+))? using the webUI$/
 	 *
 	 * @param string $emailAddress

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -527,7 +527,7 @@ class OwncloudPage extends Page {
 					if (typeof window.activeAjaxCount === "number") {
 						result = result + window.activeAjaxCount;
 					}
-					if (typeof jQuery.active === "number") {
+					if (typeof jQuery !== "undefined" && typeof jQuery.active === "number") {
 						result = result + jQuery.active;
 					}
 					return result;

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -30,7 +30,8 @@ Feature: reset the password
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" and confirms with the same password using the webUI
-    Then the email address "user1@example.org" should have received an email with the body containing
+    Then the user should be redirected to the login page
+    And the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
       """
@@ -43,7 +44,8 @@ Feature: reset the password
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" and confirms with the same password using the webUI
-    Then the email address "user1@example.org" should have received an email with the body containing
+    Then the user should be redirected to the login page
+    And the email address "user1@example.org" should have received an email with the body containing
       """
       Password changed successfully
       """

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -36,7 +36,8 @@ Feature: reset the password using an email address
 			Could not reset password because the token is invalid
 			"""
     #When the user resets the password to "%alt3%" using the webUI
-    #Then the email address "user1@example.org" should have received an email with the body containing
+    #Then the user should be redirected to the login page
+    #And the email address "user1@example.org" should have received an email with the body containing
 	#		"""
 	#		Password changed successfully
 	#		"""

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -65,7 +65,8 @@ Feature: add users
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
     And the user sets the password to "%regular%" and confirms with the same password using the webUI
-    Then the email address "guiusr1@owncloud" should have received an email with the body containing
+    Then the user should be redirected to the login page
+    And the email address "guiusr1@owncloud" should have received an email with the body containing
       """
       Password changed successfully
       """
@@ -159,7 +160,8 @@ Feature: add users
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
     And the user sets the password to "%regular%" and confirms with the same password using the webUI
-    Then the email address "guiusr1@owncloud" should have received an email with the body containing
+    Then the user should be redirected to the login page
+    And the email address "guiusr1@owncloud" should have received an email with the body containing
       """
       Password changed successfully
       """


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
We were getting CI failures during resetting/setting the password regarding the `jQuery` not getting found when we evaluate script, and only on Firefox.
```
Firefox WebDriver\Exception\JavaScriptError: ReferenceError: jQuery is not defined
Build info: version: '3.8.1', revision: '6e95a6684b', time: '2017-12-01T19:05:32.194Z'
      #1 /drone/src/vendor-bin/behat/vendor/instaclick/php-webdriver/lib/WebDriver/AbstractWebDriver.php(218): WebDriver\AbstractWebDriver->curl('POST', '/execute', Array)
      #2 /drone/src/vendor-bin/behat/vendor/instaclick/php-webdriver/lib/WebDriver/Container.php(224): WebDriver\AbstractWebDriver->__call('execute', Array)
      #3 /drone/src/vendor-bin/behat/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php(949): WebDriver\Container->__call('execute', Array)
      #4 /drone/src/vendor-bin/behat/vendor/behat/mink/src/Session.php(336): Behat\Mink\Driver\Selenium2Driver->evaluateScript('return (\n\t\t\t\tfu...')
      #5 /drone/src/tests/acceptance/features/lib/OwncloudPage.php(555): Behat\Mink\Session->evaluateScript('(\n\t\t\t\tfunction ...')
      #6 /drone/src/tests/acceptance/features/lib/OwncloudPage.php(595): Page\OwncloudPage->waitForAjaxCallsToStart(Object(Behat\Mink\Session))
      #7 /drone/src/tests/acceptance/features/lib/LoginPage.php(219): Page\OwncloudPage->waitForAjaxCallsToStartAndFinish(Object(Behat\Mink\Session))
      #8 /tmp/ProxyManagerGeneratedProxy__PM__PageLoginPageGenerated6312256563dff9947346b9792a817253.php(94): Page\LoginPage->resetThePassword('aVeryLongPasswo...', 'aVeryLongPasswo...', Object(Behat\Mink\Session))
      #9 /drone/src/tests/acceptance/features/bootstrap/WebUILoginContext.php(557): ProxyManagerGeneratedProxy\__PM__\Page\LoginPage\Generated6312256563dff9947346b9792a817253->resetThePassword('aVeryLongPasswo...', 'aVeryLongPasswo...', Object(Behat\Mink\Session))
      #10 [internal function]: WebUILoginContext->theUserResetsThePasswordWithSameConfirmationToUsingTheWebui('aVeryLongPasswo...')
```

Looking into it, there were no waits of any sorts, so, I added wait for the reset/set password page to load via #35115. But, this did not solve any issues. So, next thing that came to mind, was that the jQuery might not have been available at the time we evaluate the script as the page must still be loading. But, this was only partially true. 

The reset/set password form was submitted, and then, the check for `ajax` calls were done. When we submit the form, and the client-side validation checks out, the user is redirected to the login page. So, when that `ajax` call ran, the form was submitted and the login page was getting loaded making the `jQuery` not available. This did escaped the `waitTillJqueryIsLoaded` as it was still on the reset/set password page when that function ran. The `waitForAjaxCallsToStartAndFinish` is not useful here anyway (as page reload happens to different page, so, before the timeout is reached, another page might already be getting loaded).

The ajax calls do happen if `user_management` and `password_policy` app is installed. But, later page reloads, due to which it won't be effective/useful to check for `ajax` calls, and the responsibility should be shifted to later steps to handle. I'll make a test PR for `user_management` and `password_policy`. Let, this PR stay here for few days (and, run multiple times) to ensure this does not happen again.

The PR #35123 even though did not solve the issue, are, I believe necessary to reduce the flakiness.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Trying to fix CI issue in Firefox.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
[Acceptance tests failure](https://drone.owncloud.com/owncloud/core/17168/903).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Needs to be tested thoroughly in CI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
