### PR TITLE
Fix invalid token on pw reset

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -36,6 +36,7 @@ use \OCP\IURLGenerator;
 use \OCP\IRequest;
 use \OCP\IL10N;
 use \OCP\IConfig;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
@@ -203,6 +204,22 @@ class LostController extends Controller {
 	 * @return array
 	 */
 	public function email($user) {
+		try {
+			$userObject = $this->userManager->get($user);
+			if ($userObject === null) {
+				$users = $this->userManager->getByEmail($user);
+				// we only allow login by email if unique
+				if (\count($users) === 1) {
+					$user = $users[0]->getUID();
+				}
+			}
+			if ($userObject instanceof IUser) {
+				$user = $userObject->getUID();
+			}
+		} catch (\Exception $e) {
+			// Do not disclose any information during User lookup
+			return $this->success();
+		}
 		// FIXME: use HTTP error codes
 		try {
 			list($link, $token) = $this->generateTokenAndLink($user);

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -23,23 +23,16 @@ Feature: reset the password using an email address
       Use the following link to reset your password: <a href=
       """
 
-  @skipOnEncryption
-  # consider adding this to the smoke tests when the issue is fixed @smokeTest
-  @issue-32889
+  @skipOnEncryption @smokeTest
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    # The issue is that the system thinks the link token is invalid
-    And a lost password reset error message with this text should be displayed on the webUI:
-			"""
-			Could not reset password because the token is invalid
-			"""
-    #When the user resets the password to "%alt3%" using the webUI
-    #Then the user should be redirected to the login page
-    #And the email address "user1@example.org" should have received an email with the body containing
-	#		"""
-	#		Password changed successfully
-	#		"""
-    #When the user logs in with username "user1" and password "%alt3%" using the webUI
-    #Then the user should be redirected to a webUI page with the title "Files - %productname%"
+    When the user resets the password to "%alt3%" using the webUI
+    Then the user should be redirected to the login page
+    And the email address "user1@example.org" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    When the user logs in with username "user1" and password "%alt3%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -28,7 +28,7 @@ Feature: reset the password using an email address
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from email address "user1@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
-    When the user resets the password to "%alt3%" using the webUI
+    When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the user should be redirected to the login page
     And the email address "user1@example.org" should have received an email with the body containing
       """


### PR DESCRIPTION
## Description
The Password reset link is not working if a user used his e-mail address as a log in attribute.

## Expected Behaviour
1) Log in a user with his e-mail address and wrong password
2) Click on "Reset Password" Link
3) Click on Reset Link in E-Mail
4) See Reset Form

## What happens instead
![Screenshot_2019-06-19 ownCloud Enterprise Edition](https://user-images.githubusercontent.com/4378513/59755467-3d1c8e80-9288-11e9-8699-d680a280f2bc.png)

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3316

## Motivation and Context
Registration in Customer Portal is broken

## How Has This Been Tested?
1) Log in a user with his e-mail address and wrong password
2) Click on "Reset Password" Link
3) Click on reset Link in E-Mail
4) Reset the pw

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests modified
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
