### PR TITLE
Fixup check_apache_module_enabled in run.sh

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -265,8 +265,9 @@ function assert_testing_app_enabled() {
 
 # check if certain apache_module is enabled
 # $1 admin authentication string username:password
-# $2 the full url to the testing app
+# $2 the full url to the testing app on the server to check
 # $3 Module to check for
+# $4 text description of the server being checked, e.g. "local", "remote"
 # return 0 if given module is enabled, else return with 1
 function check_apache_module_enabled() {
 	# test if mod_rewrite is enabled
@@ -274,8 +275,9 @@ function check_apache_module_enabled() {
 	STATUS_CODE=`echo ${CURL_RESULT} | xmllint --xpath "string(ocs/meta/statuscode)" -`
 	if [[ ${STATUS_CODE} -ne 200 ]]
 	then
-		echo -n "Could not reliably determine if '$3' module is enabled, because "
+		echo -n "Could not reliably determine if '$3' module is enabled on the $4 server, because "
 		echo ${CURL_RESULT} | xmllint --xpath "string(ocs/meta/message)" -
+		echo ""
 		return 1
 	fi
 	return 0
@@ -534,7 +536,7 @@ then
 	remote_occ ${ADMIN_AUTH} ${OCC_URL} "maintenance:update:htaccess"
 	[[ $? -eq 0 ]] || { echo "${HTACCESS_UPDATE_FAILURE_MSG}"; }
 	# check if mod_rewrite module is enabled
-	check_apache_module_enabled ${ADMIN_AUTH} ${TESTING_APP_URL} "mod_rewrite"
+	check_apache_module_enabled ${ADMIN_AUTH} ${TESTING_APP_URL} "mod_rewrite" "local"
 
 	if [ -n "${TEST_SERVER_FED_URL}" ]
 	then
@@ -543,7 +545,7 @@ then
 		remote_occ ${ADMIN_AUTH} ${OCC_FED_URL} "maintenance:update:htaccess"
 		[[ $? -eq 0 ]] || { echo "${HTACCESS_UPDATE_FAILURE_MSG/local/federated}"; }
 		# check if mod_rewrite module is enabled
-		check_apache_module_enabled ${ADMIN_AUTH} ${TESTING_APP_URL} "mod_rewrite"
+		check_apache_module_enabled ${ADMIN_AUTH} ${TESTING_APP_FED_URL} "mod_rewrite" "remote"
 	fi
 else
 	echo "Using php inbuilt server for running scenario ..."


### PR DESCRIPTION
## Description
1) Use `TESTING_APP_FED_URL` when checking the remote federated server (this was a bug in the script)
2) When reporting a problem checking if the module is enabled, mention which server it is (local or remote). That makes it easier to know what is wrong.
3) Put new lines after the message (previously the messages got all concatenated on the same line, which was ugly)

## Motivation and Context

## How Has This Been Tested?
Local runs of acceptance tests with a PHP dev server so that I get messages like:
```
Script path: /home/phil/git/owncloud/core/tests/acceptance
Not using php inbuilt server for running scenario ...
Updating .htaccess for proper rewrites
Could not reliably determine if 'mod_rewrite' module is enabled on the local server, because the server does not seem to be running behind Apache.
Could not reliably determine if 'mod_rewrite' module is enabled on the remote server, because the server does not seem to be running behind Apache.
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
