### PR TITLE
[Stable10] allow html in claim and use htmlname in layout

### DIFF
--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -37,10 +37,10 @@
 						<div id="header">
 							<div class="logo">
 								<h1 class="hidden-visually">
-									<?php p($theme->getName()); ?>
+									<?php print_unescaped($theme->getHTMLName()); ?>
 								</h1>
 							</div>
-							<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
+							<div id="logo-claim" style="display:none;"><?php print_unescaped($theme->getLogoClaim()); ?></div>
 						</div>
 					</header>
 				<?php endif; ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -45,7 +45,7 @@
 			<div id="header">
 				<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" id="owncloud" tabindex="1">
 					<h1 class="logo-icon">
-						<?php p($theme->getName()); ?>
+						<?php print_unescaped($theme->getHTMLName()); ?>
 					</h1>
 				</a>
 				<a href="#" class="header-appname-container menutoggle" tabindex="2">
@@ -56,7 +56,7 @@
 						<?php p(!empty($_['application']) ? $_['application'] : $l->t('Apps')); ?>
 					</h1>
 				</a>
-				<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
+				<div id="logo-claim" style="display:none;"><?php print_unescaped($theme->getLogoClaim()); ?></div>
 				<div id="settings">
 					<div id="expand" tabindex="6" role="link" class="menutoggle">
 						<?php if ($_['enableAvatars']): ?>


### PR DESCRIPTION
Signed-off-by: Jörn Friedrich Dreyer <jfd@butonic.de>
## Description
Backport of #30882 
also updated the custom theme to use html https://github.com/owncloud/theme-example/pull/7
## Related Issue
- Fixes #30881 

## Motivation and Context
To be able to use html elements in theme apps.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
