### PR TITLE
[stable10] Only test for particular known languages in testFindAvailableLanguagesWithThemes

### DIFF
--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -317,7 +317,9 @@ class FactoryTest extends TestCase {
 			->with('theme')
 			->willReturn('abc');
 
-		$this->assertEquals(['en', 'zz'], $factory->findAvailableLanguages($app), '', 0.0, 10, true);
+		$availableLanguages = $factory->findAvailableLanguages($app);
+		$this->assertContains('en', $availableLanguages);
+		$this->assertContains('zz', $availableLanguages);
 	}
 
 	public function testFindAvailableLanguagesWithAppThemes() {


### PR DESCRIPTION
Backport #35329

so that if/when translations/languages happens back in `stable10` like in `master`, the unit tests will not get broken.