### PR TITLE
[release-10.2.0] encode jobs that have an array as job value

### DIFF
--- a/core/Command/Background/Queue/Status.php
+++ b/core/Command/Background/Queue/Status.php
@@ -44,6 +44,13 @@ class Status extends Command {
 			->setDescription('List queue status');
 	}
 
+	private function getJobArgumentAsString($argument) {
+		if (\is_array($argument)) {
+			$argument = \json_encode($argument);
+		}
+		return $argument;
+	}
+
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
@@ -53,7 +60,7 @@ class Status extends Command {
 		$t = new Table($output);
 		$t->setHeaders(['Job ID', 'Job', 'Last Run', 'Job Arguments']);
 		$this->jobList->listJobs(function (IJob $job) use ($t) {
-			$t->addRow([$job->getId(), \get_class($job), \date('c', $job->getLastRun()), $job->getArgument()]);
+			$t->addRow([$job->getId(), \get_class($job), \date('c', $job->getLastRun()), $this->getJobArgumentAsString($job->getArgument())]);
 		});
 		$t->render();
 	}


### PR DESCRIPTION
Signed-off-by: Patrick Jahns <github@patrickjahns.de>

Backport #35224 to 10.2 release branch.