### PR TITLE
[stable10] Make create user steps specify explicitly that the user has skeleton files

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,7 +1,7 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: CORS headers
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiAuth/filesAppAuth.feature
+++ b/tests/acceptance/features/apiAuth/filesAppAuth.feature
@@ -2,7 +2,7 @@
 Feature: auth
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And a new client token for "user0" has been generated
 
   @smokeTest

--- a/tests/acceptance/features/apiAuth/tokenAuth.feature
+++ b/tests/acceptance/features/apiAuth/tokenAuth.feature
@@ -3,7 +3,7 @@ Feature: tokenAuth
 
   Background:
     Given using OCS API version "1"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And token auth has been enforced
 
   Scenario: creating a user with basic auth should be blocked when token auth is enforced

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -2,7 +2,7 @@
 Feature: auth
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And a new client token for "user0" has been generated
 
   Scenario: using WebDAV anonymously

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -85,7 +85,7 @@ Feature: auth
   @issue-32068
   Scenario Outline: send POST requests to OCS endpoints as normal user with wrong password
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     When user "user0" sends HTTP method "POST" to OCS API endpoint "<endpoint>" with body using password "invalid"
       | data        | doesnotmatter |
     Then the OCS status code should be "<ocs-code>"

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -1,7 +1,7 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: auth
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   @issue-32068
   Scenario Outline: using OCS anonymously

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -2,12 +2,12 @@
 Feature: auth
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   @issue-32068
   Scenario Outline: send POST requests to OCS endpoints as normal user with wrong password
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     When user "user0" sends HTTP method "POST" to OCS API endpoint "<endpoint>" with body using password "invalid"
       | data        | doesnotmatter |
     Then the OCS status code should be "<ocs-code>"

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -499,7 +499,7 @@ Feature: capabilities
 
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
@@ -528,7 +528,7 @@ Feature: capabilities
 
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
@@ -557,7 +557,7 @@ Feature: capabilities
 
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario: Getting info of comments using files endpoint

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -3,8 +3,8 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And as user "user0"
 
   @smokeTest

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -3,8 +3,8 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And as user "user0"
 
   @smokeTest
@@ -91,6 +91,6 @@ Feature: Comments
     Given the user has created folder "/FOLDER_TO_COMMENT"
     And the user has commented with content "Comment from owner" on folder "/FOLDER_TO_COMMENT"
     And user "user0" has been deleted
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     When the user creates folder "/FOLDER_TO_COMMENT" using the WebDAV API
     Then the user should have 0 comments on folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -3,8 +3,8 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And as user "user0"
 
   @smokeTest

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -3,7 +3,7 @@ Feature: favorite
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And as user "user0"
 
   Scenario Outline: Favorite a folder
@@ -83,7 +83,7 @@ Feature: favorite
 
   Scenario Outline: moving a favorite file out of a share keeps favorite state
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And the user has created folder "/shared"
     And the user has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And the user has shared folder "/shared" with user "user1"
@@ -148,7 +148,7 @@ Feature: favorite
 
   Scenario Outline: sharer file favorite state should not change the favorite state of sharee
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And the user has moved file "/textfile0.txt" to "/favoriteFile.txt"
     And the user has shared file "/favoriteFile.txt" with user "user1"
     When the user favorites element "/favoriteFile.txt" using the WebDAV API
@@ -160,7 +160,7 @@ Feature: favorite
 
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And the user has moved file "/textfile0.txt" to "/favoriteFile.txt"
     And the user has shared file "/favoriteFile.txt" with user "user1"
     When user "user1" favorites element "/favoriteFile.txt" using the WebDAV API

--- a/tests/acceptance/features/apiFederation/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederation/etagPropagation.feature
@@ -4,9 +4,9 @@ Feature: propagation of etags between federated and local server
   Background:
     Given using OCS API version "1"
     And using server "REMOTE"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And using server "LOCAL"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
 
   Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
     Given user "user1" from server "LOCAL" has shared "/PARENT" with user "user0" from server "REMOTE"

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -3,9 +3,9 @@ Feature: federated
 
   Background:
     Given using server "REMOTE"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And using server "LOCAL"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
 
   Scenario Outline: Federate share a file with another server
     Given using OCS API version "<ocs-api-version>"
@@ -163,7 +163,7 @@ Feature: federated
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "user1" creates a share using the sharing API with settings
       | path        | /textfile0 (2).txt |

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -2,7 +2,7 @@
 Feature: caldav
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   @caldav
   Scenario: Accessing a not existing calendar of another user

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -2,7 +2,7 @@
 Feature: carddav
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   @carddav
   Scenario: Accessing a not existing addressbook of another user

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -2,7 +2,7 @@
 Feature: checksums
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Uploading a file with checksum should work
     Given using <dav_version> DAV path
@@ -109,7 +109,7 @@ Feature: checksums
 
   Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given using new DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "user0" shares file "/myChecksumFile.txt" with user "user1" using the sharing API
     And user "user1" requests the checksum of "/myChecksumFile.txt" via propfind
@@ -117,7 +117,7 @@ Feature: checksums
 
   Scenario: Sharing and modifying a file should return correct checksum in the propfind using new DAV path
     Given using new DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "user0" shares file "/myChecksumFile.txt" with user "user1" using the sharing API
     And user "user1" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/myChecksumFile.txt" using the WebDAV API

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -7,8 +7,8 @@ Feature: external-storage
 
   @public_link_share-feature-required
   Scenario: Share by public link a file inside a local external storage
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/foo"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
     And user "user0" has shared folder "/local_storage/foo" with user "user1"
@@ -23,16 +23,16 @@ Feature: external-storage
       | mimetype | httpd/unix-directory |
 
   Scenario: Move a file into storage
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/foo1"
     When user "user0" moves file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt" using the WebDAV API
     Then as "user1" file "/local_storage/foo1/textfile0.txt" should exist
     And as "user0" file "/local_storage/foo1/textfile0.txt" should exist
 
   Scenario: Move a file out of storage
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/foo2"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
     When user "user1" moves file "/local_storage/foo2/textfile0.txt" to "/local.txt" using the WebDAV API
@@ -41,7 +41,7 @@ Feature: external-storage
     And as "user1" file "/local.txt" should exist
 
   Scenario: Download a file that exists in filecache but not storage fails with 404
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/foo3"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
     And file "foo3/textfile0.txt" has been deleted from local storage on the server
@@ -50,7 +50,7 @@ Feature: external-storage
     And as "user0" file "local_storage/foo3/textfile0.txt" should not exist
 
   Scenario: Upload a file to external storage while quota is set on home storage
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "1 B"
     When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/local_storage/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
@@ -58,7 +58,7 @@ Feature: external-storage
 
   Scenario Outline: query OCS endpoint for information about the mount
     Given using OCS API version "<ocs_api_version>"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     When user "user0" sends HTTP method "GET" to OCS API endpoint "<endpoint>"
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -8,7 +8,7 @@ Feature: quota
 
   Scenario Outline: Uploading a file as owner having enough quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "10 MB"
     When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
@@ -20,7 +20,7 @@ Feature: quota
   @smokeTest
   Scenario Outline: Uploading a file as owner having insufficient quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "20 B"
     When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
@@ -32,7 +32,7 @@ Feature: quota
 
   Scenario Outline: Overwriting a file as owner having enough quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "10 MB"
     And user "user0" has uploaded file with content "test" to "/testquota.txt"
     When user "user0" overwrites file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
@@ -44,7 +44,7 @@ Feature: quota
 
   Scenario Outline: Overwriting a file as owner having insufficient quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "20 B"
     And user "user0" has uploaded file with content "test" to "/testquota.txt"
     When user "user0" overwrites file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
@@ -59,8 +59,8 @@ Feature: quota
 
   Scenario Outline: Uploading a file in received folder having enough quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "20 B"
     And the quota of user "user1" has been set to "10 MB"
     And user "user1" has created folder "/testquota"
@@ -74,8 +74,8 @@ Feature: quota
 
   Scenario Outline: Uploading a file in received folder having insufficient quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "10 MB"
     And the quota of user "user1" has been set to "20 B"
     And user "user1" has created folder "/testquota"
@@ -90,8 +90,8 @@ Feature: quota
 
   Scenario Outline: Overwriting a file in received folder having enough quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "20 B"
     And the quota of user "user1" has been set to "10 MB"
     And user "user1" has created folder "/testquota"
@@ -106,8 +106,8 @@ Feature: quota
 
   Scenario Outline: Overwriting a file in received folder having insufficient quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "10 MB"
     And the quota of user "user1" has been set to "20 B"
     And user "user1" has created folder "/testquota"
@@ -125,8 +125,8 @@ Feature: quota
 
   Scenario Outline: Overwriting a received file having enough quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "20 B"
     And the quota of user "user1" has been set to "10 MB"
     And user "user1" has uploaded file with content "test" to "/testquota.txt"
@@ -140,8 +140,8 @@ Feature: quota
 
   Scenario Outline: Overwriting a received file having insufficient quota
     Given using <dav_version> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user0" has been set to "10 MB"
     And the quota of user "user1" has been set to "20 B"
     And user "user1" has moved file "/textfile0.txt" to "/testquota.txt"

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -17,14 +17,14 @@ Feature: add user
     And user "brand-new-user" should be able to access a skeleton file
 
   Scenario: admin tries to create an existing user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"
     And the API should not return any data
 
   Scenario: admin tries to create an existing disabled user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And user "brand-new-user" has been disabled
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "102"
@@ -86,7 +86,7 @@ Feature: add user
       | BrAnD-nEw-UsEr  |
 
   Scenario: admin tries to create an existing user but with username containing capital letters
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator sends a user creation request for user "BRAND-NEW-USER" password "%alt1%" using the provisioning API
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -9,7 +9,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest
   Scenario: admin deletes the user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And a new client token for the administrator has been generated
     And a new browser session for the administrator has been started
@@ -19,8 +19,8 @@ Feature: access user provisioning API using app password
     And user "brand-new-user" should not exist
 
   Scenario: subadmin gets users in their group
-    Given user "brand-new-user" has been created with default attributes
-    And user "another-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "another-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "another-new-user" has been added to group "new-group"
     And user "brand-new-user" has been made a subadmin of group "new-group"
@@ -34,7 +34,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest
   Scenario: normal user gets their own information using the app password
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | newuser  | New User    |
     And a new client token for "newuser" has been generated
@@ -45,8 +45,8 @@ Feature: access user provisioning API using app password
     And the display name returned by the API should be "New User"
 
   Scenario: subadmin tries to get users of other group
-    Given user "brand-new-user" has been created with default attributes
-    And user "another-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "another-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "another-new-group" has been created
     And user "another-new-user" has been added to group "another-new-group"
@@ -59,8 +59,8 @@ Feature: access user provisioning API using app password
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get other user information using the app password
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     And a new client token for "newuser" has been generated
     And a new browser session for "newuser" has been started
     And the user has generated a new app password named "my-client"

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: create a subadmin
 
   @smokeTest
   Scenario: admin creates a subadmin
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     When the administrator makes user "brand-new-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "100"
@@ -25,7 +25,7 @@ Feature: create a subadmin
     And user "not-user" should not be a subadmin of group "new-group"
 
   Scenario: admin tries to create a subadmin using a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator makes user "brand-new-user" a subadmin of group "not-group" using the provisioning API
     Then the OCS status code should be "102"
@@ -33,8 +33,8 @@ Feature: create a subadmin
     And the API should not return any data
 
   Scenario: subadmin of a group tries to make another user subadmin of their group
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "brand-new-user" has been added to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -9,14 +9,14 @@ Feature: delete users
 
   @smokeTest
   Scenario: Delete a user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
   Scenario: Delete a user, and specify the user name in different case
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator deletes user "Brand-New-User" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -24,8 +24,8 @@ Feature: delete users
 
   @smokeTest
   Scenario: subadmin deletes a user in their group
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -35,8 +35,8 @@ Feature: delete users
     And user "brand-new-user" should not exist
 
   Scenario: normal user tries to delete a user
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     When user "user1" deletes user "user2" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -16,7 +16,7 @@ Feature: disable an app
     And app "comments" should be disabled
 
   Scenario: subadmin tries to disable an app
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
     And app "comments" has been enabled
@@ -26,7 +26,7 @@ Feature: disable an app
     And app "comments" should be enabled
 
   Scenario: normal user tries to disable an app
-    Given user "newuser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
     And app "comments" has been enabled
     When user "newuser" disables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -9,7 +9,7 @@ Feature: disable user
 
   @smokeTest
   Scenario: admin disables an user
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     When the administrator disables user "user1" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -17,8 +17,8 @@ Feature: disable user
 
   @smokeTest
   Scenario: Subadmin should be able to disable an user in their group
-    Given user "subadmin" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "user1" has been added to group "new-group"
@@ -29,8 +29,8 @@ Feature: disable user
     And user "user1" should be disabled
 
   Scenario: Subadmin should not be able to disable an user not in their group
-    Given user "subadmin" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been added to group "new-group"
@@ -42,8 +42,8 @@ Feature: disable user
     And user "user1" should be enabled
 
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-    Given user "another-admin" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "another-admin" has been added to group "admin"
     And user "subadmin" has been added to group "new-group"
@@ -55,7 +55,7 @@ Feature: disable user
     And user "another-admin" should be enabled
 
   Scenario: Admin can disable another admin user
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     When the administrator disables user "another-admin" using the provisioning API
     Then the OCS status code should be "100"
@@ -63,7 +63,7 @@ Feature: disable user
     And user "another-admin" should be disabled
 
   Scenario: Admin can disable subadmins in the same group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"
