### PR TITLE
[release-10.2.1] Return "password fields" only if public-link password is set. #35541

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -201,8 +201,12 @@ class Share20OcsController extends OCSController {
 			$result['share_with'] = $share->getSharedWith();
 			$result['share_with_displayname'] = $group !== null ? $group->getDisplayName() : $share->getSharedWith();
 		} elseif ($share->getShareType() === Share::SHARE_TYPE_LINK) {
-			$result['share_with'] = '***redacted***';
-			$result['share_with_displayname'] = '***redacted***';
+			if ($share->getPassword() !== null) {
+				// Misleading names ahead!: This fields are miss-used to
+				// read/write public link password-hashes
+				$result['share_with'] = '***redacted***';
+				$result['share_with_displayname'] = '***redacted***';
+			}
 			$result['name'] = $share->getName();
 
 			$result['token'] = $share->getToken();

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -192,6 +192,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | welcome.txt   |
+      | password | %public%      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
@@ -203,6 +204,29 @@ Feature: sharing
       | uid_owner              | user0          |
       | share_with             | ***redacted*** |
       | share_with_displayname | ***redacted*** |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario Outline: Getting the share information of passwordless public-links hides credential placeholders
+    Given using OCS API version "<ocs_api_version>"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path     | welcome.txt   |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | file_target            | /welcome.txt   |
+      | path                   | /welcome.txt   |
+      | item_type              | file           |
+      | share_type             | 3              |
+      | permissions            | 1              |
+      | uid_owner              | user0          |
+    And the fields of the last response should not include
+      | share_with             | ***redacted*** |
+      | share_with_displayname | ***redacted*** |
+
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1372,6 +1372,28 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then the fields of the last response should not include
+	 *
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function checkFieldsNotInResponse($body) {
+		if ($body instanceof TableNode) {
+			$fd = $body->getRowsHash();
+
+			foreach ($fd as $field => $value) {
+				$value = $this->replaceValuesFromTable($field, $value);
+				if ($this->isFieldInResponse($field, $value)) {
+					PHPUnit\Framework\Assert::fail(
+						"$field has value $value"
+					);
+				}
+			}
+		}
+	}
+
+	/**
 	 * @When user :user removes all shares from the file named :fileName using the sharing API
 	 * @Given user :user has removed all shares from the file named :fileName
 	 *


### PR DESCRIPTION
The iOS client uses the presence of these fields to determine if a
password is required.

Despite their names they are historically used to store pw-hashes for public-links.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Port of #35544



## Related Issue
- Fixes https://github.com/owncloud/core/issues/35541

## Motivation and Context
Fix https://github.com/owncloud/core/issues/35541 for 10.2.1

## How Has This Been Tested?
- 🤖 automated tests have been ported (there were some merge conflicts though )
- ❗️ NEEDS careful testing 👋 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
🚫 