### PR TITLE
Do not use skeleton file when not required

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -15,7 +15,7 @@ Feature: admin storage settings
     Then the external storage form should not be displayed on the storage settings page
 
   Scenario: administrator creates a local storage mount
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and without skeleton files
     And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
     When the administrator creates the local storage mount "local_storage1" using the webUI
@@ -23,7 +23,7 @@ Feature: admin storage settings
     Then folder "local_storage1" should be listed on the webUI
 
   Scenario: administrator assigns an applicable user to a local storage mount
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -41,7 +41,7 @@ Feature: admin storage settings
     And folder "local_storage2" should be listed on the webUI
 
   Scenario: user should get access if the user is removed from the applicable user and the user was the only applicable user
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -56,7 +56,7 @@ Feature: admin storage settings
     And folder "local_storage1" should be listed on the webUI
 
   Scenario: administrator should be able to create a local mount for a specific group
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -72,7 +72,7 @@ Feature: admin storage settings
     And folder "local_storage1" should not be listed on the webUI
 
   Scenario: removing group from applicable group of a local mount
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -122,7 +122,7 @@ Feature: admin storage settings
     And folder "local_storage1" should not be listed on the webUI
 
   Scenario: local storage mount is not deleted when the one of two users applicable to the mount is deleted
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -5,10 +5,8 @@ Feature: accept/decline shares coming from internal users
   So that I can keep my file system clean
 
   Background:
-    Given these users have been created with default attributes:
-      | username |
-      | user1    |
-      | user2    |
+    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user2" has been created with default attributes
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -21,45 +19,37 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     When user "user1" logs in using the webUI
-    Then folder "simple-folder (2)" should not be listed on the webUI
-    And file "testimage (2).jpg" should not be listed on the webUI
+    Then folder "simple-folder" should not be listed on the webUI
+    And file "testimage.jpg" should not be listed on the webUI
     But folder "simple-folder" should be listed in the shared-with-you page on the webUI
     And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
     And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
 
-  Scenario: receive shares with same name from different users
-    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user3" has been created with default attributes
-    And user "user2" has shared folder "/simple-folder" with user "user3"
-    And user "user1" has shared folder "/simple-folder" with user "user3"
-    When user "user3" logs in using the webUI
-    Then folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
-
   Scenario: receive shares with same name from different users, accept one by one
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user3" has been created with default attributes
+    And user "user3" has been created with default attributes and without skeleton files
     And user "user2" has created folder "/simple-folder/from_user2"
     And user "user2" has shared folder "/simple-folder" with user "user3"
+    And user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/from_user1"
     And user "user1" has shared folder "/simple-folder" with user "user3"
     And user "user3" has logged in using the webUI
     When the user accepts share "simple-folder" offered by user "User One" using the webUI
     And the user accepts share "simple-folder" offered by user "User Two" using the webUI
-    Then folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
-    And folder "simple-folder (3)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder" shared by "User One" should be in state "" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
     And user "user3" should see the following elements
-      | /simple-folder%20(2)/from_user1/ |
-      | /simple-folder%20(3)/from_user2/ |
+      | /simple-folder/from_user1/       |
+      | /simple-folder%20(2)/from_user2/ |
 
   Scenario: receive shares with same name from different users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user3" has been created with default attributes
-    And user "user2" has shared folder "/simple-folder" with user "user3"
-    And user "user1" has shared folder "/simple-folder" with user "user3"
-    When user "user3" logs in using the webUI
-    Then folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user3" has shared folder "/simple-folder" with user "user1"
+    When user "user1" logs in using the webUI
+    Then folder "simple-folder" shared by "User Three" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
   @smokeTest
@@ -69,12 +59,12 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
     When the user accepts share "simple-folder" offered by user "User Two" using the webUI
-    Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI after a page reload
+    And folder "simple-folder" should be in state "" in the shared-with-you page on the webUI after a page reload
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI after a page reload
-    And folder "simple-folder (2)" should be listed in the files page on the webUI
-    And file "testimage (2).jpg" should not be listed in the files page on the webUI
+    And folder "simple-folder" should be listed in the files page on the webUI
+    And file "testimage.jpg" should not be listed in the files page on the webUI
 
   @smokeTest
   Scenario: decline an offered (pending) share
