### PR TITLE
set default expiration date if expiration date is enforced and it is new share

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -331,6 +331,13 @@ class Manager implements IManager {
 
 		// If we enforce the expiration date check that is does not exceed
 		if ($this->shareApiLinkDefaultExpireDateEnforced()) {
+			// If expiredate is empty and it is a new share, set a default one if there is a default
+			if ($this->isNewShare($share) && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
+				$expirationDate = new \DateTime();
+				$expirationDate->setTime(0, 0, 0);
+				$expirationDate->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));
+			}
+
 			if ($expirationDate === null) {
 				throw new \InvalidArgumentException('Expiration date is enforced');
 			}
@@ -1548,5 +1555,19 @@ class Manager implements IManager {
 		}
 
 		return \md5(\json_encode($perms->toArray()));
+	}
+
+	/**
+	 * @param IShare $share
+	 * @return boolean
+	 */
+	private function isNewShare(IShare $share) {
+		$fullId = null;
+		try {
+			$fullId = $share->getFullId();
+		} catch (\UnexpectedValueException $e) {
+			// This is a new share
+		}
+		return ($fullId === null);
 	}
 }


### PR DESCRIPTION
## Description
Automatic expiration date setting behavior changed with #34971. It caused regression on client sides. This PR fixes this regression by keeping #34971's functionality. 

If max expiration date is enforced set default expiration date for new share. @ckamm please check the behavior is same as expected or not. 

@micbar @pmaier1  we should consider this PR for v10.2.1.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/35550

## Motivation and Context
Automatic expiration date setting behavior changed with #34971. It caused regression on client sides. This PR fixes this regression by keeping #34971's functionality. 

## How Has This Been Tested?.
To test issue #35550 
- Activate, "Set expiration date" and enforce max expiration date.
- Try to create new public link from a desktop client
- It should create link and fill expiration date with default.

To test issue #34960
- Activate, "Set expiration date" but not enforce.
- Click share a file via public link and remove default expiration date from its input field. The share should be created without an expiration date.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
