### PR TITLE
[stable10] add activity for self unshare action

### DIFF
--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -59,6 +59,7 @@ class Activity implements IExtension {
 	const SUBJECT_RESHARED_USER_BY = 'reshared_user_by';
 	const SUBJECT_UNSHARED_USER_SELF = 'unshared_user_self';
 	const SUBJECT_UNSHARED_USER_BY = 'unshared_user_by';
+	const SUBJECT_UNSHARED_FROM_SELF = 'unshared_from_self';
 
 	const SUBJECT_SHARED_GROUP_SELF = 'shared_group_self';
 	const SUBJECT_RESHARED_GROUP_BY = 'reshared_group_by';
@@ -218,6 +219,8 @@ class Activity implements IExtension {
 				return (string) $l->t('You removed the share of %2$s for %1$s', $params);
 			case self::SUBJECT_UNSHARED_USER_BY:
 				return (string) $l->t('%2$s removed the share of %3$s for %1$s', $params);
+			case self::SUBJECT_UNSHARED_FROM_SELF:
+				return (string) $l->t('You unshared %1$s shared by %2$s from self', $params);
 
 			case self::SUBJECT_SHARED_GROUP_SELF:
 				return (string) $l->t('You shared %1$s with group %2$s', $params);
@@ -272,6 +275,8 @@ class Activity implements IExtension {
 				return (string) $l->t('Removed share for %2$s', $params);
 			case self::SUBJECT_UNSHARED_USER_BY:
 				return (string) $l->t('%2$s removed share for %3$s', $params);
+			case self::SUBJECT_UNSHARED_FROM_SELF:
+				return (string) $l->t('Unshared %1$s from self', $params);
 
 			case self::SUBJECT_SHARED_GROUP_SELF:
 				return (string) $l->t('Shared with group %2$s', $params);
@@ -366,7 +371,8 @@ class Activity implements IExtension {
 						1 => 'username',
 						2 => 'username',
 					];
-
+				case self::SUBJECT_UNSHARED_FROM_SELF:
+					return [0 => 'file', 1 => 'username'];
 				case self::SUBJECT_SHARED_GROUP_SELF:
 				case self::SUBJECT_UNSHARED_GROUP_SELF:
 					return [

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -150,9 +150,6 @@ class Application extends App {
 			);
 		});
 
-		/*
-		 * Register trashbin service
-		 */
 		$container->registerService('Hooks', function ($c) {
 			return new Hooks(
 				$c->getServer()->getLazyRootFolder(),
@@ -160,6 +157,7 @@ class Application extends App {
 				$c->getServer()->getEventDispatcher(),
 				$c->getServer()->getShareManager(),
 				$c->query(NotificationPublisher::class),
+				$c->getServer()->getActivityManager(),
 				$c->getServer()->getUserSession()
 			);
 		});

--- a/apps/files_sharing/tests/AppInfo/ApplicationTest.php
+++ b/apps/files_sharing/tests/AppInfo/ApplicationTest.php
@@ -34,5 +34,8 @@ class ApplicationTest extends TestCase {
 		$this->assertNotNull(
 			$app->getContainer()->query('Share20OcsController')
 		);
+		$this->assertNotNull(
+			$app->getContainer()->query('Hooks')
+		);
 	}
 }


### PR DESCRIPTION
Backport of #35083
## Description
This PR publishes an activity entry by listening to self unshare events. 
As far as I see, current sharing activities are published in this class by the activity app: https://github.com/owncloud/activity/blob/master/lib/FilesHooks.php. However, IMHO, holding them in files_sharing app is better. So, I added this event listener on files_sharing app. Am I missing something here?

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/2541
- Fixes https://github.com/owncloud/activity/issues/615

## Motivation and Context
whenever a recipient "unshares from self" they should see an activity in their activity stream that says they did so. This would help them to find out why something disappeared from their file tree in case they don't remember doing it. 

## How Has This Been Tested?
Unit tests and manually with the following steps:
- Activate activity app
- Create two users (`user1`, `user2`)
- Share a file from `user1` to `user2`
- Login with `user2` and unshare the file from `user2`
- `user2` should see this action in the activity stream

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 