### PR TITLE
[stable10] Rename share icon to be adblock friendly

### DIFF
--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -45,7 +45,7 @@ OCA.Sharing.App = {
 		this._registerPendingShareActions(fileActions);
 		this._extendFileList(this._inFileList);
 		this._inFileList.appName = t('files_sharing', 'Shared with you');
-		this._inFileList.$el.find('#emptycontent').html('<div class="icon-share"></div>' +
+		this._inFileList.$el.find('#emptycontent').html('<div class="icon-shared"></div>' +
 			'<h2>' + t('files_sharing', 'Nothing shared with you yet') + '</h2>' +
 			'<p>' + t('files_sharing', 'Files and folders others share with you will show up here') + '</p>');
 		return this._inFileList;
@@ -68,7 +68,7 @@ OCA.Sharing.App = {
 
 		this._extendFileList(this._outFileList);
 		this._outFileList.appName = t('files_sharing', 'Shared with others');
-		this._outFileList.$el.find('#emptycontent').html('<div class="icon-share"></div>' +
+		this._outFileList.$el.find('#emptycontent').html('<div class="icon-shared"></div>' +
 			'<h2>' + t('files_sharing', 'Nothing shared yet') + '</h2>' +
 			'<p>' + t('files_sharing', 'Files and folders you share will show up here') + '</p>');
 		return this._outFileList;

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -162,7 +162,7 @@
 				altText: t('core', 'Share'),
 				mime: 'all',
 				permissions: OC.PERMISSION_ALL,
-				iconClass: 'icon-share',
+				iconClass: 'icon-shared',
 				type: OCA.Files.FileActions.TYPE_INLINE,
 				actionHandler: function(fileName) {
 					fileList.showDetailsView(fileName, 'shareTabView');

--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -149,7 +149,7 @@ class Activity implements IExtension {
 		switch ($type) {
 			case self::TYPE_SHARED:
 			case self::TYPE_REMOTE_SHARE:
-				return 'icon-share';
+				return 'icon-shared';
 			case self::TYPE_PUBLIC_LINKS:
 				return 'icon-download';
 		}

--- a/apps/files_sharing/lib/Panels/Personal/Section.php
+++ b/apps/files_sharing/lib/Panels/Personal/Section.php
@@ -36,7 +36,7 @@ class Section implements ISection {
 	}
 
 	public function getIconName() {
-		return 'share';
+		return 'shared';
 	}
 
 	public function getID() {

--- a/apps/files_sharing/tests/ActivityTest.php
+++ b/apps/files_sharing/tests/ActivityTest.php
@@ -24,6 +24,8 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OCA\Files_Sharing\Activity;
+
 /**
  * Class ActivityTest
  *
@@ -34,13 +36,13 @@ namespace OCA\Files_Sharing\Tests;
 class ActivityTest extends TestCase {
 
 	/**
-	 * @var \OCA\Files_Sharing\Activity
+	 * @var Activity
 	 */
 	private $activity;
 
 	protected function setUp() {
 		parent::setUp();
-		$this->activity = new \OCA\Files_Sharing\Activity(
+		$this->activity = new Activity(
 			$this->getMockBuilder('OCP\L10N\IFactory')
 				->disableOriginalConstructor()
 				->getMock(),
@@ -71,8 +73,25 @@ class ActivityTest extends TestCase {
 
 	public function dataTestGetDefaultType() {
 		return [
-			['email', [\OCA\Files_Sharing\Activity::TYPE_SHARED, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE]],
-			['stream', [\OCA\Files_Sharing\Activity::TYPE_SHARED, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::TYPE_PUBLIC_LINKS]],
+			['email', [Activity::TYPE_SHARED, Activity::TYPE_REMOTE_SHARE]],
+			['stream', [Activity::TYPE_SHARED, Activity::TYPE_REMOTE_SHARE, Activity::TYPE_PUBLIC_LINKS]],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetTypeIcon
+	 *
+	 * @param string $type
+	 * @param string$expectedResult
+	 */
+	public function testGetTypeIcon($type, $expectedResult) {
+		$this->assertSame($expectedResult, $this->activity->getTypeIcon($type));
+	}
+
+	public function dataGetTypeIcon() {
+		return [
+			[Activity::TYPE_SHARED, 'icon-shared'],
+			[Activity::TYPE_PUBLIC_LINKS, 'icon-download'],
 		];
 	}
 }

--- a/apps/files_sharing/tests/Panels/Personal/SectionTest.php
+++ b/apps/files_sharing/tests/Panels/Personal/SectionTest.php
@@ -44,7 +44,7 @@ class SectionTest extends \Test\TestCase {
 	}
 
 	public function testGetIconName() {
-		$this->assertEquals('share', $this->section->getIconName());
+		$this->assertEquals('shared', $this->section->getIconName());
 	}
 
 	public function testGetID() {

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -84,7 +84,7 @@ describe('OCA.Sharing.Util tests', function() {
 			}]);
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder.svg');
 		});
@@ -104,7 +104,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('Shared');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 		});
@@ -125,7 +125,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('Shared');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(false);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(false);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(true);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-public.svg');
 		});
@@ -146,7 +146,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('User One');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 		});
@@ -167,7 +167,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('Shared with User One, User Two');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 		});
@@ -274,7 +274,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).toEqual('Group One, Group Two, User One, User Two');
 
 			expect($action.find('>span').text().trim()).toEqual('Shared with Group One, Group Two, User One, User Two');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 		it('updates share icon after updating shares of a file', function() {
@@ -307,7 +307,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).toEqual('User One, User Three, User Two');
 
 			expect($action.find('>span').text().trim()).toEqual('Shared with User One, User Three, User Two');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 		it('removes share icon after removing all shares from a file', function() {
@@ -363,7 +363,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).toEqual('User Two');
 
 			expect($action.find('>span').text().trim()).toEqual('User One');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 		it('keep share text after unsharing reshare', function() {
@@ -394,7 +394,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).not.toBeDefined();
 
 			expect($action.find('>span').text().trim()).toEqual('User One');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 	});

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -110,7 +110,7 @@ OC.Share = _.extend(OC.Share || {}, {
 		}
 		// TODO: iterating over the files might be more efficient
 		for (item in OC.Share.statuses){
-			var iconClass = 'icon-share';
+			var iconClass = 'icon-shared';
 			var data = OC.Share.statuses[item];
 			var hasLink = data.link;
 			// Links override shared in terms of icon display
@@ -118,7 +118,7 @@ OC.Share = _.extend(OC.Share || {}, {
 				iconClass = 'icon-public';
 			}
 			if (itemType !== 'file' && itemType !== 'folder') {
-				$('a.share[data-item="'+item+'"] .icon').removeClass('icon-share icon-public').addClass(iconClass);
+				$('a.share[data-item="'+item+'"] .icon').removeClass('icon-shared icon-public').addClass(iconClass);
 			} else {
 				// TODO: ultimately this part should be moved to files_sharing app
 				var file = $fileList.find('tr[data-id="'+item+'"]');
@@ -176,12 +176,12 @@ OC.Share = _.extend(OC.Share || {}, {
 					}
 				} else if (OC.Share.itemShares[index].length > 0) {
 					shares = true;
-					iconClass = 'icon-share';
+					iconClass = 'icon-shared';
 				}
 			}
 		});
 		if (itemType != 'file' && itemType != 'folder') {
-			$('a.share[data-item="'+itemSource+'"] .icon').removeClass('icon-share icon-public').addClass(iconClass);
+			$('a.share[data-item="'+itemSource+'"] .icon').removeClass('icon-shared icon-public').addClass(iconClass);
 		} else {
 			var $tr = $('tr').filterAttr('data-id', String(itemSource));
 			if ($tr.length > 0) {
@@ -265,7 +265,7 @@ OC.Share = _.extend(OC.Share || {}, {
 		var recipients;
 		var owner = $tr.attr('data-share-owner');
 		var shareFolderIcon;
-		var iconClass = 'icon-share';
+		var iconClass = 'icon-shared';
 		action.removeClass('shared-style');
 		// update folder icon
 		if (type === 'dir' && (hasShares || hasLink || owner)) {
@@ -315,7 +315,7 @@ OC.Share = _.extend(OC.Share || {}, {
 		if (hasLink) {
 			iconClass = 'icon-public';
 		}
-		icon.removeClass('icon-share icon-public').addClass(iconClass);
+		icon.removeClass('icon-shared icon-public').addClass(iconClass);
 	},
 	/**
 	 *

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -160,45 +160,6 @@ OC.Share = _.extend(OC.Share || {}, {
 			}
 		}
 	},
-	updateIcon:function(itemType, itemSource) {
-		var shares = false;
-		var link = false;
-		var image = OC.imagePath('core', 'actions/share');
-		var iconClass = '';
-		$.each(OC.Share.itemShares, function(index) {
-			if (OC.Share.itemShares[index]) {
-				if (index == OC.Share.SHARE_TYPE_LINK) {
-					if (OC.Share.itemShares[index] == true) {
-						shares = true;
-						iconClass = 'icon-public';
-						link = true;
-						return;
-					}
-				} else if (OC.Share.itemShares[index].length > 0) {
-					shares = true;
-					iconClass = 'icon-shared';
-				}
-			}
-		});
-		if (itemType != 'file' && itemType != 'folder') {
-			$('a.share[data-item="'+itemSource+'"] .icon').removeClass('icon-shared icon-public').addClass(iconClass);
-		} else {
-			var $tr = $('tr').filterAttr('data-id', String(itemSource));
-			if ($tr.length > 0) {
-				// it might happen that multiple lists exist in the DOM
-				// with the same id
-				$tr.each(function() {
-					OC.Share.markFileAsShared($(this), shares, link);
-				});
-			}
-		}
-		if (shares) {
-			OC.Share.statuses[itemSource] = OC.Share.statuses[itemSource] || {};
-			OC.Share.statuses[itemSource]['link'] = link;
-		} else {
-			delete OC.Share.statuses[itemSource];
-		}
-	},
 	/**
 	 * Format a remote address
 	 *

--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -31,7 +31,7 @@
 			'</div>' +
 			'{{#if ../socialShareEnabled}}' +
 			'<div class="link-entry--icon-button shareLink" title="{{../shareText}}">' +
-			'	<span class="icon icon-share"></span>' +
+			'	<span class="icon icon-shared"></span>' +
 			'	<span class="hidden">{{../shareText}}</span>' +
 			'</div>' +
 			'{{/if}}' +

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -203,7 +203,7 @@ class SettingsManager implements ISettingsManager {
 				new Section('authentication', $this->l->t('User Authentication'), 87, 'user'),
 				new Section('encryption', $this->l->t('Encryption'), 85, 'password'),
 				new Section('workflow', $this->l->t('Workflows & Tags'), 85, 'workflows'),
-				new Section('sharing', $this->l->t('Sharing'), 80, 'share'),
+				new Section('sharing', $this->l->t('Sharing'), 80, 'shared'),
 				new Section('search', $this->l->t('Search'), 75, 'search'),
 				new Section('help', $this->l->t('Help & Tips'), -5, 'info'),
 				new Section('additional', $this->l->t('Additional'), -10, 'more'),

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -717,8 +717,8 @@ li > a.icon-search {
 	background-image: url("../../core/img/actions/search.svg");
 }
 
-li > a.icon-share {
-	background-image: url("../../core/img/actions/share.svg");
+li > a.icon-shared {
+	background-image: url("../../core/img/actions/shared.svg");
 }
 
 li > a.icon-folder {

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -76,6 +76,11 @@ class SettingsManagerTest extends TestCase {
 		);
 	}
 
+	public function testGetBuiltInSections() {
+		$sections = $this->invokePrivate($this->settingsManager, 'getBuiltInSections', ['admin']);
+		$this->assertNotEmpty($sections);
+	}
+
 	public function testGetBuiltInPanel() {
 		$panel = $this->settingsManager->getBuiltInPanel('OC\Settings\Panels\Personal\Profile');
 		$this->assertNotFalse($panel);


### PR DESCRIPTION
Backport of #35147
## Description
This PR renames 'icon-share' to 'icon-shared' to be Adblock friendly. Also, we have two duplicated icon for share:
- https://github.com/owncloud/core/blob/master/core/img/actions/shared.svg
- https://github.com/owncloud/core/blob/master/core/img/actions/share.svg 
With this PR core will not use `share.svg` anymore. However, since some of the apps (Activity, Contacts) still using `share.svg`, I did not touch it. If we migrate them to use `shared.svg`, we can delete duplicated `share.svg`. @PVince81 Should we spend time for it? It will require re-release these apps.

As @PVince81 stated https://github.com/owncloud/core/issues/35070#issuecomment-486668832,  this PR could have an impact on some themes that might use 'icon-share', so would consider this a breaking change that needs mentioning in release notes. @pmaier1 FYI.

## Related Issue
- Fixes #35070
- Fixes #33642

## Motivation and Context
Users using an advertisement blocker extension on the browser can not see 'icon-share' and this situation reducing user experience.

## How Has This Been Tested?
1- Enable AdblockPlus Mozilla extension and also open blocking social media icons tracking
2- Share Icons should be visible (It should be not visible on the current master).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: 