### PR TITLE
make search tests more flexible

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -102,9 +102,14 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" and limits the results to "1" items using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result should contain "1" entries
-    And the search result should contain these entries:
-      | /upload folder |
+    And the search result should contain any "1" of these entries:
+      | /just-a-folder/upload.txt     |
+      | /just-a-folder/uploadÜठिF.txt |
+      | /upload folder                |
+      | /upload.txt                   |
+      | /फनी näme/upload.txt          |
+      | /upload😀 😁                  |
+      | /upload😀 😁/upload😀 😁.txt  |
     Examples:
       | dav_version |
       | old         |


### PR DESCRIPTION
## Description
these tests fail in drone for encryption, files_primary_s3 and user_ldap. I guess its because of the new uploaded files that contain the "upload" string and some other one gets to be shown first in some cases

CC @bhawanaprasain 

## Motivation and Context
fix CI
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
