### PR TITLE
Acceptance test for renaming subfolders with same name  shared by pub…

### DIFF
--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -28,7 +28,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
 /**
  * Shared By Link page.
  */
-class SharedByLinkPage extends FilesPageBasic {
+class SharedByLinkPage extends FilesPageCRUD {
 
 	/**
 	 *

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -392,3 +392,24 @@ Feature: Share by public link
     And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should not have changed
     And file "lorem (2).txt" should not be listed on the webUI
+
+  @issue-35177
+  Scenario: User renames a subfolder among subfolders with same names which are shared by public links
+    Given user "user1" has created folder "nf1"
+    And user "user1" has created folder "nf1/newfolder"
+    And user "user1" has created folder "nf2"
+    And user "user1" has created folder "nf2/newfolder"
+    And user "user1" has created folder "test"
+    And user "user1" has created folder "test/test"
+    And user "user1" has created a public link share with settings
+      | path | nf1/newfolder |
+    And user "user1" has created a public link share with settings
+      | path | nf2/newfolder |
+    And user "user1" has created a public link share with settings
+      | path | test/test |
+    And the user has browsed to the shared-by-link page
+    When the user renames folder "newfolder" to "newfolder1" using the webUI
+    Then folder "newfolder1" should be listed on the webUI
+    And folder "newfolder" should not be listed on the webUI
+    #And folder "newfolder" should be listed on the webUI
+    And folder "test" should be listed on the webUI


### PR DESCRIPTION
## Description
When users of ownCloud  try to rename one of the subfolders among subfolders with same name but different  path ,  all the subfolders are not listed in webUI  after renaming one of the subfolders.
## Related Issue
- Issue : #35177

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: <link> 

