### PR TITLE
apiShareManagementBasic don't use skeleton files when not required

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -9,7 +9,7 @@ Feature: sharing
   @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a new share with user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -43,7 +43,7 @@ Feature: sharing
 
   Scenario Outline: Creating a new share with user who already received a share through their group
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "welcome.txt" with group "grp1"
@@ -146,7 +146,7 @@ Feature: sharing
 
   Scenario Outline: Creating a new share with a disabled user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has been disabled
     When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -158,7 +158,7 @@ Feature: sharing
   @issue-32068
   Scenario: Creating a new share with a disabled user
     Given using OCS API version "2"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has been disabled
     When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "997"
@@ -342,7 +342,7 @@ Feature: sharing
 
   Scenario Outline: sharing subfolder when parent already shared
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/sub"
@@ -358,7 +358,7 @@ Feature: sharing
 
   Scenario Outline: sharing subfolder when parent already shared with group of sharer
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "user0" has been added to group "grp1"
     And user "user0" has created folder "/test"
@@ -375,10 +375,12 @@ Feature: sharing
 
   Scenario Outline: sharing subfolder of already shared folder, GET result is correct
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
-    And user "user3" has been created with default attributes
-    And user "user4" has been created with default attributes
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+      | user4    |
     And user "user0" has created folder "/folder1"
     And user "user0" has shared file "/folder1" with user "user1"
     And user "user0" has shared file "/folder1" with user "user2"
@@ -404,7 +406,7 @@ Feature: sharing
   @issue-33733
   Scenario Outline: Cannot create share with zero permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
       | path        | welcome.txt |
       | shareWith   | user1       |
@@ -421,7 +423,7 @@ Feature: sharing
   @issue-33733 @skipOnLDAP @user_ldap-issue-378
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And group "excludedFromSharing" has been created
     And user "user0" has been added to group "excludedFromSharing"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -441,7 +443,7 @@ Feature: sharing
   @issue-33733
   Scenario Outline: user who is excluded from sharing tries to share a file with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And group "excludedFromSharing" has been created
     And group "anotherGroup" has been created
     And user "user0" has been added to group "excludedFromSharing"
@@ -463,7 +465,7 @@ Feature: sharing
   @issue-33733 @skipOnLDAP @user_ldap-issue-378
   Scenario Outline: user who is excluded from sharing tries to share a folder with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And group "excludedFromSharing" has been created
     And user "user0" has been added to group "excludedFromSharing"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -483,7 +485,7 @@ Feature: sharing
   @issue-33733
   Scenario Outline: user who is excluded from sharing tries to share a folder with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And group "excludedFromSharing" has been created
     And group "anotherGroup" has been created
     And user "user0" has been added to group "excludedFromSharing"
@@ -504,7 +506,7 @@ Feature: sharing
 
   Scenario Outline: user shares a file with file name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -518,7 +520,7 @@ Feature: sharing
   Scenario Outline: user shares a file with file name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has been added to group "grp1"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with group "grp1" using the sharing API
@@ -532,7 +534,7 @@ Feature: sharing
 
   Scenario Outline: user shares a folder with folder name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
     When user "user0" shares folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" with user "user1" using the sharing API
@@ -547,7 +549,7 @@ Feature: sharing
   Scenario Outline: user shares a folder with folder name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has been added to group "grp1"
     And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
@@ -591,7 +593,7 @@ Feature: sharing
 
   @skipOnEncryption @issue-encryption-126
   Scenario: share with user when username contains capital letters
-    Given these users have been created:
+    Given these users have been created without skeleton files:
       | username |
       | user1    |
     When user "user0" shares file "/welcome.txt" with user "USER1" using the sharing API
@@ -607,7 +609,7 @@ Feature: sharing
       | /welcome.txt |
 
   Scenario: creating a new share with user of a group when username contains capital letters
