### PR TITLE
Fix permission and update behaviour for public link

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -831,6 +831,11 @@ OC.Uploader.prototype = _.extend({
 			}
 			var fileInfo = fileList.findFile(file.name);
 			if (fileInfo) {
+				var sharePermission = parseInt($("#sharePermission").val());
+				if (sharePermission === (OC.PERMISSION_READ | OC.PERMISSION_CREATE)) {
+					OC.Notification.show(t('files', 'The file {file} already exists', {file: fileInfo.name}), {type: 'error'});
+					return false;
+				}
 				conflicts.push([
 					// original
 					_.extend(fileInfo, {

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -461,7 +461,7 @@ class Share20OcsController extends OCSController {
 				);
 			} elseif ($permissions === \OCP\Constants::PERMISSION_CREATE ||
 				$permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) ||
-				$permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE)) {
+				$permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE)) {
 				$share->setPermissions($permissions);
 			} else {
 				// because when "publicUpload" is passed usually no permissions are set,
@@ -776,6 +776,7 @@ class Share20OcsController extends OCSController {
 			if ($newPermissions !== null &&
 				$newPermissions !== Constants::PERMISSION_READ &&
 				$newPermissions !== Constants::PERMISSION_CREATE &&
+				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE) &&
 				// legacy
 				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE) &&
 				// correct

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -265,8 +265,8 @@
 
 				publicUploadWriteLabel       : t('core', 'Download / View / Upload'),
 				publicUploadWriteDescription : t('core', 'Recipients can view, download and upload contents.'),
-				publicUploadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE,
-				publicUploadWriteSelected    : this.model.get('permissions') === (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE),
+				publicUploadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_CREATE,
+				publicUploadWriteSelected    : this.model.get('permissions') === (OC.PERMISSION_READ | OC.PERMISSION_CREATE),
 
 				publicReadWriteLabel       : t('core', 'Download / View / Edit'),
 				publicReadWriteDescription : t('core', 'Recipients can view, download and edit contents.'),

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -50,7 +50,7 @@ class SharingHelper {
 	 *                                                    1 = read; 2 = update; 4 = create;
 	 *                                                    8 = delete; 16 = share; 31 = all
 	 *                                                    15 = change
-	 *                                                    7 = uploadwriteonly
+	 *                                                    5 = uploadwriteonly
 	 *                                                    (default: 31, for public shares: 1)
 	 *                                                    Pass either the (total) number,
 	 *                                                    or the keyword,
@@ -171,7 +171,7 @@ class SharingHelper {
 					'read' => 1,
 					'update' => 2,
 					'create' => 4,
-					'uploadwriteonly' => 7,
+					'uploadwriteonly' => 5,
 					'delete' => 8,
 					'change' => 15,
 					'share' => 16,

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -203,13 +203,13 @@ Feature: sharing
     And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /afolder |
-      | permissions | 7        |
+      | permissions | 5        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the share fields of the last share should include
       | id          | A_NUMBER |
       | share_type  | 3        |
-      | permissions | 7        |
+      | permissions | 5        |
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -328,8 +328,5 @@ Feature: sharing
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
     When the public uploads file "test.txt" with content "test" using the public WebDAV API
-    And the public uploads file "test.txt" with content "test2" with autorename mode using the public WebDAV API
-    And the public uploads file "test.txt" with content "test3" with autorename mode using the public WebDAV API
+    And the public uploads file "test.txt" with content "test2" using the public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
-    And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
-    And the content of file "/FOLDER/test (3).txt" for user "user0" should be "test3"

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1003,18 +1003,16 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user uploads file :name and clicks :label button :number_of times using webUI
+	 * @When the user uploads file :name :number_of times using webUI
 	 *
 	 * @param string $name
-	 * @param string $label
 	 * @param int $number_of
 	 *
 	 * @return void
 	 */
-	public function theUserClicksUploadAndCancelMultipleTimes($name, $label, $number_of) {
+	public function theUserClicksUploadAndCancelMultipleTimes($name, $number_of) {
 		for ($i = 0; $i < $number_of; $i++) {
 			$this->theUserUploadsFileUsingTheWebUI($name);
-			$this->theUserChoosesToInTheUploadDialog($label);
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 		}
 	}

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -373,22 +373,17 @@ Feature: Share by public link
     And the public accesses the last created public link using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-  Scenario: user edits the permission of an already existing public link from read-write to upload-write-without-overwrite
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
-    When the user changes the permission of the public link named "Public link" to "upload-write-without-modify"
-    And the public accesses the last created public link using the webUI
-    When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And file "lorem (2).txt" should be listed on the webUI
-
-  Scenario: user creates public link with view download and upload feature and uploads and cancels same file multiple times to verify the conflict dialog exits after clicking cancel button
+  Scenario: user creates public link with view download and upload feature and uploads same file name and verifies no auto-renamed file seen in UI
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
-    When the user uploads file "lorem.txt" and clicks "Cancel" button 10 times using webUI
-    Then no dialog should be displayed on the webUI
-    And no notification should be displayed on the webUI
+    When the user uploads file "lorem.txt" 5 times using webUI
+    Then notifications should be displayed on the webUI with the text
+      | The file lorem.txt already exists |
+      | The file lorem.txt already exists |
+      | The file lorem.txt already exists |
+      | The file lorem.txt already exists |
+      | The file lorem.txt already exists |
     And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should not have changed
     And file "lorem (2).txt" should not be listed on the webUI


### PR DESCRIPTION
Remove update permission for Download/View/Upload
option for public link. And hence the behaviour of
public links created using this option has changed.
1. User cannot delete the files/folders inside this public link.
2. User cannot update the files which are already present
in the public link
3. User cannot rename files.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR addresses the changes below:
When user selects the `Download / View / Upload` option to create public link, the update permission for the link is no longer available. Which means the share permission will be `5` ( i.e, READ | CREATE ). And due to this change, the public link UI behaves as follows:
When a public link share is created for a folder with permission `Download / View / Upload` below are the changes observed:
- Cannot delete the files.
- Folders can be renamed. The folder rename occurs because of calculation PERMISSION_SHARE | PERMISSION_CREATE | PERMISSION_READ. And this results in `21`. Now https://github.com/owncloud/core/blob/master/apps/dav/lib/Connector/Sabre/Node.php#L344 adds `CK` to the permissions. Which brings the `Rename` to the folder. But I have observed that if a folder when shared to an oC user ( within oC instance ), change the edit permissions of the shared folder to create and delete. The folder inside the shared folder gets `Rename`, `Download` and `Delete`. Whereas the files inside the shared folder get `Download` and `Delete`. Now change the permission of shared folder to `create` and `change`. The folder inside the shared folder gets `Rename` and `Download` option. Where as the files inside the shared folder gets `Download` and `Delete`. 
Let me know considering this behaviour if the folder rename visible in the UI looks ok or not?
- Files and Folders can be downloaded.
- Folders with same name cannot be created.
- Files with same name when uploaded throws notification message in the UI.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35192

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Updated the permission for the `Download / View / Upload` option to create public link. Accordingly minor changes to update the UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create public link with `Download / View / Upload` and verified the share permissions in the share table is `5`. Here is the screenshot:
```
mysql> select id, share_name, file_target, permissions, token from oc_share;
+----+-------------+-------------------+-------------+-----------------+
| id | share_name  | file_target       | permissions | token           |
+----+-------------+-------------------+-------------+-----------------+
|  1 | Public link | /publicLinkUpload |           5 | DiMnszGUqdxXdRJ |
+----+-------------+-------------------+-------------+-----------------+
1 row in set (0.00 sec)

mysql>
```
- [x] Tested by uploading a file, say `a.txt` to the newly created public link
- [x] Tested uploading same file name results in notification as shown 
![notification](https://user-images.githubusercontent.com/3600427/57507539-bbe2eb00-731c-11e9-9925-98c6682025fc.png)
- [x] Tested and no conflict dialog window appears when same file is uplaoded.
- [x] Tested creating a folder in the new public link
- [x] Tested cannot create same folder name which already exists in the UI 
![samefolder](https://user-images.githubusercontent.com/3600427/57507637-fba9d280-731c-11e9-817c-d602b0397254.png)
- [x] Tested rename not shown in the files listed in the public link
- [x] Tested and shows rename for the folder in the public link
- [x] Tested delete is not shown in the 3 dots for folder and files. Also when all the files are selected no delete is shown in the UI.
- [x] Tested download is shown when the 3 dots are clicked for the folder and for file. Also when all files are selected download button is shown in the UI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
