### PR TITLE
Treat send attempt as unsuccessful when there is a message.

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -967,13 +967,17 @@ class Share20OcsController extends OCSController {
 			Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
 		}
 
-		$message = empty($result)
-			? null
-			: $this->l->t(
+		if (empty($result)) {
+			$message = null;
+			$data = ['status' => 'success'];
+		} else {
+			$message = $this->l->t(
 				"Couldn't send mail to following recipient(s): %s ",
 				\implode(', ', $result)
 			);
-		return new Result([], 200, $message);
+			$data = ['status' => 'error'];
+		}
+		return new Result($data, 200, $message);
 	}
 
 	/**
@@ -992,7 +996,7 @@ class Share20OcsController extends OCSController {
 	public function notifyRecipientsDisabled($itemSource, $itemType, $shareType, $recipient) {
 		// FIXME: migrate to a new share API
 		Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
-		return new Result();
+		return new Result(['status' => 'success']);
 	}
 
 	/**

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -369,7 +369,7 @@
 			$loading.removeClass('hidden');
 
 			this.model.sendNotificationForShare(shareType, shareWith, true).then(function(result) {
-				if (result.ocs.meta.status === 'ok') {
+				if (result.ocs.data.status === 'success') {
 					OC.Notification.showTemporary(t('core', 'Email notification was sent!'));
 					$target.remove();
 				} else {

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -221,7 +221,7 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(notificationStub.called).toEqual(true);
 			notificationStub.restore();
 
-			deferred.resolve({ ocs: { meta: {status: 'ok' }}});
+			deferred.resolve({ ocs: { data : { status: 'success'},  meta: {message: null }}});
 			expect(notifStub.calledOnce).toEqual(true);
 			notifStub.restore();
 
@@ -247,7 +247,7 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(notificationStub.called).toEqual(true);
 			notificationStub.restore();
 
-			deferred.resolve({ ocs: { meta: {status: 'error', message: 'message'}}});
+			deferred.resolve({ ocs: { data: {status: 'error'}, meta: {message: 'message'}}});
 			expect(notifStub.calledOnce).toEqual(true);
 			notifStub.restore();
 


### PR DESCRIPTION


## Description
`result.ocs.meta.status` is 200 when the email was not sent.

## Related Issue
- Fixes #35218 

## Motivation and Context
Frontend says that email is  successfully sent even when it has been not sent.

## How Has This Been Tested?
See #35218 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