@@ -85,8 +75,8 @@ Feature: accept/decline shares coming from internal users
     When the user declines share "simple-folder" offered by user "User Two" using the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And file "testimage (2).jpg" should not be listed in the files page on the webUI
+    And folder "simple-folder" should not be listed in the files page on the webUI
+    And file "testimage.jpg" should not be listed in the files page on the webUI
 
   @smokeTest
   Scenario: decline an accepted share (with page-reload in between)
@@ -96,11 +86,11 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
-    And the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
-    Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the user declines share "simple-folder" offered by user "User Two" using the webUI
+    Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And file "testimage (2).jpg" should not be listed in the files page on the webUI
+    And folder "simple-folder" should not be listed in the files page on the webUI
+    And file "testimage.jpg" should not be listed in the files page on the webUI
 
   Scenario: decline an accepted share (without any page-reload in between)
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -108,11 +98,11 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared file "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
     When the user accepts share "simple-folder" offered by user "User Two" using the webUI
-    And the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
-    Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
+    And the user declines share "simple-folder" offered by user "User Two" using the webUI
+    Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And file "testimage (2).jpg" should not be listed in the files page on the webUI
+    And folder "simple-folder" should not be listed in the files page on the webUI
+    And file "testimage.jpg" should not be listed in the files page on the webUI
 
   Scenario: accept a previously declined share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -121,10 +111,10 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     And the user declines share "simple-folder" offered by user "User Two" using the webUI
     When the user accepts share "simple-folder" offered by user "User Two" using the webUI
-    Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should be listed in the files page on the webUI
-    And file "testimage (2).jpg" should not be listed in the files page on the webUI
+    And folder "simple-folder" should be listed in the files page on the webUI
+    And file "testimage.jpg" should not be listed in the files page on the webUI
 
   Scenario: accept a share that you received as user and as group member
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -133,8 +123,8 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
-    Then folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should be listed in the files page on the webUI
+    Then folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
+    And folder "simple-folder" should be listed in the files page on the webUI
 
   Scenario: reject a share that you received as user and as group member
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -144,7 +134,7 @@ Feature: accept/decline shares coming from internal users
     When the user declines share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should not be listed in the files page on the webUI
+    And folder "simple-folder" should not be listed in the files page on the webUI
 
   Scenario: reshare a share that you received to a group that you are member of
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -152,11 +142,11 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has logged in using the webUI
     When the user accepts share "simple-folder" offered by user "User Two" using the webUI
     And the user has browsed to the files page
-    And the user shares folder "simple-folder (2)" with group "grp1" using the webUI
-    And the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
+    And the user shares folder "simple-folder" with group "grp1" using the webUI
+    And the user declines share "simple-folder" offered by user "User Two" using the webUI
     And the user reloads the current page of the webUI
-    Then folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should not be listed in the files page on the webUI
+    Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And folder "simple-folder" should not be listed in the files page on the webUI
 
   @smokeTest
   Scenario: unshare an accepted share on the "All files" page
@@ -166,12 +156,12 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has accepted the share "/simple-folder" offered by user "user2"
     And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
     And user "user1" has logged in using the webUI
-    When the user unshares folder "simple-folder (2)" using the webUI
-    And the user unshares file "testimage (2).jpg" using the webUI
-    Then folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And file "testimage (2).jpg" should not be listed in the files page on the webUI
-    And folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+    When the user unshares folder "simple-folder" using the webUI
+    And the user unshares file "testimage.jpg" using the webUI
+    Then folder "simple-folder" should not be listed in the files page on the webUI
+    And file "testimage.jpg" should not be listed in the files page on the webUI
+    And folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
   @smokeTest
   Scenario: Auto-accept shares
@@ -179,42 +169,42 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
     When user "user1" logs in using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    And file "testimage (2).jpg" should be listed on the webUI
-    And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
-    And file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    And file "testimage.jpg" should be listed on the webUI
+    And folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "" in the shared-with-you page on the webUI
 
   Scenario: decline auto-accepted shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user declines share "simple-folder (2)" offered by user "User Two" using the webUI
-    And the user declines share "testimage (2).jpg" offered by user "User Two" using the webUI
+    When the user declines share "simple-folder" offered by user "User Two" using the webUI
+    And the user declines share "testimage.jpg" offered by user "User Two" using the webUI
     And the user has browsed to the files page
