### PR TITLE
fix snakeoil tests

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -591,23 +591,26 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnEncryption @issue-encryption-126
-  @skipOnLDAP @skipOnStorage:ceph @issue-QA-623
+  @issue-35484
   Scenario: share with user when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
       | user1    |
-    When user "user0" shares file "/welcome.txt" with user "USER1" using the sharing API
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
+    When user "user0" shares file "/randomfile.txt" with user "USER1" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the fields of the last response should include
-      | share_with  |  USER1       |
-      | file_target | /welcome.txt |
-      | path        | /welcome.txt |
-      | permissions | 19           |
-      | uid_owner   | user0        |
-    And user "user1" should see the following elements
-      | /welcome.txt |
+      | share_with  | USER1           |
+      | file_target | /randomfile.txt |
+      | path        | /randomfile.txt |
+      | permissions | 19              |
+      | uid_owner   | user0           |
+    #And user "user1" should see the following elements
+    #  | /randomfile.txt |
+    #And the content of file "randomfile.txt" for user "user1" should be "user0 file"
+    And user "user1" should not see the following elements
+      | /randomfile.txt |
 
   Scenario: creating a new share with user of a group when username contains capital letters
     Given these users have been created without skeleton files:
@@ -615,11 +618,13 @@ Feature: sharing
       | user1    |
     And group "grp1" has been created
     And user "USER1" has been added to group "grp1"
-    And user "user0" has shared file "welcome.txt" with group "grp1"
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
+    And user "user0" has shared file "randomfile.txt" with group "grp1"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should see the following elements
-      | /welcome.txt |
+      | /randomfile.txt |
+    And the content of file "randomfile.txt" for user "user1" should be "user0 file"
 
   Scenario Outline: Share of folder to a group with emoji in the name
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
## Description
these tests did not test anything, when running on an installation from git `welcome.txt` is there when disabling skeleton folder
when running on a QA tarball installation the tests did fail see https://github.com/owncloud/QA/issues/623

issue with sharing with different cases usernames: https://github.com/owncloud/core/issues/35484

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/QA/issues/623

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
