### PR TITLE
webui sharing public without skeleton

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1360,6 +1360,8 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3085,7 +3085,7 @@ trait Provisioning {
 	 *
 	 * @return string
 	 */
-	public function popSkeletonDirectoryConfig($baseUrl) {
+	public function popSkeletonDirectoryConfig($baseUrl = null) {
 		$this->runOcc(
 			["config:system:get skeletondirectory"],
 			null, null, $baseUrl

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -9,17 +9,21 @@ Feature: Share by public link
   So that public sharing is limited according to organization policy
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario: simple sharing by public link
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
+    Given user "user2" has been created with default attributes and skeleton files
+    And user "user2" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
@@ -34,6 +38,9 @@ Feature: Share by public link
 
   @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read |
     And the public accesses the last created public link using the webUI
@@ -42,92 +49,119 @@ Feature: Share by public link
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
+    And using server "LOCAL"
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
     And the public adds the public link to "%remote_server%" as user "user2" with password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
+    And the content of file "simple-folder/lorem.txt" for user "user2" on server "REMOTE" should be "original content"
     And it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
+    And using server "LOCAL"
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
     And the public adds the public link to "%remote_server%" as user "user2" with password "%alt2%" using the webUI
     And the user accepts the offered remote shares using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
+    And the content of file "simple-folder/lorem.txt" for user "user2" on server "REMOTE" should be "original content"
     When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
 
   Scenario: public should be able to access a public link with correct password
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     And the public accesses the last created public link with password "pass123" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: public should not be able to access a public link with wrong password
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     And the public tries to access the last created public link with wrong password "pass12" using the webUI
     Then the public should not get access to the publicly shared file
 
   Scenario: user shares a public link with folder longer than 64 chars and shorter link name
-    Given user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
-    And the user has reloaded the current page of the webUI
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI with
       | name | short_linkname |
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user tries to create a public link with read only permission without entering share password while enforce password on read only public share is enforced
-    Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
+    And parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the user tries to create a new public link for folder "simple-folder" using the webUI
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And the public link should not have been generated
 
   Scenario: user tries to create a public link with read-write permission without entering share password while enforce password on read-write public share is enforced
-    Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
+    And parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And the public link should not have been generated
 
   Scenario: user tries to create a public link with write only permission without entering share password while enforce password on write only public share is enforced
-    Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
+    And parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | permission | upload |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And the public link should not have been generated
 
   Scenario: user creates a public link with read-write permission without entering share password while enforce password on read only public share is enforced
-    Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: public should be able to access the shared file through public link
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for file 'lorem.txt' using the webUI
     And the public accesses the last created public link using the webUI
-    Then the text preview of the public link should contain "Lorem ipsum dolor sit amet, consectetur"
+    Then the text preview of the public link should contain "Sed ut perspiciatis"
     And the content of the file shared by the last public link should be the same as "lorem.txt"
 
   Scenario: user shares a public link via email
-    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And the user has reloaded the current page of the webUI
+    Given user "user1" has created folder "/simple-folder"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
@@ -137,8 +171,9 @@ Feature: Share by public link
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email and sends a copy to self
-    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And the user has reloaded the current page of the webUI
+    Given user "user1" has created folder "/simple-folder"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email       | foo@bar.co |
       | emailToSelf | true       |
@@ -154,8 +189,9 @@ Feature: Share by public link
     And the email address "user1@example.org" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email with multiple addresses
-    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And the user has reloaded the current page of the webUI
+    Given user "user1" has created folder "/simple-folder"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co, foo@barr.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
@@ -171,7 +207,8 @@ Feature: Share by public link
 
   Scenario: user shares a public link via email with a personal message
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And the user has reloaded the current page of the webUI
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email           | foo@bar.co  |
       | personalMessage | lorem ipsum |
@@ -187,7 +224,8 @@ Feature: Share by public link
 
   Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And the user has reloaded the current page of the webUI
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder"
     And the user opens the public link share tab
     And the user opens the create public link share popup
@@ -217,7 +255,8 @@ Feature: Share by public link
 
   Scenario: user edits a public link and does not save the changes
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And the user has reloaded the current page of the webUI
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | email    | foo1234@bar.co |
       | password | pass123        |
@@ -229,7 +268,8 @@ Feature: Share by public link
 
   Scenario: user shares a public link via email with a personal message
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And the user has reloaded the current page of the webUI
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email           | foo@bar.co  |
       | personalMessage | lorem ipsum |
@@ -244,7 +284,10 @@ Feature: Share by public link
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   Scenario: user edits a name of an already existing public link
-    Given the user has created a new public link for folder "simple-folder" using the webUI
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI
     And the user has opened the public link share tab
     When the user renames the public link name from "Public link" to "simple-folder Share"
     And the public accesses the last created public link using the webUI
@@ -252,27 +295,37 @@ Feature: Share by public link
 
   Scenario: user shares a file through public link and then it appears in a Shared by link page
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
     And the user has reloaded the current page of the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page
     Then folder "simple-folder" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     When the user changes the password of the public link named "Public link" to "pass1234"
     And the public accesses the last created public link with password "pass1234" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link and tries to access with old password
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     When the user changes the password of the public link named "Public link" to "pass1234"
     And the public tries to access the last created public link with wrong password "pass123" using the webUI
     Then the public should not get access to the publicly shared file
 
   Scenario: user edits the permission of an already existing public link from read-write to read
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the user changes the permission of the public link named "Public link" to "read"
     And the public accesses the last created public link using the webUI
@@ -280,7 +333,11 @@ Feature: Share by public link
     And it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user edits the permission of an already existing public link from read to read-write
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read |
     When the user changes the permission of the public link named "Public link" to "read-write"
     And the public accesses the last created public link using the webUI
@@ -292,22 +349,26 @@ Feature: Share by public link
     And the deleted elements should not be listed on the webUI after a page reload
 
   Scenario: user changes the expiration date of an already existing public link using webUI
-    Given user "user1" has created a share with settings
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | 14-10-2038  |
       | shareType  | 3           |
+    And user "user1" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "21-07-2038"
     And the user gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | expiration | 21-07-2038 |
 
   Scenario: user tries to change the expiration date of the public link to past date using webUI
-    Given user "user1" has created a share with settings
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | 14-10-2038  |
       | shareType  | 3           |
+    And user "user1" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "14-09-2017"
     And the user gets the info of the last share using the sharing API
     Then the user should see an error message on the public link share dialog saying "Expiration date is in the past"
@@ -315,6 +376,10 @@ Feature: Share by public link
       | expiration | 14-10-2038 |
 
   Scenario: share two file with same name but different paths by public link
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
     And the user closes the details dialog
     And the user opens folder "simple-folder" using the webUI
@@ -324,18 +389,24 @@ Feature: Share by public link
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
 
   Scenario: user removes the public link of a file
-    Given the user has created a new public link for file "lorem.txt" using the webUI
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for file "lorem.txt" using the webUI
     When the user removes the public link of file "lorem.txt" using the webUI
     Then the public should see an error message "File not found" while accessing last created public link using the webUI
 
   Scenario: user cancel removes operation for the public link of a file
-    Given the user has created a new public link for file "lorem.txt" using the webUI
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for file "lorem.txt" using the webUI
     When the user tries to remove the public link of file "lorem.txt" but later cancels the remove dialog using webUI
     And the public accesses the last created public link using the webUI
     Then the content of the file shared by the last public link should be the same as "lorem.txt"
 
   Scenario: user creates a multiple public link of a file and delete the first link
-    Given the user has created a new public link for file "lorem.txt" using the webUI with
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for file "lorem.txt" using the webUI with
       | name | first-link |
     And the user has created a new public link for file "lorem.txt" using the webUI with
       | name | second-link |
@@ -346,7 +417,9 @@ Feature: Share by public link
     And the number of public links should be 2
 
   Scenario: user creates a multiple public link of a file and delete the second link
-    Given the user has created a new public link for file "lorem.txt" using the webUI with
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for file "lorem.txt" using the webUI with
       | name | first-link |
     And the user has created a new public link for file "lorem.txt" using the webUI with
       | name | second-link |
@@ -357,7 +430,9 @@ Feature: Share by public link
     And the number of public links should be 2
 
   Scenario: user creates a multiple public link of a file and delete the third link
-    Given the user has created a new public link for file "lorem.txt" using the webUI with
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for file "lorem.txt" using the webUI with
       | name | first-link |
     And the user has created a new public link for file "lorem.txt" using the webUI with
       | name | second-link |
@@ -368,13 +443,19 @@ Feature: Share by public link
     And the number of public links should be 2
 
   Scenario: user creates public link with view and upload feature
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user creates public link with view download and upload feature and uploads same file name and verifies no auto-renamed file seen in UI
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
     When the user uploads file "lorem.txt" 5 times using webUI
@@ -385,7 +466,7 @@ Feature: Share by public link
       | The file lorem.txt already exists |
       | The file lorem.txt already exists |
     And file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" should not have changed
+    And the content of file "simple-folder/lorem.txt" should be "original content"
     And file "lorem (2).txt" should not be listed on the webUI
 
   @issue-35177
@@ -402,6 +483,7 @@ Feature: Share by public link
       | path | nf2/newfolder |
     And user "user1" has created a public link share with settings
       | path | test/test |
+    And user "user1" has logged in using the webUI
     And the user has browsed to the shared-by-link page
     When the user renames folder "newfolder" to "newfolder1" using the webUI
     Then folder "newfolder1" should be listed on the webUI
@@ -418,6 +500,7 @@ Feature: Share by public link
         | path | nf1/newfolder |
       And user "user1" has created a public link share with settings
         | path | test |
+      And user "user1" has logged in using the webUI
       And the user has browsed to the shared-by-link page
       When the user renames folder "test" to "newfolder" using the webUI
       Then near folder "test" a tooltip with the text 'newfolder already exists' should be displayed on the webUI
@@ -426,7 +509,10 @@ Feature: Share by public link
         #| newfolder |
 
   Scenario: Permissions work correctly on public link share with upload-write-without-modify
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     When the public accesses the last created public link using the webUI
     Then the option to rename file "lorem.txt" should not be available on the webUI
@@ -434,7 +520,10 @@ Feature: Share by public link
     And the option to upload file should be available on the webUI
 
   Scenario: Permissions work correctly on public link share with read-write
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI
@@ -442,7 +531,10 @@ Feature: Share by public link
     And the option to upload file should be available on the webUI
 
   Scenario: User tries to upload existing file in public link share with permissions upload-write-without-modify
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
     When the user uploads file "lorem.txt" using the webUI
@@ -451,7 +543,10 @@ Feature: Share by public link
     And file "lorem (2).txt" should not be listed on the webUI
 
   Scenario: User tries to upload existing file in public link share with permissions read-write
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
@@ -459,7 +554,11 @@ Feature: Share by public link
     And file "lorem (2).txt" should be listed on the webUI
 
   Scenario: Editing the permission on a existing share from read-write to upload-write-without-modify works correctly
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has uploaded file "filesForUpload/lorem-big.txt" to "/simple-folder/lorem-big.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     Then it should be possible to delete file "lorem.txt" using the webUI
@@ -471,7 +570,11 @@ Feature: Share by public link
     Then the option to delete file "lorem-big.txt" should not be available on the webUI
 
   Scenario: Editing the permission on a existing share from upload-write-without-modify to read-write works correctly
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has uploaded file "filesForUpload/lorem-big.txt" to "/simple-folder/lorem-big.txt"
+    And user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
     Then the option to delete file "lorem.txt" should not be available on the webUI
@@ -485,12 +588,13 @@ Feature: Share by public link
   Scenario: user tries to deletes the expiration date of already existing public link using webUI when expiration date is enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "user1" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | + 5 days    |
       | shareType  | 3           |
-    When the user reloads the current page of the webUI
+    And user "user1" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     Then the user should see an error message on the public link popup saying "Expiration date is required"
     And the user gets the info of the last share using the sharing API
@@ -499,12 +603,13 @@ Feature: Share by public link
 
   Scenario: user deletes the expiration date of already existing public link using webUI when expiration date is set but not enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "user1" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate |  + 5 days   |
       | shareType  | 3           |
-    When the user reloads the current page of the webUI
+    And user "user1" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     And the user gets the info of the last share using the sharing API
     And the fields of the last response should include


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Do not use skeleton files for ```webUISharingPublic```  to speed up CI
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of https://github.com/owncloud/QA/issues/622

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
