### PR TITLE
detect correct uid when even wrong casing in given uid for files:scan

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -386,9 +386,10 @@ class Scan extends Base {
 			if (\is_object($user)) {
 				$user = $user->getUID();
 			}
-			$path = $inputPath ? $inputPath : '/' . $user;
 			$user_count += 1;
 			if ($this->userManager->userExists($user)) {
+				$user = $this->userManager->get($user)->getUID();
+				$path = $inputPath ? $inputPath : '/' . $user;
 				# add an extra line when verbose is set to optical separate users
 				if ($verbose) {
 					$output->writeln("");


### PR DESCRIPTION
## Description
When doing a files:scan and entering the user id in the wrong case. The job tells, that no files are scanned. This PR fixes issue by learning correct uid from user manager. @pako81 since casing is not important in our uid policy, in my opinion this solution better than throwing an error. Do you think this PR is acceptable with this behavior?
## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3308

## Motivation and Context
Solving bugs.

## How Has This Been Tested?
- use files:scan command with wrong casing
- it should detect correct uid and work

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
