### PR TITLE
Add no skeleton steps in webUIRestrictSharing

### DIFF
--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -5,11 +5,12 @@ Feature: disable sharing
   So that users cannot share files
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Users tries to share via WebUI when Sharing is disabled
-    Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
+    Given user "user1" has created folder "simple-folder"
+    And the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
     When user "user1" logs in using the webUI
     Then it should not be possible to share folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -6,7 +6,7 @@ Feature: restrict resharing
   I want to be able to forbid a user that received a share from me to share it further
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -15,6 +15,8 @@ Feature: restrict resharing
       | grp1      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
+    And user "user1" has created folder "simple-folder"
+    And user "user2" has created folder "simple-folder"
     And user "user2" has logged in using the webUI
 
   @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -5,18 +5,18 @@ Feature: restrict Sharing
   So that users can only share files with specific users and groups
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
-      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
       | grp2      |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
-    And user "user3" has been added to group "grp2"
+    And user "user1" has created folder "simple-folder"
+    And user "user2" has created folder "simple-folder"
     And user "user2" has logged in using the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -41,7 +41,10 @@ Feature: restrict Sharing
 
   @TestAlsoOnExternalUserBackend
   Scenario: Do not restrict users to only share with groups they are member of
-    Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
+    Given user "user3" has been created with default attributes and without skeleton files
+    And user "user3" has been added to group "grp2"
+    And user "user3" has created folder "simple-folder"
+    And the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
     And the user browses to the files page
     When the user shares folder "simple-folder" with group "grp2" using the webUI
     And the user re-logs in as "user3" using the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Do not use skeleton files for ```webUIRestrictSharing``` to speed up CI
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>
Part of https://github.com/owncloud/QA/issues/622
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
