### PR TITLE
restore acceptance tests to the correct server

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -462,7 +462,11 @@ trait AppConfiguration {
 				|| $currentConfigList["system"][$configKey] !== $this->savedConfigList[$server]['system'][$configKey]
 			) {
 				SetupHelper::runOcc(
-					['config:system:set', "--type=json", "--value=" . \json_encode($configValue), $configKey]
+					['config:system:set', "--type=json", "--value=" . \json_encode($configValue), $configKey],
+					$this->getAdminUsername(),
+					$this->getAdminPassword(),
+					$this->getBaseUrl(),
+					$this->getOcPath()
 				);
 			}
 		}


### PR DESCRIPTION
## Description
follow up PR #35119
when restoring settings we need to make sure they are restored to the correct server

## Motivation and Context
CI in encryption was broken with strange errors
log contains these messages: `Could not decrypt the private key from user \"admin\"\" during login. Assume password change on the user back-end. Error message: Bad Signature`
after a long time of digging I found something very confusing:
- when the server starts and sets up encryption it takes the correct secret from the config
- after a while it switches to the secret of the federated server.
see: https://drone.owncloud.com/owncloud/encryption/688/12
all is well till line 72, then suddenly the secret changes, and so all hashes etc. are wrong
you can see the secrets in "configure-federation-server" and in "install-app"

## How Has This Been Tested?
:robot:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
