### PR TITLE
Log exceptions from exceptionHandler method

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -55,10 +55,9 @@ class Application {
 	 * @param EventDispatcherInterface $dispatcher
 	 * @param IRequest $request
 	 */
-	public function __construct(IConfig $config, EventDispatcherInterface $dispatcher, IRequest $request) {
-		$defaults = new OC_Defaults;
+	public function __construct(IConfig $config, SymfonyApplication $application, EventDispatcherInterface $dispatcher, IRequest $request) {
 		$this->config = $config;
-		$this->application = new SymfonyApplication($defaults->getName(), \OC_Util::getVersionString());
+		$this->application = $application;
 		$this->dispatcher = $dispatcher;
 		$this->request = $request;
 	}

--- a/tests/acceptance/features/cliMain/maintenance.feature
+++ b/tests/acceptance/features/cliMain/maintenance.feature
@@ -32,4 +32,4 @@ Feature: Maintenance command
   Scenario: Running single repair step without providing value should fail
     When the administrator invokes occ command "maintenance:repair --single"
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The "--single" option requires a value'
+    And the command output should contain the text 'The "--single" option requires a value'

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -40,4 +40,4 @@ Feature: security certificates
 
   Scenario: Import random file as certificate
     When the administrator imports security certificate from the path "tests/data/lorem.txt"
-    Then the command error output should contain the text "Certificate could not get parsed."
+    Then the command output should contain the text "Certificate could not get parsed."


### PR DESCRIPTION
Log exceptions from console.php

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Log exceptions from console.php. As of now the exceptions are thrown in the console and then the script is exited. Before the script exits, it would be better to log the exception. This change set achieves the goal.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Log the exception that happens in the `exceptionHandler()` in console.php

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I updated the changes as shown below
   - Before line `require_once 'public/Constants.php';` in lib/base.php add `hello`
   - Now run `./occ a:l`, you should see exception:
```
Cannot load Xdebug - it was already loaded
System is broken.
ParseError: syntax error, unexpected 'require_once' (T_REQUIRE_ONCE) in /home/sujith/test/owncloud3/lib/base.php:61
Stack trace:
#0 /home/sujith/test/owncloud3/occ(11): require_once()
#1 {main}%
```
   - Now remove `hello` and add `throw new \Exception('foo');` and re-run the command `./occ a:l`, you should see message like this in the console.
```
System is broken.
Exception: foo in /home/sujith/test/owncloud3/lib/base.php:60
Stack trace:
#0 /home/sujith/test/owncloud3/console.php(65): require_once()
#1 /home/sujith/test/owncloud3/occ(11): require_once('/home/sujith/te...')
#2 {main}%
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
