### PR TITLE
Change 'in the webUI' to 'on  the webUI'

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1118,8 +1118,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserOpensTheSharingTabFromTheActionMenuOfFileUsingTheWebui($entryName) {
-		$this->theUserOpensTheFileActionMenuOfFileFolderInTheWebui($entryName);
-		$this->theUserClicksTheFileActionInTheWebui("details");
+		$this->theUserOpensTheFileActionMenuOfFileFolderOnTheWebui($entryName);
+		$this->theUserClicksTheFileActionOnTheWebui("details");
 		$this->theUserSwitchesToTabInDetailsPanelUsingTheWebui("sharing");
 		$this->filesPage->waitForAjaxCallsToStartAndFinish($this->getSession());
 	}
@@ -1411,7 +1411,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @param string $shouldOrNot
 	 * @param string $typeOfFilesPage
 	 * @param string $folder
-	 * @param string $path if set, name and path (shown in the webUI) of the file need match
+	 * @param string $path if set, name and path (shown on the webUI) of the file to match
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -1699,7 +1699,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the option to (delete|rename|download)\s?(?:file|folder) "([^"]*)" should (not|)\s?be available in the webUI$/
+	 * @Then /^the option to (delete|rename|download)\s?(?:file|folder) "([^"]*)" should (not|)\s?be available on the webUI$/
 	 *
 	 * @param string $action
 	 * @param string $name
@@ -1724,7 +1724,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the option to upload file should (not|)\s?be available in the webUI$/
+	 * @Then /^the option to upload file should (not|)\s?be available on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 *
@@ -2031,27 +2031,27 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user opens the file action menu of file/folder :name in the webUI
+	 * @When the user opens the file action menu of file/folder :name on the webUI
 	 *
 	 * @param string $name Name of the file/Folder
 	 *
 	 * @return void
 	 */
