### PR TITLE
Test that an emoji works in the user full name via API

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -73,14 +73,18 @@ Feature: edit users
       | email | brand-new-user@example.com |
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
-  Scenario: a normal user should be able to change their display name
+  Scenario Outline: a normal user should be able to change their display name
     Given user "brand-new-user" has been created with default attributes and skeleton files
-    When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
+    When user "brand-new-user" changes the display name of user "brand-new-user" to "<display-name>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
-      | displayname | Alan Border |
-    And the display name of user "brand-new-user" should be "Alan Border"
+      | displayname | <display-name> |
+    And the display name of user "brand-new-user" should be "<display-name>"
+    Examples:
+      | display-name   |
+      | Alan Border    |
+      | Phil Cyclist 🚴 |
 
   Scenario: a normal user should not be able to change their quota
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -73,14 +73,18 @@ Feature: edit users
       | email | brand-new-user@example.com |
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
-  Scenario: a normal user should be able to change their display name
+  Scenario Outline: a normal user should be able to change their display name
     Given user "brand-new-user" has been created with default attributes and skeleton files
-    When user "brand-new-user" changes the display name of user "brand-new-user" to "Alan Border" using the provisioning API
+    When user "brand-new-user" changes the display name of user "brand-new-user" to "<display-name>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the attributes of user "brand-new-user" returned by the API should include
-      | displayname | Alan Border |
-    And the display name of user "brand-new-user" should be "Alan Border"
+      | displayname | <display-name> |
+    And the display name of user "brand-new-user" should be "<display-name>"
+    Examples:
+      | display-name   |
+      | Alan Border    |
+      | Phil Cyclist 🚴 |
 
   Scenario: a normal user should not be able to change their quota
     Given user "brand-new-user" has been created with default attributes and skeleton files


### PR DESCRIPTION
## Description
Test setting the user display name (full name) including an emoji via the Provisioning API.

(I was looking around these files anyway and noticed that this test scenario was still to-do in the issue)

Note: these emoji tests are mostly being done using the AP for now. The webUI chromedriver does not like typing emojis, so more effort is needed to try and work-around that.

## Related Issue
#34437 

## How Has This Been Tested?
Local run of test scenario.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
