### PR TITLE
Use no skeleton files on webUIPersonalSettings

### DIFF
--- a/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
@@ -4,9 +4,11 @@ Feature: Control access to edit fullname of user through config file
   I want to control the access to users to edit their fullname in settings page
   So that users can edit their fullname after getting permission from administrator
 
-  Scenario: Admin gives access to users to change their full name
-    Given user "user1" has been created with default attributes and skeleton files
+  Background:
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
+
+  Scenario: Admin gives access to users to change their full name
     When the administrator updates system config key "allow_user_to_change_display_name" with value "true" and type "boolean" using the occ command
     And the user browses to the personal general settings page
     And the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
@@ -15,9 +17,7 @@ Feature: Control access to edit fullname of user through config file
     And the attributes of user "user1" returned by the API should include
       | displayname | my#very&weird?नेपालि%name |
 
-  Scenario: Admin doesnot give access to users to change their full name
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+  Scenario: Admin does not give access to users to change their full name
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
     And the user browses to the personal general settings page
     Then the user should not be able to change the full name using the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -5,7 +5,7 @@ Feature: Change own email address on the personal settings page
   So that I can be reached by the owncloud server
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -5,7 +5,7 @@ Feature: Change own full name on the personal settings page
   So that other users can recognize me by it
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -5,7 +5,7 @@ Feature: Change Login Password
   So that I can login with my new password
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -5,7 +5,7 @@ Feature: personal general settings
   So that I can personalise the User Interface
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
@@ -15,6 +15,7 @@ Feature: personal general settings
     Then the user should be redirected to a webUI page with the title "Настройки - %productname%"
 
   Scenario: change language and check that file actions menu have been translated
+    Given the user has created folder "simple-folder"
     When the user changes the language to "हिन्दी" using the webUI
     And the user browses to the files page
     And the user opens the file action menu of folder "simple-folder" on the webUI
@@ -22,6 +23,7 @@ Feature: personal general settings
     And the user should see "Delete" file action translated to "हटाना" on the webUI
 
   Scenario: change language using the occ command and check that file actions menu have been translated
+    Given the user has created folder "simple-folder"
     When the administrator changes the language of user "user1" to "fr" using the occ command
     And the user browses to the files page
     And the user opens the file action menu of folder "simple-folder" on the webUI
@@ -29,6 +31,7 @@ Feature: personal general settings
     And the user should see "Delete" file action translated to "Supprimer" on the webUI
 
   Scenario: change language to invalid language using the occ command and check that the language defaults back to english
+    Given the user has created folder "simple-folder"
     When the administrator changes the language of user "user1" to "not-valid-lan" using the occ command
     And the user browses to the files page
     And the user opens the file action menu of folder "simple-folder" on the webUI
@@ -47,17 +50,20 @@ Feature: personal general settings
     And group "another-group" should be displayed on the personal general settings page on the webUI
 
   Scenario: User sets profile picture from their existing cloud file
-    Given the user has deleted any existing profile picture
+    Given user "user1" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+    And the user has deleted any existing profile picture
     When the user sets profile picture to "testimage.jpg" from their cloud files using the webUI
     Then the preview of the profile picture should be shown on the webUI
 
   Scenario: User deletes the existing profile picture
-    Given the user has set profile picture to "testimage.jpg" from their cloud files
+    Given user "user1" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+    And the user has set profile picture to "testimage.jpg" from their cloud files
     When the user deletes the existing profile picture
     Then the preview of the profile picture should not be shown on the webUI
 
   Scenario: User uploads new profile picture
-    Given the user has deleted any existing profile picture
+    Given user "user1" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+    And the user has deleted any existing profile picture
     When the user uploads "testavatar.png" as a new profile picture using the webUI
     Then the preview of the profile picture should be shown on the webUI
 

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -5,7 +5,7 @@ Feature: personal security settings
   So that I can enable, allow and deny access to and from other storage systems or resources
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user1" has logged in using the webUI
     And the user has browsed to the personal security settings page
 


### PR DESCRIPTION
## Description
Don't user skeleton files on `webUIPersonalSettings`

## Related Issue
https://github.com/owncloud/QA/issues/622

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>