### PR TITLE
Add cli tests for config file values

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -797,6 +797,55 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Then the system config key :key from the last command output should match value :value of type :type
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @param string $type
+	 *
+	 * @return void
+	 */
+	public function theSystemConfigKeyFromLastCommandOutputShouldContainValue(
+		$key, $value, $type
+	) {
+		$configList = \json_decode(
+			$this->featureContext->getStdOutOfOccCommand(), true
+		);
+		$systemConfig = $configList['system'];
+
+		// convert the value to it's respective type based on type given in the type column
+		if ($type === 'boolean') {
+			$value = $value === 'true' ? true : false;
+		} elseif ($type === 'integer') {
+			$value = (int) $value;
+		} elseif ($type === 'json') {
+			// if the expected value of the key is a json
+			// match the value with the regular expression
+			$actualKeyValuePair = \json_encode(
+				$systemConfig[$key], JSON_UNESCAPED_SLASHES
+			);
+
+			PHPUnit\Framework\Assert::assertThat(
+				$actualKeyValuePair,
+				PHPUnit\Framework\Assert::matchesRegularExpression($value)
+			);
+			return;
+		}
+
+		if (!\array_key_exists($key, $systemConfig)) {
+			PHPUnit\Framework\Assert::fail(
+				"system config doesn't contain key: " . $key
+			);
+		}
+
+		PHPUnit\Framework\Assert::assertEquals(
+			$value,
+			$systemConfig[$key],
+			"config: $key doesn't contain value: $value"
+		);
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -35,3 +35,22 @@ Feature: add and delete app configs using occ command
     Then the command should have been successful
     And the command output should contain the apps configs
 
+  Scenario: app directory should be listed in the config file
+    When the administrator lists the config keys
+    Then the command should have been successful
+    And the system config key "apps_paths" from the last command output should match value '/\"url\":\"\/apps\",\"writable\":false/' of type "json"
+
+  Scenario: app-external directory should be listed in the config
+    When the administrator lists the config keys
+    Then the command should have been successful
+    And the system config key "apps_paths" from the last command output should match value '/\"url\":\"\/apps-external\",\"writable\":true/' of type "json"
+
+  Scenario: log time zone should be listed in the config file
+    When the administrator lists the config keys
+    Then the command should have been successful
+    And the system config key "logtimezone" from the last command output should match value "UTC" of type "string"
+
+  Scenario: server installed should be listed in the config file
+    When the administrator lists the config keys
+    Then the command should have been successful
+    And the system config key "installed" from the last command output should match value "true" of type "boolean"


### PR DESCRIPTION
## Description
Add cli tests for checking `config.php` default values.

## Related Issue
#31347

## Motivation and Context

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 