@@ -74,7 +74,7 @@ Feature: disable user
     And user "subadmin" should be disabled
 
   Scenario: Admin user cannot disable himself
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     When user "another-admin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "101"
@@ -82,15 +82,15 @@ Feature: disable user
     And user "another-admin" should be enabled
 
   Scenario: disable an user with a regular user
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     When user "user1" disables user "user2" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "user2" should be enabled
 
   Scenario: Subadmin should not be able to disable himself
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -101,7 +101,7 @@ Feature: disable user
 
   @smokeTest
   Scenario: Making a web request with a disabled user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has been disabled
     When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -9,7 +9,7 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user email
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
@@ -17,14 +17,14 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the display of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And the display name of user "brand-new-user" should be "A New User"
 
   Scenario: the administrator can edit a user display name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
@@ -32,14 +32,14 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user quota
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: the administrator can override an existing user email
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -50,8 +50,8 @@ Feature: edit users
 
   @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -63,7 +63,7 @@ Feature: edit users
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: a normal user should be able to change their email address
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -72,7 +72,7 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   Scenario: a normal user should be able to change their display name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -81,7 +81,7 @@ Feature: edit users
     And the display name of user "brand-new-user" should be "Alan Border"
 
   Scenario: a normal user should not be able to change their quota
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -17,7 +17,7 @@ Feature: enable an app
     And the information for app "comments" should have a valid version
 
   Scenario: subadmin tries to enable an app
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
     And app "comments" has been disabled
@@ -27,7 +27,7 @@ Feature: enable an app
     And app "comments" should be disabled
 
   Scenario: normal user tries to enable an app
-    Given user "newuser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
     And app "comments" has been disabled
     When user "newuser" enables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -9,7 +9,7 @@ Feature: enable user
 
   @smokeTest
   Scenario: admin enables an user
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has been disabled
     When the administrator enables user "user1" using the provisioning API
     Then the OCS status code should be "100"
@@ -17,7 +17,7 @@ Feature: enable user
     And user "user1" should be enabled
 
   Scenario: admin enables another admin user
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When the administrator enables user "another-admin" using the provisioning API
@@ -26,7 +26,7 @@ Feature: enable user
     And user "another-admin" should be enabled
 
   Scenario: admin enables subadmins in the same group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"
@@ -38,15 +38,15 @@ Feature: enable user
     And user "subadmin" should be enabled
 
   Scenario: admin tries to enable himself
-    And user "another-admin" has been created with default attributes
+    And user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When user "another-admin" tries to enable user "another-admin" using the provisioning API
     Then user "another-admin" should be disabled
 
   Scenario: normal user tries to enable other user
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been disabled
     When user "user1" tries to enable user "user2" using the provisioning API
     Then the OCS status code should be "997"
@@ -54,7 +54,7 @@ Feature: enable user
     And user "user2" should be disabled
 
   Scenario: subadmin tries to enable himself
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -65,6 +65,6 @@ Feature: enable user
     And user "subadmin" should be disabled
 
   Scenario: Making a web request with an enabled user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -9,7 +9,7 @@ Feature: get subadmins
 
   @smokeTest
   Scenario: admin gets subadmin users of a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
     When the administrator gets all the subadmins of group "new-group" using the provisioning API
@@ -19,7 +19,7 @@ Feature: get subadmins
     And the HTTP status code should be "200"
 
   Scenario: admin tries to get subadmin users of a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator gets all the subadmins of group "not-group" using the provisioning API
     Then the OCS status code should be "101"
@@ -27,8 +27,8 @@ Feature: get subadmins
     And the API should not return any data
 
   Scenario: subadmin tries to get other subadmins of the same group
-    Given user "subadmin" has been created with default attributes
-    And user "newsubadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "newsubadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newsubadmin" has been made a subadmin of group "new-group"
@@ -38,8 +38,8 @@ Feature: get subadmins
     And the API should not return any data
 
   Scenario: normal user tries to get the subadmins of the group
-    Given user "newuser" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "newuser" gets all the subadmins of group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -9,7 +9,7 @@ Feature: get user
 
   @smokeTest
   Scenario: admin gets an existing user
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator retrieves the information of user "brand-new-user" using the provisioning API
@@ -26,7 +26,7 @@ Feature: get user
 
   @smokeTest
   Scenario: a subadmin gets information of a user in their group
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | subadmin | Sub Admin   |
       | newuser  | New User    |
@@ -40,8 +40,8 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin tries to get information of a user not in their group
-    Given user "subadmin" has been created with default attributes
-    And user "newuser" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "newuser" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
     When user "subadmin" retrieves the information of user "newuser" using the provisioning API
@@ -50,8 +50,8 @@ Feature: get user
     And the API should not return any data
 
   Scenario: a normal user tries to get information of another user
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     When user "anotheruser" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
@@ -59,7 +59,7 @@ Feature: get user
 
   @smokeTest
   Scenario: a normal user gets their own information
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | newuser  | New User    |
     When user "newuser" retrieves the information of user "newuser" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -9,7 +9,7 @@ Feature: get users
 
   @smokeTest
   Scenario: admin gets all users
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -19,8 +19,8 @@ Feature: get users
 
   @smokeTest
   Scenario: subadmin gets the users in their group
-    Given user "brand-new-user" has been created with default attributes
-    And user "another-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "another-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been made a subadmin of group "new-group"
@@ -31,8 +31,8 @@ Feature: get users
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get other users
-    Given user "normaluser" has been created with default attributes
-    And user "newuser" has been created with default attributes
+    Given user "normaluser" has been created with default attributes and skeleton files
+    And user "newuser" has been created with default attributes and skeleton files
     When user "normaluser" gets the list of all users using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: remove subadmin
 
   @smokeTest
   Scenario: admin removes subadmin from a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
     When the administrator removes user "brand-new-user" from being a subadmin of group "new-group" using the provisioning API
@@ -18,10 +18,10 @@ Feature: remove subadmin
     And user "brand-new-user" should not be a subadmin of group "new-group"
 
   Scenario: subadmin tries to remove other subadmin in the group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "newsubadmin" has been created with default attributes
+    And user "newsubadmin" has been created with default attributes and skeleton files
     And user "newsubadmin" has been made a subadmin of group "new-group"
     When user "subadmin" removes user "newsubadmin" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
@@ -29,8 +29,8 @@ Feature: remove subadmin
     And user "newsubadmin" should be a subadmin of group "new-group"
 
   Scenario: normal user tries to remove subadmin in the group
-    Given user "subadmin" has been created with default attributes
-    And user "newuser" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "newuser" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newuser" has been added to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -9,7 +9,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: reset user password
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -25,7 +25,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user in their group
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -39,7 +39,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: subadmin should not be able to reset the password of a user not in their group
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -52,7 +52,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password   | displayname    | email                    |
       | brand-new-user | %regular%  | New user       | brand.new.user@oc.com.np |
       | wannabeadmin   | %altadmin% | Wanna Be Admin | wanna.be.admin@oc.com.np |
@@ -63,7 +63,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When user "brand-new-user" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -74,7 +74,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario Outline: reset user password including emoji
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "<password>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -17,14 +17,14 @@ Feature: add user
     And user "brand-new-user" should be able to access a skeleton file
 
   Scenario: admin tries to create an existing user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
 
   Scenario: admin tries to create an existing disabled user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And user "brand-new-user" has been disabled
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "400"
@@ -86,7 +86,7 @@ Feature: add user
       | BrAnD-nEw-UsEr  |
 
   Scenario: admin tries to create an existing user but with username containing capital letters
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator sends a user creation request for user "BRAND-NEW-USER" password "%alt1%" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -9,7 +9,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest
   Scenario: admin deletes the user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And a new client token for the administrator has been generated
     And a new browser session for the administrator has been started
@@ -19,8 +19,8 @@ Feature: access user provisioning API using app password
     And user "brand-new-user" should not exist
 
   Scenario: subadmin gets users in their group
-    Given user "brand-new-user" has been created with default attributes
-    And user "another-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "another-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "another-new-user" has been added to group "new-group"
     And user "brand-new-user" has been made a subadmin of group "new-group"
@@ -34,7 +34,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest
   Scenario: normal user gets their own information using the app password
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | newuser  | New User    |
     And a new client token for "newuser" has been generated
@@ -45,8 +45,8 @@ Feature: access user provisioning API using app password
     And the display name returned by the API should be "New User"
 
   Scenario: subadmin tries to get users of other group
-    Given user "brand-new-user" has been created with default attributes
-    And user "another-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "another-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "another-new-group" has been created
     And user "another-new-user" has been added to group "another-new-group"
@@ -59,8 +59,8 @@ Feature: access user provisioning API using app password
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get other user information using the app password
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     And a new client token for "newuser" has been generated
     And a new browser session for "newuser" has been started
     And the user has generated a new app password named "my-client"

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: create a subadmin
 
   @smokeTest
   Scenario: admin creates a subadmin
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     When the administrator makes user "brand-new-user" a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "200"
@@ -25,7 +25,7 @@ Feature: create a subadmin
     And user "not-user" should not be a subadmin of group "new-group"
 
   Scenario: admin tries to create a subadmin using a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator makes user "brand-new-user" a subadmin of group "not-group" using the provisioning API
     Then the OCS status code should be "400"
@@ -33,8 +33,8 @@ Feature: create a subadmin
 
   @issue-31276
   Scenario: subadmin of a group tries to make another user subadmin of their group
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "brand-new-user" has been added to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -9,14 +9,14 @@ Feature: delete users
 
   @smokeTest
   Scenario: Delete a user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
   Scenario: Delete a user, and specify the user name in different case
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator deletes user "Brand-New-User" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -24,8 +24,8 @@ Feature: delete users
 
   @smokeTest
   Scenario: subadmin deletes a user in their group
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -36,8 +36,8 @@ Feature: delete users
 
   @issue-31276
   Scenario: normal user tries to delete a user
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     When user "user1" deletes user "user2" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -17,7 +17,7 @@ Feature: disable an app
 
   @issue-31276
   Scenario: subadmin tries to disable an app
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
     And app "comments" has been enabled
@@ -29,7 +29,7 @@ Feature: disable an app
 
   @issue-31276
   Scenario: normal user tries to disable an app
-    Given user "newuser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
     And app "comments" has been enabled
     When user "newuser" disables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -9,7 +9,7 @@ Feature: disable user
 
   @smokeTest
   Scenario: admin disables an user
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     When the administrator disables user "user1" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -17,8 +17,8 @@ Feature: disable user
 
   @smokeTest
   Scenario: Subadmin should be able to disable an user in their group
-    Given user "subadmin" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "user1" has been added to group "new-group"
@@ -30,8 +30,8 @@ Feature: disable user
 
   @issue-31276
   Scenario: Subadmin should not be able to disable an user not in their group
-    Given user "subadmin" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been added to group "new-group"
@@ -45,8 +45,8 @@ Feature: disable user
 
   @issue-31276
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-    Given user "another-admin" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "another-admin" has been added to group "admin"
     And user "subadmin" has been added to group "new-group"
@@ -59,7 +59,7 @@ Feature: disable user
     And user "another-admin" should be enabled
 
   Scenario: Admin can disable another admin user
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     When the administrator disables user "another-admin" using the provisioning API
     Then the OCS status code should be "200"
@@ -67,7 +67,7 @@ Feature: disable user
     And user "another-admin" should be disabled
 
   Scenario: Admin can disable subadmins in the same group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"
@@ -78,7 +78,7 @@ Feature: disable user
     And user "subadmin" should be disabled
 
   Scenario: Admin user cannot disable himself
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     When user "another-admin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "400"
@@ -87,8 +87,8 @@ Feature: disable user
 
   @issue-31276
   Scenario: disable an user with a regular user
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     When user "user1" disables user "user2" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
@@ -96,7 +96,7 @@ Feature: disable user
     And user "user2" should be enabled
 
   Scenario: Subadmin should not be able to disable himself
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -107,7 +107,7 @@ Feature: disable user
 
   @smokeTest
   Scenario: Making a web request with a disabled user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has been disabled
     When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
     And the HTTP status code should be "403"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -9,7 +9,7 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user email
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
@@ -17,14 +17,14 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the display of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the display name of user "brand-new-user" should be "A New User"
 
   Scenario: the administrator can edit a user display name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
@@ -32,14 +32,14 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user quota
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: the administrator can override existing user email
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -50,8 +50,8 @@ Feature: edit users
 
   @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -63,7 +63,7 @@ Feature: edit users
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: a normal user should be able to change their email address
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -72,7 +72,7 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   Scenario: a normal user should be able to change their display name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -81,7 +81,7 @@ Feature: edit users
     And the display name of user "brand-new-user" should be "Alan Border"
 
   Scenario: a normal user should not be able to change their quota
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -17,7 +17,7 @@ Feature: enable an app
 
   @issue-31276
   Scenario: subadmin tries to enable an app
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
     And app "comments" has been disabled
@@ -29,7 +29,7 @@ Feature: enable an app
 
   @issue-31276
   Scenario: normal user tries to enable an app
-    Given user "newuser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
     And app "comments" has been disabled
     When user "newuser" enables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -9,7 +9,7 @@ Feature: enable user
 
   @smokeTest
   Scenario: admin enables an user
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has been disabled
     When the administrator enables user "user1" using the provisioning API
     Then the OCS status code should be "200"
@@ -17,7 +17,7 @@ Feature: enable user
     And user "user1" should be enabled
 
   Scenario: admin enables another admin user
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When the administrator enables user "another-admin" using the provisioning API
@@ -26,7 +26,7 @@ Feature: enable user
     And user "another-admin" should be enabled
 
   Scenario: admin enables subadmins in the same group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"
