### PR TITLE
Skip smb_windows drone job because fsweb.test.owncloud.com is not working

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -766,13 +766,13 @@ matrix:
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
-      TEST_SUITE: phpunit
-      COVERAGE: true
-      DB_TYPE: sqlite
-      FILES_EXTERNAL_TYPE: smb_windows
-      INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
+    #- PHP_VERSION: 7.1
+    #  TEST_SUITE: phpunit
+    #  COVERAGE: true
+    #  DB_TYPE: sqlite
+    #  FILES_EXTERNAL_TYPE: smb_windows
+    #  INSTALL_SERVER: true
+    #  INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit


### PR DESCRIPTION
## Description
`fsweb.test.owncloud.com` is used by the smb_windows drone CI  job.
That system is not working properly at present, so CI is always failing in core.
For the moment, skip the job. If the system comes back properly, or some other solution is worked out in the related issue, then we can easily bring this job back.

## Related Issue
#35415 

## Motivation and Context
Make CI pass so developers can get on with life.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
