### PR TITLE
Enhance re share tests

### DIFF
--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -3,67 +3,162 @@ Feature: sharing
 
   Background:
     Given using old DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
 
   Scenario Outline: User is not allowed to reshare file
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created a share with settings
       | path        | /textfile0.txt |
       | shareType   | 0              |
       | shareWith   | user1          |
-      | permissions | 8              |
+      | permissions | 15             |
     When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0 (2).txt |
-      | shareType   | 0                  |
-      | shareWith   | user2              |
-      | permissions | 31                 |
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user2          |
+      | permissions | 15             |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
+    And as "user2" file "/textfile0.txt" should not exist
+    But as "user1" file "/textfile0.txt" should exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
+
+  Scenario Outline: User is allowed to reshare file with the same permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created a share with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user1          |
+      | permissions | 17             |
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user2          |
+      | permissions | 17             |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user2" file "/textfile0.txt" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: User is allowed to reshare file with less permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created a share with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user1          |
+      | permissions | 31             |
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user2          |
+      | permissions | 17             |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user2" file "/textfile0.txt" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   Scenario Outline: User is not allowed to reshare file with more permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created a share with settings
       | path        | /textfile0.txt |
       | shareType   | 0              |
       | shareWith   | user1          |
-      | permissions | 16             |
+      | permissions | 17             |
     When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0 (2).txt |
-      | shareType   | 0                  |
-      | shareWith   | user2              |
-      | permissions | 31                 |
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user2          |
+      | permissions | 31             |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
+    And as "user2" file "/textfile0.txt" should not exist
+    But as "user1" file "/textfile0.txt" should exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
 
-  Scenario Outline: Do not allow reshare to exceed permissions
+  Scenario Outline: Update of reshare can reduce permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user1 |
+      | permissions | 23    |
+    And user "user1" has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user2 |
+      | permissions | 23    |
+    When user "user1" updates the last share using the sharing API with
+      | permissions | 17 |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @issue-35528
+  Scenario Outline: Update of reshare can increase permissions to the maximum allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user1 |
+      | permissions | 23    |
+    And user "user1" has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user2 |
+      | permissions | 17    |
+    When user "user1" updates the last share using the sharing API with
+      | permissions | 23 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    #Then the OCS status code should be "<ocs_status_code>"
+    #And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+      #| ocs_api_version | ocs_status_code |
+      #| 1               | 100             |
+      #| 2               | 200             |
+
+  Scenario Outline: Do not allow update of reshare to exceed permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
     And user "user0" has created a share with settings
       | path        | /TMP  |
       | shareType   | 0     |
       | shareWith   | user1 |
       | permissions | 21    |
-    And as user "user1"
-    And the user has created a share with settings
+    And user "user1" has created a share with settings
       | path        | /TMP  |
       | shareType   | 0     |
       | shareWith   | user2 |
       | permissions | 21    |
-    When the user updates the last share using the sharing API with
+    When user "user1" updates the last share using the sharing API with
       | permissions | 31 |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
@@ -72,19 +167,134 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
+  Scenario Outline: User is allowed to reshare a sub-folder with the same permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has created folder "/TMP/SUB"
+    And user "user0" has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user1 |
+      | permissions | 17    |
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /TMP/SUB |
+      | shareType   | 0        |
+      | shareWith   | user2    |
+      | permissions | 17       |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user2" folder "/SUB" should exist
+    And as "user1" file "/TMP/SUB" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: User is not allowed to reshare a sub-folder with more permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has created folder "/TMP/SUB"
+    And user "user0" has created a share with settings
+      | path        | /TMP  |
+      | shareType   | 0     |
+      | shareWith   | user1 |
+      | permissions | 17    |
+    When user "user1" creates a share using the sharing API with settings
+      | path        | /TMP/SUB |
+      | shareType   | 0        |
+      | shareWith   | user2    |
+      | permissions | 31       |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user2" folder "/SUB" should not exist
+    But as "user1" file "/TMP/SUB" should exist
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  Scenario Outline: User is allowed to update reshare of a sub-folder with less permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has created folder "/TMP/SUB"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 23
+    And user "user1" has shared folder "/TMP/SUB" with user "user2" with permissions 23
+    When user "user1" updates the last share using the sharing API with
+      | permissions | 17 |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user2" folder "/SUB" should exist
+    But user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/SUB/textfile.txt"
+    And as "user1" file "/TMP/SUB" should exist
+    And user "user1" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/SUB/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @issue-35528
+  Scenario Outline: User is allowed to update reshare of a sub-folder to the maximum allowed permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has created folder "/TMP/SUB"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 23
+    And user "user1" has shared folder "/TMP/SUB" with user "user2" with permissions 17
+    When user "user1" updates the last share using the sharing API with
+      | permissions | 23 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    #Then the OCS status code should be "<ocs_status_code>"
+    #And the HTTP status code should be "200"
+    And as "user2" folder "/SUB" should exist
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/SUB/textfile.txt"
+    #And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/SUB/textfile.txt"
+    And as "user1" file "/TMP/SUB" should exist
+    And user "user1" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/SUB/textfile.txt"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+      #| ocs_api_version | ocs_status_code |
+      #| 1               | 100             |
+      #| 2               | 200             |
+
+  Scenario Outline: User is not allowed to update reshare of a sub-folder with more permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has created folder "/TMP/SUB"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 17
+    And user "user1" has shared folder "/TMP/SUB" with user "user2" with permissions 17
+    When user "user1" updates the last share using the sharing API with
+      | permissions | 31 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user2" folder "/SUB" should exist
+    But user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/SUB/textfile.txt"
+    And as "user1" file "/TMP/SUB" should exist
+    But user "user1" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/SUB/textfile.txt"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
   Scenario: Reshared files can be still accessed if a user in the middle removes it.