@@ -38,7 +38,7 @@ Feature: enable user
     And user "subadmin" should be enabled
 
   Scenario: admin tries to enable himself
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When user "another-admin" tries to enable user "another-admin" using the provisioning API
@@ -46,8 +46,8 @@ Feature: enable user
 
   @issue-31276
   Scenario: normal user tries to enable other user
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been disabled
     When user "user1" tries to enable user "user2" using the provisioning API
     Then the OCS status code should be "997"
@@ -56,7 +56,7 @@ Feature: enable user
     And user "user2" should be disabled
 
   Scenario: subadmin tries to enable himself
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -67,6 +67,6 @@ Feature: enable user
     And user "subadmin" should be disabled
 
   Scenario: Making a web request with an enabled user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -9,7 +9,7 @@ Feature: get subadmins
 
   @smokeTest
   Scenario: admin gets subadmin users of a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
     When the administrator gets all the subadmins of group "new-group" using the provisioning API
@@ -19,7 +19,7 @@ Feature: get subadmins
     And the HTTP status code should be "200"
 
   Scenario: admin tries to get subadmin users of a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator gets all the subadmins of group "not-group" using the provisioning API
     Then the OCS status code should be "400"
@@ -28,8 +28,8 @@ Feature: get subadmins
 
   @issue-31276
   Scenario: subadmin tries to get other subadmins of the same group
-    Given user "subadmin" has been created with default attributes
-    And user "newsubadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "newsubadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newsubadmin" has been made a subadmin of group "new-group"
@@ -41,8 +41,8 @@ Feature: get subadmins
 
   @issue-31276
   Scenario: normal user tries to get the subadmins of the group
-    Given user "newuser" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "newuser" gets all the subadmins of group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -9,7 +9,7 @@ Feature: get user
 
   @smokeTest
   Scenario: admin gets an existing user
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator retrieves the information of user "brand-new-user" using the provisioning API
@@ -26,7 +26,7 @@ Feature: get user
 
   @smokeTest
   Scenario: a subadmin gets information of a user in their group
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | subadmin | Sub Admin   |
       | newuser  | New User    |
@@ -40,8 +40,8 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin tries to get information of a user not in their group
-    Given user "subadmin" has been created with default attributes
-    And user "newuser" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "newuser" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
     When user "subadmin" retrieves the information of user "newuser" using the provisioning API
@@ -51,8 +51,8 @@ Feature: get user
 
   @issue-31276
   Scenario: a normal user tries to get information of another user
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     When user "anotheruser" retrieves the information of user "newuser" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
@@ -61,7 +61,7 @@ Feature: get user
 
   @smokeTest
   Scenario: a normal user gets their own information
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | newuser  | New User    |
     When user "newuser" retrieves the information of user "newuser" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -9,7 +9,7 @@ Feature: get users
 
   @smokeTest
   Scenario: admin gets all users
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -19,8 +19,8 @@ Feature: get users
 
   @smokeTest
   Scenario: subadmin gets the users in their group
-    Given user "brand-new-user" has been created with default attributes
-    And user "another-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "another-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been made a subadmin of group "new-group"
@@ -32,8 +32,8 @@ Feature: get users
 
   @issue-31276
   Scenario: normal user tries to get other users
-    Given user "normaluser" has been created with default attributes
-    And user "newuser" has been created with default attributes
+    Given user "normaluser" has been created with default attributes and skeleton files
+    And user "newuser" has been created with default attributes and skeleton files
     When user "normaluser" gets the list of all users using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: remove subadmin
 
   @smokeTest
   Scenario: admin removes subadmin from a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"
     When the administrator removes user "brand-new-user" from being a subadmin of group "new-group" using the provisioning API
@@ -19,10 +19,10 @@ Feature: remove subadmin
 
   @issue-31276
   Scenario: subadmin tries to remove other subadmin in the group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    And user "newsubadmin" has been created with default attributes
+    And user "newsubadmin" has been created with default attributes and skeleton files
     And user "newsubadmin" has been made a subadmin of group "new-group"
     When user "subadmin" removes user "newsubadmin" from being a subadmin of group "new-group" using the provisioning API
     Then the OCS status code should be "997"
@@ -32,8 +32,8 @@ Feature: remove subadmin
 
   @issue-31276
   Scenario: normal user tries to remove subadmin in the group
-    Given user "subadmin" has been created with default attributes
-    And user "newuser" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "newuser" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newuser" has been added to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -9,7 +9,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: reset user password
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -25,7 +25,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user in their group
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -39,7 +39,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: subadmin should not be able to reset the password of a user not in their group
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -52,7 +52,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password   | displayname    | email                    |
       | brand-new-user | %regular%  | New user       | brand.new.user@oc.com.np |
       | wannabeadmin   | %altadmin% | Wanna Be Admin | wanna.be.admin@oc.com.np |
@@ -63,7 +63,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When user "brand-new-user" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -74,7 +74,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario Outline: reset user password including emoji
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "<password>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -104,14 +104,14 @@ Feature: add groups
     And group "new-group" should exist
 
   Scenario: normal user tries to create a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" tries to send a group creation request for group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "new-group" should not exist
 
   Scenario: subadmin tries to create a group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to send a group creation request for group "another-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -9,7 +9,7 @@ Feature: add users to group
 
   @smokeTest
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
@@ -21,7 +21,7 @@ Feature: add users to group
       | नेपाली        | Unicode group name          |
 
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
@@ -48,7 +48,7 @@ Feature: add users to group
 
   @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     #And group "<group_id>" has been created
@@ -66,7 +66,7 @@ Feature: add users to group
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -83,14 +83,14 @@ Feature: add users to group
       | brand-new-user | NEW-GROUP | New-Group | new-group |
 
   Scenario: normal user tries to add himself to a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" tries to add himself to group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
 
   Scenario: admin tries to add user to a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator tries to add user "brand-new-user" to group "not-group" using the provisioning API
     Then the OCS status code should be "102"
@@ -98,7 +98,7 @@ Feature: add users to group
     And the API should not return any data
 
   Scenario: admin tries to add user to a group without sending the group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator tries to add user "brand-new-user" to group "" using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
@@ -113,8 +113,8 @@ Feature: add users to group
     And the API should not return any data
 
   Scenario: a subadmin cannot add users to groups the subadmin is responsible for
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to add user "brand-new-user" to group "new-group" using the provisioning API
@@ -123,8 +123,8 @@ Feature: add users to group
     And user "brand-new-user" should not belong to group "new-group"
 
   Scenario: a subadmin cannot add users to groups the subadmin is not responsible for
-    Given user "other-subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "other-subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "other-group" has been created
     And user "other-subadmin" has been made a subadmin of group "other-group"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -84,7 +84,7 @@ Feature: delete groups
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
   Scenario: normal user tries to delete the group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     When user "brand-new-user" tries to delete group "new-group" using the provisioning API
@@ -93,7 +93,7 @@ Feature: delete groups
     And group "new-group" should exist
 
   Scenario: subadmin of the group tries to delete the group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to delete group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
@@ -9,8 +9,8 @@ Feature: get group
 
   @smokeTest
   Scenario: admin gets users in the group
-    Given user "brand-new-user" has been created with default attributes
-    And user "123" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "123" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "123" has been added to group "new-group"
@@ -50,9 +50,9 @@ Feature: get group
 
   @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "user1" has been added to group "new-group"
@@ -65,7 +65,7 @@ Feature: get group
       | user2 |
 
   Scenario: subadmin tries to get users in a group they are not responsible for
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -74,7 +74,7 @@ Feature: get group
     And the HTTP status code should be "401"
 
   Scenario: normal user tries to get users in their group
-    Given user "newuser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
     And group "new-group" has been created
     When user "newuser" gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -9,7 +9,7 @@ Feature: get subadmin groups
 
   @smokeTest
   Scenario: admin gets subadmin groups of a user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "😅 😆" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -9,7 +9,7 @@ Feature: get user groups
 
   @smokeTest
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
     And group "new-group" has been created
     And group "0" has been created
@@ -37,7 +37,7 @@ Feature: get user groups
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
   @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
     And group "new-group" has been created
     And group "0" has been created
@@ -79,8 +79,8 @@ Feature: get user groups
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group
-    Given user "newuser" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And group "anothergroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
@@ -93,8 +93,8 @@ Feature: get user groups
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get the groups of another user
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
     When user "anotheruser" gets all the groups of user "newuser" using the provisioning API
@@ -103,7 +103,7 @@ Feature: get user groups
     And the API should not return any data
 
   Scenario: admin gets groups of an user who is not in any groups
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -9,7 +9,7 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -23,7 +23,7 @@ Feature: remove a user from a group
       | नेपाली      | Unicode group name          |
 
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -52,7 +52,7 @@ Feature: remove a user from a group
 
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     #And group "<group_id>" has been created
@@ -72,7 +72,7 @@ Feature: remove a user from a group
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -92,7 +92,7 @@ Feature: remove a user from a group
       | brand-new-user | NEW-GROUP | New-Group | new-group |
 
   Scenario: admin tries to remove a user from a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator removes user "brand-new-user" from group "not-group" using the provisioning API
     Then the OCS status code should be "102"
@@ -101,8 +101,8 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario: a subadmin can remove users from groups the subadmin is responsible for
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -112,8 +112,8 @@ Feature: remove a user from a group
     And user "brand-new-user" should not belong to group "new-group"
 
   Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
-    Given user "other-subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "other-subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "other-group" has been created
     And user "brand-new-user" has been added to group "new-group"
@@ -124,8 +124,8 @@ Feature: remove a user from a group
     And user "brand-new-user" should belong to group "new-group"
 
   Scenario: normal user tries to remove a user in their group
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "newuser" has been added to group "new-group"
     And user "anotheruser" has been added to group "new-group"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -106,7 +106,7 @@ Feature: add groups
 
   @issue-31276
   Scenario: normal user tries to create a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" tries to send a group creation request for group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
@@ -114,7 +114,7 @@ Feature: add groups
     And group "new-group" should not exist
 
   Scenario: subadmin tries to create a group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to send a group creation request for group "another-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -9,7 +9,7 @@ Feature: add users to group
 
   @smokeTest
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
@@ -21,7 +21,7 @@ Feature: add users to group
       | नेपाली      | Unicode group name          |
 
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
@@ -48,7 +48,7 @@ Feature: add users to group
 
   @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     #And group "<group_id>" has been created
@@ -66,7 +66,7 @@ Feature: add users to group
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -84,7 +84,7 @@ Feature: add users to group
 
   @issue-31276
   Scenario: normal user tries to add himself to a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" tries to add himself to group "new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
@@ -92,7 +92,7 @@ Feature: add users to group
     And the API should not return any data
 
   Scenario: admin tries to add user to a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator tries to add user "brand-new-user" to group "not-group" using the provisioning API
     Then the OCS status code should be "400"
@@ -100,7 +100,7 @@ Feature: add users to group
     And the API should not return any data
 
   Scenario: admin tries to add user to a group without sending the group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator tries to add user "brand-new-user" to group "" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
@@ -115,8 +115,8 @@ Feature: add users to group
     And the API should not return any data
 
   Scenario: subadmin adds users to groups the subadmin is responsible for
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to add user "brand-new-user" to group "new-group" using the provisioning API
@@ -125,8 +125,8 @@ Feature: add users to group
     And user "brand-new-user" should not belong to group "new-group"
 
   Scenario: subadmin tries to add user to groups the subadmin is not responsible for
-    Given user "other-subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "other-subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "other-group" has been created
     And user "other-subadmin" has been made a subadmin of group "other-group"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -85,7 +85,7 @@ Feature: delete groups
 
   @issue-31276
   Scenario: normal user tries to delete the group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     When user "brand-new-user" tries to delete group "new-group" using the provisioning API
@@ -96,7 +96,7 @@ Feature: delete groups
 
   @issue-31276
   Scenario: subadmin of the group tries to delete the group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to delete group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
@@ -9,8 +9,8 @@ Feature: get group
 
   @smokeTest
   Scenario: admin gets users in the group
-    Given user "brand-new-user" has been created with default attributes
-    And user "123" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And user "123" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "123" has been added to group "new-group"
@@ -50,9 +50,9 @@ Feature: get group
 
   @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "user1" has been added to group "new-group"
@@ -66,7 +66,7 @@ Feature: get group
 
   @issue-31276
   Scenario: subadmin tries to get users in a group they are not responsible for
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -77,7 +77,7 @@ Feature: get group
 
   @issue-31276
   Scenario: normal user tries to get users in their group
-    Given user "newuser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
     And group "new-group" has been created
     When user "newuser" gets all the members of group "new-group" using the provisioning API
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -9,7 +9,7 @@ Feature: get subadmin groups
 
   @smokeTest
   Scenario: admin gets subadmin groups of a user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "😅 😆" has been created
     And user "brand-new-user" has been made a subadmin of group "new-group"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -9,7 +9,7 @@ Feature: get user groups
 
   @smokeTest
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
     And group "new-group" has been created
     And group "0" has been created
@@ -37,7 +37,7 @@ Feature: get user groups
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
   @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
     And group "new-group" has been created
     And group "0" has been created
@@ -79,8 +79,8 @@ Feature: get user groups
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group
-    Given user "newuser" has been created with default attributes
-    And user "subadmin" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And group "anothergroup" has been created
     And user "subadmin" has been made a subadmin of group "newgroup"
