### PR TITLE
Use no skeleton on webUIFavorites

### DIFF
--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -5,13 +5,13 @@ Feature: Mark file as favorite
   I would like to mark any file/folder as favorite
   So that I can find my favorite file/folder easily
 
-  Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
-    And the user has browsed to the files page
-
   @smokeTest
   Scenario: mark a file as favorite and list it in favorites page
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
     When the user marks file "data.zip" as favorite using the webUI
     Then file "data.zip" should be marked as favorite on the webUI
     When the user reloads the current page of the webUI
@@ -20,6 +20,11 @@ Feature: Mark file as favorite
     And file "lorem.txt" should not be listed in the favorites page on the webUI
 
   Scenario: mark a folder as favorite and list it in favorites page
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
     When the user marks folder "simple-folder" as favorite using the webUI
     Then folder "simple-folder" should be marked as favorite on the webUI
     When the user reloads the current page of the webUI
@@ -28,6 +33,9 @@ Feature: Mark file as favorite
     And folder "simple-empty-folder" should not be listed in the favorites page on the webUI
 
   Scenario: mark files with same name and different path as favorites and list them in favourites page
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
     When the user marks file "lorem.txt" as favorite using the webUI
     And the user marks folder "simple-empty-folder" as favorite using the webUI
     And the user opens folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -6,7 +6,9 @@ Feature: Unmark file/folder as favorite
   So that I can remove my favorite file/folder from favorite page
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    And user "user1" has created folder "/simple-folder"
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -35,7 +37,7 @@ Feature: Unmark file/folder as favorite
     When the user browses to the files page
     Then file "data.zip" should not be marked as favorite on the webUI
 
-  Scenario: unmark a folder as favorite from files page
+  Scenario: unmark a folder as favorite from favorite page
     Given the user has marked folder "simple-folder" as favorite using the webUI
     And the user has browsed to the favorites page
     When the user unmarks the favorited folder "simple-folder" using the webUI


### PR DESCRIPTION
## Description
Don't user skeleton files on `webUIFavorites`

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>