### PR TITLE
Refactor reShare.feature to use the 'shares file with, with permissions' steps

### DIFF
--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -9,16 +9,8 @@ Feature: sharing
   Scenario Outline: User is not allowed to reshare file
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
-    And user "user0" has created a share with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user1          |
-      | permissions | 15             |
-    When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user2          |
-      | permissions | 15             |
+    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions 3
+    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions 3 using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "user2" file "/textfile0.txt" should not exist
@@ -31,16 +23,8 @@ Feature: sharing
   Scenario Outline: User is allowed to reshare file with the same permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
-    And user "user0" has created a share with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user1          |
-      | permissions | 17             |
-    When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user2          |
-      | permissions | 17             |
+    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions 17
+    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions 17 using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user2" file "/textfile0.txt" should exist
@@ -52,16 +36,8 @@ Feature: sharing
   Scenario Outline: User is allowed to reshare file with less permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
-    And user "user0" has created a share with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user1          |
-      | permissions | 31             |
-    When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user2          |
-      | permissions | 17             |
+    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions 19
+    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions 17 using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user2" file "/textfile0.txt" should exist
@@ -73,16 +49,8 @@ Feature: sharing
   Scenario Outline: User is not allowed to reshare file with more permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
-    And user "user0" has created a share with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user1          |
-      | permissions | 17             |
-    When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user2          |
-      | permissions | 31             |
+    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions 17
+    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions 19 using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "user2" file "/textfile0.txt" should not exist
@@ -96,16 +64,8 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
-    And user "user0" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user1 |
-      | permissions | 23    |
-    And user "user1" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user2 |
-      | permissions | 23    |
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 23
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions 23
     When user "user1" updates the last share using the sharing API with
       | permissions | 17 |
     Then the OCS status code should be "<ocs_status_code>"
@@ -120,16 +80,8 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
-    And user "user0" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user1 |
-      | permissions | 23    |
-    And user "user1" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user2 |
-      | permissions | 17    |
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 23
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions 17
     When user "user1" updates the last share using the sharing API with
       | permissions | 23 |
     Then the OCS status code should be "404"
@@ -148,16 +100,8 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
-    And user "user0" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user1 |
-      | permissions | 21    |
-    And user "user1" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user2 |
-      | permissions | 21    |
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 21
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions 21
     When user "user1" updates the last share using the sharing API with
       | permissions | 31 |
     Then the OCS status code should be "404"
@@ -172,16 +116,8 @@ Feature: sharing
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
     And user "user0" has created folder "/TMP/SUB"
-    And user "user0" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user1 |
-      | permissions | 17    |
-    When user "user1" creates a share using the sharing API with settings
-      | path        | /TMP/SUB |
-      | shareType   | 0        |
-      | shareWith   | user2    |
-      | permissions | 17       |
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 17
+    When user "user1" shares folder "/TMP/SUB" with user "user2" with permissions 17 using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user2" folder "/SUB" should exist
@@ -196,16 +132,8 @@ Feature: sharing
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
     And user "user0" has created folder "/TMP/SUB"
-    And user "user0" has created a share with settings
-      | path        | /TMP  |
-      | shareType   | 0     |
-      | shareWith   | user1 |
-      | permissions | 17    |
-    When user "user1" creates a share using the sharing API with settings
-      | path        | /TMP/SUB |
-      | shareType   | 0        |
-      | shareWith   | user2    |
-      | permissions | 31       |
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions 17
+    When user "user1" shares folder "/TMP/SUB" with user "user2" with permissions 31 using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "user2" folder "/SUB" should not exist
@@ -434,17 +362,9 @@ Feature: sharing
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
-    And user "user0" has created a share with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user1          |
-      | permissions | 31             |
+    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions 19
     And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-    When user "user1" creates a share using the sharing API with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user2          |
-      | permissions | 31             |
+    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions 19 using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "user2" file "/textfile0.txt" should not exist
@@ -456,11 +376,7 @@ Feature: sharing
   Scenario Outline: ordinary sharing is allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-    When user "user0" creates a share using the sharing API with settings
-      | path        | /textfile0.txt |
-      | shareType   | 0              |
-      | shareWith   | user1          |
-      | permissions | 31             |
+    When user "user0" shares file "/textfile0.txt" with user "user1" with permissions 19 using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user1" file "/textfile0.txt" should exist

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -290,7 +290,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-33733 @public_link_share-feature-required
+  @public_link_share-feature-required
   Scenario Outline: Do not allow public sharing of the root
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
@@ -300,7 +300,6 @@ Feature: sharing
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |
-    #  | 1               | 403             | 403              |
       | 2               | 403             | 403              |
 
   @public_link_share-feature-required