@@ -94,8 +94,8 @@ Feature: get user groups
 
   @issue-31276
   Scenario: normal user tries to get the groups of another user
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "newuser" has been added to group "newgroup"
     When user "anotheruser" gets all the groups of user "newuser" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -9,7 +9,7 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -23,7 +23,7 @@ Feature: remove a user from a group
       | नेपाली      | Unicode group name          |
 
    Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -52,7 +52,7 @@ Feature: remove a user from a group
 
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
       # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     #And group "<group_id>" has been created
@@ -72,7 +72,7 @@ Feature: remove a user from a group
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -92,7 +92,7 @@ Feature: remove a user from a group
       | brand-new-user | NEW-GROUP | New-Group | new-group |
 
   Scenario: admin tries to remove a user from a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator removes user "brand-new-user" from group "not-group" using the provisioning API
     Then the OCS status code should be "400"
@@ -101,8 +101,8 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario: a subadmin can remove users from groups the subadmin is responsible for
-    Given user "subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
@@ -112,8 +112,8 @@ Feature: remove a user from a group
     And user "brand-new-user" should not belong to group "new-group"
 
   Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
-    Given user "other-subadmin" has been created with default attributes
-    And user "brand-new-user" has been created with default attributes
+    Given user "other-subadmin" has been created with default attributes and skeleton files
+    And user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And group "other-group" has been created
     And user "brand-new-user" has been added to group "new-group"
@@ -125,8 +125,8 @@ Feature: remove a user from a group
 
   @issue-31276
   Scenario: normal user tries to remove a user in their group
-    Given user "newuser" has been created with default attributes
-    And user "anotheruser" has been created with default attributes
+    Given user "newuser" has been created with default attributes and skeleton files
+    And user "anotheruser" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "newuser" has been added to group "new-group"
     And user "anotheruser" has been added to group "new-group"

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -7,9 +7,9 @@ Feature: accept/decline shares coming from internal users
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -6,8 +6,8 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: user tries to share a file with another user when the sharing api has been disabled
@@ -98,7 +98,7 @@ Feature: sharing
   Scenario Outline: user shares a file with user who is in their group when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -114,7 +114,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp2" has been created
     And group "grp1" has been created
