### PR TITLE
[10.2.0] Backport of The public link edit template was outside public upload check

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -27,12 +27,12 @@
 				'<label class="bold" for="sharingDialogAllowPublicRead-{{cid}}">{{publicReadLabel}}</label>' +
 				'<p><em>{{publicReadDescription}}</em></p>' +
 			'</div>' +
+			'{{#if publicUploadPossible}}' +
 			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
 				'<p><em>{{publicReadWriteDescription}}</em></p>' +
 			'</div>' +
-			'{{#if publicUploadPossible}}' +
 			'<div id="allowpublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadWriteValue}}" name="publicPermissions" id="sharingDialogAllowpublicUploadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowpublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -209,7 +209,54 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 				});
 				view.render();
 				expect(view.$('.publicPermissions').length).toEqual(4);
+				expect(view.$('.publicPermissions').context.innerHTML).toContain('Download / View');
+				expect(view.$('.publicPermissions').context.innerHTML).toContain('Download / View / Edit');
+				expect(view.$('.publicPermissions').context.innerHTML).toContain('Download / View / Upload');
+				expect(view.$('.publicPermissions').context.innerHTML).toContain('Upload only (File Drop)');
 			});
+			it('renders listing radio buttons for file when public upload is allowed globally', function () {
+				fileInfoModel = new OCA.Files.FileInfoModel({
+					id: '123',
+					name: 'file.txt',
+					path: '/subdir',
+					size: 100,
+					mimetype: 'text/plain',
+					permissions: 31,
+					sharePermissions: 31
+				});
+				itemModel = new OC.Share.ShareItemModel({
+					itemType: 'file',
+					itemSource: 123,
+					permissions: 31
+				}, {
+					configModel: configModel,
+					fileInfoModel: fileInfoModel
+				});
+
+				model = new OC.Share.ShareModel({
+					id: 1,
+					name: 'first link',
+					token: 'tehtokenz',
+					shareType: OC.Share.SHARE_TYPE_LINK,
+					itemType: 'file',
+					stime: 1489657516,
+					permissions: OC.PERMISSION_READ
+				});
+
+				view = new OC.Share.ShareDialogLinkShareView({
+					model: model,
+					itemModel: itemModel
+				});
+
+				model.set({
+					permissions: OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE
+				});
+
+				view.render();
+				expect(view.$('.publicPermissions').length).toEqual(1);
+				expect(view.$('.publicPermissions').context.innerHTML).toContain('Download / View');
+			});
+
 			it('renders checkbox disabled when public upload is disallowed by user', function() {
 				publicUploadConfigStub.returns(true);
 				model.set({


### PR DESCRIPTION
The public link edit template was outside public upload check.
And hence for creating the public link for files the full
permission option was shown. This change tries to address
the issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The `Download / View / Edit` option was outside the check for variable `publicUploadPossible` in the template. And this caused the issue for files. When user tries to create the public links for files the `Download / View / Edit` option is visible. But when user clicks it only view permission is available for the public link created. So in this change set the `Download / View / Edit` option is added inside the `publicUploadPossible` check and hence the consistency is brought back for creating public links for files.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35223

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `Download / View / Edit` option was moved out of the `publicUploadPossible` check in the template. Hence there caused inconistency when the public links for files created.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- For folder when the public link is created here is the screenshot 
![folder](https://user-images.githubusercontent.com/3600427/57778660-2b544280-7742-11e9-83ee-90343eda987f.png)
- For file when the public link is created here is the screenshot 
![file](https://user-images.githubusercontent.com/3600427/57778688-3ad38b80-7742-11e9-89bb-7c6debe53c91.png)



## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
