### PR TITLE
Do not allow to set higher permissions on a public link share for a r…

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -825,6 +825,14 @@ class Share20OcsController extends OCSController {
 			}
 
 			if ($newPermissions !== null) {
+				$shareHome = $this->rootFolder->getUserFolder($share->getSharedBy());
+				$nodes = $shareHome->getById($share->getNode()->getId());
+				foreach ($nodes as $node) {
+					if (($node->getPermissions() | $newPermissions) !== $node->getPermissions()) {
+						return new Result(null, 404, 'Cannot increase permission of ' . $share->getTarget());
+					}
+				}
+
 				$share->setPermissions($newPermissions);
 				$permissions = $newPermissions;
 			}

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -28,6 +28,7 @@ use OC\OCS\Result;
 use OCA\Files_Sharing\Controller\Share20OcsController;
 use OCA\Files_Sharing\Service\NotificationPublisher;
 use OCA\Files_Sharing\SharingBlacklist;
+use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
@@ -1663,7 +1664,50 @@ class Share20OcsControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
+	public function testUpdateLinkHigherPermissions() {
+		$node = $this->createMock(Folder::class);
+		$share = $this->newShare();
+		$share->setPermissions(Constants::PERMISSION_READ)
+			->setSharedBy($this->currentUser->getUID())
+			->setShareType(Share::SHARE_TYPE_LINK)
+			->setNode($node)
+			->setTarget('/foo/bar');
+
+		$node->expects($this->once())
+			->method('lock')
+			->with(ILockingProvider::LOCK_SHARED);
+
+		$this->request
+			->method('getParam')
+			->willReturnMap([
+				['permissions', null, '15'],
+			]);
+
+		$originalNode = $this->createMock(File::class);
+		$originalNode->method('getPermissions')->willReturn(17);
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([$originalNode]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
+		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
+		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
+
+		$expected = new Result(null, 404, 'Cannot increase permission of /foo/bar');
+		$result = $this->ocs->updateShare(42);
+
+		$this->assertEquals($expected->getMeta(), $result->getMeta());
+		$this->assertEquals($expected->getData(), $result->getData());
+	}
+
 	public function testUpdateLinkShareClear() {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
 		$ocs = $this->mockFormatShare();
 
 		$node = $this->createMock(Folder::class);
@@ -1710,6 +1754,12 @@ class Share20OcsControllerTest extends TestCase {
 	}
 
 	public function testUpdateLinkShareSet() {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
 		$ocs = $this->mockFormatShare();
 
 		$folder = $this->createMock(Folder::class);
@@ -1754,6 +1804,12 @@ class Share20OcsControllerTest extends TestCase {
 	 * @dataProvider publicUploadParamsProvider
 	 */
 	public function testUpdateLinkShareEnablePublicUpload($params) {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
 		$ocs = $this->mockFormatShare();
 
 		$folder = $this->createMock(Folder::class);
@@ -1796,6 +1852,12 @@ class Share20OcsControllerTest extends TestCase {
 	}
 
 	public function testUpdateLinkShareInvalidDate() {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
 		$ocs = $this->mockFormatShare();
 
 		$folder = $this->createMock(Folder::class);
@@ -1994,6 +2056,12 @@ class Share20OcsControllerTest extends TestCase {
 	}
 
 	public function testUpdateLinkSharePublicUploadDoesNotChangeOther() {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
 		$ocs = $this->mockFormatShare();
 
 		$date = new \DateTime('2000-01-01');
@@ -2035,6 +2103,12 @@ class Share20OcsControllerTest extends TestCase {
 	}
 
 	public function testUpdateLinkSharePermissions() {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
 		$ocs = $this->mockFormatShare();
 
 		$date = new \DateTime('2000-01-01');
@@ -2077,6 +2151,12 @@ class Share20OcsControllerTest extends TestCase {
 	}
 
 	public function testUpdateLinkShareCreateOnly() {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
+
 		$ocs = $this->mockFormatShare();
 
 		$folder = $this->createMock(Folder::class);
@@ -2342,9 +2422,13 @@ class Share20OcsControllerTest extends TestCase {
 	 * @dataProvider publicUploadParamsProvider
 	 */
 	public function testUpdateShareCannotIncreasePermissionsPublicLink($params) {
-		$ocs = $this->mockFormatShare();
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder
+			->method('getUserFolder')
+			->willReturn($userFolder);
 
-		$date = new \DateTime('2000-01-01');
+		$ocs = $this->mockFormatShare();
 
 		$folder = $this->createMock(Folder::class);
 

--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -359,7 +359,6 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
-  @issue-enterprise-3364
   Scenario Outline: increasing permissions of a public link from a sub-folder of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
@@ -372,24 +371,13 @@ Feature: sharing
     And publicly uploading a file should not work
     When user "user1" updates the last share using the sharing API with
       | permissions | 15 |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    #Then the OCS status code should be "404"
-    #And the HTTP status code should be "<http_status_code>"
-    And publicly uploading a file should work
-    #And publicly uploading a file should not work
-    # Delete the following 4 steps when fixing the issue:
-    And the public should be able to upload file "file.txt" with content "some text" to the last public shared folder
-    And as "user0" file "/test/sub/file.txt" should exist
-    And as "user1" file "/test/sub/file.txt" should exist
-    And the content of file "/test/sub/file.txt" for user "user0" should be "some text"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And publicly uploading a file should not work
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
-      #| ocs_api_version | http_status_code |
-      #| 1               | 200              |
-      #| 2               | 404              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
…esource which was shared with limited permissions

## Description
As the acceptance scenario shows a public link is not allowed to have more permissions then the original share.

## Related Issue
- refs owncloud/enterprise#3364

## How Has This Been Tested?
- running acceptance tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
