### PR TITLE
Use skeleton files only when necessary in webuiCreateDelete and webUISharingIntGrp suites

### DIFF
--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -5,7 +5,7 @@ Feature: create folders
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -30,11 +30,15 @@ Feature: create folders
     Then folder "sub-folder" should be listed on the webUI
 
   Scenario: Create a folder with existing name
+    Given user "user1" has created folder "/simple-folder"
+    And the user has reloaded the current page of the webUI
     When the user creates a folder with the invalid name "simple-folder" using the webUI
     Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed on the webUI
 
   Scenario: Create a folder in a public share
-    Given the user has created a new public link for folder "simple-empty-folder" using the webUI with
+    Given user "user1" has created folder "/simple-empty-folder"
+    And the user has reloaded the current page of the webUI
+    And the user has created a new public link for folder "simple-empty-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     When the user creates a folder with the name "top-folder" using the webUI

--- a/tests/acceptance/features/webUICreateDelete/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFoldersEdgeCases.feature
@@ -5,7 +5,7 @@ Feature: create folder
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -39,8 +39,8 @@ Feature: create folder
 
   @smokeTest
   Scenario Outline: Create a sub-folder inside an existing folder with problematic name
-	# Use an existing folder with problematic name to create a sub-folder
-	# Uses the folder created by skeleton
+    Given user "user1" has created folder <folder>
+    And the user has reloaded the current page of the webUI
     When the user opens folder <folder> using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then folder "sub-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -117,7 +117,7 @@ Feature: deleting files and folders
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   Scenario: delete files from shared with others page
-    Given user "user2" has been created with default attributes
+    Given user "user2" has been created with default attributes and without skeleton files
     Given the user has shared file "lorem.txt" with user "User Two" using the webUI
     And the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user has browsed to the shared-with-others page

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -5,11 +5,11 @@ Feature: Sharing files and folders with internal groups
   So that those groups can access the files and folders
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
-      | user3    |
+    And user "user3" has been created with default attributes
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -23,15 +23,15 @@ Feature: Sharing files and folders with internal groups
     When the user shares folder "simple-folder" with group "grp1" using the webUI
     And the user shares file "testimage.jpg" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    And folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
-    And file "testimage (2).jpg" should be listed on the webUI
-    And file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    And folder "simple-folder" should be marked as shared with "grp1" by "User Three" on the webUI
+    And file "testimage.jpg" should be listed on the webUI
+    And file "testimage.jpg" should be marked as shared with "grp1" by "User Three" on the webUI
     When the user re-logs in as "user2" using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    And folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
-    And file "testimage (2).jpg" should be listed on the webUI
-    And file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    And folder "simple-folder" should be marked as shared with "grp1" by "User Three" on the webUI
+    And file "testimage.jpg" should be listed on the webUI
+    And file "testimage.jpg" should be marked as shared with "grp1" by "User Three" on the webUI
 
   @TestAlsoOnExternalUserBackend @skipOnFIREFOX
   Scenario: share a file with an internal group a member overwrites and unshares the file
@@ -112,19 +112,19 @@ Feature: Sharing files and folders with internal groups
     Given group "system-group" has been created
     And the administrator has browsed to the admin sharing settings page
     When the administrator excludes group "system-group" from receiving shares using the webUI
-    Then user "user1" should not be able to share file "lorem.txt" with group "system-group" using the sharing API
+    Then user "user3" should not be able to share file "lorem.txt" with group "system-group" using the sharing API
 
   Scenario: user tries to share a folder in a group which is excluded from receiving share
     Given group "system-group" has been created
     And the administrator has browsed to the admin sharing settings page
     When the administrator excludes group "system-group" from receiving shares using the webUI
-    Then user "user1" should not be able to share folder "simple-folder" with group "system-group" using the sharing API
+    Then user "user3" should not be able to share folder "simple-folder" with group "system-group" using the sharing API
 
   Scenario: autocompletion for a group that is excluded from receiving shares
     Given group "system-group" has been created
     And the administrator has browsed to the admin sharing settings page
     When the administrator excludes group "system-group" from receiving shares using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user3" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
     And the user types "system-group" in the share-with-field
@@ -184,7 +184,7 @@ Feature: Sharing files and folders with internal groups
   @mailhog
   Scenario: user should get an error message when trying to send notification by email to the group where some user have set up their email and others haven't
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And these users have been created:
+    And these users have been created without skeleton files:
       | username           |
       | brand-new-user     |
       | off-brand-new-user |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -5,11 +5,11 @@ Feature: Sharing files and folders with internal groups
   So that those groups can access the files and folders
 
   Scenario Outline: sharing  files and folder with an internal problematic group name
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
-      | user3    |
+    And user "user3" has been created with default attributes
     And these groups have been created:
       | groupname |
       | <group>   |
@@ -19,15 +19,15 @@ Feature: Sharing files and folders with internal groups
     When the user shares folder "simple-folder" with group "<group>" using the webUI
     And the user shares file "testimage.jpg" with group "<group>" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    And folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
-    And file "testimage (2).jpg" should be listed on the webUI
-    And file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    And folder "simple-folder" should be marked as shared with "<group>" by "User Three" on the webUI
+    And file "testimage.jpg" should be listed on the webUI
+    And file "testimage.jpg" should be marked as shared with "<group>" by "User Three" on the webUI
     When the user re-logs in as "user2" using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    And folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
-    And file "testimage (2).jpg" should be listed on the webUI
-    And file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    And folder "simple-folder" should be marked as shared with "<group>" by "User Three" on the webUI
+    And file "testimage.jpg" should be listed on the webUI
+    And file "testimage.jpg" should be marked as shared with "<group>" by "User Three" on the webUI
     Examples:
       | group     |
       | ?\?@#%@,; |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Remove the usage of skeleton in acceptance test suites `webUICreateDelete` and `webUISharingInternalGroups` when the skeleton files are not required.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related Issue https://github.com/owncloud/QA/issues/621

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The tests in CI take forever to complete. So to speed them up minimize the use of skeleton files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
