### PR TITLE
get rid of "the share fields of the last share should include" step

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -12,7 +12,7 @@ Feature: federated
     When user "user1" from server "LOCAL" shares "/textfile0.txt" with user "user0" from server "REMOTE" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id                     | A_NUMBER       |
       | item_type              | file           |
       | item_source            | A_NUMBER       |
@@ -38,7 +38,7 @@ Feature: federated
     When user "user0" from server "REMOTE" shares "/textfile0.txt" with user "user1" from server "LOCAL" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id                     | A_NUMBER       |
       | item_type              | file           |
       | item_source            | A_NUMBER       |
@@ -172,7 +172,7 @@ Feature: federated
       | permissions | 19                 |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id                     | A_NUMBER           |
       | item_type              | file               |
       | item_source            | A_NUMBER           |

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -16,7 +16,7 @@ Feature: external-storage
       | path | foo |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id       | A_NUMBER             |
       | url      | AN_URL               |
       | token    | A_TOKEN              |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -13,7 +13,7 @@ Feature: sharing
     When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | share_with  | user1        |
       | file_target | /welcome.txt |
       | path        | /welcome.txt |
@@ -30,7 +30,7 @@ Feature: sharing
     When user "user0" shares file "/welcome.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | share_with  | grp1         |
       | file_target | /welcome.txt |
       | path        | /welcome.txt |
@@ -50,7 +50,7 @@ Feature: sharing
     When user "user0" shares file "/welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | share_with  | user1        |
       | file_target | /welcome.txt |
       | path        | /welcome.txt |
@@ -96,7 +96,7 @@ Feature: sharing
       | permissions | 31          |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | file_target | /welcome.txt |
       | path        | /welcome.txt |
       | item_type   | file         |
@@ -130,7 +130,7 @@ Feature: sharing
       | path     | welcome.txt   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | file_target            | /welcome.txt   |
       | path                   | /welcome.txt   |
       | item_type              | file           |
@@ -173,7 +173,7 @@ Feature: sharing
       | path | /afolder |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id          | A_NUMBER |
       | share_type  | 3        |
       | permissions | 1        |
@@ -191,7 +191,7 @@ Feature: sharing
       | path | /afolder |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id          | A_NUMBER |
       | share_type  | 3        |
       | permissions | 1        |
@@ -209,7 +209,7 @@ Feature: sharing
       | permissions | 15       |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id          | A_NUMBER |
       | share_type  | 3        |
       | permissions | 15       |
@@ -227,7 +227,7 @@ Feature: sharing
       | permissions | 5        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id          | A_NUMBER |
       | share_type  | 3        |
       | permissions | 5        |

--- a/tests/acceptance/features/apiShareManagementBasic/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/updateShare.feature
@@ -315,7 +315,8 @@ Feature: sharing
     And user "user0" has shared folder "/folder1" with user "user1" with permissions 31
     And user "user1" has shared folder "/folder1/folder2" with user "user2" with permissions 31
     When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the WebDAV API
-    Then the share fields of the last share should include
+    And user "user1" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
@@ -342,7 +343,8 @@ Feature: sharing
     And user "user0" has shared folder "/user0-folder" with user "user1" with permissions 31
     And user "user2" has shared folder "/user2-folder" with user "user1" with permissions 31
     When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the WebDAV API
-    Then the share fields of the last share should include
+    And user "user2" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
@@ -451,8 +453,8 @@ Feature: sharing
       | permissions | 7 |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When the user gets the info of the last share using the sharing API
-    Then the share fields of the last share should include
+    When user "user0" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
       | permissions | 7 |
     When the public deletes file "CHILD/child.txt" from the last public share using the public WebDAV API
     Then the HTTP status code should be "403"
@@ -471,8 +473,8 @@ Feature: sharing
       | permissions | 15 |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When the user gets the info of the last share using the sharing API
-    Then the share fields of the last share should include
+    When user "user0" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
       | permissions | 15 |
     When the public deletes file "CHILD/child.txt" from the last public share using the public WebDAV API
     Then the HTTP status code should be "204"

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -95,7 +95,7 @@ Feature: sharing
     When user "user0" gets the info of the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the share fields of the last share should include
+    And the fields of the last response should include
       | id                     | A_NUMBER           |
       | item_type              | file               |
       | item_source            | A_NUMBER           |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -590,7 +590,6 @@ trait Sharing {
 		$this->response = HttpRequestHelper::put(
 			$fullUrl, $user, $this->getPasswordForUser($user), null, $fd
 		);
-		$this->lastShareData = $this->getResponseXml();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -690,17 +690,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @param string $field
-	 * @param string $contentExpected
-	 *
-	 * @return bool
-	 */
-	public function isFieldInShareResponse($field, $contentExpected) {
-		$data = $this->lastShareData->data[0];
-		return $this->isFieldInResponse($field, $contentExpected, $data);
-	}
-
-	/**
 	 * @Then /^file "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $filename
@@ -1305,28 +1294,6 @@ trait Sharing {
 	public function checkingTheResponseEntriesCount($count) {
 		$actualCount = \count($this->getResponseXml()->data[0]);
 		PHPUnit\Framework\Assert::assertEquals($count, $actualCount);
-	}
-
-	/**
-	 * @Then /^the share fields of the last share should include$/
-	 *
-	 * @param TableNode|null $body
-	 *
-	 * @return void
-	 */
-	public function checkShareFields($body) {
-		if ($body instanceof TableNode) {
-			$fd = $body->getRowsHash();
-
-			foreach ($fd as $field => $value) {
-				$value = $this->replaceValuesFromTable($field, $value);
-				if (!$this->isFieldInShareResponse($field, $value)) {
-					PHPUnit\Framework\Assert::fail(
-						"$field doesn't have value $value"
-					);
-				}
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) saving the response of the share data after update  was added in #35204 but causes problems when an invalid request was done but the original `lastShareData` need to be accessed e.g in `\Sharing::getMimeTypeOfLastSharedFile()`
2) completely get rid of `Then the share fields of the last share should include`.
If we done the share creation request directly before the check we should use we use `Then the fields of the last response should include`.
If there are some steps in between the share creation and the check, we anyway should query the current state of the share by `When user "..." gets the info of the last share using the sharing API`, otherwise we only check the saved data and not the current state of the share

## Motivation and Context
fixing CI in various apps that were broken by #35204

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
