### PR TITLE
Fix cleanup of orphaned properties

### DIFF
--- a/apps/dav/lib/BackgroundJob/CleanProperties.php
+++ b/apps/dav/lib/BackgroundJob/CleanProperties.php
@@ -79,11 +79,11 @@ class CleanProperties extends TimedJob {
 		/**
 		 * select prop.fileid from oc_properties prop
 		 * left join oc_filecache fc on fc.fileid = prop.fileid
-		 * where fc.fileid is not null limit 200
+		 * where prop.fileid is not null and fc.fileid is null limit 200
 		 */
 		$qb->select('prop.fileid')
 			->from('properties', 'prop')
-			->where($qb->expr()->isNull('fc.fileid'))
+			->where($qb->expr()->andX($qb->expr()->isNotNull('prop.fileid'), $qb->expr()->isNull('fc.fileid')))
 			->leftJoin('prop', 'filecache', 'fc', $qb->expr()->eq('prop.fileid', 'fc.fileid'))
 			->setMaxResults(self::CHUNK_SIZE);
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
It was not working correctly when some property already had NULL fileid.
In such cases, `fileid` was cast to 0 and then used in a `... WHERE fileid in (0)`
query which was not matching NULLs as expected.
Example of such property is `{http://owncloud.org/ns}calendar-enabled`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35292

## Motivation and Context
Fix for hanging cron.php

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a live installation.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
