### PR TITLE
[stable10]  Acceptance test for group names with emoji

### DIFF
--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -17,7 +17,7 @@ Feature: add groups
       | group_id    | comment                     |
       | simplegroup | nothing special here        |
       | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | नेपाली        | Unicode group name          |
 
   Scenario Outline: admin creates a group
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API
@@ -42,6 +42,7 @@ Feature: add groups
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😅 😆               | emoji                                   |
 
     # Note: these groups do get created OK, but:
     # 1) the "should exist" step fails because the API to check their existence does not work.

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -18,7 +18,7 @@ Feature: add users to group
       | group_id    | comment                     |
       | simplegroup | nothing special here        |
       | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | नेपाली        | Unicode group name          |
 
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes
@@ -44,6 +44,7 @@ Feature: add users to group
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😁 😂               | emoji                                   |
 
   @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -18,7 +18,7 @@ Feature: delete groups
       | group_id    | comment                     |
       | simplegroup | nothing special here        |
       | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | नेपाली        | Unicode group name          |
 
   Scenario Outline: admin deletes a group
     Given group "<group_id>" has been created
@@ -44,6 +44,7 @@ Feature: delete groups
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😁 😂               | emoji                                   |
 
   @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -11,10 +11,13 @@ Feature: get subadmin groups
   Scenario: admin gets subadmin groups of a user
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
+    And group "😅 😆" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
+    And user "brand-new-user" has been made a subadmin of group "😅 😆"
     When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
     Then the subadmin groups returned by the API should be
       | new-group |
+      | 😅 😆      |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -16,18 +16,21 @@ Feature: get user groups
     And group "Admin & Finance (NP)" has been created
     And group "admin:Pokhara@Nepal" has been created
     And group "नेपाली" has been created
+    And group "😅 😆" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been added to group "0"
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
     And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
     And user "brand-new-user" has been added to group "नेपाली"
+    And user "brand-new-user" has been added to group "😅 😆"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
       | new-group            |
       | 0                    |
       | Admin & Finance (NP) |
       | admin:Pokhara@Nepal  |
-      | नेपाली               |
+      | नेपाली                 |
+      | 😅 😆                |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -48,6 +48,7 @@ Feature: remove a user from a group
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😁 😂               | emoji                                   |
 
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -42,6 +42,7 @@ Feature: add groups
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😅 😆               | emoji                                   |
 
     # Note: these groups do get created OK, but:
     # 1) the "should exist" step fails because the API to check their existence does not work.

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -44,6 +44,7 @@ Feature: add users to group
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😅 😆               | emoji                                   |
 
   @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -44,6 +44,7 @@ Feature: delete groups
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😅 😆               | emoji                                   |
 
   @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -11,10 +11,13 @@ Feature: get subadmin groups
   Scenario: admin gets subadmin groups of a user
     Given user "brand-new-user" has been created with default attributes
     And group "new-group" has been created
+    And group "😅 😆" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
+    And user "brand-new-user" has been made a subadmin of group "😅 😆"
     When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
     Then the subadmin groups returned by the API should be
       | new-group |
+      | 😅 😆      |
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -16,11 +16,13 @@ Feature: get user groups
     And group "Admin & Finance (NP)" has been created
     And group "admin:Pokhara@Nepal" has been created
     And group "नेपाली" has been created
+    And group "😅 😆" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been added to group "0"
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
     And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
     And user "brand-new-user" has been added to group "नेपाली"
+    And user "brand-new-user" has been added to group "😅 😆"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
       | new-group            |
@@ -28,6 +30,7 @@ Feature: get user groups
       | Admin & Finance (NP) |
       | admin:Pokhara@Nepal  |
       | नेपाली               |
+      | 😅 😆                |
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -22,7 +22,7 @@ Feature: remove a user from a group
       | España      | special European characters |
       | नेपाली      | Unicode group name          |
 
-  Scenario Outline: admin removes a user from a group
+   Scenario Outline: admin removes a user from a group
     Given user "brand-new-user" has been created with default attributes
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
@@ -48,6 +48,7 @@ Feature: remove a user from a group
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
+      | 😅 😆               | emoji                                   |
 
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name


### PR DESCRIPTION
Backport on #35247

## Description
Using these tests we can check if we can create group names with emojis .

Part of issue #34437 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