-	public function theUserOpensTheFileActionMenuOfFileFolderInTheWebui($name) {
+	public function theUserOpensTheFileActionMenuOfFileFolderOnTheWebui($name) {
 		$session = $this->getSession();
 		$this->selectedFileRow = $this->getCurrentPageObject()->findFileRowByName($name, $session);
 		$this->openedFileActionMenu = $this->selectedFileRow->openFileActionsMenu($session);
 	}
 
 	/**
-	 * @Then the user should see :action_label file action translated to :translated_label in the webUI
+	 * @Then the user should see :action_label file action translated to :translated_label on the webUI
 	 *
 	 * @param string $action_label
 	 * @param string $translated_label
 	 *
 	 * @return void
 	 */
-	public function theUserShouldSeeFileActionTranslatedToInTheWebui($action_label, $translated_label) {
+	public function theUserShouldSeeFileActionTranslatedToOnTheWebui($action_label, $translated_label) {
 		PHPUnit\Framework\Assert::assertSame(
 			$translated_label,
 			$this->openedFileActionMenu->getActionLabelLocalized($action_label)
@@ -2059,14 +2059,14 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user clicks the :action_label file action in the webUI
+	 * @When the user clicks the :action_label file action on the webUI
 	 *
 	 * @param string $action_label
 	 *
 	 * @throws \Exception
 	 * @return void
 	 */
-	public function theUserClicksTheFileActionInTheWebui($action_label) {
+	public function theUserClicksTheFileActionOnTheWebui($action_label) {
 		switch ($action_label) {
 			case "details":
 				$this->openedFileActionMenu->openDetails();
@@ -2087,11 +2087,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the details dialog should be visible in the webUI
+	 * @Then the details dialog should be visible on the webUI
 	 *
 	 * @return void
 	 */
-	public function theDetailsDialogShouldBeVisibleInTheWebui() {
+	public function theDetailsDialogShouldBeVisibleOnTheWebui() {
 		PHPUnit\Framework\Assert::assertTrue($this->filesPage->getDetailsDialog()->isDialogVisible());
 	}
 
@@ -2152,12 +2152,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		if ($should) {
 			PHPUnit\Framework\Assert::assertTrue(
 				$detailsDialog->isCommentOnUI($text),
-				"Failed to find comment with text $text in the webUI"
+				"Failed to find comment with text $text on the webUI"
 			);
 		} else {
 			PHPUnit\Framework\Assert::assertFalse(
 				$detailsDialog->isCommentOnUI($text),
-				"The comment with text $text exists in the webUI"
+				"The comment with text $text exists on the webUI"
 			);
 		}
 	}

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -108,13 +108,13 @@ class WebUIHelpAndTipsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the link for :linkTitle should be shown in the webUI
+	 * @Then the link for :linkTitle should be shown on the webUI
 	 *
 	 * @param string $linkTitle
 	 *
 	 * @return void
 	 */
-	public function theLinkForShouldBeShownInTheWebui($linkTitle) {
+	public function theLinkForShouldBeShownOnTheWebui($linkTitle) {
 		$link = $this->helpAndTipsPage->getLinkByTitle($linkTitle);
 		$this->helpAndTipsPage->assertElementNotNull(
 			$link,

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -188,34 +188,34 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @Then the owncloud version should be displayed on the personal general settings page in the webUI
+	 * @Then the owncloud version should be displayed on the personal general settings page on the webUI
 	 *
 	 * @return void
 	 */
-	public function theOwncloudVersionShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui() {
+	public function theOwncloudVersionShouldBeDisplayedOnThePersonalGeneralSettingsPageOnTheWebui() {
 		PHPUnit\Framework\Assert::assertTrue($this->personalGeneralSettingsPage->isVersionDisplayed());
 	}
 
 	/**
-	 * @Then the federated cloud id for user :user should be displayed on the personal general settings page in the webUI
+	 * @Then the federated cloud id for user :user should be displayed on the personal general settings page on the webUI
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
-	public function theFederatedCloudIdForUserShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($user) {
+	public function theFederatedCloudIdForUserShouldBeDisplayedOnThePersonalGeneralSettingsPageOnTheWebui($user) {
 		$userFederatedCloudId = $user . "@" . $this->featureContext->getLocalBaseUrlWithoutScheme();
 		PHPUnit\Framework\Assert::assertEquals($this->personalGeneralSettingsPage->getFederatedCloudID(), $userFederatedCloudId);
 	}
 
 	/**
-	 * @Then group :groupName should be displayed on the personal general settings page in the webUI
+	 * @Then group :groupName should be displayed on the personal general settings page on the webUI
 	 *
 	 * @param string $groupName
 	 *
 	 * @return void
 	 */
-	public function groupShouldBeDisplayedOnThePersonalGeneralSettingsPageInTheWebui($groupName) {
+	public function groupShouldBeDisplayedOnThePersonalGeneralSettingsPageOnTheWebui($groupName) {
 		PHPUnit\Framework\Assert::assertTrue($this->personalGeneralSettingsPage->isGroupNameDisplayed($groupName));
 	}
 
@@ -280,17 +280,17 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theUserHasSetProfilePictureToFromTheirCloudFiles($filename) {
 		$this->theUserSetsProfilePictureToFromTheirCloudFiles($filename);
-		$this->thePreviewOfTheProfilePictureShouldBeShownInTheWebui("");
+		$this->thePreviewOfTheProfilePictureShouldBeShownOnTheWebui("");
 	}
 
 	/**
-	 * @Then /^the preview of the profile picture should (not|)\s?be shown in the webUI$/
+	 * @Then /^the preview of the profile picture should (not|)\s?be shown on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 *
 	 * @return void
 	 */
-	public function thePreviewOfTheProfilePictureShouldBeShownInTheWebui($shouldOrNot) {
+	public function thePreviewOfTheProfilePictureShouldBeShownOnTheWebui($shouldOrNot) {
 		if ($shouldOrNot !== "not") {
 			PHPUnit\Framework\Assert::assertTrue(
 				$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -95,22 +95,22 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @Then User-based auto accepting checkbox should not be displayed on the personal sharing settings page in the webUI
+	 * @Then User-based auto accepting checkbox should not be displayed on the personal sharing settings page on the webUI
 	 *
 	 * @return void
 	 */
-	public function autoAcceptingCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageInTheWebui() {
+	public function autoAcceptingCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageOnTheWebui() {
 		PHPUnit\Framework\Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAutoAcceptLocalSharesCheckboxDisplayed()
 		);
 	}
 
 	/**
-	 * @Then User-based auto accepting from trusted servers checkbox should not be displayed on the personal sharing settings page in the webUI
+	 * @Then User-based auto accepting from trusted servers checkbox should not be displayed on the personal sharing settings page on the webUI
 	 *
 	 * @return void
 	 */
-	public function autoAcceptingFederatedCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageInTheWebui() {
+	public function autoAcceptingFederatedCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageOnTheWebui() {
 		PHPUnit\Framework\Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAutoAcceptFederatedSharesCheckboxDisplayed()
 		);

--- a/tests/acceptance/features/bootstrap/WebUITagsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUITagsContext.php
@@ -81,7 +81,7 @@ class WebUITagsContext extends RawMinkContext implements Context {
 		$this->filesPage->getDetailsDialog()->addTag($tagName);
 
 		// For tags to be created, OC checks (|for the permission) if the tag could be created
-		// and if it can, then only it creates a tag. So, in the webUI, it does two
+		// and if it can, then only it creates a tag. So, on the webUI, it does two
 		// requests before the tags are created.
 		// If we use a single wait, it returns after it has checked for the permission.
 		// Locally that passes but sometimes fail on the ci. So, we need two waits for each requests.

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -652,7 +652,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	}
 
 	/**
-	 * Return is New File/folder button is available in the webUI
+	 * Return is New File/folder button is available on the webUI
 	 *
 	 * @return boolean
 	 */

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -223,7 +223,7 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
-	 * get the list of comments listed in the webUI
+	 * get the list of comments listed on the webUI
 	 *
 	 * @return NodeElement[]
 	 */
@@ -233,7 +233,7 @@ class DetailsDialog extends OwncloudPage {
 		);
 	}
 	/**
-	 * check if a comment with given text is listed in the webUI
+	 * check if a comment with given text is listed on the webUI
 	 *
 	 * @param string $text
 	 *
@@ -254,7 +254,7 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
-	 * add a comment in a file whose details dialog is shown in the webUI
+	 * add a comment in a file whose details dialog is shown on the webUI
 	 *
 	 * @param Session $session
 	 * @param string $content
@@ -290,7 +290,7 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
-	 * delete the comment in a file whose details dialog is shown in the webUI with given content
+	 * delete the comment in a file whose details dialog is shown on the webUI with given content
 	 *
 	 * @param string $content
 	 *

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -260,7 +260,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	}
 
 	/**
-	 * Check if the preview of the profile pic is shown in the webui
+	 * Check if the preview of the profile pic is shown on the webui
 	 *
 	 * @return boolean
 	 */

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -114,7 +114,7 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
-	 * Check if the auto accept local shares checkbox is shown in the webui
+	 * Check if the auto accept local shares checkbox is shown on the webui
 	 *
 	 * @return boolean
 	 */
@@ -127,7 +127,7 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
-	 * Check if the auto accept local shares checkbox is shown in the webui
+	 * Check if the auto accept local shares checkbox is shown on the webui
 	 *
 	 * @return boolean
 	 */
@@ -140,7 +140,7 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
-	 * Check if the allow finding you via autocomplete checkbox is shown in the webui
+	 * Check if the allow finding you via autocomplete checkbox is shown on the webui
 	 *
 	 * @return boolean
 	 */

--- a/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
+++ b/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
@@ -8,7 +8,7 @@ Feature: Help and tips page
     Given the administrator has browsed to the help and tips page
 
   Scenario Outline: Admin can view links in help and tips page
-    Then the link for "<linkName>" should be shown in the webUI
+    Then the link for "<linkName>" should be shown on the webUI
     And the link for "<linkName>" should be valid
     Examples:
       | linkName                        |

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -13,9 +13,9 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_versions-app-required
   Scenario: View different areas of the details panel in files page
-    When the user opens the file action menu of file "lorem.txt" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
+    When the user opens the file action menu of file "lorem.txt" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
     When the user switches to "sharing" tab in details panel using the webUI
     Then the "sharing" details panel should be visible
@@ -28,9 +28,9 @@ Feature: User can open the details panel for any file or folder
   Scenario: View different areas of the details panel in favorites page
     When the user marks file "lorem.txt" as favorite using the webUI
     And the user browses to the favorites page
-    And the user opens the file action menu of file "lorem.txt" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
+    And the user opens the file action menu of file "lorem.txt" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
     When the user switches to "sharing" tab in details panel using the webUI
     Then the "sharing" details panel should be visible
@@ -44,9 +44,9 @@ Feature: User can open the details panel for any file or folder
     Given the user has created a new public link for folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page
     Then folder "simple-folder" should be listed on the webUI
-    When the user opens the file action menu of folder "simple-folder" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
+    When the user opens the file action menu of folder "simple-folder" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
     When the user switches to "sharing" tab in details panel using the webUI
     Then the "sharing" details panel should be visible
@@ -59,9 +59,9 @@ Feature: User can open the details panel for any file or folder
     And the user has shared folder "simple-folder" with user "User Two" using the webUI
     When the user browses to the shared-with-others page
     Then folder "simple-folder" should be listed on the webUI
-    When the user opens the file action menu of folder "simple-folder" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
+    When the user opens the file action menu of folder "simple-folder" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
     When the user switches to "sharing" tab in details panel using the webUI
     Then the "sharing" details panel should be visible
@@ -75,9 +75,9 @@ Feature: User can open the details panel for any file or folder
     And the user re-logs in as "user2" using the webUI
     When the user browses to the shared-with-you page
     Then folder "simple-folder (2)" should be listed on the webUI
-    When the user opens the file action menu of folder "simple-folder (2)" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
+    When the user opens the file action menu of folder "simple-folder (2)" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
     When the user switches to "sharing" tab in details panel using the webUI
     Then the "sharing" details panel should be visible
@@ -91,9 +91,9 @@ Feature: User can open the details panel for any file or folder
     When the user browses to the tags page
     And the user searches for tag "simple" using the webUI
     Then folder "simple-folder" should be listed on the webUI
-    When the user opens the file action menu of folder "simple-folder" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
+    When the user opens the file action menu of folder "simple-folder" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
     When the user switches to "sharing" tab in details panel using the webUI
     Then the "sharing" details panel should be visible

--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -43,7 +43,7 @@ Feature: Versions of a file
     And the versions list should contain 2 entries
 
   @skipOnStorage:ceph @files_primary_s3-issue-155
-  Scenario: file versions cannot be seen in the webUI after deleting versions
+  Scenario: file versions cannot be seen on the webUI after deleting versions
     Given user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "new lorem content" to "/lorem-file.txt"
@@ -54,7 +54,7 @@ Feature: Versions of a file
     And the versions list should contain 0 entries
 
   @skipOnStorage:ceph @files_primary_s3-issue-155
-  Scenario: file versions cannot be seen in the webUI only for user whose versions is deleted
+  Scenario: file versions cannot be seen on the webUI only for user whose versions is deleted
     Given user "user1" has been created with default attributes
     And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
@@ -72,7 +72,7 @@ Feature: Versions of a file
     Then the versions list should contain 1 entries
 
   @skipOnStorage:ceph @files_primary_s3-issue-155
-  Scenario: file versions cannot be seen in the webUI for all users after deleting versions for all users
+  Scenario: file versions cannot be seen on the webUI for all users after deleting versions for all users
     Given user "user1" has been created with default attributes
     And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -17,23 +17,23 @@ Feature: personal general settings
   Scenario: change language and check that file actions menu have been translated
     When the user changes the language to "हिन्दी" using the webUI
     And the user browses to the files page
-    And the user opens the file action menu of folder "simple-folder" in the webUI
-    Then the user should see "Details" file action translated to "विवरण" in the webUI
-    And the user should see "Delete" file action translated to "हटाना" in the webUI
+    And the user opens the file action menu of folder "simple-folder" on the webUI
+    Then the user should see "Details" file action translated to "विवरण" on the webUI
+    And the user should see "Delete" file action translated to "हटाना" on the webUI
 
   Scenario: change language using the occ command and check that file actions menu have been translated
     When the administrator changes the language of user "user1" to "fr" using the occ command
     And the user browses to the files page
-    And the user opens the file action menu of folder "simple-folder" in the webUI
-    Then the user should see "Details" file action translated to "Détails" in the webUI
-    And the user should see "Delete" file action translated to "Supprimer" in the webUI
+    And the user opens the file action menu of folder "simple-folder" on the webUI
+    Then the user should see "Details" file action translated to "Détails" on the webUI
+    And the user should see "Delete" file action translated to "Supprimer" on the webUI
 
   Scenario: change language to invalid language using the occ command and check that the language defaults back to english
     When the administrator changes the language of user "user1" to "not-valid-lan" using the occ command
     And the user browses to the files page
-    And the user opens the file action menu of folder "simple-folder" in the webUI
-    Then the user should see "Details" file action translated to "Details" in the webUI
-    And the user should see "Delete" file action translated to "Delete" in the webUI
+    And the user opens the file action menu of folder "simple-folder" on the webUI
+    Then the user should see "Details" file action translated to "Details" on the webUI
+    And the user should see "Delete" file action translated to "Delete" on the webUI
 
   Scenario: user sees displayed version number, groupnames and federated cloud ID on the personal general settings page
     Given group "new-group" has been created
@@ -41,25 +41,25 @@ Feature: personal general settings
     And user "user1" has been added to group "new-group"
     And user "user1" has been added to group "another-group"
     And the user has reloaded the current page of the webUI
-    Then the owncloud version should be displayed on the personal general settings page in the webUI
-    And the federated cloud id for user "user1" should be displayed on the personal general settings page in the webUI
-    And group "new-group" should be displayed on the personal general settings page in the webUI
-    And group "another-group" should be displayed on the personal general settings page in the webUI
+    Then the owncloud version should be displayed on the personal general settings page on the webUI
+    And the federated cloud id for user "user1" should be displayed on the personal general settings page on the webUI
+    And group "new-group" should be displayed on the personal general settings page on the webUI
+    And group "another-group" should be displayed on the personal general settings page on the webUI
 
   Scenario: User sets profile picture from their existing cloud file
     Given the user has deleted any existing profile picture
     When the user sets profile picture to "testimage.jpg" from their cloud files using the webUI
-    Then the preview of the profile picture should be shown in the webUI
+    Then the preview of the profile picture should be shown on the webUI
 
   Scenario: User deletes the existing profile picture
     Given the user has set profile picture to "testimage.jpg" from their cloud files
     When the user deletes the existing profile picture
-    Then the preview of the profile picture should not be shown in the webUI
+    Then the preview of the profile picture should not be shown on the webUI
 
   Scenario: User uploads new profile picture
     Given the user has deleted any existing profile picture
     When the user uploads "testavatar.png" as a new profile picture using the webUI
-    Then the preview of the profile picture should be shown in the webUI
+    Then the preview of the profile picture should be shown on the webUI
 
   Scenario Outline: User tries to upload different files as profile picture
     Given the user has deleted any existing profile picture

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -274,7 +274,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
-    Then User-based auto accepting checkbox should not be displayed on the personal sharing settings page in the webUI
+    Then User-based auto accepting checkbox should not be displayed on the personal sharing settings page on the webUI
 
   Scenario: Admin disables auto-accept setting again after user enabled personal auto-accept setting
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -100,7 +100,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And the user has browsed to the personal sharing settings page
-    Then User-based auto accepting from trusted servers checkbox should not be displayed on the personal sharing settings page in the webUI
+    Then User-based auto accepting from trusted servers checkbox should not be displayed on the personal sharing settings page on the webUI
 
   @skip @issue-34742
   Scenario: User-based & global auto accepting is enabled but remote server is not trusted

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -429,17 +429,17 @@ Feature: Share by public link
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     When the public accesses the last created public link using the webUI
-    Then the option to rename file "lorem.txt" should not be available in the webUI
-    And the option to delete file "lorem.txt" should not be available in the webUI
-    And the option to upload file should be available in the webUI
+    Then the option to rename file "lorem.txt" should not be available on the webUI
+    And the option to delete file "lorem.txt" should not be available on the webUI
+    And the option to upload file should be available on the webUI
 
   Scenario: Permissions work correctly on public link share with read-write
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
-    Then the option to rename file "lorem.txt" should be available in the webUI
-    And the option to delete file "lorem.txt" should be available in the webUI
-    And the option to upload file should be available in the webUI
+    Then the option to rename file "lorem.txt" should be available on the webUI
+    And the option to delete file "lorem.txt" should be available on the webUI
+    And the option to upload file should be available on the webUI
 
   Scenario: User tries to upload existing file in public link share with permissions upload-write-without-modify
     Given the user has created a new public link for folder "simple-folder" using the webUI with
@@ -468,13 +468,13 @@ Feature: Share by public link
     And the user opens the public link share tab
     And the user changes the permission of the public link named "Public link" to "upload-write-without-modify"
     And the public accesses the last created public link using the webUI
-    Then the option to delete file "lorem-big.txt" should not be available in the webUI
+    Then the option to delete file "lorem-big.txt" should not be available on the webUI
 
   Scenario: Editing the permission on a existing share from upload-write-without-modify to read-write works correctly
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
-    Then the option to delete file "lorem.txt" should not be available in the webUI
+    Then the option to delete file "lorem.txt" should not be available on the webUI
     When the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
     And the user opens the public link share tab


### PR DESCRIPTION
## Description
Change "in the webUI" and `InTheWebUI` in acceptance tests to "on".

## Motivation and Context
For the majority of webUI acceptance tests we write "on the webUI". But for some steps we have been inconsistent and written "in the webUI". Make it consistent.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