-    Given these users have been created:
+    Given these users have been created without skeleton files:
       | username |
       | user1    |
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -3,11 +3,11 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
 
   Scenario Outline: Delete all group shares
-    Given using OCS API version "<ocs_api_version>"
+    Given user "user0" has been created with default attributes
+    And user "user1" has been created with default attributes
+    And using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "textfile0.txt" with group "grp1"
@@ -23,7 +23,9 @@ Feature: sharing
 
   @smokeTest
   Scenario Outline: delete a share
-    Given using OCS API version "<ocs_api_version>"
+    Given user "user0" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has shared file "textfile0.txt" with user "user1"
     When user "user0" deletes the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -36,6 +38,10 @@ Feature: sharing
 
   Scenario: orphaned shares
     Given using OCS API version "1"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
     And a new browser session for "user0" has been started
     And user "user0" has created folder "/common"
     And user "user0" has created folder "/common/sub"
@@ -46,9 +52,13 @@ Feature: sharing
 
   Scenario Outline: sharing subfolder of already shared folder, GET result is correct
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
-    And user "user3" has been created with default attributes
-    And user "user4" has been created with default attributes
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+      | user3    |
+      | user4    |
     And user "user0" has created folder "/folder1"
     And user "user0" has shared file "/folder1" with user "user1"
     And user "user0" has shared file "/folder1" with user "user2"
@@ -76,6 +86,8 @@ Feature: sharing
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
+    And user "user0" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -89,6 +101,8 @@ Feature: sharing
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
+    And user "user0" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has created folder "/shared/sub"
     And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
@@ -106,6 +120,10 @@ Feature: sharing
   Scenario Outline: unshare from self
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
     And user "user2" has been created with default attributes
     And user "user2" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
@@ -124,6 +142,8 @@ Feature: sharing
 
   Scenario: sharee of a read-only share folder tries to delete the shared folder
     Given using OCS API version "1"
+    And user "user0" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "shared" with user "user1" with permissions 1
@@ -133,6 +153,8 @@ Feature: sharing
 
   Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
     Given using OCS API version "1"
+    And user "user0" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "shared" with user "user1" with permissions 4
@@ -142,6 +164,10 @@ Feature: sharing
 
   Scenario: sharee of an upload-only shared folder tries to delete their file in the folder
     Given using OCS API version "1"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
     And user "user0" has created folder "/shared"
     And user "user0" has shared folder "shared" with user "user1" with permissions 4
     When user "user1" uploads file "filesForUpload/textfile.txt" to "shared/textfile.txt" using the WebDAV API

--- a/tests/acceptance/features/apiShareManagementBasic/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/updateShare.feature
@@ -9,8 +9,10 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Allow modification of reshare
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
     And user "user0" has created folder "/TMP"
     And user "user0" has shared folder "TMP" with user "user1"
     And user "user1" has shared folder "TMP" with user "user2"
@@ -276,7 +278,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 17
     And as user "user1"
@@ -307,8 +309,10 @@ Feature: sharing
       | 2               | 400              |
 
   Scenario: Share ownership change after moving a shared file outside of an outer share
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
     And user "user0" has created folder "/folder1"
     And user "user0" has created folder "/folder1/folder2"
     And user "user1" has created folder "/moved-out"
@@ -335,8 +339,10 @@ Feature: sharing
     And as "user2" folder "/folder2" should exist
 
   Scenario: Share ownership change after moving a shared file to another share
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
     And user "user0" has created folder "/user0-folder"
     And user "user0" has created folder "/user0-folder/folder2"
     And user "user2" has created folder "/user2-folder"
@@ -365,7 +371,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     And as user "user1"
@@ -385,7 +391,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 17
     And as user "user1"
@@ -405,7 +411,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
     And as user "user1"
@@ -424,7 +430,7 @@ Feature: sharing
 
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user2" has been created with default attributes
     And group "grp1" has been created
     And user "user2" has been added to group "grp1"


### PR DESCRIPTION
## Description
Don't user skeleton files when not required

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>