@@ -407,7 +406,6 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-33733
   Scenario Outline: Cannot create share with zero permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
@@ -416,15 +414,13 @@ Feature: sharing
       | shareWith   | user1       |
       | shareType   | 0           |
       | permissions | 0           |
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "400"
     And the HTTP status code should be "<http_status_code>"
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 400             | 200              |
-    #  | 1               | 400             | 400              |
-      | 2               | 400             | 400              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 400              |
 
-  @issue-33733 @skipOnLDAP @user_ldap-issue-378
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
@@ -434,17 +430,14 @@ Feature: sharing
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
     And user "user0" has moved file "welcome.txt" to "fileToShare.txt"
     When user "user0" shares file "fileToShare.txt" with user "user1" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" file "fileToShare.txt" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-    #  | 1               | 403             | 403              |
-      | 2               | 200             | 200              |
-    #  | 2               | 403             | 403              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 403              |
 
-  @issue-33733
   Scenario Outline: user who is excluded from sharing tries to share a file with a group
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
@@ -456,17 +449,14 @@ Feature: sharing
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
     And user "user0" has moved file "welcome.txt" to "fileToShare.txt"
     When user "user0" shares file "fileToShare.txt" with group "anotherGroup" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" file "fileToShare.txt" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-    #  | 1               | 403             | 403              |
-      | 2               | 200             | 200              |
-    #  | 2               | 403             | 403              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 403              |
 
-  @issue-33733 @skipOnLDAP @user_ldap-issue-378
   Scenario Outline: user who is excluded from sharing tries to share a folder with another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
@@ -476,17 +466,14 @@ Feature: sharing
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
     And user "user0" has created folder "folderToShare"
     When user "user0" shares folder "folderToShare" with user "user1" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" folder "folderToShare" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-    #  | 1               | 403             | 403              |
-      | 2               | 200             | 200              |
-    #  | 2               | 403             | 403              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 403              |
 
-  @issue-33733
   Scenario Outline: user who is excluded from sharing tries to share a folder with a group
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
@@ -498,15 +485,13 @@ Feature: sharing
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
     And user "user0" has created folder "folderToShare"
     When user "user0" shares file "folderToShare" with group "anotherGroup" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" file "folderToShare" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-    #  | 1               | 403             | 403              |
