### PR TITLE
webUISharingExternal use no skeleton

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -296,12 +296,16 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles($user) {
-		$path = $this->popSkeletonDirectoryConfig();
+		$baseUrl = $this->getBaseUrl();
+		$path = $this->popSkeletonDirectoryConfig($baseUrl);
 		try {
 			$this->userHasBeenCreatedWithDefaultAttributes($user);
 		} finally {
 			// restore skeletondirectory even if user creation failed
-			$this->runOcc(["config:system:set skeletondirectory --value $path"]);
+			$this->runOcc(
+				["config:system:set skeletondirectory --value $path"],
+				null, null, $baseUrl
+			);
 		}
 	}
 
@@ -315,14 +319,18 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theseUsersHaveBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles(TableNode $table) {
-		$path = $this->popSkeletonDirectoryConfig();
+		$baseUrl = $this->getBaseUrl();
+		$path = $this->popSkeletonDirectoryConfig($baseUrl);
 		try {
 			foreach ($table as $row) {
 				$this->userHasBeenCreatedWithDefaultAttributes($row['username']);
 			}
 		} finally {
 			// restore skeletondirectory even if user creation failed
-			$this->runOcc(["config:system:set skeletondirectory --value $path"]);
+			$this->runOcc(
+				["config:system:set skeletondirectory --value $path"],
+				null, null, $baseUrl
+			);
 		}
 	}
 
@@ -337,12 +345,16 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theseUsersHaveBeenCreatedWithoutSkeletonFiles(TableNode $table) {
-		$path = $this->popSkeletonDirectoryConfig();
+		$baseUrl = $this->getBaseUrl();
+		$path = $this->popSkeletonDirectoryConfig($baseUrl);
 		try {
 			$this->theseUsersHaveBeenCreated("", "", $table);
 		} finally {
 			// restore skeletondirectory even if user creation failed
-			$this->runOcc(["config:system:set skeletondirectory --value $path"]);
+			$this->runOcc(
+				["config:system:set skeletondirectory --value $path"],
+				null, null, $baseUrl
+			);
 		}
 	}
 
