### PR TITLE
Fix path option for the verify checksum command

### DIFF
--- a/apps/files/tests/Command/VerifyChecksumsTest.php
+++ b/apps/files/tests/Command/VerifyChecksumsTest.php
@@ -258,7 +258,8 @@ class VerifyChecksumsTest extends TestCase {
 
 		$this->cmd->execute([
 			'-r' => null,
-			'-p' => "{$this->user1}/files/dir/nested"
+			'-u' => $this->user1,
+			'-p' => "dir/nested"
 		]);
 
 		$this->assertChecksumsAreCorrect([
@@ -357,6 +358,16 @@ class VerifyChecksumsTest extends TestCase {
 			VerifyChecksums::EXIT_INVALID_ARGS,
 			$this->cmd->getStatusCode(),
 			'User and path must return invalid args status code when combined'
+		);
+
+		$this->cmd->execute([
+			'-p' => '/some/path/for/testing?'
+		]);
+
+		$this->assertEquals(
+			VerifyChecksums::EXIT_INVALID_ARGS,
+			$this->cmd->getStatusCode(),
+			'User name cannot be omitted when path is provided.'
 		);
 	}
 }


### PR DESCRIPTION
Fix path option for the verify checksum command

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The verify checksum command was failing to fix the checksum when path option is provided as:
- `$user/files/foo` or `/$user/files/foo/bar`

The reason for this is `get()` in the https://github.com/owncloud/core/blob/master/lib/private/Files/Node/Root.php#L180 will add extra entry in the cache. This PR tries to resolve the issue by analyzing the input by checking if the path contains `$user/files`, if so then `getUserFolder` would be used to access the file provided using -p option of the command.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR solves the addition of the file path to the filecache table, when -p option is used with the command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Here is how the tests done:
- Modify the checksum for the files `welcome.txt` and `a.txt` for the user `admin`.
- Now execute the command to fix the checksum as shown:
```
sujith@sujith-ownCloud  ~/test/owncloud3   log-exception-console ●  ./occ files:checksums:verify -r -p /admin/files/welcome.txt
Cannot load Xdebug - it was already loaded
Mismatch for home::admin/files/welcome.txt:
 Filecache:     SHA1:eeb2c08011374d8ad4e483a4938e1aa1007c089a MD5:368e3a6cb99f88c3543123931d786e22 ADLER32:c5ad3a64
 Actual:        SHA1:eeb2c08011374d8ad4e483a4938e1aa1007c089d MD5:368e3a6cb99f88c3543123931d786e21 ADLER32:c5ad3a63
Repairing files/welcome.txt
 sujith@sujith-ownCloud  ~/test/owncloud3   log-exception-console ●  ./occ files:checksums:verify -r -p /admin/files/a.txt      
Cannot load Xdebug - it was already loaded
Mismatch for home::admin/files/a.txt:
 Filecache:     SHA1:eeb2c08011374d8ad4e483a4938e1aa1007c089a MD5:368e3a6cb99f88c3543123931d786e22 ADLER32:c5ad3a64
 Actual:        SHA1:ec223a7d316191091cd10fc04401e41de66ffee4 MD5:545ce406d805800b01fad61055c7d4d2 ADLER32:194703d6
Repairing files/a.txt
 sujith@sujith-ownCloud  ~/test/owncloud3   log-exception-console ● 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
