### PR TITLE
Revert "[stable10] Skip smb_windows drone job because fsweb.test.owncloud.com is not working"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -782,13 +782,13 @@ matrix:
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    #- PHP_VERSION: 7.1
-    #  TEST_SUITE: phpunit
-    #  COVERAGE: true
-    #  DB_TYPE: sqlite
-    #  FILES_EXTERNAL_TYPE: smb_windows
-    #  INSTALL_SERVER: true
-    #  INSTALL_TESTING_APP: true
+    - PHP_VERSION: 7.1
+      TEST_SUITE: phpunit
+      COVERAGE: true
+      DB_TYPE: sqlite
+      FILES_EXTERNAL_TYPE: smb_windows
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit


### PR DESCRIPTION
Reverts owncloud/core#35418

When the `fsweb` CI problem is fixed, then we can get CI green for this PR and merge it.

Related to issue #35415 

Update 2019-07-04: the `fsweb.test.owncloud.com` name should now translate to `172.16.115.3` and the unit tests should access that and work.

Ready for green CI and PR review.