### PR TITLE
Fix feature context undefined on provisioning.php

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -279,14 +279,14 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles($user) {
-		$this->featureContext->runOcc(["config:system:get skeletondirectory"]);
-		$path = \trim($this->featureContext->getStdOutOfOccCommand());
-		$this->featureContext->runOcc(["config:system:delete skeletondirectory"]);
+		$this->runOcc(["config:system:get skeletondirectory"]);
+		$path = \trim($this->getStdOutOfOccCommand());
+		$this->runOcc(["config:system:delete skeletondirectory"]);
 		try {
-			$this->featureContext->userHasBeenCreatedWithDefaultAttributes($user);
+			$this->userHasBeenCreatedWithDefaultAttributes($user);
 		} finally {
 			// restore skeletondirectory even if user creation failed
-			$this->featureContext->runOcc(["config:system:set skeletondirectory --value $path"]);
+			$this->runOcc(["config:system:set skeletondirectory --value $path"]);
 		}
 	}
 


### PR DESCRIPTION
## Description
#35355 introduced `featureContext undefined` error in drone when the step was called 
on activity app.

## Related Issue

## Motivation and Context

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>