### PR TITLE
Use full skeleton for webUI browseDirectlyToDetailsTab.feature

### DIFF
--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -5,14 +5,7 @@ Feature: browse directly to details tab
   So that I can see the details immediately without needing to click in the UI
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has uploaded file with content "some content" to "/block-aligned.txt"
-    And user "user1" has uploaded file with content "some content" to "/simple-folder/block-aligned.txt"
-    And user "user1" has uploaded file with content "some content" to "/lorem.txt"
-    And user "user1" has uploaded file with content "some content" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file with content "some content" to "/zzzz-must-be-last-file-in-folder.txt"
-    And user "user1" has uploaded file with content "some content" to "/simple-folder/zzzz-must-be-last-file-in-folder.txt"
+    Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
 
   @smokeTest


### PR DESCRIPTION
## Description
When doing "Speed up CI" changes, `browseDirectlyToDetailsTab.feature` was adjusted to not use the full skeleton. But there are test scenarios that want to check what happens when there is a long list of files to be displayed, and we want to browse directly to a file down the end of the list. For these scenarios to be realistic, they need to have a longer list of files.

Put back the full skeleton.

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
Make sure test scenarios are effective.

## How Has This Been Tested?
#35283 fixed a bug in `browseDirectlyToDetailsTab`.
To test the effectiveness of the test scenarios:

- remove the code added by #35283 to `apps/files/js/filelist.js`
- run `browseDirectlyToDetailsTab.feature` - it still all passes :(
- make the changes in this PR (use the full skeleton)
- run `browseDirectlyToDetailsTab.feature` - there are some test fails :) so the tests are now effective
- paste back the code to `apps/files/js/filelist.js`
- run `browseDirectlyToDetailsTab.feature` - it passes :) - the code change makes the tests pass

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
