### PR TITLE
[stable10] Remove deprecated default attributes test steps

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -256,7 +256,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has been created with default attributes$/
 	 * @Given /^user "([^"]*)" has been created with default attributes and skeleton files$/
 	 *
 	 * @param string $user
@@ -331,21 +330,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given these users have been created with skeleton files:
-	 * expects a table of users with the heading
-	 * "|username|password|displayname|email|"
-	 * password, displayname & email are optional
-	 *
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 */
-	public function theseUsersHaveBeenCreatedWithSkeletonFiles(TableNode $table) {
-		$this->theseUsersHaveBeenCreated("", "", $table);
-	}
-
-	/**
-	 * @Given /^these users have been created\s?(with default attributes|with default attributes and skeleton files|)\s?(but not initialized|):$/
+	 * @Given /^these users have been created with ?(default attributes and|) skeleton files ?(but not initialized|):$/
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
 	 * password, displayname & email are optional

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -5,7 +5,7 @@ Feature: manage user quota
   So that users can only take up a certain amount of storage space
 
   Background:
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
       | user1    |
     And the administrator has logged in using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -5,7 +5,7 @@ Feature: delete users
   So that I can remove users
 
   Background:
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -5,7 +5,7 @@ Feature: disable users
   So that I can remove access to unnecessary users
 
   Background:
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -5,7 +5,7 @@ Feature: add users
   So that I can see various details about users
 
   Background:
-    Given these users have been created with default attributes but not initialized:
+    Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
       | user1    |
       | user2    |

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -65,7 +65,7 @@ Feature: Autocompletion of share-with names
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And these users have been created but not initialized:
+    And these users have been created with skeleton files but not initialized:
       | username | password | displayname | email        |
       | use      | %alt1%   | Use         | uz@oc.com.np |
     And the user has opened the share dialog for folder "simple-folder"

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -247,7 +247,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test sharing folder to a remote server and resharing it back to the local
     Given using server "LOCAL"
-    And these users have been created:
+    And these users have been created with skeleton files:
       | username |
       | user2    |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
@@ -261,7 +261,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test resharing folder as readonly and set it as readonly by resharer
     Given using server "LOCAL"
-    And these users have been created:
+    And these users have been created with skeleton files:
       | username |
       | user2    |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
@@ -279,7 +279,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test resharing folder and set it as readonly by owner
     Given using server "LOCAL"
-    And these users have been created:
+    And these users have been created with skeleton files:
       | username |
       | user2    |
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI

--- a/tests/acceptance/features/webUIUserKeysType/userKeys.feature
+++ b/tests/acceptance/features/webUIUserKeysType/userKeys.feature
@@ -6,7 +6,7 @@ Feature: encrypt files using user specific keys
 
   Background:
     Given app "encryption" has been enabled
-    And these users have been created but not initialized:
+    And these users have been created with skeleton files but not initialized:
       | username       |
       | brand-new-user |
     And encryption has been enabled
@@ -27,7 +27,7 @@ Feature: encrypt files using user specific keys
     Then file "textfile0.txt" of user "brand-new-user" should be encrypted
 
   Scenario: decrypt user keys based encryption of all users
-    Given these users have been created but not initialized:
+    Given these users have been created with skeleton files but not initialized:
       | username         |
       | another-new-user |
     And the administrator has set the encryption type to "user-keys"


### PR DESCRIPTION
Backport  #35451 

plus related changes to step text of bundled encryption and user_management acceptance tests that are in core `stable10`