### PR TITLE
Get rid of setting configs via WebUISharingContext

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1401,7 +1401,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->featureContext = $environment->getContext('FeatureContext');
 		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
 		$this->webUIFilesContext = $environment->getContext('WebUIFilesContext');
-		$this->setupSharingConfigs();
 	}
 
 	/**
@@ -1434,96 +1433,5 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				'boolean'
 			);
 		}
-	}
-
-	/**
-	 * @return void
-	 */
-	private function setupSharingConfigs() {
-		$settings = [
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' => 'api_enabled',
-				'testingApp' => 'core',
-				'testingParameter' => 'shareapi_enabled',
-				'testingState' => true
-			],
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' => 'public@@@enabled',
-				'testingApp' => 'core',
-				'testingParameter' => 'shareapi_allow_links',
-				'testingState' => true
-			],
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' => 'public@@@upload',
-				'testingApp' => 'core',
-				'testingParameter' => 'shareapi_allow_public_upload',
-				'testingState' => true
-			],
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' => 'group_sharing',
-				'testingApp' => 'core',
-				'testingParameter' => 'shareapi_allow_group_sharing',
-				'testingState' => true
-			],
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' => 'share_with_group_members_only',
-				'testingApp' => 'core',
-				'testingParameter' => 'shareapi_only_share_with_group_members',
-				'testingState' => false
-			],
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' => 'share_with_membership_groups_only',
-				'testingApp' => 'core',
-				'testingParameter' => 'shareapi_only_share_with_membership_groups',
-				'testingState' => false
-			],
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' =>
-					'user_enumeration@@@enabled',
-				'testingApp' => 'core',
-				'testingParameter' =>
-					'shareapi_allow_share_dialog_user_enumeration',
-				'testingState' => true
-			],
-			[
-				'capabilitiesApp' => 'files_sharing',
-				'capabilitiesParameter' =>
-					'user_enumeration@@@group_members_only',
-				'testingApp' => 'core',
-				'testingParameter' =>
-					'shareapi_share_dialog_user_enumeration_group_members',
-				'testingState' => false
-			],
-			[
-				'capabilitiesApp' => 'federation',
-				'capabilitiesParameter' => 'outgoing',
-				'testingApp' => 'files_sharing',
-				'testingParameter' => 'outgoing_server2server_share_enabled',
-				'testingState' => true
-			],
-			[
-				'capabilitiesApp' => 'federation',
-				'capabilitiesParameter' => 'incoming',
-				'testingApp' => 'files_sharing',
-				'testingParameter' => 'incoming_server2server_share_enabled',
-				'testingState' => true
-			]
-		];
-
-		$change = AppConfigHelper::setCapabilities(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$settings,
-			$this->webUIGeneralContext->getSavedCapabilitiesXml()[$this->featureContext->getBaseUrl()]
-		);
-		$this->webUIGeneralContext->addToSavedCapabilitiesChanges($change);
 	}
 }


### PR DESCRIPTION
We already set the capabilities via FeatureContext on both fed and local servers.
The same settings were run twice causing conflicts, causing some of the enabled
configs to get disabled. The settings are already tracked (on [Sharing.php](https://github.com/owncloud/core/blob/fef563fff799a717541184bf1a63197c3862c5d5/tests/acceptance/features/bootstrap/Sharing.php#L1695)), so they were redundant.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fed sharing on remote server was getting disabled after running the tests. Took too much time to pin this down. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
./core/occ config:list files_sharing
./fed_core/occ config:list files_sharing
make test-acceptance-webui BEHAT_FEATURE=tests/acceptance/features/webUISharingExternal/federationSharing.feature:25
./core/occ config:list files_sharing
./fed_core/occ config:list files_sharing
```
Previously, the last output would show fed_sharing disabled. Now, it should not be disabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
