### PR TITLE
Only test for particular known languages in testFindAvailableLanguagesWithThemes

### DIFF
--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -317,7 +317,9 @@ class FactoryTest extends TestCase {
 			->with('theme')
 			->willReturn('abc');
 
-		$this->assertEquals(['en', 'zz'], $factory->findAvailableLanguages($app), '', 0.0, 10, true);
+		$availableLanguages = $factory->findAvailableLanguages($app);
+		$this->assertContains('en', $availableLanguages);
+		$this->assertContains('zz', $availableLanguages);
 	}
 
 	public function testFindAvailableLanguagesWithAppThemes() {


### PR DESCRIPTION
## Description
Adjust the failing unit test so that it just checks that the 2 "known" languages exist, and not that they are the only languages. Because who knows what other languages get added to the system over time.

Note: other unit tests in the same file have taken a similar approach and just check for `en` and `zz` and do not care if there are more languages than this.

## Related Issue
- Fixes #35330

## Motivation and Context
Make  CI great again.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
