### PR TITLE
Use standalone-chrome-debug:3.141.59-oxygen to get chrome 74

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -505,7 +505,7 @@ services:
         DB_TYPE: oracle
 
   chrome:
-    image: selenium/standalone-chrome-debug:latest
+    image: selenium/standalone-chrome-debug:3.141.59-oxygen
     pull: true
     environment:
       - JAVA_OPTS=-Dselenium.LOGGER.level=WARNING


### PR DESCRIPTION
## Description
`selenium/standalone-chrome-debug` was updated to chrome 75  https://hub.docker.com/r/selenium/standalone-chrome-debug/tags
webUI acceptance tests do not work, they fail to even see the login screen!

Go back to the previous `selenium/standalone-chrome-debug:3.141.59-oxygen` version that had chrome 74

## Related Issue
#35444 

## Motivation and Context
Make CI great again.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
