### PR TITLE
Accessing sharetab directly for a long list of files

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2539,6 +2539,18 @@
 			}
 			if (!_.isUndefined(detailTabId)) {
 				var filename = file[file.length - 1];
+				//Double check if the area that you are scrolling is beyond the page limit?
+				var pageSize = this.pageSize();
+				var index = _.findIndex(this.files, function (obj) {
+					return obj.name === filename;
+				});
+				if (index >= pageSize) {
+					var numberOfMorePagesToScroll = Math.floor(index / pageSize);
+					while (numberOfMorePagesToScroll > 0) {
+						this._nextPage();
+						numberOfMorePagesToScroll--;
+					}
+				}
 				this.showDetailsView(filename, detailTabId);
 			}
 			this.highlightFiles(file, function($tr) {

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -23,12 +23,11 @@ Feature: browse directly to details tab
 
   #merge this tests into previous scenario when bug is fixed
   @smokeTest
-  @issue-35200
   Scenario Outline: Browse directly to the sharing details of a file
     When the user tries to browse directly to display the "sharing" details of file "<file>" in folder "<folder>"
     #Then the thumbnail should be visible in the details panel
     Then the "sharing" details panel should be visible
-    And the share-with field should not be visible in the details panel
+    And the share-with field should be visible in the details panel
     #And the share-with field should be visible in the details panel
     Examples:
       | file                                 | folder        | comment   |
@@ -48,7 +47,6 @@ Feature: browse directly to details tab
       | lorem.txt         | simple-folder | a file somewhere in between |
 
   #merge this tests into previous scenario when bug is fixed
-  @issue-35200
   @comments-app-required
   Scenario Outline: Browse directly to the comments details of a file
     When the user tries to browse directly to display the "comments" details of file "<file>" in folder "<folder>"
@@ -72,7 +70,6 @@ Feature: browse directly to details tab
       | lorem.txt         | simple-folder | a file somewhere in between |
 
   #merge this tests into previous scenario when bug is fixed
-  @issue-35200
   @files_versions-app-required
   Scenario Outline: Browse directly to the versions details of a file
     When the user tries to browse directly to display the "versions" details of file "<file>" in folder "<folder>"


### PR DESCRIPTION
Accessing sharetab directly for a long list of
files caused problems. The pages need to be fetched
appropriately to get the data. This changeset fixes
the problem.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Lets say we have 30 files listed in the the UI. The maximum page size we have is 18. And hence when user tries to access the 19th file from the UI using `http://localhost/testing3/index.php/apps/files/?dir=/test&&scrollto=file19.txt&details=shareTabView` ( where `file19.txt` ) is the 19th file in the list, then the sharetab would be shown without any details. The reason for this is its the 19th element and hence the filelist doesn't have the `tr` added. So to solve this issue, the index of the file from the `this.files` is taken. And this would help to calculate the number of attempts required to fetch the page so that we get the data.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35200

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to fetch the pages to get the data populated, so that when they are accessed for the share tab field, the tab does not show empty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  Create a folder test
- Upload 150 files
- [x] Access 15th elements sharetab field
- [x] Access 110th file's share tab field
- [x] Access 150th files share tab field
- [x] Access 190th files share tab field
- [x] Access 210th files share tab field shows 
![beyondarray](https://user-images.githubusercontent.com/3600427/58079473-b2843900-7bce-11e9-9595-6a7f33912e68.png)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
