### PR TITLE
webdav lock protection without skeleton

### DIFF
--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -6,15 +6,16 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with skeleton files:
+    Given these users have been created without skeleton files:
       |username      |
       |brand-new-user|
-    And user "brand-new-user" has logged in using the webUI
 
   Scenario Outline: deleting a file in a public share of a locked folder
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has created folder "/simple-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
@@ -27,4 +28,3 @@ Feature: Locks
       | lockscope |
       | exclusive |
       | shared    |
-

--- a/tests/acceptance/features/webUIWebdavLockProtection/move.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/move.feature
@@ -6,15 +6,16 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with skeleton files:
+    Given these users have been created without skeleton files:
       | username       |
       | brand-new-user |
-    And user "brand-new-user" has logged in using the webUI
 
   Scenario Outline: moving a locked file
-    Given user "brand-new-user" has locked file "lorem.txt" setting following properties
+    Given user "brand-new-user" has created folder "/simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "brand-new-user" has locked file "lorem.txt" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     When the user moves file "lorem.txt" into folder "simple-empty-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "lorem.txt" because either the file or the target are locked. |
@@ -29,9 +30,12 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: moving a file trying to overwrite a locked file
-    Given user "brand-new-user" has locked file "/simple-folder/lorem.txt" setting following properties
+    Given user "brand-new-user" has created folder "/simple-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "brand-new-user" has locked file "/simple-folder/lorem.txt" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     When the user moves file "lorem.txt" into folder "simple-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "lorem.txt" because either the file or the target are locked. |
@@ -44,9 +48,11 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: moving a file into a locked folder
-    Given user "brand-new-user" has locked file "/simple-empty-folder" setting following properties
+    Given user "brand-new-user" has created folder "/simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "brand-new-user" has locked file "/simple-empty-folder" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     When the user moves file "lorem.txt" into folder "simple-empty-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "lorem.txt" because either the file or the target are locked. |
@@ -61,9 +67,10 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: renaming of a locked file
-    Given user "brand-new-user" has locked file "lorem.txt" setting following properties
+    Given user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "brand-new-user" has locked file "lorem.txt" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     When the user renames file "lorem.txt" to "a-renamed-file.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       | The file "lorem.txt" is locked and can not be renamed. |
@@ -78,9 +85,11 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: renaming a file in a public share of a locked folder
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has created folder "/simple-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
@@ -96,9 +105,12 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: moving a locked file into an other folder in a public share
-    Given user "brand-new-user" has locked file "simple-folder/lorem.txt" setting following properties
+    Given user "brand-new-user" has created folder "/simple-folder"
+    And user "brand-new-user" has created folder "/simple-folder/simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "brand-new-user" has locked file "simple-folder/lorem.txt" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
@@ -113,4 +125,3 @@ Feature: Locks
       | lockscope |
       | exclusive |
       | shared    |
-

--- a/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
@@ -6,19 +6,19 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with skeleton files:
+    Given these users have been created without skeleton files:
       | username       |
       | brand-new-user |
-    And user "brand-new-user" has logged in using the webUI
 
   Scenario Outline: uploading a file, trying to overwrite a locked file
-    Given user "brand-new-user" has locked file "lorem.txt" setting following properties
+    Given user "brand-new-user" has uploaded file with content "original content" to "/lorem.txt"
+    And user "brand-new-user" has locked file "lorem.txt" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       | The file lorem.txt is currently locked, please try again later |
-    And the content of "lorem.txt" should not have changed
+    And the content of file "/lorem.txt" for user "brand-new-user" should be "original content"
     And file "lorem.txt" should be marked as locked on the webUI
     And file "lorem.txt" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
     And 1 locks should be reported for file "lorem.txt" of user "brand-new-user" by the WebDAV API
@@ -28,13 +28,16 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: uploading a file, trying to overwrite a file in a locked folder
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has created folder "/simple-folder"
+    And user "brand-new-user" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | <lockscope> |
+    And user "brand-new-user" has logged in using the webUI
     And the user has opened folder "simple-folder" using the webUI
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       | The file lorem.txt is currently locked, please try again later |
-    And the content of "lorem.txt" should not have changed
+    And the content of file "/simple-folder/lorem.txt" for user "brand-new-user" should be "original content"
     And file "lorem.txt" should be marked as locked on the webUI
     And file "lorem.txt" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
     And 1 locks should be reported for file "simple-folder/lorem.txt" of user "brand-new-user" by the WebDAV API
@@ -44,8 +47,10 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: uploading a new file into a locked folder
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has created folder "/simple-folder"
+    And user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | <lockscope> |
+    And user "brand-new-user" has logged in using the webUI
     And the user has opened folder "simple-folder" using the webUI
     When the user uploads file "new-lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
@@ -58,19 +63,20 @@ Feature: Locks
       | shared    |
 
   Scenario Outline: uploading a file, trying to overwrite a file in a locked folder in a public share
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has created folder "/simple-folder"
+    And user "brand-new-user" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | <lockscope> |
-    And the user has browsed to the files page
+    And user "brand-new-user" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       | The file lorem.txt is currently locked, please try again later |
-    And the content of "simple-folder/lorem.txt" should not have changed
+    And the content of file "/simple-folder/lorem.txt" should be "original content"
     And 1 locks should be reported for file "simple-folder/lorem.txt" of user "brand-new-user" by the WebDAV API
     Examples:
       | lockscope |
       | exclusive |
       | shared    |
-


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Do not use skeleton files for ```webUIWebdavLockProtection``` to speed up CI
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of https://github.com/owncloud/QA/issues/622

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
