### PR TITLE
Remove deprecated default attributes test steps

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -256,7 +256,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has been created with default attributes$/
 	 * @Given /^user "([^"]*)" has been created with default attributes and skeleton files$/
 	 *
 	 * @param string $user
@@ -331,21 +330,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given these users have been created with skeleton files:
-	 * expects a table of users with the heading
-	 * "|username|password|displayname|email|"
-	 * password, displayname & email are optional
-	 *
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 */
-	public function theseUsersHaveBeenCreatedWithSkeletonFiles(TableNode $table) {
-		$this->theseUsersHaveBeenCreated("", "", $table);
-	}
-
-	/**
-	 * @Given /^these users have been created\s?(with default attributes|with default attributes and skeleton files|)\s?(but not initialized|):$/
+	 * @Given /^these users have been created with ?(default attributes and|) skeleton files ?(but not initialized|):$/
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
 	 * password, displayname & email are optional

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -65,7 +65,7 @@ Feature: Autocompletion of share-with names
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And these users have been created but not initialized:
+    And these users have been created with skeleton files but not initialized:
       | username | password | displayname | email        |
       | use      | %alt1%   | Use         | uz@oc.com.np |
     And the user has opened the share dialog for folder "simple-folder"

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -247,7 +247,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test sharing folder to a remote server and resharing it back to the local
     Given using server "LOCAL"
-    And these users have been created:
+    And these users have been created with skeleton files:
       | username |
       | user2    |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
@@ -261,7 +261,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test resharing folder as readonly and set it as readonly by resharer
     Given using server "LOCAL"
-    And these users have been created:
+    And these users have been created with skeleton files:
       | username |
       | user2    |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
@@ -279,7 +279,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test resharing folder and set it as readonly by owner
     Given using server "LOCAL"
-    And these users have been created:
+    And these users have been created with skeleton files:
       | username |
       | user2    |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI


### PR DESCRIPTION
## Description
This is a follow-on PR  from #35438 - it removes the "old" `create user` steps that did not explicitly specify that skeleton files are used.

App acceptance tests are being adjusted to use the new "and skeleton files" step forms.

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
Make all create user acceptance test steps explicitly say if the skeleton is to be used.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
