### PR TITLE
[10.2.1] The recipient of internal share should not increase permission

### DIFF
--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -2232,7 +2232,8 @@ class Share20OcsControllerTest extends TestCase {
 			->setShareType(Share::SHARE_TYPE_GROUP)
 			->setSharedWith('group1')
 			->setPermissions(\OCP\Constants::PERMISSION_READ)
-			->setNode($folder);
+			->setNode($folder)
+			->setTarget('/folderShare');
 
 		$this->request
 			->method('getParam')
@@ -2251,11 +2252,87 @@ class Share20OcsControllerTest extends TestCase {
 
 		$this->shareManager->expects($this->never())->method('updateShare');
 
-		$expected = new \OC\OCS\Result(null, 404, 'Cannot increase permissions');
+		$folderOwner = $this->createMock(IUser::class);
+		$folderOwner->method('getUID')
+			->willReturn('foo1234');
+		$userHomeFolder = $this->createMock(Folder::class);
+		$userNode = $this->createMock(Folder::class);
+		$userNode->method('getOwner')
+			->willReturn($folderOwner);
+		$userHomeFolder->method('getById')
+			->willReturn([$userNode]);
+		$this->rootFolder->method('getUserFolder')
+			->willReturn($userHomeFolder);
+
+		$expected = new Result(null, 404, 'Cannot increase permission of ' . $share->getTarget());
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
 		$this->assertEquals($expected->getData(), $result->getData());
+	}
+
+	public function providesDataForTestingIncreasePermissionRegularShare() {
+		return [
+			['file', 16, 17],
+			['file', 17, 19],
+			['folder', 17, 19],
+			['folder', 19, 21],
+			['folder', 21, 23],
+		];
+	}
+
+	/**
+	 * @dataProvider providesDataForTestingIncreasePermissionRegularShare
+	 *
+	 * @param string $nodeType
+	 * @param int $currentPermission
+	 * @param string $updatePermissionTo
+	 */
+	public function testRegularShareRecipientCannotIncreasePermission($nodeType, $currentPermission, $updatePermissionTo) {
+		$ocs = $this->mockFormatShare();
+
+		$share = \OC::$server->getShareManager()->newShare();
+		$share
+			->setId(42)
+			->setSharedBy($this->currentUser->getUID())
+			->setShareOwner('anotheruser')
+			->setShareType(Share::SHARE_TYPE_USER)
+			->setSharedWith('user1')
+			->setPermissions($currentPermission);
+
+		if ($nodeType === 'file') {
+			$file = $this->createMock(File::class);
+			$share->setNode($file);
+			$share->setTarget('/testFile');
+		} else {
+			$folder = $this->createMock(Folder::class);
+			$share->setNode($folder);
+			$share->setTarget('/testFolder');
+		}
+
+		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
+
+		$this->request
+			->method('getParam')
+			->will($this->returnValueMap([
+				['permissions', null, $updatePermissionTo],
+			]));
+
+		$folderOwner = $this->createMock(IUser::class);
+		$folderOwner->method('getUID')
+			->willReturn('foo1234');
+		$userHomeFolder = $this->createMock(Folder::class);
+		$userNode = $this->createMock(Folder::class);
+		$userNode->method('getOwner')
+			->willReturn($folderOwner);
+		$userHomeFolder->method('getById')
+			->willReturn([$userNode]);
+		$this->rootFolder->method('getUserFolder')
+			->willReturn($userHomeFolder);
+
+		$result = $ocs->updateShare(42);
+		$this->assertEquals(404, $result->getStatusCode());
+		$this->assertEquals('Cannot increase permission of ' . $share->getTarget(), $result->getMeta()['message']);
 	}
 
 	/**
@@ -2360,7 +2437,16 @@ class Share20OcsControllerTest extends TestCase {
 			->with($share)
 			->willReturn($share);
 
-		$expected = new \OC\OCS\Result();
+		$userHomeFolder = $this->createMock(Folder::class);
+		$userNode = $this->createMock(Folder::class);
+		$userNode->method('getOwner')
+			->willReturn($this->currentUser);
+		$userHomeFolder->method('getById')
+			->willReturn([$userNode]);
+		$this->rootFolder->method('getUserFolder')
+			->willReturn($userHomeFolder);
+
+		$expected = new Result();
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Backport of #35475 // #35447 

## Related Issue
-

## Motivation and Context
-
## How Has This Been Tested?
- 🤖 + needs careful testing in QA phase

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
-

## Open tasks:
-