### PR TITLE
Return false if the rename fails except for connect exceptions

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -149,7 +149,10 @@ abstract class Node implements \Sabre\DAV\INode {
 		$newPath = $parentPath . '/' . $newName;
 
 		try {
-			$this->fileView->rename($this->path, $newPath);
+			$result = $this->fileView->rename($this->path, $newPath);
+			if ($result === false) {
+				throw new Forbidden('Rename operation failed');
+			}
 		} catch (ForbiddenException $ex) {
 			throw new Forbidden($ex->getMessage(), $ex->getRetry());
 		}

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -1038,6 +1038,22 @@ class FileTest extends TestCase {
 	}
 
 	/**
+	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\Forbidden
+	 */
+	public function testSetNameRenameOperationFailed() {
+		$view = $this->createMock(View::class);
+		$view->method('verifyPath')->willReturn(true);
+		$view->method('getRelativePath')->will($this->returnArgument(0));
+		$view->method('rename')->willReturn(false);
+
+		$info = new FileInfo('/test.txt', $this->getMockStorage(), null, [
+			'permissions' => Constants::PERMISSION_ALL
+		], null);
+		$file = new File($view, $info);
+		$file->setName('/new_test_renamed.txt');
+	}
+
+	/**
 	 */
 	public function testUploadAbort() {
 		// setup

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -307,9 +307,7 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 	private function removeFromCache($path) {
 		$path = \trim($path, '/');
 		// TODO The CappedCache does not really clear by prefix. It just clears all.
-		//$this->dirCache->clear($path);
 		$this->statCache->clear($path);
-		//$this->xattrCache->clear($path);
 	}
 	/**
 	 * @param string $path
@@ -319,13 +317,13 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		$this->log('enter: '.__FUNCTION__."($path)");
 		try {
 			$result = $this->formatInfo($this->getFileInfo($path));
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-			$result = false;
-		} catch (Exception $e) {
+		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
+		} catch (Exception $e) {
+			$this->swallow(__FUNCTION__, $e);
+			$result = false;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -392,18 +390,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 				unset($this->statCache[$path]);
 				$result = true;
 			}
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
+		} catch (ConnectException $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		} catch (Exception $e) {
-			if ($e->getCode() === 16) {
-				$this->swallow(__FUNCTION__, $e);
-			} else {
-				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-				$this->leave(__FUNCTION__, $ex);
-				throw $ex;
-			}
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -482,18 +474,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 						\unlink($tmpFile);
 					});
 			}
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
+		} catch (ConnectException $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		} catch (Exception $e) {
-			if ($e->getCode() === 16) {
-				$this->swallow(__FUNCTION__, $e);
-			} else {
-				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-				$this->leave(__FUNCTION__, $ex);
-				throw $ex;
-			}
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -519,18 +505,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			}
 			$this->share->rmdir($this->buildPath($path));
 			$result = true;
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
+		} catch (ConnectException $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		} catch (Exception $e) {
-			if ($e->getCode() === 16) {
-				$this->swallow(__FUNCTION__, $e);
-			} else {
-				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-				$this->leave(__FUNCTION__, $ex);
-				throw $ex;
-			}
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -544,14 +524,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 				\fclose($fh);
 				$result = true;
 			}
+		} catch (ConnectException $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		} catch (Exception $e) {
-			if ($e->getCode() === 16) {
-				$this->swallow(__FUNCTION__, $e);
-			} else {
-				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-				$this->leave(__FUNCTION__, $ex);
-				throw $ex;
-			}
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -566,14 +544,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 				return $info->getName();
 			}, $files);
 			$result = IteratorDirectory::wrap($names);
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (Exception $e) {
+		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
+		} catch (Exception $e) {
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -583,14 +559,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		$result = false;
 		try {
 			$result = $this->getFileInfo($path)->isDirectory() ? 'dir' : 'file';
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (Exception $e) {
+		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
+		} catch (Exception $e) {
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -601,18 +575,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		$path = $this->buildPath($path);
 		try {
 			$result = $this->share->mkdir($path);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (AlreadyExistsException $e) {
-			$this->swallow(__FUNCTION__, $e);
+		} catch (ConnectException $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		} catch (Exception $e) {
-			if ($e->getCode() === 16) {
-				$this->swallow(__FUNCTION__, $e);
-			} else {
-				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-				$this->leave(__FUNCTION__, $ex);
-				throw $ex;
-			}
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -623,14 +591,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		try {
 			$this->getFileInfo($path);
 			$result = true;
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (Exception $e) {
+		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
+		} catch (Exception $e) {
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -641,14 +607,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		try {
 			$info = $this->getFileInfo($path);
 			$result = !$info->isHidden();
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (Exception $e) {
+		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
+		} catch (Exception $e) {
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -661,14 +625,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			// following windows behaviour for read-only folders: they can be written into
 			// (https://support.microsoft.com/en-us/kb/326549 - "cause" section)
 			$result = !$info->isHidden() && (!$info->isReadOnly() || $this->is_dir($path));
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (Exception $e) {
+		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
+		} catch (Exception $e) {
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -679,14 +641,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		try {
 			$info = $this->getFileInfo($path);
 			$result = !$info->isHidden() && !$info->isReadOnly();
-		} catch (NotFoundException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (ForbiddenException $e) {
-			$this->swallow(__FUNCTION__, $e);
-		} catch (Exception $e) {
+		} catch (ConnectException $e) {
 			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
+		} catch (Exception $e) {
+			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -691,7 +691,9 @@ class View {
 						\fclose($target);
 						\fclose($data);
 
-						$this->writeUpdate($storage, $internalPath);
+						if ($result) {
+							$this->writeUpdate($storage, $internalPath);
+						}
 
 						$this->changeLock($path, ILockingProvider::LOCK_SHARED);
 
@@ -952,7 +954,9 @@ class View {
 							$result = $storage2->copyFromStorage($storage1, $internalPath1, $internalPath2);
 						}
 
-						$this->writeUpdate($storage2, $internalPath2);
+						if ($result) {
+							$this->writeUpdate($storage2, $internalPath2);
+						}
 
 						$this->changeLock($path2, ILockingProvider::LOCK_SHARED);
 						$lockTypePath2 = ILockingProvider::LOCK_SHARED;
@@ -1194,14 +1198,16 @@ class View {
 					throw $e;
 				}
 
-				if (\in_array('delete', $hooks) and $result) {
-					$this->removeUpdate($storage, $internalPath);
-				}
-				if (\in_array('write', $hooks) and $operation !== 'fopen') {
-					$this->writeUpdate($storage, $internalPath);
-				}
-				if (\in_array('touch', $hooks)) {
-					$this->writeUpdate($storage, $internalPath, $extraParam);
+				if ($result) {
+					if (\in_array('delete', $hooks)) {
+						$this->removeUpdate($storage, $internalPath);
+					}
+					if (\in_array('write', $hooks) and $operation !== 'fopen') {
+						$this->writeUpdate($storage, $internalPath);
+					}
+					if (\in_array('touch', $hooks)) {
+						$this->writeUpdate($storage, $internalPath, $extraParam);
+					}
 				}
 
 				if ((\in_array('write', $hooks) || \in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
A failure during the rename operation due to insufficient permissions was causing the storage to be unavailable. In this case, the operation should return false instead of throwing a StorageNotAvailableException

## Related Issue
https://github.com/owncloud/phoenix/issues/1326

## Motivation and Context
It should fail normally instead of blocking the storage

## How Has This Been Tested?
This has been checked with the "old" UI, not with phoenix, although it's expected a similar behaviour.

1. Ensure the file can be edited by the user, but the parent folder is only readable
2. Try to rename a file.

**Note**: it seems the UI behaves badly under these circumstances. There is an error shown, but the "renamed" file disappears. The storage is available, and you can go outside and then inside the folder to make the file reappear again. The "move" http request ends up with a 404 error code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)