@@ -3069,12 +3081,20 @@ trait Provisioning {
 	/**
 	 * Removes skeleton directory config from config.php and returns the config value
 	 *
+	 * @param string $baseUrl
+	 *
 	 * @return string
 	 */
-	public function popSkeletonDirectoryConfig() {
-		$this->runOcc(["config:system:get skeletondirectory"]);
+	public function popSkeletonDirectoryConfig($baseUrl) {
+		$this->runOcc(
+			["config:system:get skeletondirectory"],
+			null, null, $baseUrl
+		);
 		$path = \trim($this->getStdOutOfOccCommand());
-		$this->runOcc(["config:system:delete skeletondirectory"]);
+		$this->runOcc(
+			["config:system:delete skeletondirectory"],
+			null, null, $baseUrl
+		);
 		return $path;
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -73,16 +73,16 @@ trait WebDav {
 	private $customDavPath = null;
 
 	private $oldAsyncSetting = null;
-	
+
 	private $oldDavSlowdownSetting = null;
-	
+
 	/**
 	 * response content parsed from XML to an array
 	 *
 	 * @var array
 	 */
 	private $responseXml = [];
-	
+
 	/**
 	 * response content parsed into a SimpleXMLElement
 	 *
@@ -1089,7 +1089,7 @@ trait WebDav {
 		if ($this->customDavPath !== null) {
 			$path = $this->customDavPath . $path;
 		}
-		
+
 		return WebDavHelper::listFolder(
 			$this->getBaseUrl(),
 			$this->getActualUsername($user),
@@ -1198,6 +1198,7 @@ trait WebDav {
 	}
 
 	/**
+	 * @Given /^user "([^"]*)" on "(LOCAL|REMOTE)" has uploaded file "([^"]*)" to "([^"]*)"$/
 	 * @When /^user "([^"]*)" on "(LOCAL|REMOTE)" uploads file "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
@@ -1323,7 +1324,7 @@ trait WebDav {
 			$user, $source, $destination, $noOfChunks, $chunkingVersion, true
 		);
 	}
-	 
+
 	/**
 	 * sets the chunking version from human readable format
 	 *
@@ -2100,7 +2101,7 @@ trait WebDav {
 			$expectedHeaderValue = $this->substituteInLineCodes(
 				$expectedHeaderValue, ['preg_quote' => ['/'] ]
 			);
-			
+
 			$returnedHeader = $this->response->getHeader($headerName);
 			PHPUnit\Framework\Assert::assertNotFalse(
 				(bool)\preg_match($expectedHeaderValue, $returnedHeader),
@@ -2205,7 +2206,7 @@ trait WebDav {
 	) {
 		$elementRows = $expectedFiles->getRows();
 		$should = ($shouldOrNot !== "not");
-		
+
 		foreach ($elementRows as $expectedFile) {
 			$fileFound = $this->findEntryFromPropfindResponse(
 				$expectedFile[0]

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -6,9 +6,17 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Background:
     Given using server "REMOTE"
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has created folder "simple-empty-folder"
+    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And using server "LOCAL"
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has created folder "simple-empty-folder"
+    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "user1" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
@@ -24,10 +32,12 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test the single steps of receiving a federation share
     Given using server "REMOTE"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | user2    |
       | user3    |
+    And user "user2" has created folder "simple-empty-folder"
+    And user "user3" has uploaded file with content "I am lorem.txt" to "/lorem.txt"
     And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And user "user2" from server "REMOTE" has shared "simple-empty-folder" with user "user1" from server "LOCAL"
     And user "user3" from server "REMOTE" has shared "lorem.txt" with user "user1" from server "LOCAL"
@@ -39,10 +49,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%?           |
     When the user accepts the offered remote shares using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
-    And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"
+    And the content of file "lorem (2).txt" for user "user1" on server "LOCAL" should be "I am lorem.txt"
     And folder "simple-folder (2)" should be listed on the webUI
     And file "lorem.txt" should be listed in folder "simple-folder (2)" on the webUI
-    And the content of "lorem.txt" on the local server should be the same as the original "simple-folder/lorem.txt"
+    And the content of file "simple-folder (2)/lorem.txt" for user "user1" on server "LOCAL" should be "I am lorem.txt inside simple-folder"
     And file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
     And folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
@@ -79,7 +89,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | /lorem%20(2).txt |
 
   Scenario: one user disabling user-based auto accepting while global is enabled has no effect on other users
-    Given user "user2" has been created with default attributes and skeleton files
+    Given user "user2" has been created with default attributes and without skeleton files
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "autoAddServers" of app "federation" has been set to "1"
     And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
@@ -175,12 +186,12 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: rename a file in a received share - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
+    When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
     And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then file "renamed file.txt" should be listed on the webUI
-    But file "lorem-big.txt" should not be listed on the webUI
-    And the content of "renamed file.txt" on the local server should be the same as the original "simple-folder/lorem-big.txt"
+    But file "lorem.txt" should not be listed on the webUI
+    And the content of file "simple-folder/renamed file.txt" for user "user1" on server "LOCAL" should be "I am lorem.txt inside simple-folder"
 
   @skipOnFIREFOX
   Scenario: rename a file in a received share - remote server shares - local server receives
@@ -188,15 +199,16 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
     When the user opens folder "simple-folder (2)" using the webUI
-    And the user renames file "lorem-big.txt" to "renamed file.txt" using the webUI
+    And the user renames file "lorem.txt" to "renamed file.txt" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then file "renamed file.txt" should be listed on the webUI
-    And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
-    But file "lorem-big.txt" should not be listed on the webUI
+    And the content of file "simple-folder/renamed file.txt" for user "user1" on server "REMOTE" should be "I am lorem.txt inside simple-folder"
+    But file "lorem.txt" should not be listed on the webUI
 
   Scenario: delete a file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    Given user "user1" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
+    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
     And user "user1" re-logs in to "%local_server%" using the webUI
@@ -204,7 +216,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then file "data.zip" should not be listed on the webUI
 
   Scenario: delete a file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    Given user "user1" on "REMOTE" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
@@ -215,7 +228,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: receive same name federation share from two users
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
@@ -245,9 +259,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test sharing folder to a remote server and resharing it back to the local
     Given using server "LOCAL"
-    And these users have been created with skeleton files:
-      | username |
-      | user2    |
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user2" has created folder "simple-folder"
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
@@ -259,9 +272,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test resharing folder as readonly and set it as readonly by resharer
     Given using server "LOCAL"
-    And these users have been created with skeleton files:
-      | username |
-      | user2    |
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user2" has created folder "simple-folder"
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
@@ -277,9 +289,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test resharing folder and set it as readonly by owner
     Given using server "LOCAL"
-    And these users have been created with skeleton files:
-      | username |
-      | user2    |
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user2" has created folder "simple-folder"
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
     And user "user1" re-logs in to "%remote_server%" using the webUI
     And the user accepts the offered remote shares using the webUI
@@ -305,7 +316,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
 
   Scenario: sharee should be able to access the files/folders inside other folder
-    Given user "user1" has created folder "simple-folder/simple-empty-folder/finalfolder"
+    Given user "user1" has created folder "simple-folder/simple-empty-folder"
+    And user "user1" has created folder "simple-folder/simple-empty-folder/finalfolder"
     And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
@@ -317,7 +329,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And folder "finalfolder" should be listed on the webUI
 
   Scenario: sharee uploads a file inside a folder of a folder
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    Given user "user1" has created folder "simple-folder/simple-empty-folder"
+    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" re-logs in to "%remote_server%" using the webUI
     And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
@@ -327,7 +340,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skipOnFIREFOX
   Scenario: rename a file in a folder inside a shared folder
-    Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    Given user "user1" has created folder "simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     And user "user1" re-logs in to "%remote_server%" using the webUI
@@ -338,7 +352,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     But as "user1" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
 
   Scenario: delete a file in a folder inside a shared folder
-    Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    Given user "user1" has created folder "simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     And user "user1" re-logs in to "%remote_server%" using the webUI


### PR DESCRIPTION
## Description
Don't user skeleton files on `webUISharingExternal`

## Related Issue
https://github.com/owncloud/QA/issues/622

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>