### PR TITLE
Make logging more verbose in case of invalid token.

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -165,6 +165,7 @@ class LostController extends Controller {
 		$splittedToken = \explode(':', $this->config->getUserValue($userId, 'owncloud', 'lostpassword', null));
 		if (\count($splittedToken) !== 2) {
 			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
+			$this->logger->info("The Token is invalid. User $userId requested a pw change with Token $token .");
 			throw new \Exception($this->l10n->t('Could not reset password because the token is invalid'));
 		}
 


### PR DESCRIPTION
## Description
Increase logging around invalid token on PW reset.

## Related Issue
- Related to  https://github.com/owncloud/enterprise/issues/3316

## Motivation and Context
DO NOT MERGE, needed for debugging only.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
