### PR TITLE
Add cli tests for background queue status and delete

### DIFF
--- a/tests/acceptance/features/cliBackground/backgroundQueue.feature
+++ b/tests/acceptance/features/cliBackground/backgroundQueue.feature
@@ -1,0 +1,30 @@
+@cli @files_trashbin-app-required
+Feature: get status, delete and execute jobs in background queue
+  As an admin
+  I want to be able to see, delete and execute the jobs in background queue
+  So that I have control over background job queue
+
+  Scenario: get the list of jobs in background queue
+    When the administrator gets all the jobs in the background queue using the occ command
+    Then the command should have been successful
+    And the command output table should contain the following text:
+      | table_column                                       |
+      | OCA\Files\BackgroundJob\ScanFiles                  |
+      | OCA\Files\BackgroundJob\DeleteOrphanedItems        |
+      | OCA\Files\BackgroundJob\CleanupFileLocks           |
+      | OCA\Files\BackgroundJob\CleanupPersistentFileLocks |
+      | OCA\DAV\CardDAV\SyncJob                            |
+      | OCA\DAV\BackgroundJob\CleanProperties              |
+      | OCA\Files_Sharing\DeleteOrphanedSharesJob          |
+      | OCA\Files_Sharing\ExpireSharesJob                  |
+      | OCA\Files_Trashbin\BackgroundJob\ExpireTrash       |
+      | OCA\Files_Versions\BackgroundJob\ExpireVersions    |
+      | OCA\UpdateNotification\Notification\BackgroundJob  |
+      | OC\Authentication\Token\DefaultTokenCleanupJob     |
+
+  Scenario: delete one of the job in background queue
+    Given user "user0" has been created with default attributes
+    And user "user0" has deleted file "/textfile0.txt"
+    When the administrator deletes last background job "OC\Command\CommandJob" using the occ command
+    Then the command should have been successful
+    And the last deleted background job "OC\Command\CommandJob" should not be listed in the background jobs queue


### PR DESCRIPTION
## Description
Add cli acceptance tests for `background:queue:status` and `background:queue: delete`

Had to create a new background job `OC\Command\CommandJob` by
deleting a file so that the `background:queue:delete` can delete this newly created
background job maintaining the test isolation.

## Related Issue
#35229

## Motivation and Context

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 