### PR TITLE
Web UI sharing internal users use no skeleton step

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -9,11 +9,14 @@ Feature: Autocompletion of share-with names
     Given these users have been created with default attributes but not initialized:
       | username    |
       | user1       |
-      | user3       |
-      | usergrp     |
       | regularuser |
-    # Some extra users to make the share autocompletion interesting
-    Given these users have been created but not initialized:
+    # Users that are in the special known users already without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user3    |
+      | usergrp  |
+    # Some extra users without skeleton files to make the share autocompletion interesting
+    And these users have been created without skeleton files:
       | username  | password  | displayname     | email          |
       | two       | %regular% | User Two        | u2@oc.com.np   |
       | u444      | %regular% | Four            | u3@oc.com.np   |
@@ -168,8 +171,8 @@ Feature: Autocompletion of share-with names
     And user "Four" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
-  Scenario: autocompletion of a pattern where the name of existing users contains the pattern at the end
-    Given user "usergrp" has logged in using the webUI
+  Scenario: autocompletion of a pattern where the name of existing users contain the pattern at the end
+    Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "r3" in the share-with-field

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -4,16 +4,15 @@ Feature: Sharing files and folders with internal users
   I want to share files and folders with other users
   So that those users can access the files and folders
 
-  Background:
-    Given these users have been created with default attributes:
-      | username |
-      | user1    |
-      | user2    |
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a file & folder with another internal user
-    Given user "user2" has logged in using the webUI
+    Given these users have been created with default attributes:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user2" has logged in using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user shares file "testimage.jpg" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
@@ -27,7 +26,9 @@ Feature: Sharing files and folders with internal users
 
   @TestAlsoOnExternalUserBackend @skipOnFIREFOX
   Scenario: share a file with another internal user who overwrites and unshares the file
-    Given user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes
+    And user "user2" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares file "new-lorem.txt" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
@@ -45,7 +46,9 @@ Feature: Sharing files and folders with internal users
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
-    Given user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes
+    And user "user2" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
@@ -72,7 +75,9 @@ Feature: Sharing files and folders with internal users
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who unshares the folder
-    Given user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes
+    And user "user2" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
@@ -88,7 +93,11 @@ Feature: Sharing files and folders with internal users
 
   @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user and prohibit deleting
-    Given user "user2" has logged in using the webUI
+    Given these users have been created with default attributes:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user2" has logged in using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
       | delete | no |
@@ -98,7 +107,9 @@ Feature: Sharing files and folders with internal users
 
   @skipOnFIREFOX
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
-    Given user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes
+    And user "user2" has logged in using the webUI
     And the user has renamed folder "simple-folder" to "new-simple-folder" using the webUI
     And the user has renamed file "lorem.txt" to "ipsum.txt" using the webUI
     And the user has shared file "ipsum.txt" with user "User One" using the webUI
@@ -109,7 +120,9 @@ Feature: Sharing files and folders with internal users
     And folder "new-simple-folder" should be listed on the webUI
 
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
-    Given user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes
+    And user "user2" has logged in using the webUI
     And the user has shared file "lorem.txt" with user "User One" using the webUI
     And the user has shared folder "simple-folder" with user "User One" using the webUI
     When the user browses to the shared-with-others page
@@ -117,7 +130,9 @@ Feature: Sharing files and folders with internal users
     And folder "simple-folder" should be listed on the webUI
 
   Scenario: share two file with same name but different paths
-    Given user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes
+    And user "user2" has logged in using the webUI
     And the user has shared file "lorem.txt" with user "User One" using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user shares file "lorem.txt" with user "User One" using the webUI
@@ -127,17 +142,25 @@ Feature: Sharing files and folders with internal users
 
   Scenario: user tries to share a file from a group which is blacklisted from sharing
     Given group "grp1" has been created
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user3    |
+    And user "user2" has been created with default attributes
     And user "user1" has been added to group "grp1"
-    And user "user3" has been created with default attributes
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the group sharing blacklist using the webUI
     Then user "user1" should not be able to share file "testimage.jpg" with user "user3" using the sharing API
 
   Scenario: user tries to share a folder from a group which is blacklisted from sharing
