### PR TITLE
[Stable10] Filter double appearing addressbooks

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -163,13 +163,20 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$principals = $this->principalBackend->getGroupMembership($principalUri, true);
 		$principals[]= $principalUri;
 
+		$addressBooksIds[] = -1;
+		foreach ($addressBooks as $book) {
+			$addressBooksIds[] = $book['id'];
+		}
+
 		$query = $this->db->getQueryBuilder();
 		$result = $query->select(['a.id', 'a.uri', 'a.displayname', 'a.principaluri', 'a.description', 'a.synctoken', 's.access'])
 			->from('dav_shares', 's')
 			->join('s', 'addressbooks', 'a', $query->expr()->eq('s.resourceid', 'a.id'))
 			->where($query->expr()->in('s.principaluri', $query->createParameter('principaluri')))
+			->andWhere($query->expr()->notIn('a.id', $query->createParameter('ownaddressbookids')))
 			->andWhere($query->expr()->eq('s.type', $query->createParameter('type')))
 			->setParameter('type', 'addressbook')
+			->setParameter('ownaddressbookids', $addressBooksIds, IQueryBuilder::PARAM_INT_ARRAY)
 			->setParameter('principaluri', $principals, IQueryBuilder::PARAM_STR_ARRAY)
 			->execute();
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/33713

## Description
<!--- Describe your changes in detail -->
Filter for the double-appearing address book, when the user is sharing an addressbook with groups he is also a member of.

## How Has This Been Tested?
- Create an addressbook in contacts app
- Share it with a group the user also belongs to
- The shared addressbook is now filtered

### before - 'test book' is shown twice - as own and as shared
![before](https://user-images.githubusercontent.com/991300/59764766-20428400-92a5-11e9-97e9-7ed49fa74876.png)

### after - shared book 'test book' is hidden because it is the same with non-shared 'test book'
![after](https://user-images.githubusercontent.com/991300/59764784-29cbec00-92a5-11e9-85a2-23334089dc9c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised:
