### PR TITLE
[stable10] Backport of Log exceptions from exceptionHandler method

### DIFF
--- a/console.php
+++ b/console.php
@@ -58,54 +58,68 @@ if (\strtoupper(\substr(PHP_OS, 0, 3)) === 'WIN') {
 function exceptionHandler($exception) {
 	echo "An unhandled exception has been thrown:" . PHP_EOL;
 	echo $exception;
+	\OC::$server->getLogger()->logException($exception);
 	exit(1);
 }
 try {
 	require_once __DIR__ . '/lib/base.php';
-
-	// set to run indefinitely if needed
-	\set_time_limit(0);
-
-	if (!OC::$CLI) {
-		echo "This script can be run from the command line only" . PHP_EOL;
-		exit(1);
-	}
-
-	\set_exception_handler('exceptionHandler');
-
-	if (!\function_exists('posix_getuid')) {
-		echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
-		exit(1);
-	}
-	$user = \posix_getpwuid(\posix_getuid());
-	$configUser = \posix_getpwuid(\fileowner(OC::$configDir . 'config.php'));
-	if ($user['name'] !== $configUser['name']) {
-		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-		echo "Current user: " . $user['name'] . PHP_EOL;
-		echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
-		echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
-		exit(1);
-	}
-
-	$oldWorkingDir = \getcwd();
-	if ($oldWorkingDir === false) {
-		echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
-		echo "Can't determine current working dir - the script will continue to work but be aware of the above fact." . PHP_EOL;
-	} elseif ($oldWorkingDir !== __DIR__ && !\chdir(__DIR__)) {
-		echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
-		echo "Can't change to ownCloud root directory." . PHP_EOL;
-		exit(1);
-	}
-
-	if (!\function_exists('pcntl_signal') && !\in_array('--no-warnings', $argv)) {
-		echo "The process control (PCNTL) extensions are required in case you want to interrupt long running commands - see http://php.net/manual/en/book.pcntl.php" . PHP_EOL;
-	}
-
-	$application = new Application(\OC::$server->getConfig(), \OC::$server->getEventDispatcher(), \OC::$server->getRequest());
-	$application->loadCommands(new ArgvInput(), new ConsoleOutput());
-	$application->run();
 } catch (Exception $ex) {
-	exceptionHandler($ex);
+	echo "Something went wrong." . PHP_EOL;
+	echo $ex;
+	exit(1);
 } catch (Error $ex) {
-	exceptionHandler($ex);
+	echo "Something fatal happened." . PHP_EOL;
+	echo $ex;
+	exit(1);
 }
+
+// set to run indefinitely if needed
+\set_time_limit(0);
+
+if (!OC::$CLI) {
+	echo "This script can be run from the command line only" . PHP_EOL;
+	exit(1);
+}
+
+\set_exception_handler('exceptionHandler');
+
+if (!\function_exists('posix_getuid')) {
+	echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
+	exit(1);
+}
+$user = \posix_getpwuid(\posix_getuid());
+$configUser = \posix_getpwuid(\fileowner(OC::$configDir . 'config.php'));
+if ($user['name'] !== $configUser['name']) {
+	echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
+	echo "Current user: " . $user['name'] . PHP_EOL;
+	echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
+	echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
+	exit(1);
+}
+
+$oldWorkingDir = \getcwd();
+if ($oldWorkingDir === false) {
+	echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+	echo "Can't determine current working dir - the script will continue to work but be aware of the above fact." . PHP_EOL;
+} elseif ($oldWorkingDir !== __DIR__ && !\chdir(__DIR__)) {
+	echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+	echo "Can't change to ownCloud root directory." . PHP_EOL;
+	exit(1);
+}
+
+if (!\function_exists('pcntl_signal') && !\in_array('--no-warnings', $argv)) {
+	echo "The process control (PCNTL) extensions are required in case you want to interrupt long running commands - see http://php.net/manual/en/book.pcntl.php" . PHP_EOL;
+}
+
+$defaults = new OC_Defaults();
+$symfonyApplication = new \Symfony\Component\Console\Application($defaults->getName(), \OC_Util::getVersionString());
+/**
+ * By default the catchExceptions is set to true. And hence the exceptions thrown
+ * from the occ commands will not reach here. Inorder to allow exceptions reach
+ * here we need to set catchExceptions as false.
+ */
+$symfonyApplication->setCatchExceptions(false);
+
+$application = new Application(\OC::$server->getConfig(), $symfonyApplication, \OC::$server->getEventDispatcher(), \OC::$server->getRequest());
+$application->loadCommands(new ArgvInput(), new ConsoleOutput());
+$application->run();

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -52,10 +52,10 @@ class Application {
 	 * @param EventDispatcherInterface $dispatcher
 	 * @param IRequest $request
 	 */
-	public function __construct(IConfig $config, EventDispatcherInterface $dispatcher, IRequest $request) {
+	public function __construct(IConfig $config, SymfonyApplication $application, EventDispatcherInterface $dispatcher, IRequest $request) {
 		$defaults = new OC_Defaults;
 		$this->config = $config;
-		$this->application = new SymfonyApplication($defaults->getName(), \OC_Util::getVersionString());
+		$this->application = $application;
 		$this->dispatcher = $dispatcher;
 		$this->request = $request;
 	}

--- a/tests/acceptance/features/cliMain/maintenance.feature
+++ b/tests/acceptance/features/cliMain/maintenance.feature
@@ -32,4 +32,4 @@ Feature: Maintenance command
   Scenario: Running single repair step without providing value should fail
     When the administrator invokes occ command "maintenance:repair --single"
     Then the command should have failed with exit code 1
-    And the command error output should contain the text 'The "--single" option requires a value'
+    And the command output should contain the text 'The "--single" option requires a value'

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -40,4 +40,4 @@ Feature: security certificates
 
   Scenario: Import random file as certificate
     When the administrator imports security certificate from the path "tests/data/lorem.txt"
-    Then the command error output should contain the text "Certificate could not get parsed."
+    Then the command output should contain the text "Certificate could not get parsed."


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Log the exceptions thrown by occ command and also echo the exceptions into the console. This solves the problem when the command is executed as cron job and due to some reason if exception happens in the command, the data is logged in to the owncloud logger. So its helpful for the admin to look for the exception due to which the command was exited. Also we set the `catchExceptions` of symfony's console application to `false`. This helps to catch the exception in owncloud's console.php. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Log the exception which is caused by the occ commands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The test at https://github.com/owncloud/core/pull/35362#issuecomment-500849944 applies here too.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
