### PR TITLE
[stable10] Backport of Fix recreate masterkey for hsm

### DIFF
--- a/apps/encryption/lib/Command/RecreateMasterKey.php
+++ b/apps/encryption/lib/Command/RecreateMasterKey.php
@@ -21,25 +21,13 @@
 
 namespace OCA\Encryption\Command;
 
-use OC\Encryption\DecryptAll;
-use OC\Encryption\Manager;
 use OC\Files\View;
-use OCA\Encryption\Crypto\EncryptAll;
-use OCA\Encryption\KeyManager;
-use OCA\Encryption\Users\Setup;
+use OCA\Encryption\Factory\EncDecAllFactory;
 use OCA\Encryption\Util;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
-use OCP\IConfig;
-use OCP\IL10N;
-use OCP\ILogger;
-use OCP\ISession;
-use OCP\IUserManager;
-use OCP\Mail\IMailer;
-use OCP\Security\ISecureRandom;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -47,17 +35,8 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class RecreateMasterKey extends Command {
 
-	/** @var Manager  */
-	protected $encryptionManager;
-
-	/** @var IUserManager  */
-	protected $userManager;
-
 	/** @var View  */
 	protected $rootView;
-
-	/** @var KeyManager  */
-	protected $keyManager;
 
 	/** @var Util  */
 	protected $util;
@@ -71,34 +50,8 @@ class RecreateMasterKey extends Command {
 	/** @var  IAppConfig */
 	protected $appConfig;
 
-	/** @var IConfig  */
-	protected $config;
-
-	/** @var ISession  */
-	protected $session;
-
-	/** @var QuestionHelper  */
-	protected $questionHelper;
-
-	/** @var Setup  */
-	protected $userSetup;
-
-	/** @var IMailer  */
-	protected $mailer;
-
-	/** @var ISecureRandom  */
-	protected $secureRandom;
-
-	/** @var IL10N  */
-	protected $l;
-
-	/** @var ILogger  */
-	protected $logger;
-
-	/** @var  */
-	protected $encryptAll;
-
-	protected $decryptAll;
+	/** @var EncDecAllFactory */
+	private $encDecAllFactory;
 
 	/** @var array files which couldn't be decrypted */
 	protected $failed;
@@ -106,42 +59,23 @@ class RecreateMasterKey extends Command {
 	/**
 	 * RecreateMasterKey constructor.
 	 *
-	 * @param IUserManager $userManager
 	 * @param View $rootView
-	 * @param KeyManager $keyManager
 	 * @param Util $util
+	 * @param \OC\Encryption\Util $encUtil
 	 * @param IAppManager $appManager
 	 * @param IAppConfig $appConfig
-	 * @param IConfig $config
-	 * @param ISession $session
-	 * @param QuestionHelper $questionHelper
-	 * @param Setup $userSetup
-	 * @param IMailer $mailer
-	 * @param ISecureRandom $secureRandom
-	 * @param IL10N $l
-	 * @param ILogger $logger
+	 * @param EncDecAllFactory $encDecAllFactory
 	 */
-	public function __construct(IUserManager $userManager, View $rootView, KeyManager $keyManager, Util $util, \OC\Encryption\Util $encUtil,
-								IAppManager $appManager, IAppConfig $appConfig, IConfig $config, ISession $session,
-								Manager $encryptionManager, QuestionHelper $questionHelper, Setup $userSetup, IMailer $mailer,
-								ISecureRandom $secureRandom, IL10N $l, ILogger $logger) {
+	public function __construct(View $rootView, Util $util, \OC\Encryption\Util $encUtil,
+								IAppManager $appManager, IAppConfig $appConfig,
+								EncDecAllFactory $encDecAllFactory) {
 		parent::__construct();
-		$this->userManager = $userManager;
 		$this->rootView = $rootView;
-		$this->keyManager = $keyManager;
 		$this->util = $util;
 		$this->encUtil = $encUtil;
 		$this->appManager = $appManager;
 		$this->appConfig = $appConfig;
-		$this->config = $config;
-		$this->session = $session;
-		$this->encryptionManager = $encryptionManager;
-		$this->questionHelper = $questionHelper;
-		$this->userSetup = $userSetup;
-		$this->mailer = $mailer;
-		$this->secureRandom = $secureRandom;
-		$this->l = $l;
-		$this->logger = $logger;
+		$this->encDecAllFactory = $encDecAllFactory;
 	}
 
 	protected function configure() {
@@ -166,14 +100,18 @@ class RecreateMasterKey extends Command {
 			$question = new ConfirmationQuestion(
 				'Warning: In order to re-create master key, the entire ownCloud filesystem will be decrypted and then encrypted using new master key.'
 				. ' Do you want to continue? (y/n)', false);
-			if ($yes || $this->questionHelper->ask($input, $output, $question)) {
+			//$questionHelper = $this->getHelper('question');
+			if ($yes || $this->getHelper('question')->ask($input, $output, $question)) {
 				$output->writeln("Decryption started\n");
 				$progress = new ProgressBar($output);
 				$progress->start();
 				$progress->setMessage("Decryption in progress...");
 				$progress->advance();
 
-				$this->decryptAllUsers($input, $output);
+				//Get DecryptAll object from the factory
+				$decryptAll = $this->encDecAllFactory->getDecryptAllObj();
+				$decryptAll->decryptAll($input, $output);
+
 				$progress->finish();
 
 				if (empty($this->failed)) {
@@ -187,69 +125,44 @@ class RecreateMasterKey extends Command {
 						$this->rootView->deleteAll($filesEncryptionDir . '/files_encryption');
 					}
 
-					$this->appConfig->setValue('core', 'encryption_enabled', 'no');
-					$this->appConfig->deleteKey('encryption', 'useMasterKey');
-					$this->appConfig->deleteKey('encryption', 'masterKeyId');
-					$this->appConfig->deleteKey('encryption', 'recoveryKeyId');
-					$this->appConfig->deleteKey('encryption', 'publicShareKeyId');
-					$this->appConfig->deleteKey('files_encryption', 'installed_version');
+					$this->util->removeEncryptionAppSettings();
 				}
 				$output->writeln("\nDecryption completed\n");
 
 				//Reencrypt again
 				$this->appManager->enableApp('encryption');
 				$this->appConfig->setValue('core', 'encryption_enabled', 'yes');
-				$this->appConfig->setValue('encryption', 'enabled', 'yes');
-				$output->writeln("Encryption started\n");
+				$this->appConfig->setValue('encryption', 'useMasterKey', '1');
 
 				$output->writeln("Waiting for creating new masterkey\n");
 
-				$this->keyManager->setPublicShareKeyIDAndMasterKeyId();
-
+				//Get the EncryptAll object from factory
+				$encryptAll = $this->encDecAllFactory->getEncryptAllObj();
+				if ($encryptAll->createMasterKey($input, $output) === false) {
+					$output->writeln("<error>Error: masterkeys creation failed</error>");
+					return 1;
+				}
 				$output->writeln("New masterkey created successfully\n");
 
-				$this->appConfig->setValue('encryption', 'enabled', 'yes');
-				$this->appConfig->setValue('encryption', 'useMasterKey', '1');
+				$output->writeln("Encryption started\n");
+				/**
+				 * We are reusing the encryptAll code but not the decryptAll. The reason being
+				 * decryptAll finishes by encrypting. Which is not what we want. This will make
+				 * things out of scope for this command. We want first the entire oC FS to be
+				 * decrypt. Then re-encrypt the entire oC FS with the new master key generated.
+				 */
+				$encryptAll->encryptAll($input, $output);
 
-				/**
-				 * Call validateShareKey method, to check if public share exists,
-				 * else create one.
-				 */
-				$this->keyManager->validateShareKey();
-				/**
-				 * Same here, check if public masterkey exists else
-				 * create one.
-				 */
-				$this->keyManager->validateMasterKey();
-				$this->encryptAllUsers($input, $output);
 				$output->writeln("\nEncryption completed successfully\n");
 				$output->writeln("\n<info>Note: All users are required to relogin.</info>\n");
+				return 0;
 			} else {
 				$output->writeln("The process is abandoned");
+				return 2;
 			}
 		} else {
 			$output->writeln("Master key is not enabled.\n");
+			return 3;
 		}
-	}
-
-	protected function decryptAllUsers(InputInterface $input, OutputInterface $output) {
-		$this->decryptAll = new DecryptAll($this->encryptionManager, $this->userManager, $this->rootView, $this->logger);
-		$this->decryptAll->decryptAll($input, $output);
-	}
-
-	protected function encryptAllUsers(InputInterface $input, OutputInterface $output) {
-		/*
-		 * We are reusing the encryptAll code but not the decryptAll. The reason being
-		 * decryptAll finishes by encrypting. Which is not what we want. This will make
-		 * things out of scope for this command. We want first the entire oC FS to be
-		 * decrypt. Then re-encrypt the entire oC FS with the new master key generated.
-		 *
-		 */
-		$this->encryptAll = new EncryptAll(
-			$this->userSetup, $this->userManager, $this->rootView,
-			$this->keyManager, $this->util, $this->config,
-			$this->mailer, $this->l, $this->questionHelper,
-			$this->secureRandom);
-		$this->encryptAll->encryptAll($input, $output);
 	}
 }

--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -120,6 +120,28 @@ class EncryptAll {
 	}
 
 	/**
+	 * Call this method only when no master key is created.
+	 *
+	 * @return bool true when masterkey and sharekey is created else false
+	 */
+	public function createMasterKey() {
+		$this->keyManager->setPublicShareKeyIDAndMasterKeyId();
+
+		/**
+		 * Call validateShareKey method, to check if public share exists,
+		 * else create one.
+		 */
+		$this->keyManager->validateShareKey();
+
+		/**
+		 * Same here, check if public masterkey exists else
+		 * create one.
+		 */
+		$this->keyManager->validateMasterKey();
+		return (!empty($this->keyManager->getPublicShareKey()) && !empty($this->keyManager->getPublicMasterKey()));
+	}
+
+	/**
 	 * start to encrypt all files
 	 *
 	 * @param InputInterface $input

--- a/apps/encryption/lib/Factory/EncDecAllFactory.php
+++ b/apps/encryption/lib/Factory/EncDecAllFactory.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Factory;
+
+use OC\Encryption\DecryptAll;
+use OC\Encryption\Manager;
+use OC\Files\View;
+use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\Crypto\CryptHSM;
+use OCA\Encryption\Crypto\EncryptAll;
+use OCA\Encryption\KeyManager;
+use OCA\Encryption\Session;
+use OCA\Encryption\Users\Setup;
+use OCA\Encryption\Util;
+use OCP\Encryption\Keys\IStorage;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Mail\IMailer;
+use OCP\Security\ISecureRandom;
+use Symfony\Component\Console\Helper\QuestionHelper;
+
+class EncDecAllFactory {
+	/** @var Manager  */
+	private $encryptionManager;
+
+	/** @var IUserManager  */
+	private $userManager;
+
+	/** @var ILogger  */
+	private $logger;
+
+	/** @var Util  */
+	private $encUtil;
+
+	/** @var IConfig  */
+	private $config;
+
+	/** @var IMailer  */
+	private $mailer;
+
+	/** @var IL10N  */
+	private $l10n;
+
+	/** @var QuestionHelper  */
+	private $questionHelper;
+
+	/** @var ISecureRandom  */
+	private $secureRandom;
+
+	/** @var IStorage  */
+	private $encStorage;
+
+	/** @var IUserSession  */
+	private $userSession;
+
+	/** @var Session  */
+	private $encSession;
+
+	/** @var CryptHSM  */
+	private $cryptHSM;
+
+	/** @var Crypt  */
+	private $crypt;
+
+	/**
+	 * EncDecAllFactory constructor.
+	 *
+	 * @param Manager $encryptionManager
+	 * @param IUserManager $userManager
+	 * @param ILogger $logger
+	 * @param Util $encUtil
+	 * @param IConfig $config
+	 * @param IMailer $mailer
+	 * @param IL10N $l10n
+	 * @param QuestionHelper $questionHelper
+	 * @param ISecureRandom $secureRandom
+	 * @param IStorage $encStorage
+	 * @param Session $encSession
+	 * @param CryptHSM $cryptHSM
+	 * @param Crypt $crypt
+	 * @param IUserSession $userSession
+	 */
+	public function __construct(Manager $encryptionManager, IUserManager $userManager,
+								ILogger $logger, Util $encUtil, IConfig $config, IMailer $mailer,
+								IL10N $l10n, QuestionHelper $questionHelper, ISecureRandom $secureRandom,
+								IStorage $encStorage, Session $encSession, CryptHSM $cryptHSM,
+								Crypt $crypt, IUserSession $userSession) {
+		$this->encryptionManager = $encryptionManager;
+		$this->userManager = $userManager;
+		$this->logger = $logger;
+		$this->encUtil = $encUtil;
+		$this->config = $config;
+		$this->mailer = $mailer;
+		$this->l10n = $l10n;
+		$this->questionHelper = $questionHelper;
+		$this->secureRandom = $secureRandom;
+		$this->encStorage = $encStorage;
+		$this->encSession = $encSession;
+		$this->cryptHSM = $cryptHSM;
+		$this->crypt = $crypt;
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * Returns DecryptAll object
+	 *
+	 * @return DecryptAll
+	 */
+	public function getDecryptAllObj() {
+		$rootView = new View("/");
+		return new DecryptAll($this->encryptionManager, $this->userManager, $rootView, $this->logger);
+	}
+
+	/**
+	 * Returns EncryptAll object
+	 *
+	 * @return EncryptAll
+	 */
+	public function getEncryptAllObj() {
+		$rootView = new View("/");
+
+		/**
+		 * The new KeyManager object is used here because of two reasons:
+		 * 1. Setup class depends on KeyManager, which depends on crypto engine
+		 * 2. EncryptAll also depends on KeyManager, which depends on crypto engine
+		 */
+		$keyManager = new KeyManager($this->encStorage, $this->getCryptoEngine(),
+			$this->config, $this->userSession, $this->encSession, $this->logger,
+			$this->encUtil);
+		$userSetup = new Setup($this->logger, $this->userSession, $this->getCryptoEngine(), $keyManager);
+		return new EncryptAll($userSetup, $this->userManager, $rootView,
+			$keyManager, $this->encUtil, $this->config, $this->mailer, $this->l10n,
+			$this->questionHelper, $this->secureRandom);
+	}
+
+	/**
+	 * Returns CryptHSM if crypto engine set to
+	 * hsm else returns Crypt
+	 *
+	 * @return Crypt|CryptHSM
+	 */
+	private function getCryptoEngine() {
+		if ($this->config->getAppValue('crypto.engine', 'internal', '') === 'hsm') {
+			return $this->cryptHSM;
+		}
+
+		return $this->crypt;
+	}
+}

--- a/apps/encryption/lib/Util.php
+++ b/apps/encryption/lib/Util.php
@@ -194,4 +194,16 @@ class Util {
 		$storage = $this->files->getMount($path)->getStorage();
 		return $storage;
 	}
+
+	/**
+	 * Deletes the encryption settings for the masterkey
+	 */
+	public function removeEncryptionAppSettings() {
+		$this->config->setAppValue('core', 'encryption_enabled', 'no');
+		$this->config->deleteAppValue('encryption', 'useMasterKey');
+		$this->config->deleteAppValue('encryption', 'masterKeyId');
+		$this->config->deleteAppValue('encryption', 'recoveryKeyId');
+		$this->config->deleteAppValue('encryption', 'publicShareKeyId');
+		$this->config->deleteAppValue('files_encryption', 'installed_version');
+	}
 }

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -676,4 +676,34 @@ class EncryptAllTest extends TestCase {
 		$result = $this->invokePrivate($this->encryptAll, 'encryptFile', ['/user1/files/bar.txt']);
 		$this->assertFalse($result);
 	}
+
+	/**
+	 * @dataProvider providesCreateMasterKeyData
+	 * @param bool $isShareKeySet
+	 * @param bool $isMasterkeySet
+	 * @param bool $expectedResult
+	 */
+	public function testCreateMasterKey($isShareKeySet, $isMasterkeySet, $expectedResult) {
+		$this->keyManager->expects($this->once())
+			->method('setPublicShareKeyIDAndMasterKeyId');
+		$this->keyManager->expects($this->once())
+			->method('validateShareKey');
+		$this->keyManager->expects($this->once())
+			->method('validateMasterKey');
+		$this->keyManager->method('getPublicShareKey')
+			->willReturn($isShareKeySet);
+		$this->keyManager->method('getPublicMasterKey')
+			->willReturn($isMasterkeySet);
+		$returnVal = $this->encryptAll->createMasterKey();
+		$this->assertEquals($expectedResult, $returnVal);
+	}
+
+	public function providesCreateMasterKeyData() {
+		return [
+			[true, false, false],
+			[true, true, true],
+			[false, true, false],
+			[false, false, false],
+		];
+	}
 }

--- a/apps/encryption/tests/Factory/EncDecAllFactoryTest.php
+++ b/apps/encryption/tests/Factory/EncDecAllFactoryTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Tests\Factory;
+
+use OC\Encryption\DecryptAll;
+use OC\Encryption\Manager;
+use OC\Files\View;
+use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\Crypto\CryptHSM;
+use OCA\Encryption\Crypto\EncryptAll;
+use OCA\Encryption\Factory\EncDecAllFactory;
+use OCA\Encryption\Session;
+use OCA\Encryption\Util;
+use OCP\Encryption\Keys\IStorage;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Mail\IMailer;
+use OCP\Security\ISecureRandom;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Test\TestCase;
+
+class EncDecAllFactoryTest extends TestCase {
+	private $encryptionManager;
+	private $userManager;
+	private $rootView;
+	private $logger;
+	private $encUtil;
+	private $config;
+	private $mailer;
+	private $l10n;
+	private $questionHelper;
+	private $secureRandom;
+	private $encStorage;
+	private $encSession;
+	private $cryptHSM;
+	private $crypt;
+	private $userSession;
+	private $encdecAllFactory;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->encryptionManager = $this->createMock(Manager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->rootView = $this->createMock(View::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->encUtil = $this->createMock(Util::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->questionHelper = $this->createMock(QuestionHelper::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->encStorage = $this->createMock(IStorage::class);
+		$this->encSession = $this->createMock(Session::class);
+		$this->cryptHSM = $this->createMock(CryptHSM::class);
+		$this->crypt = $this->createMock(Crypt::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->encdecAllFactory = new EncDecAllFactory($this->encryptionManager,
+			$this->userManager, $this->logger, $this->encUtil, $this->config,
+			$this->mailer, $this->l10n, $this->questionHelper, $this->secureRandom,
+			$this->encStorage, $this->encSession, $this->cryptHSM, $this->crypt,
+			$this->userSession);
+	}
+
+	public function testGetDecryptAllObj() {
+		$decAllObj = $this->encdecAllFactory->getDecryptAllObj();
+		$this->assertInstanceOf(DecryptAll::class, $decAllObj);
+	}
+
+	/**
+	 * @dataProvider providesHSMData
+	 * @param bool $hsmEnabled
+	 */
+	public function testGetEncryptAllObjWithHSM($hsmEnabled) {
+		$hsm = '';
+		if ($hsmEnabled === true) {
+			$hsm = 'hsm';
+		}
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['encryption', 'recoveryKeyId', '', 'foo'],
+				['crypto.engine', 'internal', '', $hsm]
+			]));
+
+		$encObject = $this->encdecAllFactory->getEncryptAllObj();
+		$this->assertInstanceOf(EncryptAll::class, $encObject);
+	}
+
+	public function providesHSMData() {
+		return [
+			[true],
+			[false],
+		];
+	}
+}

--- a/apps/encryption/tests/UtilTest.php
+++ b/apps/encryption/tests/UtilTest.php
@@ -208,4 +208,19 @@ class UtilTest extends TestCase {
 
 		$this->assertEquals($return, $this->instance->getStorage($path));
 	}
+
+	public function testRemoveEncAppSettings() {
+		$this->configMock->expects($this->once())
+			->method('setAppValue')
+			->with('core', 'encryption_enabled', 'no');
+		$this->configMock->method('deleteAppValue')
+			->will($this->returnValueMap([
+				['encryption', 'useMasterKey', ''],
+				['encryption', 'masterKeyId', ''],
+				['encryption', 'recoveryKeyId', ''],
+				['encryption', 'publicShareKeyId', ''],
+				['files_encryption', 'installed_version', ''],
+			]));
+		$this->instance->removeEncryptionAppSettings();
+	}
 }


### PR DESCRIPTION
Fix recreate masterkey for hsm

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When masterkey is enabled with hsm, the recreate mastekey command was failing. The reason for this was Crypt was pointing to wrong class. Meaning instead of `CryptHSM`, it was pointing to `Crypt`. This caused the keys to be generated in the oC instance and hence things were not working. Once the app is re-enabled, the keymanager requires to be pointed to `CryptHSM` if hsm is enabled. The switch to the `Crypt` is decided here https://github.com/owncloud/encryption/blob/master/lib/AppInfo/Application.php#L136-L149.  This pr tries to address this issue.

This change also brings usage of Factory for the EncryptAll and DecryptAll. Because the number of arguments to the constructor for the RecreateMasterKey command crossed beyond 16. And that's not something correct. The code is recactored, to bring down the arguments.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/125

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix the RecreateMasterKey command to work with HSM.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Tested with HSM. And verified that new masterkey is created/generated and the files are encrypted with the newly generated masterkey.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
