### PR TITLE
Add support for Oracle connections string to support failover setups

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -50,6 +50,7 @@ class Install extends Command {
 			->setName('maintenance:install')
 			->setDescription('Install ownCloud.')
 			->addOption('database', null, InputOption::VALUE_REQUIRED, 'Supported database type.', 'sqlite')
+			->addOption('database-connection-string', null, InputOption::VALUE_REQUIRED, 'Oracle specific connection string. As soon as this parameter is provided other parameters like database-host and database-name are not used and do not need to be provided')
 			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database.')
 			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database.', 'localhost')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database.')
@@ -108,6 +109,7 @@ class Install extends Command {
 		$dbUser = $input->getOption('database-user');
 		$dbPass = $input->getOption('database-pass');
 		$dbName = $input->getOption('database-name');
+		$dbConnectionString = $input->getOption('database-connection-string');
 		if ($db === 'oci') {
 			// an empty hostname needs to be read from the raw parameters
 			$dbHost = $input->getParameterOption('--database-host', '');
@@ -130,8 +132,8 @@ class Install extends Command {
 			if ($dbUser === null) {
 				throw new InvalidArgumentException("Database user not provided.");
 			}
-			if ($dbName === null) {
-				throw new InvalidArgumentException("Database name not provided.");
+			if ($dbName === null && $dbConnectionString === null) {
+				throw new InvalidArgumentException('Database name and connection string not provided.');
 			}
 			if ($dbPass === null) {
 				/** @var $dialog \Symfony\Component\Console\Helper\QuestionHelper */
@@ -156,6 +158,7 @@ class Install extends Command {
 			'dbpass' => $dbPass,
 			'dbname' => $dbName,
 			'dbhost' => $dbHost,
+			'dbconnectionstring' => $dbConnectionString,
 			'dbtableprefix' => $dbTablePrefix,
 			'adminlogin' => $adminLogin,
 			'adminpass' => $adminPassword,

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -29,7 +29,6 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Event\Listeners\OracleSessionInit;
 use Doctrine\DBAL\Event\Listeners\SQLSessionInit;
-use Doctrine\DBAL\Events;
 use OC\SystemConfig;
 
 /**
@@ -116,7 +115,7 @@ class ConnectionFactory {
 		switch ($normalizedType) {
 			case 'mysql':
 				$eventManager->addEventSubscriber(
-					new SQLSessionInit("SET SESSION AUTOCOMMIT=1"));
+					new SQLSessionInit('SET SESSION AUTOCOMMIT=1'));
 				break;
 			case 'oci':
 				$eventManager->addEventSubscriber(new OracleSessionInit);
@@ -172,10 +171,14 @@ class ConnectionFactory {
 			'password' => $this->config->getValue('dbpassword', ''),
 		];
 		$name = $this->config->getValue('dbname', 'owncloud');
+		$connectString = $this->config->getValue('dbconnectionstring', '');
 
 		if ($this->normalizeType($type) === 'sqlite3') {
-			$dataDir = $this->config->getValue("datadirectory", \OC::$SERVERROOT . '/data');
+			$dataDir = $this->config->getValue('datadirectory', \OC::$SERVERROOT . '/data');
 			$connectionParams['path'] = $dataDir . '/' . $name . '.db';
+		} elseif ($type === 'oci' && $connectString !== '') {
+			$connectionParams['connectstring'] = $connectString;
+			$connectionParams['dbname'] = $name;
 		} else {
 			$host = $this->config->getValue('dbhost', '');
 			if (\strpos($host, ':')) {

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -43,6 +43,8 @@ abstract class AbstractDatabase {
 	/** @var string */
 	protected $dbHost;
 	/** @var string */
+	protected $dbConnectionString;
+	/** @var string */
 	protected $tablePrefix;
 	/** @var string */
 	protected $dbprettyname;
@@ -80,11 +82,13 @@ abstract class AbstractDatabase {
 		$dbUser = $config['dbuser'];
 		$dbPass = $config['dbpass'];
 		$dbName = $config['dbname'];
+		$dbConnectionString = $config['dbconnectionstring'];
 		$dbHost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
 		$dbTablePrefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
 
 		$this->config->setSystemValues([
 			'dbname'		=> $dbName,
+			'dbconnectionstring' => $dbConnectionString,
 			'dbhost'		=> $dbHost,
 			'dbtableprefix'	=> $dbTablePrefix,
 		]);
@@ -93,6 +97,7 @@ abstract class AbstractDatabase {
 		$this->dbPassword = $dbPass;
 		$this->dbName = $dbName;
 		$this->dbHost = $dbHost;
+		$this->dbConnectionString = $dbConnectionString;
 		$this->tablePrefix = $dbTablePrefix;
 	}
 

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -51,12 +51,11 @@ class OCI extends AbstractDatabase {
 
 	public function validate($config) {
 		$errors = [];
-		if (empty($config['dbuser']) && empty($config['dbname'])) {
-			$errors[] = $this->trans->t("%s enter the database username and name.", [$this->dbprettyname]);
-		} elseif (empty($config['dbuser'])) {
-			$errors[] = $this->trans->t("%s enter the database username.", [$this->dbprettyname]);
-		} elseif (empty($config['dbname'])) {
-			$errors[] = $this->trans->t("%s enter the database name.", [$this->dbprettyname]);
+		if (empty($config['dbuser'])) {
+			$errors[] = $this->trans->t('%s enter the database username.', [$this->dbprettyname]);
+		}
+		if (empty($config['dbname']) && empty($config['dbconnectionstring'])) {
+			$errors[] = $this->trans->t('%s enter the database name or connection string.', [$this->dbprettyname]);
 		}
 		return $errors;
 	}
@@ -65,7 +64,9 @@ class OCI extends AbstractDatabase {
 		$e_host = \addslashes($this->dbHost);
 		$e_dbname = \addslashes($this->dbName);
 		//check if the database user has admin right
-		if ($e_host == '') {
+		if ($this->dbConnectionString !== null) {
+			$easy_connect_string = $this->dbConnectionString;
+		} elseif ($e_host === '') {
 			$easy_connect_string = $e_dbname; // use dbname as easy connect name
 		} else {
 			$easy_connect_string = '//'.$e_host.'/'.$e_dbname;
@@ -147,20 +148,12 @@ class OCI extends AbstractDatabase {
 		//$this->dbname = \OC_Config::getValue('dbname');
 		$this->dbPassword = $this->config->getSystemValue('dbpassword');
 
-		$e_host = \addslashes($this->dbHost);
-		$e_dbname = \addslashes($this->dbName);
-
-		if ($e_host == '') {
-			$easy_connect_string = $e_dbname; // use dbname as easy connect name
-		} else {
-			$easy_connect_string = '//'.$e_host.'/'.$e_dbname;
-		}
 		$connection = @\oci_connect($this->dbUser, $this->dbPassword, $easy_connect_string);
 		if (!$connection) {
 			throw new \OC\DatabaseSetupException($this->trans->t('Oracle username and/or password not valid'),
 					$this->trans->t('You need to enter either an existing account or the administrator.'));
 		}
-		$query = "SELECT count(*) FROM user_tables WHERE table_name = :un";
+		$query = 'SELECT count(*) FROM user_tables WHERE table_name = :un';
 		$stmt = \oci_parse($connection, $query);
 		$un = $this->tablePrefix.'users';
 		\oci_bind_by_name($stmt, ':un', $un);
@@ -174,7 +167,10 @@ class OCI extends AbstractDatabase {
 		if ($result) {
 			$row = \oci_fetch_row($stmt);
 		}
-		if (!$result or $row[0]==0) {
+		// the connection is not needed anymore
+		\oci_close($connection);
+
+		if (!$result || $row[0] == 0) {
 			\OC_DB::createDbFromStructure($this->dbDefinitionFile);
 		}
 	}
@@ -185,7 +181,7 @@ class OCI extends AbstractDatabase {
 	private function createDBUser($connection) {
 		$name = $this->dbUser;
 		$password = $this->dbPassword;
-		$query = "SELECT * FROM all_users WHERE USERNAME = :un";
+		$query = 'SELECT * FROM all_users WHERE USERNAME = :un';
 		$stmt = \oci_parse($connection, $query);
 		if (!$stmt) {
 			$entry = $this->trans->t('DB Error: "%s"', [$this->getLastError($connection)]) . '<br />';
@@ -219,7 +215,7 @@ class OCI extends AbstractDatabase {
 				$this->logger->warning($entry, ['app' => 'setup.oci']);
 			}
 		} else { // change password of the existing role
-			$query = "ALTER USER :un IDENTIFIED BY :pw";
+			$query = 'ALTER USER :un IDENTIFIED BY :pw';
 			$stmt = \oci_parse($connection, $query);
 			if (!$stmt) {
 				$entry = $this->trans->t('DB Error: "%s"', [$this->getLastError($connection)]) . '<br />';

--- a/tests/drone/install-server.sh
+++ b/tests/drone/install-server.sh
@@ -116,9 +116,15 @@ install_cmd="maintenance:install -vvv \
       --data-dir=${DATA_DIRECTORY} "
 
 if [[ "${DB_TYPE}" != "sqlite" ]]; then
-  install_cmd+=" --database-host=${DB_TYPE} \
-                 --database-user=${DB_USERNAME} \
-                 --database-pass=${DB_PASSWORD}"
+    if [[ "${DB_TYPE}" != "oracle" ]]; then
+      install_cmd+=" --database-host=${DB_TYPE} \
+                     --database-user=${DB_USERNAME} \
+                     --database-pass=${DB_PASSWORD}"
+    else
+      install_cmd+=" --database-connection-string=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=${DB_TYPE})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=XE))) \
+                     --database-user=${DB_USERNAME} \
+                     --database-pass=${DB_PASSWORD}"
+    fi
 fi
 
 


### PR DESCRIPTION
## Description
Some failover/HA configurations in the Oracle world require support of connect strings.
Examples can be found here: https://docs.oracle.com/database/121/HABPT/config_fcf.htm#HABPT5391

This PR adds installation and operations using a new database config parameter: dbconnectionstring in config.php

## Motivation and Context
Support Oracle HA/Failover scenarios

## How Has This Been Tested?
- basic connectivity is done manually and using drone
- real fail over scenario is to be tested manually as well

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