-    Given group "grp1" has been created
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user3    |
+    And user "user2" has been created with default attributes
+    And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And user "user3" has been created with default attributes
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the group sharing blacklist using the webUI
@@ -146,7 +169,11 @@ Feature: Sharing files and folders with internal users
   Scenario: member of a blacklisted from sharing group tries to re-share a file received as a share
     Given these users have been created with default attributes:
       | username |
+      | user1    |
       | user3    |
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user2    |
       | user4    |
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
@@ -157,8 +184,10 @@ Feature: Sharing files and folders with internal users
     Then user "user1" should not be able to share file "/testimage (2).jpg" with user "User Four" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a folder received as a share
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user1    |
+      | user2    |
       | user3    |
       | user4    |
     And group "grp1" has been created
@@ -171,10 +200,12 @@ Feature: Sharing files and folders with internal users
     Then user "user1" should not be able to share folder "/common" with user "User Four" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file inside a folder received as a share
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user3    |
+      | user1    |
+      | user2    |
       | user4    |
+    And user "user3" has been created with default attributes
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
@@ -186,8 +217,10 @@ Feature: Sharing files and folders with internal users
     Then user "user1" should not be able to share file "/common/testimage.jpg" with user "User Four" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a folder inside a folder received as a share
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user1    |
+      | user2    |
       | user3    |
       | user4    |
     And the administrator has browsed to the admin sharing settings page
@@ -200,8 +233,8 @@ Feature: Sharing files and folders with internal users
 
   Scenario: user tries to share a file from a group which is blacklisted from sharing using webUI from files page
     Given group "grp1" has been created
+    And user "user1" has been created with default attributes
     And user "user1" has been added to group "grp1"
-    And user "user3" has been created with default attributes
     And the administrator has browsed to the admin sharing settings page
     And the administrator has enabled exclude groups from sharing from the admin sharing settings page
     When the administrator adds group "grp1" to the group sharing blacklist using the webUI
@@ -212,8 +245,12 @@ Feature: Sharing files and folders with internal users
 
   Scenario: user tries to re-share a file from a group which is blacklisted from sharing using webUI from shared with you page
     Given group "grp1" has been created
+    And these users have been created with default attributes:
+      | username |
+      | user1    |
+      | user2    |
     And user "user1" has been added to group "grp1"
-    And user "user3" has been created with default attributes
+    And user "user3" has been created with default attributes and without skeleton files
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And the administrator has browsed to the admin sharing settings page
     And the administrator has enabled exclude groups from sharing from the admin sharing settings page
@@ -226,7 +263,11 @@ Feature: Sharing files and folders with internal users
     And user "user1" should not be able to share file "testimage (2).jpg" with user "User Three" using the sharing API
 
   Scenario: user shares the file/folder with another internal user and delete the share with user
-    Given user "user1" has logged in using the webUI
+    Given these users have been created with default attributes:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
     When the user opens the share dialog for file "lorem.txt"
     And the user deletes share with user "User Two" for the current file
@@ -238,6 +279,8 @@ Feature: Sharing files and folders with internal users
   @mailhog
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
+    And user "user1" has been created with default attributes
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
     And the user has opened the share dialog for file "lorem.txt"
@@ -251,9 +294,10 @@ Feature: Sharing files and folders with internal users
   @mailhog
   Scenario: user should get and error message when trying to send notification by email to a user who has not setup their email
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And these users have been created:
-      |username|password|
-      |user0   |1234    |
+    And user "user1" has been created with default attributes
+    And these users have been created without skeleton files:
+      | username | password |
+      | user0    | 1234     |
     And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user0"
     And the user has opened the share dialog for file "lorem.txt"
@@ -265,6 +309,8 @@ Feature: Sharing files and folders with internal users
   @mailhog
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
+    And user "user1" has been created with default attributes
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
     And the user has opened the share dialog for file "lorem.txt"
@@ -276,6 +322,8 @@ Feature: Sharing files and folders with internal users
 
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
+    And user "user1" has been created with default attributes
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
     When the user opens the share dialog for file "lorem.txt"


### PR DESCRIPTION
## Description
Decrease CI run time for `webUISharingInternalUsers`  suite

Many tests don't require files/folder still, the skeleton files are copied
using `user "<user-name>" has been created with default attributes and without skeleton files` 
we now don't copy skeleton files for those users.

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>