### PR TITLE
Add remove user to groups not case sensitive

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -15,6 +15,13 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
+  Scenario: Delete a user, and specify the user name in different case
+    Given user "brand-new-user" has been created with default attributes
+    When the administrator deletes user "Brand-New-User" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
+
   @smokeTest
   Scenario: subadmin deletes a user in their group
     Given user "subadmin" has been created with default attributes

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -15,6 +15,13 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
+  Scenario: Delete a user, and specify the user name in different case
+    Given user "brand-new-user" has been created with default attributes
+    When the administrator deletes user "Brand-New-User" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
+
   @smokeTest
   Scenario: subadmin deletes a user in their group
     Given user "subadmin" has been created with default attributes

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -44,6 +44,20 @@ Feature: add groups
       | staff?group         | Question mark                           |
       | 😅 😆               | emoji                                   |
 
+  Scenario Outline: group names are case-sensitive, multiple groups can exist with different upper and lower case names
+    When the administrator sends a group creation request for group "<group_id1>" using the provisioning API
+    And the administrator sends a group creation request for group "<group_id2>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id1>" should exist
+    And group "<group_id2>" should exist
+    But group "<group_id3>" should not exist
+    Examples:
+      | group_id1            | group_id2            | group_id3            |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
+
     # Note: these groups do get created OK, but:
     # 1) the "should exist" step fails because the API to check their existence does not work.
     # 2) the ordinary group deletion in AfterScenario does not work, because the

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -65,6 +65,23 @@ Feature: add users to group
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
+  Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
+    Given user "brand-new-user" has been created with default attributes
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    When the administrator adds user "<user_id>" to group "<group_id1>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should belong to group "<group_id1>"
+    But user "brand-new-user" should not belong to group "<group_id2>"
+    And user "brand-new-user" should not belong to group "<group_id3>"
+    Examples:
+      | user_id        | group_id1 | group_id2 | group_id3 |
+      | BRAND-NEW-USER | New-Group | new-group | NEW-GROUP |
+      | Brand-New-User | new-group | NEW-GROUP | New-Group |
+      | brand-new-user | NEW-GROUP | New-Group | new-group |
+
   Scenario: normal user tries to add himself to a group
     Given user "brand-new-user" has been created with default attributes
     When user "brand-new-user" tries to add himself to group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -46,6 +46,22 @@ Feature: delete groups
       | staff?group         | Question mark                           |
       | 😁 😂               | emoji                                   |
 
+  Scenario Outline: group names are case-sensitive, the correct group is deleted
+    Given group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    When the administrator deletes group "<group_id1>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id1>" should not exist
+    But group "<group_id2>" should exist
+    And group "<group_id3>" should exist
+    Examples:
+      | group_id1            | group_id2            | group_id3 |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
+
   @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
     # After fixing issue-31015, change the following step to "has been created"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
@@ -28,6 +28,26 @@ Feature: get group
     And the HTTP status code should be "200"
     And the list of users returned by the API should be empty
 
+  Scenario: admin tries to get users in a non-existent group
+    Given group "new-group" has been created
+    When the administrator gets all the members of group "not-a-group" using the provisioning API
+    Then the OCS status code should be "998"
+    And the HTTP status code should be "200"
+
+  Scenario Outline: admin tries to get users in a group but using wrong case of the group name
+    Given group "<group_id1>" has been created
+    When the administrator gets all the members of group "<group_id2>" using the provisioning API
+    Then the OCS status code should be "998"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id1            | group_id2            |
+      | case-sensitive-group | Case-Sensitive-Group |
+      | case-sensitive-group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | case-sensitive-group |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | CASE-SENSITIVE-GROUP | Case-Sensitive-Group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group |
+
   @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
     Given user "user1" has been created with default attributes

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
@@ -18,3 +18,14 @@ Feature: get groups
       | admin     |
       | new-group |
       | 0         |
+
+  Scenario: admin gets all the groups, including groups with mixed case
+    Given group "new-group" has been created
+    And group "New-Group" has been created
+    And group "NEW-GROUP" has been created
+    When the administrator gets all the groups using the provisioning API
+    Then the groups returned by the API should be
+      | admin     |
+      | new-group |
+      | New-Group |
+      | NEW-GROUP |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -71,6 +71,26 @@ Feature: remove a user from a group
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
+  Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
+    Given user "brand-new-user" has been created with default attributes
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    And user "brand-new-user" has been added to group "<group_id1>"
+    And user "brand-new-user" has been added to group "<group_id2>"
+    And user "brand-new-user" has been added to group "<group_id3>"
+    When the administrator removes user "<user_id>" from group "<group_id1>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id1>"
+    But user "brand-new-user" should belong to group "<group_id2>"
+    And user "brand-new-user" should belong to group "<group_id3>"
+    Examples:
+      | user_id        | group_id1 | group_id2 | group_id3 |
+      | BRAND-NEW-USER | New-Group | new-group | NEW-GROUP |
+      | Brand-New-User | new-group | NEW-GROUP | New-Group |
+      | brand-new-user | NEW-GROUP | New-Group | new-group |
+
   Scenario: admin tries to remove a user from a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -44,6 +44,20 @@ Feature: add groups
       | staff?group         | Question mark                           |
       | 😅 😆               | emoji                                   |
 
