### PR TITLE
[stable10] do not disable encryption app after test run

### DIFF
--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -92,7 +92,6 @@ class FixEncryptedVersionTest extends TestCase {
 		if ($user !== null) {
 			$user->delete();
 		}
-		\OC_App::disable('encryption');
 		\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(true);
 		\OC::$server->getConfig()->deleteAppValue('core', 'encryption_enabled');
 		\OC::$server->getConfig()->deleteAppValue('core', 'default_encryption_module');


### PR DESCRIPTION
## Description
currently stable10 unit tests fail in drone e.g. see https://drone.owncloud.com/owncloud/core/17499/142
`git bisect` shows that the first broken commit is 7ad78e9eb70e33e11cd7082df6bf1c4988e0b509 of PR #35000

further investigation showed that deleting that single line fixed the problem at least locally for me. Now lets see if it helps CI

**Why didn't it fail in the first place but started at some point later????**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
