### PR TITLE
[stable10] Backport to Fix response when user is removed from group

### DIFF
--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -79,7 +79,9 @@ if (\OC::$server->getGroupManager()->inGroup($username, $group)) {
 	$targetGroupObject->addUser($targetUserObject);
 }
 
-if (\OC::$server->getGroupManager()->isInGroup($username, $group)) {
+if ($action === "add" && \OC::$server->getGroupManager()->isInGroup($username, $group)) {
+	OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
+} elseif ($action === "remove" && !\OC::$server->getGroupManager()->isInGroup($username, $group)) {
 	OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
 } else {
 	OC_JSON::error();


### PR DESCRIPTION
When user is successfully removed from the group
fix message that is sent by server.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

## Description
When users are added/removed to the group the group counts should automatically updated. No error message should be seen in the console when users are added successfully to the group or deleted from the group. This PR focuses on the deletion part, though.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/35289

## Motivation and Context
Fix the removal of user issue from the group from the UI. The issue was with togglegroups.php sending response data.

## How Has This Been Tested?
- Test works as same mentioned at https://github.com/owncloud/user_management/pull/188#issuecomment-502749131

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