+  Scenario Outline: group names are case-sensitive, multiple groups can exist with different upper and lower case names
+    When the administrator sends a group creation request for group "<group_id1>" using the provisioning API
+    And the administrator sends a group creation request for group "<group_id2>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id1>" should exist
+    And group "<group_id2>" should exist
+    But group "<group_id3>" should not exist
+    Examples:
+      | group_id1            | group_id2            | group_id3            |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
+
     # Note: these groups do get created OK, but:
     # 1) the "should exist" step fails because the API to check their existence does not work.
     # 2) the ordinary group deletion in AfterScenario does not work, because the

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -65,6 +65,23 @@ Feature: add users to group
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
+  Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
+    Given user "brand-new-user" has been created with default attributes
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    When the administrator adds user "<user_id>" to group "<group_id1>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should belong to group "<group_id1>"
+    But user "brand-new-user" should not belong to group "<group_id2>"
+    And user "brand-new-user" should not belong to group "<group_id3>"
+    Examples:
+      | user_id        | group_id1 | group_id2 | group_id3 |
+      | BRAND-NEW-USER | New-Group | new-group | NEW-GROUP |
+      | Brand-New-User | new-group | NEW-GROUP | New-Group |
+      | brand-new-user | NEW-GROUP | New-Group | new-group |
+
   @issue-31276
   Scenario: normal user tries to add himself to a group
     Given user "brand-new-user" has been created with default attributes

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -46,6 +46,22 @@ Feature: delete groups
       | staff?group         | Question mark                           |
       | 😅 😆               | emoji                                   |
 
+  Scenario Outline: group names are case-sensitive, the correct group is deleted
+    Given group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    When the administrator deletes group "<group_id1>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group "<group_id1>" should not exist
+    But group "<group_id2>" should exist
+    And group "<group_id3>" should exist
+    Examples:
+      | group_id1            | group_id2            | group_id3 |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
+
   @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
     # After fixing issue-31015, change the following step to "has been created"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
@@ -28,6 +28,26 @@ Feature: get group
     And the HTTP status code should be "200"
     And the list of users returned by the API should be empty
 
+  Scenario: admin tries to get users in a non-existent group
+    Given group "new-group" has been created
+    When the administrator gets all the members of group "not-a-group" using the provisioning API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "404"
+
+  Scenario Outline: admin tries to get users in a group but using wrong case of the group name
+    Given group "<group_id1>" has been created
+    When the administrator gets all the members of group "<group_id2>" using the provisioning API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "404"
+    Examples:
+      | group_id1            | group_id2            |
+      | case-sensitive-group | Case-Sensitive-Group |
+      | case-sensitive-group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | case-sensitive-group |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | CASE-SENSITIVE-GROUP | Case-Sensitive-Group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group |
+
   @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
     Given user "user1" has been created with default attributes

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -18,3 +18,14 @@ Feature: get groups
       | admin     |
       | new-group |
       | 0         |
