### PR TITLE
Remove unnecessary create users from background in feature files for webUI tests

### DIFF
--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -8,7 +8,6 @@ Feature: deleting files and folders
     Given these users have been created with default attributes:
       | username |
       | user1    |
-      | user2    |
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -118,6 +117,7 @@ Feature: deleting files and folders
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   Scenario: delete files from shared with others page
+    Given user "user2" has been created with default attributes
     Given the user has shared file "lorem.txt" with user "User Two" using the webUI
     And the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user has browsed to the shared-with-others page

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -8,7 +8,6 @@ Feature: User can open the details panel for any file or folder
     Given these users have been created with default attributes:
       | username |
       | user1    |
-      | user2    |
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -56,7 +55,8 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
-    Given the user has shared folder "simple-folder" with user "User Two" using the webUI
+    Given user "user2" has been created with default attributes
+    And the user has shared folder "simple-folder" with user "User Two" using the webUI
     When the user browses to the shared-with-others page
     Then folder "simple-folder" should be listed on the webUI
     When the user opens the file action menu of folder "simple-folder" in the webUI
@@ -70,7 +70,8 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
-    Given the user has shared folder "simple-folder" with user "User Two" using the webUI
+    Given user "user2" has been created with default attributes
+    And the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
     When the user browses to the shared-with-you page
     Then folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -7,7 +7,6 @@ Feature: Search
 
   Background:
     Given user "user1" has been created with default attributes
-    And user "user0" has been created with default attributes
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -78,6 +77,7 @@ Feature: Search
     And file "lorem.txt" with path "/simple-folder" should be listed in the tags page on the webUI
 
   Scenario: Search for a shared file
+    Given user "user0" has been created with default attributes
     When user "user0" shares file "/lorem.txt" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "lorem" using the webUI
@@ -85,6 +85,7 @@ Feature: Search
 
   Scenario: Search for a re-shared file
     Given user "user2" has been created with default attributes
+    And user "user0" has been created with default attributes
     When user "user2" shares file "/lorem.txt" with user "user0" using the sharing API
     And user "user0" shares file "/lorem (2).txt" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
@@ -92,6 +93,7 @@ Feature: Search
     Then file "lorem (2).txt" should be listed on the webUI
 
   Scenario: Search for a shared folder
+    Given user "user0" has been created with default attributes
     When user "user0" shares folder "simple-folder" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "simple" using the webUI

--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -10,7 +10,6 @@ Feature: Versions of a file
     Given these users have been created with default attributes:
       | username |
       | user0    |
-      | user1    |
 
   @skipOnStorage:ceph @files_primary_s3-issue-67
   Scenario: upload new file with same name to see if different versions are shown
@@ -32,7 +31,8 @@ Feature: Versions of a file
     Then the content of file "lorem-file.txt" for user "user0" should be "lorem content"
 
   Scenario: sharee can see the versions of a file
-    Given user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
+    Given user "user1" has been created with default attributes
+    And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "new lorem content" to "/lorem-file.txt"
     And user "user0" has shared file "lorem-file.txt" with user "user1"
@@ -55,7 +55,8 @@ Feature: Versions of a file
 
   @skipOnStorage:ceph @files_primary_s3-issue-155
   Scenario: file versions cannot be seen in the webUI only for user whose versions is deleted
-    Given user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
+    Given user "user1" has been created with default attributes
+    And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "user1" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user1" has uploaded file with content "lorem" to "/lorem-file.txt"
@@ -72,7 +73,8 @@ Feature: Versions of a file
 
   @skipOnStorage:ceph @files_primary_s3-issue-155
   Scenario: file versions cannot be seen in the webUI for all users after deleting versions for all users
-    Given user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
+    Given user "user1" has been created with default attributes
+    And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "user1" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user1" has uploaded file with content "lorem" to "/lorem-file.txt"

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -10,7 +10,6 @@ Feature: restrict resharing
       | username |
       | user1    |
       | user2    |
-      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -9,7 +9,6 @@ Feature: accept/decline shares coming from internal users
       | username |
       | user1    |
       | user2    |
-      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -31,6 +30,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user3" has been created with default attributes
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
     When user "user3" logs in using the webUI
@@ -39,6 +39,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users, accept one by one
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user3" has been created with default attributes
     And user "user2" has created folder "/simple-folder/from_user2"
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has created folder "/simple-folder/from_user1"
@@ -54,6 +55,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "user3" has been created with default attributes
     And user "user2" has shared folder "/simple-folder" with user "user3"
     And user "user1" has shared folder "/simple-folder" with user "user3"
     When user "user3" logs in using the webUI

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -8,7 +8,6 @@ Feature: Creation of tags for the files and folders
     Given these users have been created with default attributes:
       | username |
       | user1    |
-      | user2    |
     And the user has browsed to the login page
     And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
@@ -40,6 +39,7 @@ Feature: Creation of tags for the files and folders
 
   @skipOnFIREFOX
   Scenario: Create and add tag on a shared file
+    Given user "user2" has been created with default attributes
     When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -8,12 +8,12 @@ Feature: Deletion of existing tags from files and folders
     Given these users have been created with default attributes:
       | username |
       | user1    |
-      | user2    |
     And the user has browsed to the login page
     And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
 @skipOnFIREFOX
   Scenario: Delete a tag in a shared file
+    Given user "user2" has been created with default attributes
     When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI

--- a/tests/acceptance/features/webUITags/removeTags.feature
+++ b/tests/acceptance/features/webUITags/removeTags.feature
@@ -8,7 +8,6 @@ Feature: Removal of already existing tags from files and folders
     Given these users have been created with default attributes:
       | username |
       | user1    |
-      | user2    |
     And the user has browsed to the login page
     And the user has logged in with username "user1" and password "%alt1%" using the webUI
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Remove create user steps from background for users which are not used in most of the scenarios.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to https://github.com/owncloud/QA/issues/621

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
