### PR TITLE
[Stable10] Catch internal server error from remote on decline

### DIFF
--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -34,6 +34,7 @@ use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\IConfig;
 use OCA\FederatedFileSharing\BackgroundJob\RetryJob;
+use OCP\Share\Events\DeclineShare;
 
 class NotificationsTest extends \Test\TestCase {
 
@@ -199,5 +200,20 @@ class NotificationsTest extends \Test\TestCase {
 				true
 			]
 		);
+	}
+
+	public function testDeclineEvent() {
+		$dispatcher = \OC::$server->getEventDispatcher();
+		$event = $dispatcher->dispatch(
+			DeclineShare::class,
+			new DeclineShare(
+				[
+					'remote_id' => '4354353',
+					'remote' => 'http://localhost',
+					'share_token' => 'ohno'
+				]
+			)
+		);
+		$this->assertInstanceOf(DeclineShare::class, $event);
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/35178

## Description
Handle 500 exception on declining a share

## Motivation and Context
Before 10.2 response for declining non-existing shares was 500
https://github.com/owncloud/core/pull/34786 changes HTTP status from 500 to 410 
But declining any non-existing share for OC lower than 10.2 still causing unhandled exception.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

