### PR TITLE
skip tests on encryption that fail because of a known issue

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -72,6 +72,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario Outline: reset user password including emoji
     Given these users have been created:
       | username       | password  | displayname | email                    |
@@ -80,10 +81,10 @@ Feature: reset user password
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
     Examples:
       | password        | comment  |
       | 😛 😜           | smileys  |
       | 🐶🐱 🐭           | Animals  |
       | ⌚️ 📱 📲 💻           | objects  |
       | 🚴🏿‍♀️ 🚴‍♂️            | cycling |
-    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -72,6 +72,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario Outline: reset user password including emoji
     Given these users have been created:
       | username       | password  | displayname | email                    |
@@ -80,10 +81,10 @@ Feature: reset user password
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
     Examples:
       | password        | comment  |
       | 😛 😜           | smileys  |
       | 🐶🐱 🐭           | Animals  |
       | ⌚️ 📱 📲 💻           | objects  |
       | 🚴🏿‍♀️ 🚴‍♂️            | cycling |
-    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"


### PR DESCRIPTION
## Description
this tests were added in #35315 but fail on encryption because of https://github.com/owncloud/encryption/issues/57
Also placed the example table at the end

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