-    Given user "user2" has been created with default attributes and skeleton files
-    And user "user3" has been created with default attributes and skeleton files
+    Given user "user2" has been created with default attributes and without skeleton files
+    And user "user3" has been created with default attributes and without skeleton files
     And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user1" has moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
+    And user "user1" has moved file "/textfile0.txt" to "/textfile0_shared.txt"
     And user "user1" has shared file "textfile0_shared.txt" with user "user2"
     And user "user2" has shared file "textfile0_shared.txt" with user "user3"
     When user "user1" deletes file "/textfile0_shared.txt" using the WebDAV API
-    And user "user3" downloads file "/textfile0_shared.txt" with range "bytes=1-7" using the WebDAV API
-    Then the downloaded content should be "wnCloud"
+    Then the content of file "/textfile0_shared.txt" for user "user2" should be "ownCloud test text file 0" plus end-of-line
+    Then the content of file "/textfile0_shared.txt" for user "user3" should be "ownCloud test text file 0" plus end-of-line
 
   @public_link_share-feature-required
-  Scenario Outline: resharing using a public link with read only permissions is not allowed
+  Scenario Outline: creating a public link from a share with read permission only is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions 1
@@ -99,13 +309,32 @@ Feature: sharing
       | 2               | 404              |
 
   @public_link_share-feature-required
-  Scenario Outline: resharing using a public link with read and write permissions only is not allowed
+  Scenario Outline: creating a public link from a share with share+read only permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
-    And user "user0" has shared folder "/test" with user "user1" with permissions 15
+    And user "user0" has uploaded file with content "some content" to "/test/file.txt"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 17
     When user "user1" creates a public link share using the sharing API with settings
       | path         | /test |
       | publicUpload | false |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the public should be able to download file "file.txt" from inside the last public shared folder and the content should be "some content"
+    But publicly uploading a file should not work
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario Outline: creating an upload public link from a share with share+read only permissions is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 17
+    When user "user1" creates a public link share using the sharing API with settings
+      | path         | /test |
+      | permissions  | 15    |
+      | publicUpload | true  |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -113,9 +342,98 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
+  @public_link_share-feature-required
+  Scenario Outline: creating a public link from a share with read+write permissions only is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created folder "/test"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 15
+    When user "user1" creates a public link share using the sharing API with settings
+      | path         | /test |
+      | publicUpload | true  |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  @public_link_share-feature-required
+  Scenario Outline: creating a public link from a share with share+read+write permissions is allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created folder "/test"
+    And user "user0" has uploaded file with content "some content" to "/test/file.txt"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 31
+    When user "user1" creates a public link share using the sharing API with settings
+      | path         | /test |
+      | publicUpload | false |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the public should be able to download file "file.txt" from inside the last public shared folder and the content should be "some content"
+    But publicly uploading a file should not work
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created folder "/test"
+    And user "user0" has uploaded file with content "some content" to "/test/file.txt"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 31
+    When user "user1" creates a public link share using the sharing API with settings
+      | path         | /test |
+      | permissions  | 15    |
+      | publicUpload | true  |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the public should be able to download file "file.txt" from inside the last public shared folder and the content should be "some content"
+    And publicly uploading a file should work
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario Outline: creating an upload public link from a sub-folder of a share with share+read only permissions is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created folder "/test"
+    And user "user0" has created folder "/test/sub"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 17
+    When user "user1" creates a public link share using the sharing API with settings
+      | path         | /test/sub |
+      | permissions  | 15        |
+      | publicUpload | true      |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  @public_link_share-feature-required
+  Scenario Outline: increasing permissions of a public link of a share with share+read only permissions is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has created folder "/test"
+    And user "user0" has created folder "/test/sub"
+    And user "user0" has shared folder "/test" with user "user1" with permissions 17
+    And user "user1" has created a public link share with settings
+      | path         | /test |
+      | permissions  | 1     |
+      | publicUpload | false |
+    When user "user1" updates the last share using the sharing API with
+      | permissions | 15 |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And publicly uploading a file should not work
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created a share with settings
       | path        | /textfile0.txt |
       | shareType   | 0              |
@@ -123,14 +441,30 @@ Feature: sharing
       | permissions | 31             |
     And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
     When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0 (2).txt |
