### PR TITLE
Adjust 'Enforce as maximum expiration date' UI text

### DIFF
--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -68,7 +68,7 @@
 			<?php else: ?>
 				<input type="checkbox" name="shareapi_enforce_expire_date" id="shareapiEnforceExpireDate" class="checkbox" value="1" />
 			<?php endif; ?>
-			<label class="indent" for="shareapiEnforceExpireDate"><?php p($l->t('Enforce expiration date'));?></label><br/>
+			<label class="indent" for="shareapiEnforceExpireDate"><?php p($l->t('Enforce as maximum expiration date'));?></label><br/>
 		</span>
 
 		<input type="checkbox" name="shareapi_allow_public_notification" id="allowPublicMailNotification" class="checkbox"


### PR DESCRIPTION
## Description
Adjust the text describing the "Enforce expiration date" checkbox for link sharing so that it is clear that it is enforced as the maximum expiration date.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3385

## How Has This Been Tested?
Observe the UI sharing settings page.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
