### PR TITLE
test app version after app was updated to new patch version

### DIFF
--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -15,3 +15,19 @@ Feature: AppManagement
     And app "multidirtest" with version "1.0.5" has been put in dir "apps2"
     When the administrator gets the path for app "multidirtest" using the occ command
     Then the path to "multidirtest" should be "apps2"
+
+  Scenario: Update of patch version of an app
+    Given app "updatetest" with version "2.0.0" has been put in dir "apps"
+    And app "updatetest" has been enabled
+    And app "updatetest" has been disabled
+    When the administrator puts app "updatetest" with version "2.0.1" in dir "apps"
+    And the administrator enables app "updatetest"
+    Then the installed version of "updatetest" should be "2.0.1"
+
+  Scenario: Update of patch version of an app but update is put in alternative folder
+    Given app "updatetest" with version "2.0.0" has been put in dir "apps"
+    And app "updatetest" has been enabled
+    And app "updatetest" has been disabled
+    When the administrator puts app "updatetest" with version "2.0.1" in dir "apps2"
+    And the administrator enables app "updatetest"
+    Then the installed version of "updatetest" should be "2.0.1"


### PR DESCRIPTION
## Description
check if the app version is corrects written to the DB after a new patch version of the app is installed
to test minor versions is currently not possible because the require to run `occ upgrade` and we only can do that through the testing app, the testing app does not work when upgrade is needed

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/613

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
