### PR TITLE
move user creation without skeleton from activity app

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -282,8 +282,12 @@ trait Provisioning {
 		$this->featureContext->runOcc(["config:system:get skeletondirectory"]);
 		$path = \trim($this->featureContext->getStdOutOfOccCommand());
 		$this->featureContext->runOcc(["config:system:delete skeletondirectory"]);
-		$this->featureContext->userHasBeenCreatedWithDefaultAttributes($user);
-		$this->featureContext->runOcc(["config:system:set skeletondirectory --value $path"]);
+		try {
+			$this->featureContext->userHasBeenCreatedWithDefaultAttributes($user);
+		} finally {
+			// restore skeletondirectory even if user creation failed
+			$this->featureContext->runOcc(["config:system:set skeletondirectory --value $path"]);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -272,6 +272,21 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Given /^user "([^"]*)" has been created with default attributes and without skeleton files$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles($user) {
+		$this->featureContext->runOcc(["config:system:get skeletondirectory"]);
+		$path = \trim($this->featureContext->getStdOutOfOccCommand());
+		$this->featureContext->runOcc(["config:system:delete skeletondirectory"]);
+		$this->featureContext->userHasBeenCreatedWithDefaultAttributes($user);
+		$this->featureContext->runOcc(["config:system:set skeletondirectory --value $path"]);
+	}
+
+	/**
 	 * @Given /^these users have been created\s?(with default attributes|)\s?(but not initialized|):$/
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
@@ -2069,7 +2084,7 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 	}
-	
+
 	/**
 	 * @Given /^user "([^"]*)" has been made a subadmin of group "([^"]*)"$/
 	 *
@@ -2790,7 +2805,7 @@ trait Provisioning {
 		}
 		$this->usingServer($previousServer);
 	}
-	
+
 	/**
 	 * @BeforeScenario
 	 *
@@ -2800,7 +2815,7 @@ trait Provisioning {
 		$this->enabledApps = $this->getEnabledApps();
 		$this->disabledApps = $this->getDisabledApps();
 	}
-	
+
 	/**
 	 * @AfterScenario
 	 *


### PR DESCRIPTION
## Description
Move user creation without skeleton method from activity app to the core.

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>