### PR TITLE
quote inline code when checking response

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -322,7 +322,7 @@ class WebDavPropertiesContext implements Context {
 		);
 		$value = $xmlPart[0]->__toString();
 		$pattern = $this->featureContext->substituteInLineCodes(
-			$pattern
+			$pattern, ['preg_quote' => ['/'] ]
 		);
 		PHPUnit\Framework\Assert::assertRegExp(
 			$pattern, $value,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
if the replacement value of an inline code contains a `/` we need to quote is

## Motivation and Context
in tests like `apiWebdavLocks/publicLinkLockdiscovery.feature:18` we substitute `%base_path%` and if that contains `/` like `owncloud-10.2.0/rc3` we get errors like `Warning: preg_match(): Unknown modifier 'r' in /home/artur/www/owncloud-core/lib/composer/phpunit/phpunit/src/Framework/Constraint/RegularExpression.php line 47`

## How Has This Been Tested?
make sure tests run that did not run before

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
