### PR TITLE
Acceptance test for renaming folders with  different path in Shared B…

### DIFF
--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -126,6 +126,23 @@ class FilesPage extends FilesPageBasic {
 	}
 
 	/**
+	 * returns the tooltip that is displayed next to the filename
+	 * if something is wrong
+	 *
+	 * @param string $fileName
+	 * @param Session $session
+	 *
+	 * @return string
+	 */
+	public function getTooltipOfFile(
+		$fileName, Session $session
+	) {
+		return $this->filesPageCRUDFunctions->getTooltipOfFile(
+			$fileName, $session
+		);
+	}
+
+	/**
 	 *
 	 * @throws ElementNotFoundException
 	 * @return string
@@ -255,21 +272,6 @@ class FilesPage extends FilesPageBasic {
 		$this->filesPageCRUDFunctions->moveFileTo(
 			$name, $destination, $session, $maxRetries
 		);
-	}
-
-	/**
-	 * returns the tooltip that is displayed next to the filename
-	 * if something is wrong
-	 *
-	 * @param string $fileName
-	 * @param Session $session
-	 *
-	 * @return string
-	 * @throws ElementNotFoundException
-	 */
-	public function getTooltipOfFile($fileName, Session $session) {
-		$fileRow = $this->findFileRowByName($fileName, $session);
-		return $fileRow->getTooltip();
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -152,6 +152,20 @@ class FilesPageCRUD extends FilesPageBasic {
 	}
 
 	/**
+	 * returns the tooltip that is displayed next to the filename
+	 * if something is wrong
+	 *
+	 * @param string $fileName
+	 * @param Session $session
+	 *
+	 * @return string
+	 */
+	public function getTooltipOfFile($fileName, Session $session) {
+		$fileRow = $this->findFileRowByName($fileName, $session);
+		return $fileRow->getTooltip();
+	}
+
+	/**
 	 * {@inheritDoc}
 	 *
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -413,3 +413,18 @@ Feature: Share by public link
     And folder "newfolder" should not be listed on the webUI
     #And folder "newfolder" should be listed on the webUI
     And folder "test" should be listed on the webUI
+
+    @issue-35174
+    Scenario: User renames folders with different path in Shared by link page
+      Given user "user1" has created folder "nf1"
+      And user "user1" has created folder "nf1/newfolder"
+      And user "user1" has created folder "test"
+      And user "user1" has created a public link share with settings
+        | path | nf1/newfolder |
+      And user "user1" has created a public link share with settings
+        | path | test |
+      And the user has browsed to the shared-by-link page
+      When the user renames folder "test" to "newfolder" using the webUI
+      Then near folder "test" a tooltip with the text 'newfolder already exists' should be displayed on the webUI
+      #Then folder "newfolder" should be listed on the webUI
+      #And folder "newfolder" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -426,5 +426,6 @@ Feature: Share by public link
       And the user has browsed to the shared-by-link page
       When the user renames folder "test" to "newfolder" using the webUI
       Then near folder "test" a tooltip with the text 'newfolder already exists' should be displayed on the webUI
-      #Then folder "newfolder" should be listed on the webUI
-      #And folder "newfolder" should be listed on the webUI
+      #Then the following folder should be listed on the webUI
+        #| newfolder |
+        #| newfolder |


### PR DESCRIPTION


## Description
 If a user tries to  rename a folder  with the name of one of the enlisted folders having different path in shared by link section then the user cannot rename the folder with the name of enlisted folders.

## Related Issue
Issue : #35174



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