-      | shareType   | 0                  |
-      | shareWith   | user2              |
-      | permissions | 31                 |
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user2          |
+      | permissions | 31             |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And as "user2" file "/textfile0 (2).txt" should not exist
+    And as "user2" file "/textfile0.txt" should not exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
+
+  Scenario Outline: ordinary sharing is allowed when allow resharing has been disabled
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
+    When user "user0" creates a share using the sharing API with settings
+      | path        | /textfile0.txt |
+      | shareType   | 0              |
+      | shareWith   | user1          |
+      | permissions | 31             |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user1" file "/textfile0.txt" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -107,6 +107,35 @@ class PublicWebDavContext implements Context {
 	}
 	
 	/**
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the public WebDAV API$/
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function downloadPublicFileInsideAFolder($path) {
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
+			$path, "", ""
+		);
+	}
+
+	/**
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" using the public WebDAV API$/
+	 *
+	 * @param string $path
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
+		$path, $password = ""
+	) {
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
+			$path, $password, ""
+		);
+	}
+
+	/**
 	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $path
@@ -115,17 +144,9 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function downloadPublicFileInsideAFolderWithRange($path, $range) {
-		$path = \ltrim($path, "/");
-		$fullUrl = $this->featureContext->getBaseUrl() . "/public.php/webdav/$path";
-		$headers = [
-			'X-Requested-With' => 'XMLHttpRequest',
-			'Range' => $range
-		];
-		$response = HttpRequestHelper::get(
-			$fullUrl, $this->featureContext->getLastShareData()->data->token,
-			"", $headers
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
+			$path, "", $range
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -137,16 +158,18 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
+	public function publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
 		$path, $password, $range
 	) {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
 		$fullUrl = $this->featureContext->getBaseUrl() . "/public.php/webdav/$path";
 		$headers = [
-			'X-Requested-With' => 'XMLHttpRequest',
-			'Range' => $range
+			'X-Requested-With' => 'XMLHttpRequest'
 		];
+		if ($range !== "") {
+			$headers['Range'] = $range;
+		}
 		$response = HttpRequestHelper::get(
 			$fullUrl, $this->featureContext->getLastShareData()->data->token,
 			$password, $headers
@@ -223,6 +246,39 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder and the content should be "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function shouldBeAbleToDownloadFileInsidePublicSharedFolder(
+		$path, $content
+	) {
+		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+			"", $path, "", $content
+		);
+	}
+
+	/**
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder with password "([^"]*)" and the content should be "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $password
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
+		$path, $password, $content
+	) {
+		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+			"", $path, $password, $content
+		);
+	}
+
+	/**
 	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $range
@@ -232,10 +288,10 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
+	public function shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
 		$range, $path, $password, $content
 	) {
-		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
 			$path, $password, $range
 		);
 		$this->featureContext->downloadedContentShouldBe($content);
@@ -250,12 +306,30 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function shouldBeAbleToDownloadFileInsidePublicSharedFolder(
+	public function shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolder(
 		$range, $path, $content
 	) {
-		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
-			$path, null, $range
+		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+			$range, $path, "", $content
 		);
+	}
+
+	/**
+	 * @Then /^the public should be able to upload file "([^"]*)" with content "([^"]*)" to the last public shared folder$/
+	 *
+	 * @param string $path
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function shouldBeAbleToUploadFileWithContentToTheLastPublicSharedFolder(
+		$path, $content
+	) {
+		$this->publiclyUploadingContent($path, $content);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			"201", "Failed to upload file to public share"
+		);
+		$this->downloadPublicFileInsideAFolder($path);
 		$this->featureContext->downloadedContentShouldBe($content);
 	}
 
@@ -294,7 +368,7 @@ class PublicWebDavContext implements Context {
 			$response->getStatusCode()
 		);
 		$this->shouldBeAbleToDownloadFileInsidePublicSharedFolder(
-			"bytes=0-3", $path, $content
+			$path, $content
 		);
 	}
 


### PR DESCRIPTION
## Description
1) Adjust test scenarios so that `user0` has skeleton files, and other users (who receive shares) do not have skeleton files. This makes the test sequences a bit easier, because the received share names do not have `(2)` on them.

2) Add some extra `Then` steps to existing scenarios to check that the correct share and reshare recipients can or cannot see the shared file/folder. This helps verify that the sharing and resharing combinations really are working, and not just that some OCS/HTTP status codes were as expected.

3) Add more combinations of resharing with less, the same and more permissions of the received share, and of a sub-folder in a received share.

4) Add scenarios for resharing and then (attempting to) update the re-share to have more/same/less permissions.

5) Add scenarios for creating a public link share of a received share. Make sure that you can't give more permissions in the public link share then what you received from the original sharer.

6) Added 2 scenarios for issue #35528 related to trying to increase the permissions on a reshare, where you are just increasing the permissions to a level that should be allowed.

7) Added various combinations of steps for "the public downloads file" with a without password, and "the public should be able to download file" etc that were missing. There were already steps that did this in some combinations, and checking ranges of bytes in the file etc. 

## Related Issue
https://github.com/owncloud/enterprise/issues/3364

## Motivation and Context

## How Has This Been Tested?
Local acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