-    Then folder "simple-folder (2)" should not be listed on the webUI
-    And file "testimage (2).jpg" should not be listed on the webUI
-    And folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+    Then folder "simple-folder" should not be listed on the webUI
+    And file "testimage.jpg" should not be listed on the webUI
+    And folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
   Scenario: unshare auto-accepted shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with group "grp1"
     And user "user2" has shared folder "/testimage.jpg" with user "user1"
     And user "user1" has logged in using the webUI
-    When the user unshares folder "simple-folder (2)" using the webUI
-    And the user unshares file "testimage (2).jpg" using the webUI
-    Then folder "simple-folder (2)" should not be listed on the webUI
-    And file "testimage (2).jpg" should not be listed on the webUI
-    And folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
-    And file "testimage (2).jpg" should be in state "Declined" in the shared-with-you page on the webUI
+    When the user unshares folder "simple-folder" using the webUI
+    And the user unshares file "testimage.jpg" using the webUI
+    Then folder "simple-folder" should not be listed on the webUI
+    And file "testimage.jpg" should not be listed on the webUI
+    And folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
   Scenario: unshare renamed shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
+    And user "user1" has moved folder "/simple-folder" to "/simple-folder-renamed"
     And user "user1" has logged in using the webUI
     When the user unshares folder "simple-folder-renamed" using the webUI
     Then folder "simple-folder-renamed" should not be listed on the webUI
@@ -223,9 +213,10 @@ Feature: accept/decline shares coming from internal users
   Scenario: unshare moved shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder/shared"
+    And user "user1" has created folder "/new-folder"
+    And user "user1" has moved folder "/simple-folder" to "/new-folder/shared"
     And user "user1" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
+    When the user opens folder "new-folder" using the webUI
     And the user unshares folder "shared" using the webUI
     Then folder "shared" should not be listed on the webUI
     And folder "shared" should be in state "Declined" in the shared-with-you page on the webUI
@@ -233,7 +224,7 @@ Feature: accept/decline shares coming from internal users
   Scenario: unshare renamed shares, accept it again
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
+    And user "user1" has moved folder "/simple-folder" to "/simple-folder-renamed"
     And user "user1" has logged in using the webUI
     When the user unshares folder "simple-folder-renamed" using the webUI
     And the user accepts share "simple-folder-renamed" offered by user "User Two" using the webUI
@@ -248,8 +239,8 @@ Feature: accept/decline shares coming from internal users
     And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
     And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
     And the user browses to the files page
-    Then folder "simple-folder (2)" should not be listed on the webUI
-    And file "testimage (2).jpg" should not be listed on the webUI
+    Then folder "simple-folder" should not be listed on the webUI
+    And file "testimage.jpg" should not be listed on the webUI
     But folder "simple-folder" should be listed in the shared-with-you page on the webUI
     And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
     And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
@@ -263,12 +254,12 @@ Feature: accept/decline shares coming from internal users
     And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
     And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
     And the user browses to the files page
-    Then folder "simple-folder (2)" should be listed on the webUI
-    And file "testimage (2).jpg" should be listed on the webUI
-    And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
-    And file "testimage (2).jpg" should be listed in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And file "testimage (2).jpg" should be in state "" in the shared-with-you page on the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    And file "testimage.jpg" should be listed on the webUI
+    And folder "simple-folder" should be listed in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
+    And folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
+    And file "testimage.jpg" should be in state "" in the shared-with-you page on the webUI
 
   Scenario: User-based accepting checkbox is not visible while global is disabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -286,8 +277,8 @@ Feature: accept/decline shares coming from internal users
     And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
     And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
     And the user browses to the files page
-    Then folder "simple-folder (2)" should not be listed on the webUI
-    And file "testimage (2).jpg" should not be listed on the webUI
+    Then folder "simple-folder" should not be listed on the webUI
+    And file "testimage.jpg" should not be listed on the webUI
     And folder "simple-folder" should be listed in the shared-with-you page on the webUI
     And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
     And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Do not use skeleton folder for `webUIAcceptShare` and `webUIAdminSettings` suites to speed up CI.

## Related Issue
- ~~Fixes~~ Part of https://github.com/owncloud/QA/issues/621

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
