### PR TITLE
[stable10] fix diff between master and stable10 in Auth tests

### DIFF
--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -82,39 +82,6 @@ Feature: auth
       | 1               |/privatedata/getattribute                        | 997      | 401       |
       | 2               |/privatedata/getattribute                        | 997      | 401       |
 
-  @issue-32068
-  Scenario Outline: send POST requests to OCS endpoints as normal user with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes and skeleton files
-    When user "user0" sends HTTP method "POST" to OCS API endpoint "<endpoint>" with body using password "invalid"
-      | data        | doesnotmatter |
-    Then the OCS status code should be "<ocs-code>"
-    And the HTTP status code should be "<http-code>"
-    Examples:
-      | ocs_api_version |endpoint                                             | ocs-code | http-code |
-      | 1               |/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/shares                    | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/shares                    | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
-      | 1               |/cloud/apps/testing                                  | 997      | 401       |
-      | 2               |/cloud/apps/testing                                  | 997      | 401       |
-      | 1               |/cloud/groups                                        | 997      | 401       |
-      | 2               |/cloud/groups                                        | 997      | 401       |
-      | 1               |/cloud/users                                         | 997      | 401       |
-      | 2               |/cloud/users                                         | 997      | 401       |
-      | 1               |/cloud/users/user0/groups                            | 997      | 401       |
-      | 2               |/cloud/users/user0/groups                            | 997      | 401       |
-      | 1               |/cloud/users/user0/subadmins                         | 997      | 401       |
-      | 2               |/cloud/users/user0/subadmins                         | 997      | 401       |
-      | 1               |/person/check                                        | 101      | 200       |
-      | 2               |/person/check                                        | 400      | 400       |
-      | 1               |/privatedata/deleteattribute/testing/test            | 997      | 401       |
-      | 2               |/privatedata/deleteattribute/testing/test            | 997      | 401       |
-      | 1               |/privatedata/setattribute/testing/test               | 997      | 401       |
-      | 2               |/privatedata/setattribute/testing/test               | 997      | 401       |
-
   Scenario Outline: using OCS with admin basic auth
     When the administrator requests "<endpoint>" with "GET" using basic auth
     Then the OCS status code should be "<ocs-code>"
@@ -151,52 +118,6 @@ Feature: auth
       | 2               |/cloud/users                                     | 997      | 401       |
       | 1               |/privatedata/getattribute                        | 997      | 401       |
       | 2               |/privatedata/getattribute                        | 997      | 401       |
-
-  @issue-32068
-  Scenario Outline: send PUT requests to OCS endpoints as admin with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    When the administrator sends HTTP method "PUT" to OCS API endpoint "<endpoint>" with body using password "invalid"
-      | data        | doesnotmatter |
-    Then the OCS status code should be "<ocs-code>"
-    And the HTTP status code should be "<http-code>"
-    Examples:
-      | ocs_api_version |endpoint                              | ocs-code | http-code |
-      | 1               |/apps/files_sharing/api/v1/shares/123 | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/shares/123 | 997      | 401       |
-      | 1               |/cloud/users/user0                    | 997      | 401       |
-      | 2               |/cloud/users/user0                    | 997      | 401       |
-      | 1               |/cloud/users/user0/disable            | 997      | 401       |
-      | 2               |/cloud/users/user0/disable            | 997      | 401       |
-      | 1               |/cloud/users/user0/enable             | 997      | 401       |
-      | 2               |/cloud/users/user0/enable             | 997      | 401       |
-
-  @issue-32068
-  Scenario Outline: send DELETE requests to OCS endpoints as admin with wrong password
-    Given using OCS API version "<ocs_api_version>"
-    And group "group1" has been created
-    When the administrator sends HTTP method "DELETE" to OCS API endpoint "<endpoint>" using password "invalid"
-    Then the OCS status code should be "<ocs-code>"
-    And the HTTP status code should be "<http-code>"
-    Examples:
-      | ocs_api_version |endpoint                                             | ocs-code | http-code |
-      | 1               |/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/remote_shares/123         | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares/123         | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/shares/123                | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/shares/123                | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       |
-      | 1               |/cloud/apps/testing                                  | 997      | 401       |
-      | 2               |/cloud/apps/testing                                  | 997      | 401       |
-      | 1               |/cloud/groups/group1                                 | 997      | 401       |
-      | 2               |/cloud/groups/group1                                 | 997      | 401       |
-      | 1               |/cloud/users/user0                                   | 997      | 401       |
-      | 2               |/cloud/users/user0                                   | 997      | 401       |
-      | 1               |/cloud/users/user0/groups                            | 997      | 401       |
-      | 2               |/cloud/users/user0/groups                            | 997      | 401       |
-      | 1               |/cloud/users/user0/subadmins                         | 997      | 401       |
-      | 2               |/cloud/users/user0/subadmins                         | 997      | 401       |
 
   Scenario Outline: using OCS with token auth of a normal user
     Given a new client token for "user0" has been generated


### PR DESCRIPTION
## Description
in https://github.com/owncloud/core/pull/34645/commits/3dabf0448871f625c93212068a06f080a9abe8c1 tests were copied to new files, but not deleted from the old one
compare master commit where it happened correctly https://github.com/owncloud/core/pull/34643/commits/13625fe61f8cb1452742ca54201598b14aed7395

that resulted in conflicts for https://github.com/owncloud/core/pull/35472

CC @bhawanaprasain 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