-    And user "user3" has been created with default attributes
+    And user "user3" has been created with default attributes and skeleton files
     And user "user3" has been added to group "grp2"
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -143,7 +143,7 @@ Feature: sharing
   Scenario Outline: user who is a member of a group tries to share a file in the group when group sharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -4,8 +4,8 @@ Feature: sharing
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
 

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -4,9 +4,9 @@ Feature: sharing
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
 
   Scenario: Keep usergroup shares (#22143)
     Given group "grp1" has been created

--- a/tests/acceptance/features/apiShareManagement/multilinksharing.feature
+++ b/tests/acceptance/features/apiShareManagement/multilinksharing.feature
@@ -3,7 +3,7 @@ Feature: multilinksharing
 
   Background:
     Given using old DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And as user "user0"
 
   @smokeTest

--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -3,12 +3,12 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
 
   Scenario Outline: User is not allowed to reshare file
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | /textfile0.txt |
       | shareType   | 0              |
@@ -28,7 +28,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare file with more permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | /textfile0.txt |
       | shareType   | 0              |
@@ -48,7 +48,7 @@ Feature: sharing
 
   Scenario Outline: Do not allow reshare to exceed permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/TMP"
     And user "user0" has created a share with settings
       | path        | /TMP  |
@@ -71,8 +71,8 @@ Feature: sharing
       | 2               | 404              |
 
   Scenario: Reshared files can be still accessed if a user in the middle removes it.
-    Given user "user2" has been created with default attributes
-    And user "user3" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user1" has moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
     And user "user1" has shared file "textfile0_shared.txt" with user "user2"
@@ -113,7 +113,7 @@ Feature: sharing
 
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | /textfile0.txt |
       | shareType   | 0              |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   @skipOnEncryptionType:user-keys @issue-32322
@@ -238,7 +238,7 @@ Feature: sharing
 
   Scenario Outline: Share of folder and sub-folder to same user - core#20645
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp4" has been created
     And user "user1" has been added to group "grp4"
     When user "user0" shares file "/PARENT" with user "user1" using the sharing API
@@ -261,8 +261,8 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Share of folder to a group
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
@@ -315,8 +315,8 @@ Feature: sharing
   @smokeTest
   Scenario: unique target names for incoming shares
     Given using OCS API version "1"
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/foo"
     And user "user1" has created folder "/foo"
     When user "user0" shares file "/foo" with user "user2" using the sharing API
@@ -327,7 +327,7 @@ Feature: sharing
 
   Scenario Outline: sharing again an own file while belonging to a group
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user1" has shared file "welcome.txt" with group "grp1"
@@ -622,8 +622,8 @@ Feature: sharing
 
   Scenario Outline: Share of folder to a group with emoji in the name
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And group "😀 😁" has been created
     And user "user1" has been added to group "😀 😁"
     And user "user2" has been added to group "😀 😁"

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -5,8 +5,8 @@ Feature: sharing
     Given using old DAV path
 
   Scenario Outline: Delete all group shares
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
@@ -23,7 +23,7 @@ Feature: sharing
 
   @smokeTest
   Scenario Outline: delete a share
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs_api_version>"
     And user "user0" has shared file "textfile0.txt" with user "user1"
@@ -86,7 +86,7 @@ Feature: sharing
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -101,7 +101,7 @@ Feature: sharing
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has created folder "/shared/sub"
@@ -124,7 +124,7 @@ Feature: sharing
       | username |
       | user0    |
       | user1    |
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
     And user "user2" has shared file "/PARENT/parent.txt" with group "grp1"
@@ -142,7 +142,7 @@ Feature: sharing
 
   Scenario: sharee of a read-only share folder tries to delete the shared folder
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -153,7 +153,7 @@ Feature: sharing
 
   Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"

--- a/tests/acceptance/features/apiShareManagementBasic/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/updateShare.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Allow modification of reshare
@@ -245,7 +245,7 @@ Feature: sharing
 
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "textfile0.txt" with group "grp1"
@@ -431,7 +431,7 @@ Feature: sharing
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user2" has been added to group "grp1"
     And user "user1" has been added to group "grp1"

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -3,8 +3,8 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Sharee can see the share

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -4,8 +4,8 @@ Feature: sharing
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario: moving a file into a share as recipient

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest @public_link_share-feature-required
   Scenario: Downloading from upload-only share is forbidden
@@ -16,8 +16,8 @@ Feature: sharing
     And the HTTP status code should be "404"
 
   Scenario: Share a file by multiple channels and download from sub-folder and direct file share
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
@@ -37,7 +37,7 @@ Feature: sharing
 
   @smokeTest
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with default permissions
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     When user "user0" creates a share using the sharing API with settings
       | path      | PARENT |
       | shareType | user   |
@@ -45,7 +45,7 @@ Feature: sharing
     Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     When user "user0" has shared folder "PARENT" with group "grp1"
@@ -59,7 +59,7 @@ Feature: sharing
     Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     When user "user0" creates a share using the sharing API with settings
       | path        | PARENT |
       | shareType   | user   |
@@ -68,7 +68,7 @@ Feature: sharing
     Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     When user "user0" creates a share using the sharing API with settings
@@ -87,7 +87,7 @@ Feature: sharing
     Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     When user "user0" creates a share using the sharing API with settings
       | path        | PARENT |
       | shareType   | user   |
@@ -96,7 +96,7 @@ Feature: sharing
     Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     When user "user0" creates a share using the sharing API with settings

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -3,8 +3,8 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Correct webdav share-permissions for owned file

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -3,8 +3,8 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: getting all shares of a user using that user
@@ -35,8 +35,8 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
-    And user "user3" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user0" has shared file "textfile0.txt" with user "user2"
     When user "user0" gets all the shares from the file "textfile0.txt" using the sharing API
@@ -53,8 +53,8 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file with reshares
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
-    And user "user3" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user1" has shared file "textfile0 (2).txt" with user "user2"
     When user "user0" gets all the shares with reshares from the file "textfile0.txt" using the sharing API
@@ -72,7 +72,7 @@ Feature: sharing
   Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been added to group "grp1"
     And user "user2" has created folder "/shared"
     And user "user2" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -120,7 +120,7 @@ Feature: sharing
 
   Scenario Outline: Get a share with a user that didn't receive the share
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     When user "user2" gets the info of the last share using the sharing API
     Then the OCS status code should be "404"
@@ -133,7 +133,7 @@ Feature: sharing
   @skipOnLDAP
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And group "group0" has been created
     And user "user1" has been added to group "group0"
     And user "user2" has been added to group "group0"

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest @public_link_share-feature-required
   Scenario: Uploading same file to a public upload-only share multiple times
@@ -39,7 +39,7 @@ Feature: sharing
     And the HTTP status code should be "403"
 
   Scenario: Uploading file to a user read-only share folder does not work
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -50,7 +50,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
     Given using <dav-path> DAV path
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
@@ -86,7 +86,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a user upload-only share folder works
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -101,7 +101,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group upload-only share folder works
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
@@ -129,7 +129,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Uploading file to a user read/write share folder works
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -144,7 +144,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read/write share folder works
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
@@ -162,7 +162,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Check quota of owners parent directory of a shared file
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user1" has been set to "0"
     And user "user0" has moved file "/welcome.txt" to "/myfile.txt"
     And user "user0" has shared file "myfile.txt" with user "user1"
@@ -185,7 +185,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -201,7 +201,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
@@ -228,7 +228,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with upload-only permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -244,7 +244,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with upload-only permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user0" has created a share with settings
@@ -300,7 +300,7 @@ Feature: sharing
 
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" creates folder "/READ_ONLY" using the WebDAV API
     And user "user0" has created a share with settings
       | path        | /READ_ONLY |

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -2,7 +2,7 @@
 Feature: sharees
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | sharee1  |
@@ -453,7 +453,7 @@ Feature: sharees
   @skipOnLDAP
   Scenario Outline: Enumerate only group members - only show partial results from member groups
     Given using OCS API version "<ocs-api-version>"
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | another  | Another     |
     And user "Another" has been added to group "ShareeGroup2"

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -8,7 +8,7 @@ Feature: Display notifications when receiving a share
     Given app "notifications" has been enabled
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -4,7 +4,7 @@ Feature: Assign tags to file/folder
   So that I can organize the files/folders easily
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -3,7 +3,7 @@ Feature: Title of your feature
   I want to use this template for my feature file
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And as user "user1"
 
   Scenario: User can assign tags when in the tag's groups

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -5,7 +5,7 @@ Feature: Creation of tags
   So that I could categorize my files
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -4,7 +4,7 @@ Feature: Deletion of tags
   I want to delete the tags that are already created
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And as user "user0"
 
   @smokeTest

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -4,7 +4,7 @@ Feature: Editing the tags
   I want to be able to change the tags I have created
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And as user "user0"
 
   @smokeTest

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -2,7 +2,7 @@
 Feature: tags
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -4,7 +4,7 @@ Feature: Unassigning tags from file/folder
   I want to be able to remove tags from file/folder
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -11,7 +11,7 @@ Feature: files and folders can be deleted from the trashbin
   @smokeTest
   Scenario Outline: Trashbin can be emptied
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And a new browser session for "user0" has been started
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -11,7 +11,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @smokeTest
   Scenario Outline: deleting a file moves it to trashbin
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     When user "user0" deletes file "/textfile0.txt" using the WebDAV API
     Then as "user0" file "/textfile0.txt" should exist in trash
     But as "user0" file "/textfile0.txt" should not exist
@@ -22,7 +22,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a folder moves it to trashbin
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/tmp"
     When user "user0" deletes folder "/tmp" using the WebDAV API
     Then as "user0" folder "/tmp" should exist in trash
@@ -33,7 +33,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a file in a folder moves it to the trashbin root
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
@@ -47,8 +47,8 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a file in a shared folder moves it to the trashbin root
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -63,8 +63,8 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a shared folder moves it to trashbin
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -77,8 +77,8 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a received folder doesn't move it to trashbin
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -92,8 +92,8 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a file in a received folder moves it to trashbin
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -112,7 +112,7 @@ Feature: files and folders exist in the trashbin after being deleted
   # thus testing the required behavior.
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/folderA"
     And user "user0" has created folder "/folderB"
     And user "user0" has created folder "/folderC"
@@ -141,7 +141,7 @@ Feature: files and folders exist in the trashbin after being deleted
   # Note: the underlying acceptance test code ensures that each delete step is separated by a least 1 second
   Scenario Outline: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/folderA"
     And user "user0" has created folder "/folderB"
     And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
@@ -163,7 +163,7 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: Deleting a folder into external storage moves it to the trashbin
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -10,8 +10,8 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -31,7 +31,7 @@ Feature: Restore deleted files/folders
   @smokeTest
   Scenario Outline: A deleted file can be restored
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     And as "user0" file "/textfile0.txt" should exist in trash
     And user "user0" has logged in to a web-style session
@@ -53,7 +53,7 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: A file deleted from a folder can be restored to the original folder
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
@@ -68,7 +68,7 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: A file deleted from a folder is restored to root if the original folder does not exist
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
@@ -84,7 +84,7 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and restored
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
@@ -101,7 +101,7 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
@@ -122,7 +122,7 @@ Feature: Restore deleted files/folders
   Scenario Outline: Deleting a file into external storage moves it to the trashbin and can be restored
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
@@ -145,7 +145,7 @@ Feature: Restore deleted files/folders
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
     Given using old DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
@@ -162,7 +162,7 @@ Feature: Restore deleted files/folders
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
     Given using new DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has uploaded the following chunks to "/local_storage/tmp/textfile0.txt" with new chunking

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -5,7 +5,7 @@ Feature: dav-versions
   Background:
     Given using OCS API version "2"
     And using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And file "/davtest.txt" has been deleted for user "user0"
 
   Scenario: Upload file and no version is available
@@ -94,14 +94,14 @@ Feature: dav-versions
     And as user "user0" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
 
   Scenario: User cannot access meta folder of a file which is owned by somebody else
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "123" to "/davtest.txt"
     And we save it into "FILEID"
     When user "user1" sends HTTP method "PROPFIND" to URL "/remote.php/dav/meta/<<FILEID>>"
     Then the HTTP status code should be "404"
 
   Scenario: User can access meta folder of a file which is owned by somebody else but shared with that user
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "123" to "/davtest.txt"
     And user "user0" has uploaded file with content "456789" to "/davtest.txt"
     And we save it into "FILEID"
@@ -113,7 +113,7 @@ Feature: dav-versions
     Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element
 
   Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
     And user "user0" has shared file "sharefile.txt" with user "user1"
     When user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
@@ -121,7 +121,7 @@ Feature: dav-versions
     And the version folder of file "/sharefile.txt" for user "user0" should contain "1" element
 
   Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
     And user "user0" has shared file "sharefile.txt" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
@@ -131,7 +131,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "user1" should be "user0 content"
 
   Scenario: sharer can restore a file inside a shared folder modified by sharee
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -142,7 +142,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
   Scenario: sharee can restore a file inside a shared folder modified by sharee
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -153,7 +153,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -164,7 +164,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
   Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -175,7 +175,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -186,7 +186,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -197,7 +197,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -210,7 +210,7 @@ Feature: dav-versions
     And the content of file "/received/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "old content" to "/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharefile.txt"
     And user "user0" has shared file "/sharefile.txt" with user "user1"
@@ -222,7 +222,7 @@ Feature: dav-versions
     And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
 
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
@@ -235,8 +235,8 @@ Feature: dav-versions
     And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
 
   Scenario: sharer can restore a file inside a group shared folder modified by sharee
-    Given user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -2,7 +2,7 @@
 Feature: there can be only one exclusive lock on a resource
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: a second lock cannot be set on a folder when its exclusively locked
     Given using <dav-path> DAV path
@@ -86,7 +86,7 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: a share receiver cannot lock a resource exclusively locked by itself
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user1" has locked file "textfile0 (2).txt" setting following properties
       | lockscope | exclusive |
@@ -104,7 +104,7 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: a share receiver cannot lock a resource exclusively locked by the owner
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user0" has locked file "textfile0.txt" setting following properties
       | lockscope | exclusive |
@@ -122,7 +122,7 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: a share owner cannot lock a resource exclusively locked by a share receiver
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user1" has locked file "textfile0 (2).txt" setting following properties
       | lockscope | exclusive |

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -2,7 +2,7 @@
 Feature: lock folders
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: upload to a locked folder
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -2,7 +2,7 @@
 Feature: persistent-locking in case of a public link
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Uploading a file into a locked public folder
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -2,7 +2,7 @@
 Feature: LOCKDISCOVERY for public links
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: lockdiscovery root of public link when root is locked
     Given user "user0" has created a public link share of folder "PARENT" with change permission

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -2,7 +2,7 @@
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: rename a file in a locked folder
     Given using <dav-path> DAV path
@@ -54,7 +54,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @issue-34338
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared folder "PARENT" with user "user1"
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
@@ -88,7 +88,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @issue-34360
   Scenario Outline: two users having both a shared lock can use the resource
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And user "user0" has locked file "textfile0.txt" setting following properties
       | lockscope | shared |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -2,7 +2,7 @@
 Feature: lock should propagate correctly if a share is reshared
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
     | username |
     | user0    |
     | user1    |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -2,7 +2,7 @@
 Feature: set timeouts of LOCKS
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: set timeout on folder
     Given using <dav-path> DAV path
@@ -33,7 +33,7 @@ Feature: set timeouts of LOCKS
 
   Scenario Outline: as owner set timeout on folder as receiver check it
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared folder "PARENT" with user "user1"
     When user "user0" locks folder "PARENT" using the WebDAV API setting following properties
       | lockscope | shared    |
@@ -62,7 +62,7 @@ Feature: set timeouts of LOCKS
 
   Scenario Outline: as share receiver set timeout on folder as owner check it
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared folder "PARENT" with user "user1"
     When user "user1" locks folder "PARENT (2)" using the WebDAV API setting following properties
       | lockscope | shared    |

--- a/tests/acceptance/features/apiWebdavLocks2/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/unlock.feature
@@ -2,7 +2,7 @@
 Feature: UNLOCK locked items
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     
   Scenario Outline: unlock a single lock set by the user itself
     Given using <dav-path> DAV path
@@ -48,7 +48,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has locked file "PARENT/parent.txt" setting following properties
       | lockscope | <lock-scope> |
     And user "user0" has shared file "PARENT/parent.txt" with user "user1"
@@ -65,7 +65,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as share receiver unlocking a file in a share locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has locked file "PARENT/parent.txt" setting following properties
       | lockscope | <lock-scope> |
     And user "user0" has shared folder "PARENT" with user "user1"
@@ -82,7 +82,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     And user "user0" has shared folder "PARENT" with user "user1"
@@ -103,7 +103,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has locked file "PARENT/parent.txt" setting following properties
       | lockscope | <lock-scope> |
     And user "user0" has shared file "PARENT/parent.txt" with user "user1"
@@ -120,7 +120,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as share receiver unlock a shared file
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared file "PARENT/parent.txt" with user "user1"
     And user "user1" has locked file "parent.txt" setting following properties
       | lockscope | <lock-scope> |
@@ -137,7 +137,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as owner unlocking a shared file locked by the receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared file "PARENT/parent.txt" with user "user1"
     And user "user1" has locked file "parent.txt" setting following properties
       | lockscope | <lock-scope> |
@@ -154,7 +154,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as owner unlocking a file in a share that was locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared folder "PARENT" with user "user1"
     And user "user1" has locked file "PARENT (2)/parent.txt" setting following properties
       | lockscope | <lock-scope> |
@@ -171,7 +171,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: as owner unlocking a shared folder locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has shared folder "PARENT" with user "user1"
     And user "user1" has locked folder "PARENT (2)" setting following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -6,7 +6,7 @@ Feature: move (rename) file
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Moving a file
@@ -66,7 +66,7 @@ Feature: move (rename) file
 
   Scenario Outline: Moving a file to a folder with no permissions
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
@@ -84,7 +84,7 @@ Feature: move (rename) file
 
   Scenario Outline: Moving a file to overwrite a file in a folder with no permissions
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
@@ -141,7 +141,7 @@ Feature: move (rename) file
 
   Scenario Outline: Checking file id after a move between received shares
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/folderA"
     And user "user0" has created folder "/folderB"
     And user "user0" has shared folder "/folderA" with user "user1"

--- a/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
@@ -6,7 +6,7 @@ Feature: move (rename) file
 
   Background:
     Given using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the administrator has enabled async operations
 
   Scenario Outline: Moving a file
@@ -84,7 +84,7 @@ Feature: move (rename) file
       | /textfile1.txt |
 
   Scenario: Moving a file to a folder with no permissions
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
@@ -102,7 +102,7 @@ Feature: move (rename) file
       | /textfile0.txt |
 
   Scenario: Moving a file to overwrite a file in a folder with no permissions
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
@@ -189,7 +189,7 @@ Feature: move (rename) file
   Scenario Outline: enabling async operations does no difference to normal MOVE - Moving a file to a folder with no permissions
     Given the administrator has enabled async operations
     And using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |

--- a/tests/acceptance/features/apiWebdavMove/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFolder.feature
@@ -6,7 +6,7 @@ Feature: move (rename) folder
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Renaming a folder to a backslash encoded should return an error
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
@@ -6,7 +6,7 @@ Feature: delete file
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: delete a file

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -6,7 +6,7 @@ Feature: delete folder
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: delete a folder
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
@@ -6,7 +6,7 @@ Feature: delete folder contents
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Removing everything of a folder
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -6,7 +6,7 @@ Feature: download file
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: download a file

--- a/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
@@ -22,7 +22,7 @@ Feature: refuse access
 
   Scenario Outline: A disabled user cannot use webdav
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has been disabled
     When user "user1" downloads file "/welcome.txt" using the WebDAV API
     Then the HTTP status code should be "401"

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -5,7 +5,7 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/just-a-folder"
     And user "user0" has created folder "/फनी näme"
     And user "user0" has created folder "/upload folder"

--- a/tests/acceptance/features/apiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/copyFile.feature
@@ -6,7 +6,7 @@ Feature: copy file
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Copying a file
@@ -44,7 +44,7 @@ Feature: copy file
 
   Scenario Outline: Copying a file to a folder with no permissions
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
@@ -62,7 +62,7 @@ Feature: copy file
 
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |

--- a/tests/acceptance/features/apiWebdavProperties/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/createFolder.feature
@@ -6,7 +6,7 @@ Feature: create folder
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: create a folder
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -6,7 +6,7 @@ Feature: get file properties
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Do a PROPFIND of various file names
@@ -71,7 +71,7 @@ Feature: get file properties
 
   Scenario Outline: A file that is shared to a user has a share-types property
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has created a share with settings
       | path        | test  |
@@ -124,7 +124,7 @@ Feature: get file properties
   @skipOnLDAP @user_ldap-issue-268 @public_link_share-feature-required
   Scenario Outline: A file that is shared by user,group and link has a share-types property
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp2" has been created
     And user "user0" has created folder "/test"
     And user "user0" has created a share with settings

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -6,7 +6,7 @@ Feature: get quota
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Retrieving folder quota when no quota is set
     Given using <dav_version> DAV path
@@ -29,7 +29,7 @@ Feature: get quota
 
   Scenario Outline: Retrieving folder quota of shared folder with quota when no quota is set for recipient
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has been given unlimited quota
     And the quota of user "user1" has been set to "10 MB"
     And user "user1" has created folder "/testquota"
@@ -60,7 +60,7 @@ Feature: get quota
 
   Scenario Outline: Retrieving folder quota when quota is set and a file was recieved
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user1" has been set to "1 KB"
     And user "user0" has uploaded file "/user0.txt" of 93 bytes
     And user "user0" has shared file "user0.txt" with user "user1"

--- a/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
@@ -6,7 +6,7 @@ Feature: set file properties
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Setting custom DAV property and reading it
@@ -47,7 +47,7 @@ Feature: set file properties
 
   Scenario Outline: Setting custom DAV property on a shared file as an owner and reading as a recipient
     Given using <dav_version> DAV path
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/testcustompropshared.txt"
     And user "user0" has created a share with settings
       | path        | testcustompropshared.txt |

--- a/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
@@ -6,7 +6,7 @@ Feature: upload file
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: upload a file and check download content

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
@@ -6,7 +6,7 @@ Feature: upload file using new chunking
 
   Background:
     Given using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And the administrator has enabled async operations

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
@@ -7,7 +7,7 @@ Feature: upload file using new chunking
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
 

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
@@ -7,7 +7,7 @@ Feature: upload file using old chunking
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -331,8 +331,21 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^these users have been created\s?(with default attributes|)\s?(but not initialized|):$/
-	 * @Given /^these users have been created\s?(with default attributes and skeleton files|)\s?(but not initialized|):$/
+	 * @Given these users have been created with skeleton files:
+	 * expects a table of users with the heading
+	 * "|username|password|displayname|email|"
+	 * password, displayname & email are optional
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theseUsersHaveBeenCreatedWithSkeletonFiles(TableNode $table) {
+		$this->theseUsersHaveBeenCreated("", "", $table);
+	}
+
+	/**
+	 * @Given /^these users have been created\s?(with default attributes|with default attributes and skeleton files|)\s?(but not initialized|):$/
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
 	 * password, displayname & email are optional

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -257,6 +257,7 @@ trait Provisioning {
 
 	/**
 	 * @Given /^user "([^"]*)" has been created with default attributes$/
+	 * @Given /^user "([^"]*)" has been created with default attributes and skeleton files$/
 	 *
 	 * @param string $user
 	 *
@@ -331,6 +332,7 @@ trait Provisioning {
 
 	/**
 	 * @Given /^these users have been created\s?(with default attributes|)\s?(but not initialized|):$/
+	 * @Given /^these users have been created\s?(with default attributes and skeleton files|)\s?(but not initialized|):$/
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
 	 * password, displayname & email are optional

--- a/tests/acceptance/features/cliBackground/backgroundQueue.feature
+++ b/tests/acceptance/features/cliBackground/backgroundQueue.feature
@@ -23,7 +23,7 @@ Feature: get status, delete and execute jobs in background queue
       | OC\Authentication\Token\DefaultTokenCleanupJob     |
 
   Scenario: delete one of the job in background queue
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     When the administrator deletes last background job "OC\Command\CommandJob" using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliEncryption/recreatemasterkey.feature
+++ b/tests/acceptance/features/cliEncryption/recreatemasterkey.feature
@@ -7,7 +7,7 @@ Feature: recreate-master-key
     Then the downloaded content when downloading file "/somefile.txt" for user "admin" with range "bytes=0-6" should be "This is"
 
   Scenario: recreate masterkey and upload data
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     When the administrator successfully recreates the encryption masterkey using the occ command
     And user "user0" uploads chunk file "1" of "1" with "AA" to "/somefile.txt" using the WebDAV API

--- a/tests/acceptance/features/cliMain/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliMain/cliIncomingShares.feature
@@ -7,7 +7,7 @@ Feature: poll incoming shares
 
   Scenario: poll incoming share with a federation share of deep nested folders when there is a file change in remote end
     Given using server "REMOTE"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/really/"
     And user "user0" has created folder "/really/very/"
     And user "user0" has created folder "/really/very/deeply/"
@@ -17,7 +17,7 @@ Feature: poll incoming shares
     And user "user0" has created folder "/really/very/deeply/nested/folder/with/sub/"
     And user "user0" has created folder "/really/very/deeply/nested/folder/with/sub/folders"
     And using server "LOCAL"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has stored etag of element "/"
     And user "user0" from server "REMOTE" has shared "/really" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
@@ -29,10 +29,10 @@ Feature: poll incoming shares
 
   Scenario: poll incoming share with a federation share and no file change
     Given using server "REMOTE"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shareFolder/"
     And using server "LOCAL"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has stored etag of element "/"
     And user "user0" from server "REMOTE" has shared "/shareFolder" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
@@ -43,11 +43,11 @@ Feature: poll incoming shares
 
   Scenario: poll incoming share multiple times
     Given using server "REMOTE"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shareFolder/"
     And using server "LOCAL"
     And user "user1" has stored etag of element "/"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" from server "REMOTE" has shared "/shareFolder" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
@@ -60,7 +60,7 @@ Feature: poll incoming shares
     Then the etag of element "/" of user "user1" should not have changed
 
   Scenario: poll incoming share when there is no share
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has stored etag of element "/"
     When the administrator invokes occ command "incoming-shares:poll"
     Then the etag of element "/" of user "user1" should not have changed

--- a/tests/acceptance/features/cliMain/files.feature
+++ b/tests/acceptance/features/cliMain/files.feature
@@ -3,7 +3,7 @@ Feature: Files Operations command
 
   Scenario: Adding a file to local storage and running scan should add files.
     Given using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
     And the administrator has scanned the filesystem for all users
@@ -21,7 +21,7 @@ Feature: Files Operations command
 
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
     Given using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     And user "user0" has created folder "/local_storage/folder1"
     And user "user0" has created folder "/local_storage/folder2"
@@ -46,7 +46,7 @@ Feature: Files Operations command
 
   Scenario Outline: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -79,7 +79,7 @@ Feature: Files Operations command
 
   Scenario: Adding a folder to local storage, sharing with groups and running scan for a list of groups should add files for users in the groups
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -137,7 +137,7 @@ Feature: Files Operations command
 
   Scenario: administrator should be able to create a local mount for a specific user
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -152,7 +152,7 @@ Feature: Files Operations command
 
   Scenario: Deleting a file from local storage and running scan for a specific path should remove the file.
     Given using new DAV path
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/hello1.txt"
     When user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
@@ -168,7 +168,7 @@ Feature: Files Operations command
 
   Scenario: Adding a file on local storage and running file scan for a specific user should add file for only that user
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -197,7 +197,7 @@ Feature: Files Operations command
 
   Scenario: Adding a file on local storage and running file scan for a specific group should add file for only the users of that group
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -238,7 +238,7 @@ Feature: Files Operations command
 
   Scenario: administrator should be able to add more than one user as the applicable user for a local mount
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -252,7 +252,7 @@ Feature: Files Operations command
 
   Scenario: user should get access if the user is removed from the applicable user and the user was the only applicable user
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -264,7 +264,7 @@ Feature: Files Operations command
 
   Scenario: user should not get access if the user is removed from the applicable user and the user was not the only applicable user
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -277,7 +277,7 @@ Feature: Files Operations command
 
   Scenario: administrator should be able to create a local mount for a specific group
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -290,7 +290,7 @@ Feature: Files Operations command
 
   Scenario: administrator should be able to create a local mount for more than one group
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -308,7 +308,7 @@ Feature: Files Operations command
 
   Scenario: administrator should be able to create a local mount for a specific group and user
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user3    |
@@ -322,7 +322,7 @@ Feature: Files Operations command
 
   Scenario: removing group from applicable group of a local mount
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -336,7 +336,7 @@ Feature: Files Operations command
 
   Scenario: user should get access if the group of the user is removed from the applicable group and that group was the only applicable group
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -350,7 +350,7 @@ Feature: Files Operations command
 
   Scenario: user should not get access if the group of the user is removed from the applicable group and that group was not the only applicable group
     Given using new DAV path
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user3    |

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -4,8 +4,8 @@ Feature: transfer-ownership
   @smokeTest
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of a file
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
@@ -13,8 +13,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of a file after updating the file
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
     And user "user0" has uploaded the following "3" chunks to "/PARENT/textfile0.txt" with old chunking
       | 1 | AA |
@@ -26,8 +26,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of a folder
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -36,9 +36,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of file shares
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     And user "user0" has shared file "/somefile.txt" with user "user2" with permissions 19
     When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -47,9 +47,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder shared with third user
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
@@ -59,8 +59,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder shared with transfer recipient
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
@@ -72,9 +72,9 @@ Feature: transfer-ownership
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder doubly shared with third user
     Given group "group1" has been created
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been added to group "group1"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
@@ -86,9 +86,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not transfer received shares
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has created folder "/test"
     And user "user2" has shared folder "/test" with user "user0" with permissions 31
     When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -97,17 +97,17 @@ Feature: transfer-ownership
 
   @local_storage @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not transfer external storage
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command should have been successful
     And as "user1" folder "/local_storage" should not exist in the last received transfer folder
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not fail with shared trashed files
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sub"
     And user "user0" has created folder "/sub/test"
     And user "user0" has shared folder "/sub/test" with user "user2" with permissions 31
@@ -116,13 +116,13 @@ Feature: transfer-ownership
     Then the command should have been successful
 
   Scenario: transferring ownership fails with invalid source user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     When the administrator transfers ownership from "invalid_user" to "user0" using the occ command
     Then the command output should contain the text "Unknown source user"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with invalid destination user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     When the administrator transfers ownership from "user0" to "invalid_user" using the occ command
     Then the command output should contain the text "Unknown destination user"
     And the command should have failed with exit code 1
@@ -130,8 +130,8 @@ Feature: transfer-ownership
   @smokeTest
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of only a single folder containing a file
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
@@ -139,8 +139,8 @@ Feature: transfer-ownership
     And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" from the last received transfer folder should be "This is"
 
   Scenario: transferring ownership of only a single folder containing an empty folder
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/subfolder"
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
@@ -149,8 +149,8 @@ Feature: transfer-ownership
     And as "user1" folder "/test/subfolder" should exist in the last received transfer folder
 
   Scenario: transferring ownership of an account containing only an empty folder
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has deleted everything from folder "/"
     And user "user0" has created folder "/test"
     When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -159,9 +159,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of file shares
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared file "/test/somefile.txt" with user "user2" with permissions 19
@@ -171,9 +171,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required
   Scenario: transferring ownership of folder shares which has public link
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
@@ -185,9 +185,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder shared with third user
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user2" with permissions 31
@@ -197,8 +197,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder shared with transfer recipient
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions 31
@@ -210,9 +210,9 @@ Feature: transfer-ownership
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder doubly shared with third user
     Given group "group1" has been created
-    And user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has been added to group "group1"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
@@ -223,9 +223,9 @@ Feature: transfer-ownership
     And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
   Scenario: transferring ownership does not transfer received shares
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
-    And user "user2" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has created folder "/test"
     And user "user0" has created folder "/sub"
     And user "user2" has shared folder "/test" with user "user0" with permissions 31
@@ -236,8 +236,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required
   Scenario: transferring ownership of folder shared with transfer recipient and public link created of received share works
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/foo"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
@@ -252,37 +252,37 @@ Feature: transfer-ownership
 
   @local_storage
   Scenario: transferring ownership does not transfer external storage
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
     Then the command should have been successful
     And as "user1" folder "/local_storage" should not exist in the last received transfer folder
 
   Scenario: transferring ownership fails with invalid source user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "invalid_user" to "user0" using the occ command
     Then the command output should contain the text "Unknown source user"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with invalid destination user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "user0" to "invalid_user" using the occ command
     Then the command output should contain the text "Unknown destination user"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with invalid path
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
     Then the command output should contain the text "Unknown path provided"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with empty files
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has deleted everything from folder "/"
     When the administrator transfers ownership from "user0" to "user1" using the occ command
     Then the command output should contain the text "No files/folders to transfer"

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -6,7 +6,7 @@ Feature: add users to group
 
   @smokeTest
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the occ command
     Then the command should have been successful
@@ -19,7 +19,7 @@ Feature: add users to group
       | नेपाली      | Unicode group name          |
 
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -36,7 +36,7 @@ Feature: add users to group
       | brand-new-user | NEW-GROUP | New-Group | new-group |
 
   Scenario: admin tries to add user to a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator adds user "brand-new-user" to group "not-group" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -31,13 +31,13 @@ Feature: add a user using the using the occ command
       | email       | justauser@example.com |
 
   Scenario: admin tries to create an existing user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator tries to create a user "brand-new-user" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The user "brand-new-user" already exists.'
 
   Scenario: admin tries to create an existing disabled user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And user "brand-new-user" has been disabled
     When the administrator tries to create a user "brand-new-user" using the occ command
     Then the command should have failed with exit code 1
@@ -82,7 +82,7 @@ Feature: add a user using the using the occ command
     And the display name of user "brand-new-user" should be "Brand-New-User"
 
   Scenario: admin tries to create an existing user but with username containing capital letters
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator creates this user using the occ command:
       | username       |
       | Brand-New-User |

--- a/tests/acceptance/features/cliProvisioning/deleteUser.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteUser.feature
@@ -5,7 +5,7 @@ Feature: delete users
   So that I can remove users from ownCloud
 
   Scenario: admin deletes a user
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       |
       | brand-new-user |
     When the administrator deletes user "brand-new-user" using the occ command
@@ -14,7 +14,7 @@ Feature: delete users
     And user "brand-new-user" should not exist
 
   Scenario: Delete a user, and specify the user name in different case
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       |
       | brand-new-user |
     When the administrator deletes user "Brand-New-User" using the occ command

--- a/tests/acceptance/features/cliProvisioning/disableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/disableUser.feature
@@ -5,14 +5,14 @@ Feature: disable user
   So that I can remove access to files and resources for a user, without actually deleting the files and resources
 
   Scenario: admin disables an user
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     When the administrator disables user "user1" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is disabled'
     And user "user1" should be disabled
 
   Scenario: Admin can disable another admin user
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     When the administrator disables user "another-admin" using the occ command
     Then the command should have been successful
@@ -20,7 +20,7 @@ Feature: disable user
     And user "another-admin" should be disabled
 
   Scenario: Admin can disable subadmins in the same group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -5,7 +5,7 @@ Feature: edit users
   So that I can keep the user information up-to-date
 
   Scenario: the administrator can edit a user email
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The email address of brand-new-user updated to brand-new-user@example.com'
@@ -14,7 +14,7 @@ Feature: edit users
       | email | brand-new-user@example.com |
 
   Scenario: the administrator can edit a user display name
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The displayname of brand-new-user updated to A New User'
@@ -24,7 +24,7 @@ Feature: edit users
 
   @issue-23603
   Scenario: the administrator can edit a user quota
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the occ command
     Then the command should have failed with exit code 1
     #Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/enableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/enableUser.feature
@@ -5,7 +5,7 @@ Feature: enable user
   So that I can give a user access to their files and resources again if they are now authorized for that
 
   Scenario: admin enables an user
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has been disabled
     When administrator enables user "user1" using the occ command
     Then the command should have been successful
@@ -13,7 +13,7 @@ Feature: enable user
     And user "user1" should be enabled
 
   Scenario: admin enables another admin user
-    Given user "another-admin" has been created with default attributes
+    Given user "another-admin" has been created with default attributes and skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When administrator enables user "another-admin" using the occ command
@@ -22,7 +22,7 @@ Feature: enable user
     And user "another-admin" should be enabled
 
   Scenario: admin enables subadmins in the same group
-    Given user "subadmin" has been created with default attributes
+    Given user "subadmin" has been created with default attributes and skeleton files
     And group "new-group" has been created
     And user "subadmin" has been added to group "new-group"
     And the administrator has been added to group "new-group"

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -5,7 +5,7 @@ Feature: get group
   So that I can know which users are in a group
 
   Scenario: admin gets users in the group
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       |
       | brand-new-user |
       | 123            |

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -21,7 +21,7 @@ Feature: get group
       | 123            | 123          |
 
   Scenario: admin gets user in the group who is disabled
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "Anne Brown"
     And user "brand-new-user" has been disabled
     And group "new-group" has been created

--- a/tests/acceptance/features/cliProvisioning/getUser.feature
+++ b/tests/acceptance/features/cliProvisioning/getUser.feature
@@ -5,7 +5,7 @@ Feature: get user
   So that I can see the information
 
   Scenario: admin gets an existing user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "Anne Brown"
     When the administrator retrieves the information of user "brand-new-user" in JSON format using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/getUserGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getUserGroups.feature
@@ -5,7 +5,7 @@ Feature: get user groups
   So that I can manage group membership
 
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
     And group "new-group" has been created
     And group "0" has been created
@@ -28,7 +28,7 @@ Feature: get user groups
       | नेपाली               |
 
   Scenario: admin gets groups of an user who is not in any groups
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
     When the administrator gets the groups of user "brand-new-user" in JSON format using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -5,7 +5,7 @@ Feature: remove a user from a group
   So that I can manage user access to group resources
 
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the occ command
@@ -19,7 +19,7 @@ Feature: remove a user from a group
       | नेपाली      | Unicode group name          |
 
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -39,14 +39,14 @@ Feature: remove a user from a group
       | brand-new-user | NEW-GROUP | New-Group | new-group |
 
   Scenario: admin tries to remove a user from a group which does not exist
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "not-group" has been deleted
     When the administrator removes user "brand-new-user" from group "not-group" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group "not-group" does not exist'
 
   Scenario: admin tries to remove a user from a group which the user is not a member of
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "new-group" has been created
     When the administrator removes user "brand-new-user" from group "new-group" using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -5,7 +5,7 @@ Feature: reset user password
   So that I can secure individual access to resources on the ownCloud server
 
   Scenario: reset user password
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" using the occ command
@@ -15,7 +15,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: user should get email when admin does a "send email" password reset without specifying a password
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator invokes password reset for user "brand-new-user" using the occ command
@@ -27,7 +27,7 @@ Feature: reset user password
       """
 
   Scenario: user should get email when the administrator changes their password and specifies to also send email
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
@@ -41,7 +41,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: administrator gets error message while trying to reset user password with send email when the email address of the user is not setup
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname |
       | brand-new-user | %regular% | New user    |
     When the administrator invokes password reset for user "brand-new-user" using the occ command
@@ -49,7 +49,7 @@ Feature: reset user password
     And the command output should contain the text "Email address is not set for the user brand-new-user"
 
   Scenario: user should not get an email when the smtpmode value points to an invalid or missing mail program
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     And the administrator has set the mail smtpmode to "sendmail"

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -65,7 +65,7 @@ Feature: reset user password
     And the command output should contain the text 'User does not exist'
 
   Scenario: admin should be able to reset their own password
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator resets their own password to "%alt1%" using the occ command

--- a/tests/acceptance/features/cliProvisioning/userLastSeen.feature
+++ b/tests/acceptance/features/cliProvisioning/userLastSeen.feature
@@ -5,13 +5,13 @@ Feature: get user last seen
   So that I can see when the user has last logged in to the owncloud server
 
   Scenario: admin gets last seen of a user
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator retrieves the time when user "brand-new-user" was last seen using the occ command
     Then the command should have been successful
     And the command output of user last seen should be recently
 
   Scenario: admin gets last seen of a user who has not been initialized
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username       |
       | brand-new-user |
     When the administrator retrieves the time when user "brand-new-user" was last seen using the occ command

--- a/tests/acceptance/features/cliProvisioning/userReport.feature
+++ b/tests/acceptance/features/cliProvisioning/userReport.feature
@@ -5,7 +5,7 @@ Feature: get user report
   So that I can see the total number of users in an ownCloud server
 
   Scenario: admin gets the user report
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username         |
       | brand-new-user-1 |
       | brand-new-user-2 |
@@ -14,7 +14,7 @@ Feature: get user report
     And the total users returned by the command should be 3
 
   Scenario: admin gets the user report when the user is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username         |
       | brand-new-user-1 |
       | brand-new-user-2 |
@@ -24,7 +24,7 @@ Feature: get user report
     And the total users returned by the command should be 3
 
   Scenario: admin gets the user report when a user has been created and deleted
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username         |
       | brand-new-user-1 |
       | brand-new-user-2 |

--- a/tests/acceptance/features/cliProvisioning/userSettings.feature
+++ b/tests/acceptance/features/cliProvisioning/userSettings.feature
@@ -5,7 +5,7 @@ Feature: user settings
   So that I can set specific settings for a specific user
 
   Scenario: admin changes user language
-    Given user "brand-new-user" has been created with default attributes
+    Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the language of user "brand-new-user" to "fr" using the occ command
     Then the command should have been successful
     And the language of user "brand-new-user" returned by the occ command should be "fr"

--- a/tests/acceptance/features/cliTrashbin/trashbin.feature
+++ b/tests/acceptance/features/cliTrashbin/trashbin.feature
@@ -5,7 +5,7 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control user trashbin space and which files are kept in that space
 
   Scenario: delete files and folder of a user from the trashbin
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
     And user "user0" has deleted folder "/PARENT"
@@ -17,8 +17,8 @@ Feature: files and folders can be deleted from the trashbin
     And as "user0" the folder with original path "/PARENT" should not exist in trash
 
   Scenario: delete files and folder of all user from the trashbin
-    Given user "user0" has been created with default attributes
-    And user "user1" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     And user "user1" has deleted file "/textfile1.txt"
     And user "user1" has deleted folder "/PARENT"

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -89,7 +89,7 @@ Feature: admin storage settings
     And folder "local_storage1" should be listed on the webUI
 
   Scenario: administrator deletes local storage mount
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
@@ -98,7 +98,7 @@ Feature: admin storage settings
     Then folder "local_storage1" should not be listed on the webUI
 
   Scenario: local storage mount is deleted when the last user applicable to it is deleted
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
@@ -108,7 +108,7 @@ Feature: admin storage settings
     Then the last created local storage mount should not be listed on the webUI
 
   Scenario: local storage mount is not deleted when the last group applicable to it is deleted but the member of the deleted group should not have access to it
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "user0" has been added to group "newgroup"
     And the administrator has browsed to the admin storage settings page

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -6,7 +6,7 @@ Feature: Add, delete and edit comments in files and folders
   So that I can provide more information about the file/folder
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -5,7 +5,7 @@ Feature: deleting files and folders
   So that I can keep my filing system clean and tidy
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
     And user "user1" has logged in using the webUI

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -6,7 +6,7 @@ Feature: Mark file as favorite
   So that I can find my favorite file/folder easily
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -6,7 +6,7 @@ Feature: Unmark file/folder as favorite
   So that I can remove my favorite file/folder from favorite page
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -5,7 +5,7 @@ Feature: browse directly to details tab
   So that I can see the details immediately without needing to click in the UI
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -5,7 +5,7 @@ Feature: User can open the details panel for any file or folder
   So that the details of the file or folder are visible to me
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
     And user "user1" has logged in using the webUI
@@ -55,7 +55,7 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
-    Given user "user2" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
     And the user has shared folder "simple-folder" with user "User Two" using the webUI
     When the user browses to the shared-with-others page
     Then folder "simple-folder" should be listed on the webUI
@@ -70,7 +70,7 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
-    Given user "user2" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
     And the user has shared folder "simple-folder" with user "User Two" using the webUI
     And the user re-logs in as "user2" using the webUI
     When the user browses to the shared-with-you page

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -6,7 +6,7 @@ Feature: Hide file/folders
   So that I can choose to see the files that I want.
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,7 +5,7 @@ Feature: scroll menu of actions that can be done on a file into view
   So that I can manage and work with my files
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -6,7 +6,7 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -77,15 +77,15 @@ Feature: Search
     And file "lorem.txt" with path "/simple-folder" should be listed in the tags page on the webUI
 
   Scenario: Search for a shared file
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     When user "user0" shares file "/lorem.txt" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "lorem" using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
 
   Scenario: Search for a re-shared file
-    Given user "user2" has been created with default attributes
-    And user "user0" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
+    And user "user0" has been created with default attributes and skeleton files
     When user "user2" shares file "/lorem.txt" with user "user0" using the sharing API
     And user "user0" shares file "/lorem (2).txt" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
@@ -93,7 +93,7 @@ Feature: Search
     Then file "lorem (2).txt" should be listed on the webUI
 
   Scenario: Search for a shared folder
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     When user "user0" shares folder "simple-folder" with user "user1" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "simple" using the webUI

--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -7,7 +7,7 @@ Feature: Versions of a file
   So that I can have more control over the files
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
 
@@ -31,7 +31,7 @@ Feature: Versions of a file
     Then the content of file "lorem-file.txt" for user "user0" should be "lorem content"
 
   Scenario: sharee can see the versions of a file
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "new lorem content" to "/lorem-file.txt"
@@ -55,7 +55,7 @@ Feature: Versions of a file
 
   @skipOnStorage:ceph @files_primary_s3-issue-155
   Scenario: file versions cannot be seen on the webUI only for user whose versions is deleted
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "user1" has uploaded file with content "lorem content" to "/lorem-file.txt"
@@ -73,7 +73,7 @@ Feature: Versions of a file
 
   @skipOnStorage:ceph @files_primary_s3-issue-155
   Scenario: file versions cannot be seen on the webUI for all users after deleting versions for all users
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "user1" has uploaded file with content "lorem content" to "/lorem-file.txt"

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -10,7 +10,7 @@ Feature: login users
 
   @TestAlsoOnExternalUserBackend
   Scenario: simple user login
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
       | user1    |
     When user "user1" logs in using the webUI

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -5,7 +5,7 @@ Feature: reset the password
   So that I can login to my account again after forgetting the password
 
   Background:
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
       | user1    |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -5,7 +5,7 @@ Feature: reset the password using an email address
   So that I can login to my account again after forgetting the password
 
   Background:
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
       | user1    |
     And the user has browsed to the login page

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -23,7 +23,7 @@ Feature: disable users
 
   Scenario: subadmin disables a user
     Given group "grp1" has been created
-    And user "subadmin" has been created with default attributes
+    And user "subadmin" has been created with default attributes and skeleton files
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And user "subadmin" has been made a subadmin of group "grp1"

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -8,7 +8,7 @@ Feature: edit users
     Given user admin has logged in using the webUI
 
   Scenario: Admin changes the display name of the user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has browsed to the users page
     When the administrator changes the display name of user "user0" to "New User" using the webUI
     And the administrator logs out of the webUI
@@ -20,7 +20,7 @@ Feature: edit users
 
   @skipOnEncryptionType:user-keys
   Scenario: Admin changes the password of the user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has browsed to the users page
     When the administrator changes the password of user "user0" to "new_password" using the webUI
     Then user "user0" should exist
@@ -28,7 +28,7 @@ Feature: edit users
     But user "user1" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: Admin adds a user to a group
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And the administrator has browsed to the users page
     When the administrator adds user "user0" to group "grp1" using the webUI
@@ -36,7 +36,7 @@ Feature: edit users
     And user "user0" should belong to group "grp1"
 
   Scenario: Admin adds a user to a group when multiple groups are created
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
     And group "grp3" has been created
@@ -48,7 +48,7 @@ Feature: edit users
     And user "user0" should not belong to group "grp3"
 
   Scenario: Admin adds a user to multiple groups
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
     And group "grp3" has been created
@@ -61,7 +61,7 @@ Feature: edit users
     And user "user0" should not belong to group "grp1"
 
   Scenario: Admin removes a user from a group
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user0" has been added to group "grp1"
     And the administrator has browsed to the users page
@@ -70,7 +70,7 @@ Feature: edit users
     And user "user0" should not belong to group "grp1"
 
   Scenario: Admin removes user from multiple groups
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
     And group "grp3" has been created
@@ -86,7 +86,7 @@ Feature: edit users
     And user "user0" should belong to group "grp3"
 
   Scenario: Admin changes the email of the user
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has browsed to the users page
     When the administrator changes the email of user "user0" to "new_email@oc.com" using the webUI
     Then user "user0" should exist

--- a/tests/acceptance/features/webUIMasterKeyType/webUIMasterKeys.feature
+++ b/tests/acceptance/features/webUIMasterKeyType/webUIMasterKeys.feature
@@ -5,7 +5,7 @@ Feature: encrypt files using master keys
   So that I can use a common key to encrypt files of all user
 
   Scenario: user cannot access their file after recreating master key with re-login
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has set the encryption type to "masterkey"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     And user "user0" has logged in using the webUI
@@ -17,7 +17,7 @@ Feature: encrypt files using master keys
     And a message should be displayed on the general exception webUI page containing "Encryption not ready"
 
   Scenario: user can access their file after recreating master key with re-login
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has set the encryption type to "masterkey"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     And user "user0" has logged in using the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -5,7 +5,7 @@ Feature: move files
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -5,7 +5,7 @@ Feature: move folders
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
@@ -5,7 +5,7 @@ Feature: Control access to edit fullname of user through config file
   So that users can edit their fullname after getting permission from administrator
 
   Scenario: Admin gives access to users to change their full name
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     When the administrator updates system config key "allow_user_to_change_display_name" with value "true" and type "boolean" using the occ command
     And the user browses to the personal general settings page
@@ -16,7 +16,7 @@ Feature: Control access to edit fullname of user through config file
       | displayname | my#very&weird?नेपालि%name |
 
   Scenario: Admin doesnot give access to users to change their full name
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
     And the user browses to the personal general settings page

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -5,7 +5,7 @@ Feature: Change own email address on the personal settings page
   So that I can be reached by the owncloud server
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -5,7 +5,7 @@ Feature: Change own full name on the personal settings page
   So that other users can recognize me by it
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -5,7 +5,7 @@ Feature: Change Login Password
   So that I can login with my new password
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -5,7 +5,7 @@ Feature: personal general settings
   So that I can personalise the User Interface
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -5,7 +5,7 @@ Feature: personal security settings
   So that I can enable, allow and deny access to and from other storage systems or resources
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal security settings page
 

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -5,7 +5,7 @@ Feature: rename files
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -5,7 +5,7 @@ Feature: Renaming files inside a folder with problematic name
   So that I can recognize my file easily
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
 
   Scenario Outline: Rename the existing file inside a problematic folder

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -5,7 +5,7 @@ Feature: rename folders
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -5,7 +5,7 @@ Feature: disable sharing
   So that users cannot share files
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
 
   @TestAlsoOnExternalUserBackend
   @smokeTest

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -6,7 +6,7 @@ Feature: restrict resharing
   I want to be able to forbid a user that received a share from me to share it further
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -5,7 +5,7 @@ Feature: restrict Sharing
   So that users can only share files with specific users and groups
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -6,7 +6,7 @@ Feature: accept/decline shares coming from internal users
 
   Background:
     Given user "user1" has been created with default attributes and without skeleton files
-    Given user "user2" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -45,7 +45,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user3" has been created with default attributes
+    And user "user3" has been created with default attributes and skeleton files
     And user "user2" has shared folder "/simple-folder" with user "user1"
     And user "user3" has shared folder "/simple-folder" with user "user1"
     When user "user1" logs in using the webUI

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -6,7 +6,7 @@ Feature: Autocompletion of share-with names
 
   Background:
     # Users that are in the special known users already
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username    |
       | user1       |
       | regularuser |
@@ -182,7 +182,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the username of existing user contains the pattern somewhere in the middle
-    Given user "ivan" has been created with default attributes
+    Given user "ivan" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
@@ -200,7 +200,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the username of the existing user contains the pattern somewhere in the end
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username     | displayname   |
       | regularuser3 | Guest User |
     And user "user1" has logged in using the webUI
@@ -291,7 +291,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the middle but accounts medial search is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname |
       | ivan     | Ivan         |
     And user "user1" has logged in using the webUI
@@ -303,7 +303,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the end but accounts medial search is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username     | displayname   |
       | regularuser3 | Guest User |
     And user "user1" has logged in using the webUI
@@ -315,7 +315,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere in the middle but accounts medial search is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname   |
       | user2    | finnance typo |
     And user "user1" has logged in using the webUI
@@ -327,7 +327,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the display name of existing user contains the pattern somewhere in the end but accounts medial search is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname   |
       | user2    | Group User |
     And user "user1" has logged in using the webUI
@@ -339,7 +339,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning but accounts medial search is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email              |
       | user2    | User2       | hello2u2@oc.com.np |
     And user "user1" has logged in using the webUI
@@ -351,7 +351,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle but accounts medial search is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email              |
       | user2    | User2       | net@oc.com.np |
     And user "user1" has logged in using the webUI
@@ -363,7 +363,7 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end but accounts medial search is disabled
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email        |
       | user2    | User2       | de@oc.com.np |
     And user "user1" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -6,9 +6,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Background:
     Given using server "REMOTE"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And using server "LOCAL"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
@@ -24,7 +24,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test the single steps of receiving a federation share
     Given using server "REMOTE"
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user2    |
       | user3    |
@@ -79,7 +79,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | /lorem%20(2).txt |
 
   Scenario: one user disabling user-based auto accepting while global is enabled has no effect on other users
-    Given user "user2" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
     And parameter "autoAddServers" of app "federation" has been set to "1"
     And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
@@ -217,7 +217,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: receive same name federation share from two users
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -9,7 +9,7 @@ Feature: Sharing files and folders with internal groups
       | username |
       | user1    |
       | user2    |
-    And user "user3" has been created with default attributes
+    And user "user3" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -171,7 +171,7 @@ Feature: Sharing files and folders with internal groups
   @mailhog
   Scenario: user should not get an email notification if the user is added to the group after the mail notification was sent
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user0" has been created with default attributes
+    And user "user0" has been created with default attributes and skeleton files
     And user "user3" has logged in using the webUI
     And user "user3" has shared file "lorem.txt" with group "grp1"
     And the user has opened the share dialog for file "lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -9,7 +9,7 @@ Feature: Sharing files and folders with internal groups
       | username |
       | user1    |
       | user2    |
-    And user "user3" has been created with default attributes
+    And user "user3" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | <group>   |

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -8,7 +8,7 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a file & folder with another internal user
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -27,7 +27,7 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend @skipOnFIREFOX
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares file "new-lorem.txt" with user "User One" using the webUI
@@ -47,7 +47,7 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "User One" using the webUI
@@ -76,7 +76,7 @@ Feature: Sharing files and folders with internal users
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who unshares the folder
     Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "User One" using the webUI
@@ -93,7 +93,7 @@ Feature: Sharing files and folders with internal users
 
   @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user and prohibit deleting
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -108,7 +108,7 @@ Feature: Sharing files and folders with internal users
   @skipOnFIREFOX
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
     Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has logged in using the webUI
     And the user has renamed folder "simple-folder" to "new-simple-folder" using the webUI
     And the user has renamed file "lorem.txt" to "ipsum.txt" using the webUI
@@ -121,7 +121,7 @@ Feature: Sharing files and folders with internal users
 
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
     Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has logged in using the webUI
     And the user has shared file "lorem.txt" with user "User One" using the webUI
     And the user has shared folder "simple-folder" with user "User One" using the webUI
@@ -131,7 +131,7 @@ Feature: Sharing files and folders with internal users
 
   Scenario: share two file with same name but different paths
     Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user2" has logged in using the webUI
     And the user has shared file "lorem.txt" with user "User One" using the webUI
     When the user opens folder "simple-folder" using the webUI
@@ -146,7 +146,7 @@ Feature: Sharing files and folders with internal users
       | username |
       | user1    |
       | user3    |
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And user "user1" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
@@ -158,7 +158,7 @@ Feature: Sharing files and folders with internal users
       | username |
       | user1    |
       | user3    |
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
@@ -167,7 +167,7 @@ Feature: Sharing files and folders with internal users
     Then user "user1" should not be able to share folder "simple-folder" with user "User Three" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file received as a share
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user3    |
@@ -205,7 +205,7 @@ Feature: Sharing files and folders with internal users
       | user1    |
       | user2    |
       | user4    |
-    And user "user3" has been created with default attributes
+    And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
@@ -233,7 +233,7 @@ Feature: Sharing files and folders with internal users
 
   Scenario: user tries to share a file from a group which is blacklisted from sharing using webUI from files page
     Given group "grp1" has been created
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user1" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
     And the administrator has enabled exclude groups from sharing from the admin sharing settings page
@@ -245,7 +245,7 @@ Feature: Sharing files and folders with internal users
 
   Scenario: user tries to re-share a file from a group which is blacklisted from sharing using webUI from shared with you page
     Given group "grp1" has been created
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -263,7 +263,7 @@ Feature: Sharing files and folders with internal users
     And user "user1" should not be able to share file "testimage (2).jpg" with user "User Three" using the sharing API
 
   Scenario: user shares the file/folder with another internal user and delete the share with user
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -279,7 +279,7 @@ Feature: Sharing files and folders with internal users
   @mailhog
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
@@ -294,7 +294,7 @@ Feature: Sharing files and folders with internal users
   @mailhog
   Scenario: user should get and error message when trying to send notification by email to a user who has not setup their email
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And these users have been created without skeleton files:
       | username | password |
       | user0    | 1234     |
@@ -309,7 +309,7 @@ Feature: Sharing files and folders with internal users
   @mailhog
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
@@ -322,7 +322,7 @@ Feature: Sharing files and folders with internal users
 
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
-    And user "user1" has been created with default attributes
+    And user "user1" has been created with default attributes and skeleton files
     And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
@@ -331,7 +331,7 @@ Feature: Sharing files and folders with internal users
 
   @issue-35382
   Scenario: user shares a file with another user with uppercase username
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And these users have been created without skeleton files:
       | username |
       | SomeUser |

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -6,7 +6,7 @@ Feature: Display notifications when receiving a share and follow embedded links
 
   Background:
     Given app "notifications" has been enabled
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -6,7 +6,7 @@ Feature: Sharing files and folders with internal groups
 
   Background:
     Given app "notifications" has been enabled
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -6,7 +6,7 @@ Feature: Sharing files and folders with internal users
 
   Background:
     Given app "notifications" has been enabled
-    And these users have been created with default attributes:
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -9,7 +9,7 @@ Feature: Share by public link
   So that public sharing is limited according to organization policy
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
 
   @smokeTest
@@ -42,7 +42,7 @@ Feature: Share by public link
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
@@ -57,7 +57,7 @@ Feature: Share by public link
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes
+    And user "user2" has been created with default attributes and skeleton files
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the user logs out of the webUI

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -5,7 +5,7 @@ Feature: Creation of tags for the files and folders
   So that I can find them easily
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
     And the user has browsed to the login page
@@ -39,7 +39,7 @@ Feature: Creation of tags for the files and folders
 
   @skipOnFIREFOX
   Scenario: Create and add tag on a shared file
-    Given user "user2" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
     When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -5,7 +5,7 @@ Feature: Deletion of existing tags from files and folders
   So that I can keep my filing system clean and tidy
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
     And the user has browsed to the login page
@@ -13,7 +13,7 @@ Feature: Deletion of existing tags from files and folders
 
 @skipOnFIREFOX
   Scenario: Delete a tag in a shared file
-    Given user "user2" has been created with default attributes
+    Given user "user2" has been created with default attributes and skeleton files
     When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
     And the user adds a tag "tag1" to the file using the webUI

--- a/tests/acceptance/features/webUITags/editTags.feature
+++ b/tests/acceptance/features/webUITags/editTags.feature
@@ -5,7 +5,7 @@ Feature: Edit tags for files and folders
   So that I can find them easily
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUITags/removeTags.feature
+++ b/tests/acceptance/features/webUITags/removeTags.feature
@@ -5,7 +5,7 @@ Feature: Removal of already existing tags from files and folders
   So that I can properly organize my filing system
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -5,7 +5,7 @@ Feature: Suggestion for matching tag names
   So that I can easily categorize the files
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
     Given user "user1" has created a "normal" tag with name "spam"

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -5,7 +5,7 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the following files have been deleted
       | name          |

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -5,7 +5,7 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -5,7 +5,7 @@ Feature: Restore deleted files/folders
   So that I can recover accidentally deleted files/folders in ownCloud
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -6,7 +6,7 @@ Feature: File Upload
   So that I can store files in ownCloud
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
 
   @smokeTest

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -8,7 +8,7 @@ Feature: File Upload
   that is not academically correct but saves a lot of time
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
 
   Scenario: simple upload of a file that does not exist before

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -6,7 +6,7 @@ Feature: Upload a file
   So that I can store it in owncloud
 
   Background:
-    Given user "user1" has been created with default attributes
+    Given user "user1" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario: simple upload of a file with the size greater than the size of quota

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -6,7 +6,7 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       |username      |
       |brand-new-user|
     And user "brand-new-user" has logged in using the webUI

--- a/tests/acceptance/features/webUIWebdavLockProtection/move.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/move.feature
@@ -6,7 +6,7 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI

--- a/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
@@ -6,7 +6,7 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -6,7 +6,7 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI
@@ -25,7 +25,7 @@ Feature: Locks
     But file "data.tar.gz" should not be marked as locked on the webUI
 
   Scenario: setting a lock shows the display name of a user in the locking details
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
     Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
@@ -38,7 +38,7 @@ Feature: Locks
 
   @issue-34315
   Scenario: setting a lock shows the current display name of a user in the locking details
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
     Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
@@ -53,7 +53,7 @@ Feature: Locks
     #And file "data.zip" should be marked as locked by user "An ordinary name" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock shows the display name of a user in the locking details (user has set email address)
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username               | displayname   | email       |
       | user-with-display-name | My fancy name | mail@oc.org |
     Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
@@ -65,7 +65,7 @@ Feature: Locks
     And file "data.zip" should be marked as locked by user "My fancy name (mail@oc.org)" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock shows the user name of a user in the locking details (user has set email address)
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username        | email       |
       | user-with-email | mail@oc.org |
     Given user "user-with-email" has locked folder "simple-folder" setting following properties
@@ -95,7 +95,7 @@ Feature: Locks
 
   @issue-33867
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-others page
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username |
       | receiver |
     And user "brand-new-user" has locked folder "simple-folder" setting following properties
@@ -146,7 +146,7 @@ Feature: Locks
 
   @issue-33867
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-you page
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username |
       | sharer   |
     And user "sharer" has locked folder "simple-folder" setting following properties
@@ -174,7 +174,7 @@ Feature: Locks
     Then folder "simple-folder" should not be marked as locked on the webUI
 
   Scenario: lock set on a shared file shows the lock information for all involved users
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username  |
       | sharer    |
       | receiver  |
@@ -228,7 +228,7 @@ Feature: Locks
     And file "data.zip" should not be marked as locked on the webUI
 
   Scenario Outline: decline locked folder
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
@@ -246,7 +246,7 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: accept previously declined locked folder
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
@@ -266,7 +266,7 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: accept previously declined locked folder but create a folder with same name in between
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
@@ -288,7 +288,7 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: creating a subfolder structure that is the same as the structure of a declined & locked share
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/parent"
@@ -311,7 +311,7 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: unsharing a locked file/folder
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username |
       | sharer   |
     And user "sharer" has locked file "lorem.txt" setting following properties

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -6,7 +6,7 @@ Feature: Unlock locked files and folders
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI
@@ -19,7 +19,7 @@ Feature: Unlock locked files and folders
     Then folder "simple-folder" should not be marked as locked on the webUI
 
   Scenario: unlocking by webDAV after the display name has been changed deletes the lock symbols at the correct files/folders
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
     Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
@@ -108,7 +108,7 @@ Feature: Unlock locked files and folders
 
   @skipOnFIREFOX
   Scenario: deleting the first one of multiple shared locks on the webUI
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username  |
       | receiver1 |
       | receiver2 |
@@ -147,7 +147,7 @@ Feature: Unlock locked files and folders
 
   @skipOnFIREFOX
   Scenario: deleting the second one of multiple shared locks on the webUI
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username  |
       | receiver1 |
       | receiver2 |
@@ -186,7 +186,7 @@ Feature: Unlock locked files and folders
 
   @skipOnFIREFOX
   Scenario: deleting the last one of multiple shared locks on the webUI
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username  |
       | receiver1 |
       | receiver2 |
@@ -224,7 +224,7 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
   Scenario Outline: deleting a lock that was created by an other user
-    Given these users have been created:
+    Given these users have been created with skeleton files:
       | username  |
       | receiver1 |
     And user "brand-new-user" has shared file "/lorem.txt" with user "receiver1"


### PR DESCRIPTION
Backport #35438 