### PR TITLE
test adding a user to a group after the group received a share

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -723,3 +723,47 @@ Feature: sharing
       | ocs_api_version |
       | 1               |
       | 2               |
+
+  @skipOnEncryptionType:user-keys @encryption-issue-132
+  Scenario Outline: share with a group and then add a user to that group
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user0" has uploaded file with content "some content" to "lorem.txt"
+    When user "user0" shares file "lorem.txt" with group "grp1" using the sharing API
+    And the administrator adds user "user2" to group "grp1" using the provisioning API
+    Then the content of file "lorem.txt" for user "user1" should be "some content"
+    And the content of file "lorem.txt" for user "user2" should be "some content"
+    Examples:
+      | ocs_api_version |
+      | 1               |
+      | 2               |
+
+  @skipOnEncryptionType:user-keys @encryption-issue-132
+  Scenario Outline: share with a group and then add a user to that group that already has a file with the shared name
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user0" has uploaded file with content "user0 content" to "lorem.txt"
+    And user "user2" has uploaded file with content "user2 content" to "lorem.txt"
+    When user "user0" shares file "lorem.txt" with group "grp1" using the sharing API
+    And the administrator adds user "user2" to group "grp1" using the provisioning API
+    Then the content of file "lorem.txt" for user "user1" should be "user0 content"
+    And the content of file "lorem.txt" for user "user2" should be "user2 content"
+    And the content of file "lorem (2).txt" for user "user2" should be "user0 content"
+    Examples:
+      | ocs_api_version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -207,8 +207,8 @@ Feature: Sharing files and folders with internal groups
       """
   Scenario: user added to a group has a share that matches the skeleton of added user
     Given user "user1" has uploaded file with content "some content" to "lorem.txt"
-    And user "user1" has shared file "lorem.txt" with group "grp1"
     And user "user3" has been added to group "grp1"
+    And user "user1" has shared file "lorem.txt" with group "grp1"
     When user "user3" logs in using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem (2).txt" should be listed on the webUI


### PR DESCRIPTION
## Description
test sharing with a group and then adding a user to that group

## Motivation and Context
the changed webUI test did do that, but not intentionally. Because that scenario does not work with user-key encryption the test did fail. see https://github.com/owncloud/encryption/issues/132
So this PR make the UI test work in encryption and adds more intentional tests for this scenario

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
