### PR TITLE
[Stable10] received shares must go into share_folder when configured

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -31,6 +31,7 @@ namespace OCA\Files_Sharing\External;
 
 use OC\Files\Filesystem;
 use OC\User\NoUserException;
+use OCA\Files_Sharing\Helper;
 use OCP\Files;
 use OCP\Notification\IManager;
 use OCP\Share\Events\AcceptShare;
@@ -142,8 +143,9 @@ class Manager {
 			return null;
 		}
 
-		$mountPoint = Files::buildNotExistingFileName('/', $name);
-		$mountPoint = Filesystem::normalizePath('/' . $mountPoint);
+		$shareFolder = Helper::getShareFolder();
+		$mountPoint = Files::buildNotExistingFileName($shareFolder, $name);
+		$mountPoint = Filesystem::normalizePath($mountPoint);
 		$hash = \md5($mountPoint);
 
 		$query = $this->connection->prepare('
@@ -189,8 +191,9 @@ class Manager {
 		$share = $this->getShare($id);
 
 		if ($share) {
-			$mountPoint = Files::buildNotExistingFileName('/', $share['name']);
-			$mountPoint = Filesystem::normalizePath('/' . $mountPoint);
+			$shareFolder = Helper::getShareFolder();
+			$mountPoint = Files::buildNotExistingFileName($shareFolder, $share['name']);
+			$mountPoint = Filesystem::normalizePath($mountPoint);
 			$hash = \md5($mountPoint);
 
 			$acceptShare = $this->connection->prepare('

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -236,6 +236,23 @@ class ManagerTest extends TestCase {
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
 	}
 
+	public function testAddShareAccepted() {
+		$shareData1 = [
+			'remote' => 'http://localhost',
+			'token' => 'token1',
+			'password' => '',
+			'name' => '/SharedFolder',
+			'owner' => 'foobar',
+			'accepted' => true,
+			'user' => $this->uid,
+		];
+
+		// Add a accepted share for "user"
+		\call_user_func_array([$this->manager, 'addShare'], $shareData1);
+		$this->setupMounts();
+		$this->assertMount($shareData1['name']);
+	}
+
 	/**
 	 * Verify that a share event matches a given share
 	 *


### PR DESCRIPTION
Backport of #35312
## Description
Federates shares currently does not respect to configured share folder. This PR resolves this bug.

## Related Issue
- Fixes #31342

## Motivation and Context
Resolving bug.

## How Has This Been Tested?
Manually by following below steps:
Scenario 1
- install two ownCloud instance
- add `'share_folder' => 'test'` to `config.php`'s of first instance
- share a file from second instance to first instance
- accept the share from first instance
- the file should be in `test` folder

Scenario 2
- install two ownCloud instance
- add second instance as a trusted server in first instance
- configure auto-accepting federated shares from trusted servers in first instance
- add `'share_folder' => 'test'` to `config.php`'s of first instance
- share a file from second instance to first instance
- the file should be in `test` folder

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 