+
+  Scenario: admin gets all the groups, including groups with mixed case
+    Given group "new-group" has been created
+    And group "New-Group" has been created
+    And group "NEW-GROUP" has been created
+    When the administrator gets all the groups using the provisioning API
+    Then the groups returned by the API should be
+      | admin     |
+      | new-group |
+      | New-Group |
+      | NEW-GROUP |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -71,6 +71,26 @@ Feature: remove a user from a group
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
+  Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
+    Given user "brand-new-user" has been created with default attributes
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    And user "brand-new-user" has been added to group "<group_id1>"
+    And user "brand-new-user" has been added to group "<group_id2>"
+    And user "brand-new-user" has been added to group "<group_id3>"
+    When the administrator removes user "<user_id>" from group "<group_id1>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id1>"
+    But user "brand-new-user" should belong to group "<group_id2>"
+    And user "brand-new-user" should belong to group "<group_id3>"
+    Examples:
+      | user_id        | group_id1 | group_id2 | group_id3 |
+      | BRAND-NEW-USER | New-Group | new-group | NEW-GROUP |
+      | Brand-New-User | new-group | NEW-GROUP | New-Group |
+      | brand-new-user | NEW-GROUP | New-Group | new-group |
+
   Scenario: admin tries to remove a user from a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1331,6 +1331,7 @@ trait BasicStructure {
 	 */
 	public function getPasswordForUser($userName) {
 		$userName = $this->getActualUsername($userName);
+		$userName = $this->normalizeUsername($userName);
 		if ($userName === $this->getAdminUsername()) {
 			return (string) $this->getAdminPassword();
 		} elseif (\array_key_exists($userName, $this->createdUsers)) {
@@ -1377,6 +1378,7 @@ trait BasicStructure {
 		// The hard-coded user names and display names are also in ldap-users.ldif
 		// for testing in an LDAP environment. The mapping must be kept the
 		// same in both places.
+		$userName = $this->normalizeUsername($userName);
 		if (\array_key_exists($userName, $this->createdUsers)) {
 			return (string) $this->createdUsers[$userName]['displayname'];
 		} elseif (\array_key_exists($userName, $this->createdRemoteUsers)) {
@@ -1419,6 +1421,7 @@ trait BasicStructure {
 		// The hard-coded user names and email addresses are also in ldap-users.ldif
 		// for testing in an LDAP environment. The mapping must be kept the
 		// same in both places.
+		$userName = $this->normalizeUsername($userName);
 		if (\array_key_exists($userName, $this->createdUsers)) {
 			return (string) $this->createdUsers[$userName]['email'];
 		} elseif (\array_key_exists($userName, $this->createdRemoteUsers)) {

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -15,6 +15,19 @@ Feature: add group
       | España      | special European characters |
       | नेपाली      | Unicode group name          |
 
+  Scenario Outline: group names are case-sensitive, multiple groups can exist with different upper and lower case names
+    When the administrator creates group "<group_id1>" using the occ command
+    And the administrator creates group "<group_id2>" using the occ command
+    Then the command should have been successful
+    And group "<group_id1>" should exist
+    And group "<group_id2>" should exist
+    But group "<group_id3>" should not exist
+    Examples:
+      | group_id1            | group_id2            | group_id3            |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
+
   Scenario: admin tries to create a group that already exists
     Given group "new-group" has been created
     When the administrator creates group "new-group" using the occ command

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -18,6 +18,23 @@ Feature: add users to group
       | España      | special European characters |
       | नेपाली      | Unicode group name          |
 
+  Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
+    Given user "brand-new-user" has been created with default attributes
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    When the administrator adds user "<user_id>" to group "<group_id1>" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'User "brand-new-user" added to group "<group_id1>"'
+    And user "brand-new-user" should belong to group "<group_id1>"
+    But user "brand-new-user" should not belong to group "<group_id2>"
+    And user "brand-new-user" should not belong to group "<group_id3>"
+    Examples:
+      | user_id        | group_id1 | group_id2 | group_id3 |
+      | BRAND-NEW-USER | New-Group | new-group | NEW-GROUP |
+      | Brand-New-User | new-group | NEW-GROUP | New-Group |
+      | brand-new-user | NEW-GROUP | New-Group | new-group |
+
   Scenario: admin tries to add user to a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -69,3 +69,22 @@ Feature: add a user using the using the occ command
     When the administrator creates user "brand-new-user" password " " group "brand-new-group" using the occ command
     Then the command should have failed with exit code 1
     And user "brand-new-user" should not exist
+
+  Scenario: admin creates a user with username that contains capital letters
+    When the administrator creates this user using the occ command:
+      | username       |
+      | Brand-New-User |
+    Then the command should have been successful
+    And the command output should contain the text 'The user "Brand-New-User" was created successfully'
+    And user "Brand-New-User" should exist
+    And user "brand-new-user" should exist
+    And user "Brand-New-User" should be able to access a skeleton file
+    And the display name of user "brand-new-user" should be "Brand-New-User"
+
+  Scenario: admin tries to create an existing user but with username containing capital letters
+    Given user "brand-new-user" has been created with default attributes
+    When the administrator creates this user using the occ command:
+      | username       |
+      | Brand-New-User |
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'The user "Brand-New-User" already exists'

--- a/tests/acceptance/features/cliProvisioning/deleteGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteGroup.feature
@@ -15,3 +15,19 @@ Feature: delete groups
       | simplegroup | nothing special here        |
       | España      | special European characters |
       | नेपाली      | Unicode group name          |
+
+  Scenario Outline: group names are case-sensitive, the correct group is deleted
+    Given group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    When the administrator deletes group "<group_id1>" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'The specified group was deleted'
+    And group "<group_id1>" should not exist
+    But group "<group_id2>" should exist
+    And group "<group_id3>" should exist
+    Examples:
+      | group_id1            | group_id2            | group_id3 |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |

--- a/tests/acceptance/features/cliProvisioning/deleteUser.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteUser.feature
@@ -13,6 +13,15 @@ Feature: delete users
     And the command output should contain the text "User with uid 'brand-new-user', display name 'brand-new-user', email '' was deleted"
     And user "brand-new-user" should not exist
 
+  Scenario: Delete a user, and specify the user name in different case
+    Given these users have been created:
+      | username       |
+      | brand-new-user |
+    When the administrator deletes user "Brand-New-User" using the occ command
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
+
   Scenario: admin tries to delete a non-existing user
     Given user "brand-new-user" has been deleted
     When the administrator deletes user "brand-new-user" using the occ command

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -31,3 +31,23 @@ Feature: get group
     And the users returned by the occ command should be
       | uid            | display name |
       | brand-new-user | Anne Brown   |
+
+  Scenario: admin tries to get users in a non-existent group
+    Given group "new-group" has been created
+    When the administrator gets the users in group "not-a-group" in JSON format using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Group not-a-group does not exist'
+
+  Scenario Outline: admin tries to get users in a group but using wrong case of the group name
+    Given group "<group_id1>" has been created
+    When the administrator gets the users in group "<group_id2>" in JSON format using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Group <group_id2> does not exist'
+    Examples:
+      | group_id1            | group_id2            |
+      | case-sensitive-group | Case-Sensitive-Group |
+      | case-sensitive-group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | case-sensitive-group |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | CASE-SENSITIVE-GROUP | Case-Sensitive-Group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group |

--- a/tests/acceptance/features/cliProvisioning/getGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroups.feature
@@ -16,3 +16,16 @@ Feature: get groups
       | admin     |
       | new-group |
       | 0         |
+
+  Scenario: admin gets all the groups, including groups with mixed case
+    Given group "new-group" has been created
+    And group "New-Group" has been created
+    And group "NEW-GROUP" has been created
+    When the administrator gets the groups in JSON format using the occ command
+    Then the command should have been successful
+    And the groups returned by the occ command should be
+      | group     |
+      | admin     |
+      | new-group |
+      | New-Group |
+      | NEW-GROUP |

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -18,6 +18,26 @@ Feature: remove a user from a group
       | España      | special European characters |
       | नेपाली      | Unicode group name          |
 
+  Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
+    Given user "brand-new-user" has been created with default attributes
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    And user "brand-new-user" has been added to group "<group_id1>"
+    And user "brand-new-user" has been added to group "<group_id2>"
+    And user "brand-new-user" has been added to group "<group_id3>"
+    When the administrator removes user "<user_id>" from group "<group_id1>" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Member "brand-new-user" removed from group "<group_id1>"'
+    And user "brand-new-user" should not belong to group "<group_id1>"
+    But user "brand-new-user" should belong to group "<group_id2>"
+    And user "brand-new-user" should belong to group "<group_id3>"
+    Examples:
+      | user_id        | group_id1 | group_id2 | group_id3 |
+      | BRAND-NEW-USER | New-Group | new-group | NEW-GROUP |
+      | Brand-New-User | new-group | NEW-GROUP | New-Group |
+      | brand-new-user | NEW-GROUP | New-Group | new-group |
+
   Scenario: admin tries to remove a user from a group which does not exist
     Given user "brand-new-user" has been created with default attributes
     And group "not-group" has been deleted


### PR DESCRIPTION
## Description
Add API and CLI acceptance tests to:
- add and delete users using different case of the username (UID)
- add and delete groups using different case of the group name, checking that distinct groups are being managed
- add and delete users in groups, using different case of user and group name, making sure that distinct groups are managed correctly, and the user names behave in the "opposite" way (they are not case-sensitive)
- when remembering the users that have been created during a test scenario, always remember the lowercase name, and index into the remembered array with the lowercase version - so that the acceptance test code happily understands that when `user0` has been created then `USER0` is deleted, that those were the same user.

## Related Issue
Part of issue #35354 

## Motivation and Context
User names (IDs) are not case-sensitive, so `user0`, `User0` and `USER0` are all the same user.
Group names are case-sensitive, so `group1`, `Group1` and `GROUP1` are 3 different groups that can have different members.

We should "document" this behaviour in acceptance tests so that we know if it accidentally changes.

## How Has This Been Tested?
Local runs of the acceptance test scenarios plus CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
