### PR TITLE
Ignore share hooks for masterkey encryption

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -750,7 +750,9 @@ class OC {
 
 	private static function registerEncryptionHooks() {
 		$enabled = self::$server->getEncryptionManager()->isEnabled();
-		if ($enabled) {
+		//Call share hooks if they are not masterkey
+		if ($enabled &&
+			(\OC::$server->getConfig()->getAppValue('encryption', 'useMasterKey', '0') === '0')) {
 			\OCP\Util::connectHook('OCP\Share', 'post_shared', 'OC\Encryption\HookManager', 'postShared');
 			\OCP\Util::connectHook('OCP\Share', 'post_unshare', 'OC\Encryption\HookManager', 'postUnshared');
 			\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OC\Encryption\HookManager', 'postRename');


### PR DESCRIPTION
Ignore share hooks for masterkey encryption

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When masterkey is enabled for encryption, and user tries to create a public link for a folder say it has 50k files, then creation of public link takes time. Probably it might also reach timeout in the UI. The root cause of the problem is the post share/unshare/rename(share)/restore froms trash(share) hooks for the encryption still follows the path of user-keys encryption. Which is absolutely not required. The masterkey doesn't have the delete the keys are then again set the keys. If its master key encryption just ignore the post share hook.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ignore post share hooks for masterkey encryption.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Tested with 5k files for creating public link and it did not took time. Also the files were downloaded from the public link I verified the contents of the file.
- [x] Tested by deleting a shared folder ( from the source user who shared the folder ) and then restoring the folder from trashbin works. I was able to view the files ( generated thumbnails for txt files ), was able to download them and the contents were verified.
- [x] Tested by renaming the shared folder ( from the source user who share the folder also from recipient user ) and it worked. Verified by downloading the file.
- [x] Tested by unsharing the folder. That is by deleting the user from the share tab of the folder ( from the initiator ).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