-      | 2               | 200             | 200              |
-    #  | 2               | 403             | 403              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 403              |
 
   Scenario Outline: user shares a file with file name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -812,6 +812,45 @@ trait Sharing {
 	}
 
 	/**
+	 *
+	 * @param string $user1
+	 * @param string $filepath
+	 * @param string $user2
+	 * @param string|int|string[]|int[] $permissions
+	 * @param bool $getShareData If true then only create the share if it is not
+	 *                           already existing, and at the end request the
+	 *                           share information and leave that in $this->response
+	 *                           Typically used in a "Given" step which verifies
+	 *                           that the share did get created successfully.
+	 *
+	 * @return void
+	 */
+	public function shareFileWithUserUsingTheSharingApi(
+		$user1, $filepath, $user2, $permissions = null, $getShareData = false
+	) {
+		$user1 = $this->getActualUsername($user1);
+		$user2 = $this->getActualUsername($user2);
+
+		$fullUrl = $this->getBaseUrl()
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?path=$filepath";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $user1, $this->getPasswordForUser($user1)
+		);
+		if ($getShareData && $this->isUserOrGroupInSharedData($user2, $permissions)) {
+			return;
+		} else {
+			$this->createShare(
+				$user1, $filepath, 0, $user2, null, null, $permissions
+			);
+		}
+		if ($getShareData) {
+			$this->response = HttpRequestHelper::get(
+				$fullUrl, $user1, $this->getPasswordForUser($user1)
+			);
+		}
+	}
+
+	/**
 	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $user1
@@ -824,23 +863,8 @@ trait Sharing {
 	public function userSharesFileWithUserUsingTheSharingApi(
 		$user1, $filepath, $user2, $permissions = null
 	) {
-		$user1 = $this->getActualUsername($user1);
-		$user2 = $this->getActualUsername($user2);
-
-		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?path=$filepath";
-		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user1, $this->getPasswordForUser($user1)
-		);
-		if ($this->isUserOrGroupInSharedData($user2, $permissions)) {
-			return;
-		} else {
-			$this->createShare(
-				$user1, $filepath, 0, $user2, null, null, $permissions
-			);
-		}
-		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user1, $this->getPasswordForUser($user1)
+		$this->shareFileWithUserUsingTheSharingApi(
+			$user1, $filepath, $user2, $permissions
 		);
 	}
 
@@ -857,8 +881,8 @@ trait Sharing {
 	public function userHasSharedFileWithUserUsingTheSharingApi(
 		$user1, $filepath, $user2, $permissions = null
 	) {
-		$this->userSharesFileWithUserUsingTheSharingApi(
-			$user1, $filepath, $user2, $permissions
+		$this->shareFileWithUserUsingTheSharingApi(
+			$user1, $filepath, $user2, $permissions, true
 		);
 		PHPUnit\Framework\Assert::assertTrue(
 			$this->isUserOrGroupInSharedData($user2, $permissions),
@@ -953,6 +977,42 @@ trait Sharing {
 	}
 
 	/**
+	 *
+	 * @param string $user
+	 * @param string $filepath
+	 * @param string $group
+	 * @param string|int|string[]|int[] $permissions
+	 * @param bool $getShareData If true then only create the share if it is not
+	 *                           already existing, and at the end request the
+	 *                           share information and leave that in $this->response
+	 *                           Typically used in a "Given" step which verifies
+	 *                           that the share did get created successfully.
+	 *
+	 * @return void
+	 */
+	public function shareFileWithGroupUsingTheSharingApi(
+		$user, $filepath, $group, $permissions = null, $getShareData = false
+	) {
+		$fullUrl = $this->getBaseUrl()
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?path=$filepath";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $user, $this->getPasswordForUser($user)
+		);
+		if ($getShareData && $this->isUserOrGroupInSharedData($group, $permissions)) {
+			return;
+		} else {
+			$this->createShare(
+				$user, $filepath, 1, $group, null, null, $permissions
+			);
+		}
+		if ($getShareData) {
+			$this->response = HttpRequestHelper::get(
+				$fullUrl, $user, $this->getPasswordForUser($user)
+			);
+		}
+	}
+
+	/**
 	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions (.*))? using the sharing API$/
 	 *
 	 * @param string $user
@@ -965,20 +1025,8 @@ trait Sharing {
 	public function userSharesFileWithGroupUsingTheSharingApi(
 		$user, $filepath, $group, $permissions = null
 	) {
-		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?path=$filepath";
-		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
-		);
-		if ($this->isUserOrGroupInSharedData($group, $permissions)) {
-			return;
-		} else {
-			$this->createShare(
-				$user, $filepath, 1, $group, null, null, $permissions
-			);
-		}
-		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+		$this->shareFileWithGroupUsingTheSharingApi(
+			$user, $filepath, $group, $permissions
 		);
 	}
 
@@ -995,8 +1043,8 @@ trait Sharing {
 	public function userHasSharedFileWithGroupUsingTheSharingApi(
 		$user, $filepath, $group, $permissions = null
 	) {
-		$this->userSharesFileWithGroupUsingTheSharingApi(
-			$user, $filepath, $group, $permissions
+		$this->shareFileWithGroupUsingTheSharingApi(
+			$user, $filepath, $group, $permissions, true
 		);
 
 		PHPUnit\Framework\Assert::assertEquals(


### PR DESCRIPTION
## Description
While testing re-sharing, and refactoring some of the test scenarios, I discovered some annoyance and error with test code for steps like `Given user "user0" has shared file...` and `When user "user0" shares file...` and similar.

The code was always checking that the share that was created was "correct", e.g. it actually got the stated permissions. For `Given` that is "a good thing", but for `When` steps we should let the `Then` steps do the checking.

The extra checking of the resulting share status was overwriting the initial `createShare` response. And so test scenarios that did a `When` followed by some checks of the OCS and HTTP status were not actually seeing and checking the real statuses returned by `createShare`

I also noticed that when sharing a file, the create and delete permissions are not relevant. You can ask for them in the create share request, and they get masked out in the permissions of the created share. This seems reasonable. It would be nice to have some test scenarios that "document" this behavior.

1) Fix the acceptance test code.
2) Refactor `reShare.feature` to use the fixed-up steps
3) Fixup the test scenarios related to issue #33733 
4) Add scenarios to `createShare.feature` that ask for create+delete on a file share

## Related Issue
#33733
https://github.com/owncloud/user_ldap/issues/378
#35558 

## Motivation and Context
Have fixed and improved sharing API test scenarios.

## How Has This Been Tested?
Local CI runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
