### PR TITLE
[stable10]  Acceptance test for giving controlled access to users to change their fullname

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -555,15 +555,17 @@ class OccContext implements Context {
 	/**
 	 * @Given the administrator has added system config key :key with value :value
 	 * @When the administrator adds/updates system config key :key with value :value using the occ command
+	 * @When the administrator adds/updates system config key :key with value :value and type :type using the occ command
 	 *
 	 * @param string $key
 	 * @param string $value
+	 * @param boolean $type
 	 *
 	 * @return void
 	 */
-	public function theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand($key, $value) {
+	public function theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand($key, $value, $type="string") {
 		$this->invokingTheCommand(
-			"config:system:set --value ${value} ${key}"
+			"config:system:set --value ${value} --type ${type} ${key}"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\PersonalGeneralSettingsPage;
+use PHPUnit\Framework\Assert;
 use TestHelpers\EmailHelper;
 
 require_once 'bootstrap.php';
@@ -154,6 +155,22 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 		$this->personalGeneralSettingsPage->changeFullname(
 			$newFullname, $this->getSession()
 		);
+	}
+
+	/**
+	 * @Then the user should not be able to change the full name using the webUI
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUserShouldNotBeAbleToChangeTheFullNameUsingTheWebui() {
+		try {
+			$this->personalGeneralSettingsPage->changeFullname(
+				"anything", $this->getSession()
+			);
+			PHPUnit\Framework\Assert::fail("changing the full name was possible, but should not");
+		} catch (Behat\Mink\Exception\ElementNotFoundException $e) {
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
@@ -1,0 +1,23 @@
+@webUI @insulated @disablePreviews
+Feature: Control access to edit fullname of user through config file
+  As an admin
+  I want to control the access to users to edit their fullname in settings page
+  So that users can edit their fullname after getting permission from administrator
+
+  Scenario: Admin gives access to users to change their full name
+    Given user "user1" has been created with default attributes
+    And user "user1" has logged in using the webUI
+    When the administrator updates system config key "allow_user_to_change_display_name" with value "true" and type "boolean" using the occ command
+    And the user browses to the personal general settings page
+    And the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
+    And the user reloads the current page of the webUI
+    Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
+    And the attributes of user "user1" returned by the API should include
+      | displayname | my#very&weird?नेपालि%name |
+
+  Scenario: Admin doesnot give access to users to change their full name
+    Given user "user1" has been created with default attributes
+    And user "user1" has logged in using the webUI
+    When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
+    And the user browses to the personal general settings page
+    Then the user should not be able to change the full name using the webUI


### PR DESCRIPTION
 Backport on #35270
## Description
We can share folders with groups having emoji in the group name 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

