### PR TITLE
webui sharing notifications without skeleton

### DIFF
--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -6,7 +6,7 @@ Feature: Display notifications when receiving a share and follow embedded links
 
   Background:
     Given app "notifications" has been enabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -15,6 +15,7 @@ Feature: Display notifications when receiving a share and follow embedded links
   @smokeTest
   Scenario: notification link redirection in case a share is pending
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/simple-folder" with user "user2"
+    And user "user1" has created folder "a-folder"
+    And user "user1" has shared folder "a-folder" with user "user2"
     When the user follows the link of the first notification on the webUI
     Then the user should be redirected to a webUI page with the title "Shared with you - %productname%"

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -6,7 +6,7 @@ Feature: Sharing files and folders with internal groups
 
   Background:
     Given app "notifications" has been enabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -20,14 +20,16 @@ Feature: Sharing files and folders with internal groups
 
   Scenario: notifications about new share is displayed
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    When user "user3" has shared folder "/simple-folder" with group "grp1"
-    And user "user3" has shared folder "/data.zip" with group "grp1"
+    And user "user3" has created folder "a-folder"
+    And user "user3" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    When user "user3" has shared folder "/a-folder" with group "grp1"
+    And user "user3" has shared file "/data.zip" with group "grp1"
     Then the user should see 2 notifications on the webUI with these details
       | title                                        |
-      | "User Three" shared "simple-folder" with you |
-      | "User Three" shared "data.zip" with you      |
+      | "User Three" shared "a-folder" with you      |
+      | "User Three" shared "data.zip" with you    |
     When the user re-logs in as "user1" using the webUI
     Then the user should see 2 notifications on the webUI with these details
       | title                                        |
-      | "User Three" shared "simple-folder" with you |
-      | "User Three" shared "data.zip" with you      |
+      | "User Three" shared "a-folder" with you      |
+      | "User Three" shared "data.zip" with you    |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -6,49 +6,51 @@ Feature: Sharing files and folders with internal users
 
   Background:
     Given app "notifications" has been enabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
       | user2    |
+    And user "user1" has created folder "a-folder"
+    And user "user1" has uploaded file "filesForUpload/data.zip" to "/data.zip"
     And user "user2" has logged in using the webUI
 
   @smokeTest
   Scenario: notifications about new share is displayed when autoacepting is disabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/simple-folder" with user "user2"
-    And user "user1" has shared folder "/data.zip" with user "user2"
+    And user "user1" has shared folder "/a-folder" with user "user2"
+    And user "user1" has shared file "/data.zip" with user "user2"
     Then the user should see 2 notifications on the webUI with these details
       | title                                      |
-      | "User One" shared "simple-folder" with you |
+      | "User One" shared "a-folder" with you |
       | "User One" shared "data.zip" with you      |
 
   @smokeTest
   Scenario: Notification is gone after accepting a share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/simple-folder" with user "user2"
-    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has shared folder "/a-folder" with user "user2"
+    And user "user1" has shared file "/data.zip" with user "user2"
     When the user accepts all shares displayed in the notifications on the webUI
     Then user "user2" should have 0 notifications
 
   @smokeTest
   Scenario: accept an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/simple-folder" with user "user2"
-    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has shared folder "/a-folder" with user "user2"
+    And user "user1" has shared file "/data.zip" with user "user2"
     When the user accepts all shares displayed in the notifications on the webUI
-    Then folder "simple-folder (2)" should be listed in the files page on the webUI
-    And folder "simple-empty-folder (2)" should be listed in the files page on the webUI
-    And folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
-    And folder "simple-empty-folder (2)" should be in state "" in the shared-with-you page on the webUI
+    Then folder "a-folder" should be listed in the files page on the webUI
+    And file "data.zip" should be listed in the files page on the webUI
+    And folder "a-folder" should be in state "" in the shared-with-you page on the webUI
+    And file "data.zip" should be in state "" in the shared-with-you page on the webUI
 
   @smokeTest
   Scenario: reject an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/simple-folder" with user "user2"
-    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has shared folder "/a-folder" with user "user2"
+    And user "user1" has shared file "/data.zip" with user "user2"
     When the user declines all shares displayed in the notifications on the webUI
-    Then folder "simple-folder (2)" should not be listed in the files page on the webUI
-    And folder "simple-empty-folder (2)" should not be listed in the files page on the webUI
-    And folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
-    And folder "simple-empty-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    Then folder "a-folder" should not be listed in the files page on the webUI
+    And file "data.zip" should not be listed in the files page on the webUI
+    And folder "a-folder" should be in state "Declined" in the shared-with-you page on the webUI
+    And file "data.zip" should be in state "Declined" in the shared-with-you page on the webUI
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Do not use skeleton files for ```webISharingNotifications``` to speed up CI
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
part of https://github.com/owncloud/QA/issues/622
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
