### PR TITLE
use a multi line approach to display share autocomplete

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -69,12 +69,16 @@
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
-	line-height: 32px;
 	vertical-align: middle;
 }
 
 .share-autocomplete-item .autocomplete-item-displayname {
 	margin-right: 5px;
+}
+
+.share-autocomplete-item .autocomplete-item-typeInfo {
+	font-size: smaller;
+	font-style: italic;
 }
 
 .share-autocomplete-item .avatardiv {

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -54,8 +54,9 @@
 					'<div class="autocomplete-item-text">' +
 						'<span class="autocomplete-item-displayname">{{displayName}}</span>' +
 						'{{#if additionalInfo}}' +
-						'<span class="autocomplete-item-additional-info">({{additionalInfo}})</span>' +
+						'<br/><span class="autocomplete-item-additional-info">({{additionalInfo}})</span>' +
 						'{{/if}}' +
+						'<br/><span class="autocomplete-item-typeInfo">{{typeInfo}}</span>' +
 					'</div>' +
 				'</div>' +
 			'</a>' +
@@ -310,20 +311,20 @@
 		autocompleteRenderItem: function(ul, item) {
 
 			var text = item.label;
+			var typeInfo = t('core', 'User');
 			if (item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
-				text = t('core', '{sharee} (group)', {
-					sharee: text
-				}, null, {escape: false});
-			} else if (item.value.shareType === OC.Share.SHARE_TYPE_REMOTE) {
+				typeInfo = t('core', 'Group');
+			}
+			if (item.value.shareType === OC.Share.SHARE_TYPE_GUEST) {
+				typeInfo = t('core', 'Guest');
+			}
+			if (item.value.shareType === OC.Share.SHARE_TYPE_REMOTE) {
 				if (item.value.server) {
-					text = t('core', '{sharee} (at {server})', {
-						sharee: text,
+					typeInfo = t('core', 'At {server}', {
 						server: item.value.server
 					});
 				} else {
-					text = t('core', '{sharee} (federated)', {
-						sharee: text
-					});
+					typeInfo = t('core', 'Federated');
 				}
 			}
 
@@ -331,6 +332,7 @@
 			var $el = $(template({
 				showAvatar: this.configModel.areAvatarsEnabled(),
 				displayName: text,
+				typeInfo: typeInfo,
 				additionalInfo: item.value.shareWithAdditionalInfo,
 				shareTypeClass: (item.value.shareType === OC.Share.SHARE_TYPE_GROUP) ? 'group' : 'user'
 			}));

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -612,6 +612,14 @@ describe('OC.Share.ShareDialogView', function() {
 											'shareType': OC.Share.SHARE_TYPE_REMOTE,
 											'shareWith': 'foo2@bar.com/baz'
 										}
+									},
+									{
+										'label': 'foo@knowncloud.com',
+										'value': {
+											'shareType': OC.Share.SHARE_TYPE_REMOTE,
+											'shareWith': 'foo@knowncloud.com',
+											'server': 'knowncloud.com'
+										}
 									}
 								]
 							}
@@ -625,6 +633,13 @@ describe('OC.Share.ShareDialogView', function() {
 					expect(response.getCall(0).args[0]).toEqual([{
 						'label': 'foo2@bar.com/baz',
 						'value': {'shareType': OC.Share.SHARE_TYPE_REMOTE, 'shareWith': 'foo2@bar.com/baz'}
+					},{
+						'label': 'foo@knowncloud.com',
+						'value': {
+							'shareType': OC.Share.SHARE_TYPE_REMOTE,
+							'shareWith': 'foo@knowncloud.com',
+							'server': 'knowncloud.com'
+						}
 					}]);
 					expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 				});

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -59,6 +59,26 @@ class FederationContext implements Context {
 	public function userFromServerSharesWithUserFromServerUsingTheSharingAPI(
 		$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
 	) {
+		$this->userFromServerSharesWithUserFromServerUsingTheSharingAPIWithPermissions(
+			$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
+		);
+	}
+	
+	/**
+	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)" using the sharing API with permissions (.*)$/
+	 *
+	 * @param string $sharerUser
+	 * @param string $sharerServer "LOCAL" or "REMOTE"
+	 * @param string $sharerPath
+	 * @param string $shareeUser
+	 * @param string $shareeServer "LOCAL" or "REMOTE"
+	 * @param int $permissions
+	 *
+	 * @return void
+	 */
+	public function userFromServerSharesWithUserFromServerUsingTheSharingAPIWithPermissions(
+		$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer, $permissions = null
+	) {
 		if ($shareeServer == "REMOTE") {
 			$shareWith
 				= "$shareeUser@" . $this->featureContext->getRemoteBaseUrl() . '/';
@@ -68,11 +88,11 @@ class FederationContext implements Context {
 		}
 		$previous = $this->featureContext->usingServer($sharerServer);
 		$this->featureContext->createShare(
-			$sharerUser, $sharerPath, 6, $shareWith, null, null, null
+			$sharerUser, $sharerPath, 6, $shareWith, null, null, $permissions
 		);
 		$this->featureContext->usingServer($previous);
 	}
-	
+
 	/**
 	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" has shared "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
 	 *
@@ -89,6 +109,32 @@ class FederationContext implements Context {
 	) {
 		$this->userFromServerSharesWithUserFromServerUsingTheSharingAPI(
 			$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
+		);
+		$this->ocsContext->assertOCSResponseIndicatesSuccess(
+			'Could not share file/folder! message: "' .
+			$this->ocsContext->getOCSResponseStatusMessage(
+				$this->featureContext->getResponse()
+			) . '"'
+		);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" has shared "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)" with permissions (.*)$/
+	 *
+	 * @param string $sharerUser
+	 * @param string $sharerServer "LOCAL" or "REMOTE"
+	 * @param string $sharerPath
+	 * @param string $shareeUser
+	 * @param string $shareeServer "LOCAL" or "REMOTE"
+	 * @param int $permissions
+	 *
+	 * @return void
+	 */
+	public function userFromServerHasSharedWithUserFromServerWithPermissions(
+		$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer, $permissions = null
+	) {
+		$this->userFromServerSharesWithUserFromServerUsingTheSharingAPIWithPermissions(
+			$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer, $permissions
 		);
 		$this->ocsContext->assertOCSResponseIndicatesSuccess(
 			'Could not share file/folder! message: "' .

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -127,7 +127,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * returns an array of the display names, keyed by username
+	 * returns an array of the user display names, keyed by username
 	 * if no "Display Name" is set the user-name is returned instead
 	 *
 	 * @return array
@@ -136,6 +136,22 @@ trait Provisioning {
 		$result = [];
 		foreach ($this->getCreatedUsers() as $username => $user) {
 			$result[$username] = $this->getUserDisplayName($username);
+		}
+		return $result;
+	}
+
+	/**
+	 * returns an array of the group display names, keyed by group name
+	 * currently group name and display name are always the same, so this
+	 * function is a convenience for getting the group names in a similar
+	 * format to what getCreatedUserDisplayNames() returns
+	 *
+	 * @return array
+	 */
+	public function getCreatedGroupDisplayNames() {
+		$result = [];
+		foreach ($this->getCreatedGroups() as $groupName => $groupData) {
+			$result[$groupName] = $groupName;
 		}
 		return $result;
 	}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1251,7 +1251,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			);
 			$sharingWasPossible = true;
 		} catch (ElementNotFoundException $e) {
-			if ($shareWith === null) {
+			if ($this->sharingDialog === null) {
 				$shareWithText = "";
 			} else {
 				if ($userOrGroup === "user") {

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1001,7 +1001,9 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theUsersOwnNameShouldNotBeListedInTheAutocompleteList() {
 		PHPUnit\Framework\Assert::assertNotContains(
-			$this->filesPage->getMyDisplayname(),
+			$this->sharingDialog->userStringsToMatchAutoComplete(
+				$this->filesPage->getMyDisplayname()
+			),
 			$this->sharingDialog->getAutocompleteItemsList()
 		);
 	}
@@ -1034,9 +1036,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function userShouldNotBeListedInTheAutocompleteListOnTheWebui($username) {
 		$names = $this->sharingDialog->getAutocompleteItemsList();
 		$userString = $this->sharingDialog->userStringsToMatchAutoComplete($username);
-		if (\in_array($userString, $names)) {
-			throw new Exception("$username ($userString) found in autocomplete list but not expected");
-		}
+		PHPUnit\Framework\Assert::assertFalse(
+			\in_array($userString, $names),
+			"$username ($userString) found in autocomplete list but not expected"
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -864,14 +864,42 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then only :userOrGroupName should be listed in the autocomplete list on the webUI
+	 * @Then only user :userName should be listed in the autocomplete list on the webUI
 	 *
-	 * @param string $userOrGroupName
+	 * @param string $userName
 	 *
 	 * @return void
 	 */
-	public function onlyUserOrGroupNameShouldBeListedInTheAutocompleteList(
-		$userOrGroupName
+	public function onlyUserNameShouldBeListedInTheAutocompleteList(
+		$userName
+	) {
+		$this->onlyNameShouldBeListedInTheAutocompleteList(
+			$this->sharingDialog->userStringsToMatchAutoComplete($userName)
+		);
+	}
+
+	/**
+	 * @Then only group :groupName should be listed in the autocomplete list on the webUI
+	 *
+	 * @param string $groupName
+	 *
+	 * @return void
+	 */
+	public function onlyGroupNameShouldBeListedInTheAutocompleteList(
+		$groupName
+	) {
+		$this->onlyNameShouldBeListedInTheAutocompleteList(
+			$this->sharingDialog->groupStringsToMatchAutoComplete($groupName)
+		);
+	}
+
+	/**
+	 * @param string $autocompleteString the full text expected in the autocomplete item
+	 *
+	 * @return void
+	 */
+	public function onlyNameShouldBeListedInTheAutocompleteList(
+		$autocompleteString
 	) {
 		$autocompleteItems = $this->sharingDialog->getAutocompleteItemsList();
 		PHPUnit\Framework\Assert::assertCount(
@@ -880,9 +908,9 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			"expected 1 autocomplete item but there are " . \count($autocompleteItems)
 		);
 		PHPUnit\Framework\Assert::assertContains(
-			$userOrGroupName,
+			$autocompleteString,
 			$autocompleteItems,
-			"'$userOrGroupName' not in autocomplete list"
+			"'$autocompleteString' not in autocomplete list"
 		);
 	}
 
@@ -989,7 +1017,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function userShouldBeListedInTheAutocompleteListOnTheWebui($username) {
 		$names = $this->sharingDialog->getAutocompleteItemsList();
 		PHPUnit\Framework\Assert::assertContains(
-			$username,
+			$this->sharingDialog->userStringsToMatchAutoComplete($username),
 			$names,
 			"$username not found in autocomplete list"
 		);

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -46,8 +46,9 @@ class SharingDialog extends OwncloudPage {
 	private $shareWithTooltipXpath = "/..//*[@class='tooltip-inner']";
 	private $shareWithAutocompleteListXpath = ".//ul[contains(@class,'ui-autocomplete')]";
 	private $autocompleteItemsTextXpath = "//*[@class='autocomplete-item-text']";
-	private $suffixToIdentifyGroups = " (group)";
-	private $suffixToIdentifyRemoteUsers = " (federated)";
+	private $suffixToIdentifyGroups = " Group";
+	private $suffixToIdentifyUsers = " User";
+	private $suffixToIdentifyRemoteUsers = " Federated";
 	private $sharerInformationXpath = ".//*[@class='reshare']";
 	private $sharedWithAndByRegEx = "^(?:[A-Z]\s)?Shared with you(?: and the group (.*))? by (.*)$";
 	private $permissionsFieldByUserName = ".//*[@id='shareWithList']//*[@class='has-tooltip username' and .='%s']/..";
@@ -152,6 +153,25 @@ class SharingDialog extends OwncloudPage {
 	}
 
 	/**
+	 * returns the user names as they could appear in an autocomplete list
+	 *
+	 * @param string|array $userNames
+	 *
+	 * @return string|array
+	 */
+	public function userStringsToMatchAutoComplete($userNames) {
+		if (\is_array($userNames)) {
+			$autocompleteStrings = [];
+			foreach ($userNames as $userName => $userDisplayName) {
+				$autocompleteStrings[$userName] = $userDisplayName . $this->suffixToIdentifyUsers;
+			}
+		} else {
+			$autocompleteStrings = $userNames . $this->suffixToIdentifyUsers;
+		}
+		return $autocompleteStrings;
+	}
+
+	/**
 	 * returns the group names as they could appear in an autocomplete list
 	 *
 	 * @param string|array $groupNames
@@ -252,7 +272,8 @@ class SharingDialog extends OwncloudPage {
 		$name, Session $session, $maxRetries = 5, $quiet = false
 	) {
 		$this->shareWithUserOrGroup(
-			$name, $name, $session, $maxRetries, $quiet
+			$name, $name . $this->suffixToIdentifyUsers,
+			$session, $maxRetries, $quiet
 		);
 	}
 

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -24,7 +24,7 @@ Feature: restrict Sharing
   Scenario: Restrict users to only share with users in their groups
     Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
     When the user browses to the files page
-    Then it should not be possible to share folder "simple-folder" with "User Three" using the webUI
+    Then it should not be possible to share folder "simple-folder" with user "User Three" using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
@@ -34,7 +34,7 @@ Feature: restrict Sharing
   Scenario: Restrict users to only share with groups they are member of
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
     When the user browses to the files page
-    Then it should not be possible to share folder "simple-folder" with "grp2" using the webUI
+    Then it should not be possible to share folder "simple-folder" with group "grp2" using the webUI
     When the user shares folder "simple-folder" with group "grp1" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
@@ -55,8 +55,8 @@ Feature: restrict Sharing
   Scenario: Forbid sharing with groups
     Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled
     When the user browses to the files page
-    Then it should not be possible to share folder "simple-folder" with "grp1" using the webUI
-    And it should not be possible to share folder "simple-folder" with "grp2" using the webUI
+    Then it should not be possible to share folder "simple-folder" with group "grp1" using the webUI
+    And it should not be possible to share folder "simple-folder" with group "grp2" using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -70,7 +70,7 @@ Feature: Autocompletion of share-with names
       | use      | %alt1%   | Use         | uz@oc.com.np |
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "Use" in the share-with-field
-    Then only "Use" should be listed in the autocomplete list on the webUI
+    Then only user "Use" should be listed in the autocomplete list on the webUI
     And user "User Two" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
@@ -83,7 +83,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
-    Then only "fi (group)" should be listed in the autocomplete list on the webUI
+    Then only group "fi" should be listed in the autocomplete list on the webUI
     And user "finance1" should not be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
@@ -201,8 +201,8 @@ Feature: Autocompletion of share-with names
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the username of the existing user contains the pattern somewhere in the end
     Given these users have been created with default attributes and skeleton files but not initialized:
-      | username     | displayname   |
-      | regularuser3 | Guest User |
+      | username     | displayname |
+      | regularuser3 | Guest User  |
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
@@ -226,7 +226,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "finn" in the share-with-field
-    Then only "John Finn Smith" should be listed in the autocomplete list on the webUI
+    Then only user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere at the end
@@ -234,7 +234,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "group" in the share-with-field
-    Then only "User Group" should be listed in the autocomplete list on the webUI
+    Then only user "User Group" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning
@@ -242,7 +242,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "u2" in the share-with-field
-    Then only "User Two" should be listed in the autocomplete list on the webUI
+    Then only user "User Two" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle
@@ -250,7 +250,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "net" in the share-with-field
-    Then only "User Group" should be listed in the autocomplete list on the webUI
+    Then only user "User Group" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end
@@ -258,7 +258,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "de" in the share-with-field
-    Then only "John Finn Smith" should be listed in the autocomplete list on the webUI
+    Then only user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing group contains the pattern somewhere in the middle but group medial search is disabled
@@ -293,25 +293,25 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the middle but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname |
-      | ivan     | Ivan         |
+      | ivan     | Ivan        |
     And user "user1" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "iv" in the share-with-field
-    Then only "Ivan" should be listed in the autocomplete list on the webUI
+    Then only user "Ivan" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
-      | username     | displayname   |
-      | regularuser3 | Guest User |
+      | username     | displayname |
+      | regularuser3 | Guest User  |
     And user "user1" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "user3" in the share-with-field
-    Then only "User Three" should be listed in the autocomplete list on the webUI
+    Then only user "User Three" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere in the middle but accounts medial search is disabled
@@ -323,19 +323,19 @@ Feature: Autocompletion of share-with names
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "finn" in the share-with-field
-    Then only "finnance typo" should be listed in the autocomplete list on the webUI
+    Then only user "finnance typo" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the display name of existing user contains the pattern somewhere in the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
-      | username | displayname   |
-      | user2    | Group User |
+      | username | displayname |
+      | user2    | Group User  |
     And user "user1" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "group" in the share-with-field
-    Then only "Group User" should be listed in the autocomplete list on the webUI
+    Then only user "Group User" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning but accounts medial search is disabled
@@ -347,19 +347,19 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "u2" in the share-with-field
-    Then only "User Two" should be listed in the autocomplete list on the webUI
+    Then only user "User Two" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
-      | username | displayname | email              |
+      | username | displayname | email         |
       | user2    | User2       | net@oc.com.np |
     And user "user1" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "net" in the share-with-field
-    Then only "User2" should be listed in the autocomplete list on the webUI
+    Then only user "User2" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end but accounts medial search is disabled
@@ -371,7 +371,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "de" in the share-with-field
-    Then only "User2" should be listed in the autocomplete list on the webUI
+    Then only user "User2" should be listed in the autocomplete list on the webUI
 
   @skipOnLDAP
   Scenario: allow user to disable autocomplete in sharing dialog

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -125,11 +125,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-    When user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user shares folder "simple-folder" with remote user "user1@%local_server_without_scheme%" using the webUI
-    And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
-      | delete | no |
-    And user "user1" re-logs in to "%local_server%" using the webUI
+    # permissions read+update+create = 7 (no delete, no (re)share permission)
+    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL" with permissions 7
+    When the user browses to the files page
     And the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI


### PR DESCRIPTION
## Description
Port of #35397 
Enhance sharing dialog UI to prevent overflow.

## Related Issue
- Fixes #35098 

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):
### Federated or Guest
![Screenshot from 2019-05-31 17-26-25](https://user-images.githubusercontent.com/1005065/58716418-458c5280-83c9-11e9-9bbc-d9f2e6553d60.png)

### Group
![Screenshot from 2019-05-31 17-26-00](https://user-images.githubusercontent.com/1005065/58716419-458c5280-83c9-11e9-905c-ad981aca5ec6.png)

### With additional user information
![Screenshot from 2019-05-31 17-25-46](https://user-images.githubusercontent.com/1005065/58716420-4624e900-83c9-11e9-8118-58c56a197eae.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
