### PR TITLE
webUIComments without skeleton

### DIFF
--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -6,10 +6,11 @@ Feature: Add, delete and edit comments in files and folders
   So that I can provide more information about the file/folder
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
+    And user "user1" has uploaded file with content "does-not-matter" to "/lorem.txt"
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 


### PR DESCRIPTION
## Description
Don't user skeleton files on `webUIComments`

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>