### PR TITLE
[stable10] How to generate fresh ca-bundle.crt

### DIFF
--- a/resources/config/readme.md
+++ b/resources/config/readme.md
@@ -14,3 +14,6 @@ Maps file extensions to mimetypes in alphabetical order. Any changes to this fil
 The first index in the mapped array is assumed to be the correct mimetype. The second one is a secure alternative.
 
 To add a custom mimetype mapping, create a `mimetypemapping.json` file in the `/config` directory.
+
+## updating/generating current ca-bundle.crt
+Use: https://github.com/curl/curl/blob/master/lib/mk-ca-bundle.pl


### PR DESCRIPTION
Backport #35245

May as well backport this just to keep `stable10` the same as `master` and the information will be there when someone had checked out `stable10`