### PR TITLE
[stable10] set default expiration date if expiration date is enforced and it is new share

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -330,6 +330,13 @@ class Manager implements IManager {
 
 		// If we enforce the expiration date check that is does not exceed
 		if ($this->shareApiLinkDefaultExpireDateEnforced()) {
+			// If expiredate is empty and it is a new share, set a default one if there is a default
+			if ($this->isNewShare($share) && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
+				$expirationDate = new \DateTime();
+				$expirationDate->setTime(0, 0, 0);
+				$expirationDate->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));
+			}
+
 			if ($expirationDate === null) {
 				throw new \InvalidArgumentException('Expiration date is enforced');
 			}
@@ -1547,5 +1554,19 @@ class Manager implements IManager {
 		}
 
 		return \md5(\json_encode($perms->toArray()));
+	}
+
+	/**
+	 * @param IShare $share
+	 * @return boolean
+	 */
+	private function isNewShare(IShare $share) {
+		$fullId = null;
+		try {
+			$fullId = $share->getFullId();
+		} catch (\UnexpectedValueException $e) {
+			// This is a new share
+		}
+		return ($fullId === null);
 	}
 }

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -62,7 +62,7 @@ class ManagerTest extends \Test\TestCase {
 	protected $manager;
 	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var IConfig */
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 	/** @var ISecureRandom */
 	protected $secureRandom;
@@ -934,19 +934,23 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($share->getExpirationDate());
 	}
 
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
 	public function testvalidateExpirationDateEnforceButNotSetNewShare() {
 		$share = $this->manager->newShare();
 
 		$this->config->method('getAppValue')
 			->will($this->returnValueMap([
+				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
+				['core', 'shareapi_expire_after_n_days', '7', '3'],
 				['core', 'shareapi_default_expire_date', 'no', 'yes'],
 				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 			]));
 
+		$expected = new \DateTime();
+		$expected->setTime(0, 0, 0);
+		$expected->add(new \DateInterval('P3D'));
 		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+		$this->assertNotNull($share->getExpirationDate());
+		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
 	public function testvalidateExpirationDateEnforceToFarIntoFuture() {


### PR DESCRIPTION
## Description
Backport of #35564 

## Related Issue
- Fixes https://github.com/owncloud/core/issues/35550

## Motivation and Context

## How Has This Been Tested?
- see discussion from @ckamm  in https://github.com/owncloud/core/pull/35564

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
⛔️ 