### PR TITLE
[10.2.1] Make the encryption:encrypt-all command to accept "-y" as input option

### DIFF
--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Input\InputOption;
 
 class EncryptAll extends Command {
 
@@ -99,13 +100,19 @@ class EncryptAll extends Command {
 			'This will encrypt all files for all users. '
 			. 'Please make sure that no user access his files during this process!'
 		);
+		$this->addOption(
+			'yes',
+			'y',
+			InputOption::VALUE_NONE,
+			'Answer yes to all questions'
+		);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		if ($this->encryptionManager->isEnabled() === false) {
 			throw new \Exception('Server side encryption is not enabled');
 		}
-
+		$yes = $input->getOption('yes');
 		$masterKeyEnabled = $this->config->getAppValue('encryption', 'useMasterKey', '');
 		$userKeyEnabled = $this->config->getAppValue('encryption', 'userSpecificKey', '');
 		if (($masterKeyEnabled === '') && ($userKeyEnabled === '')) {
@@ -122,7 +129,7 @@ class EncryptAll extends Command {
 		$output->writeln('Note: The encryption module you use determines which files get encrypted.');
 		$output->writeln('');
 		$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', false);
-		if ($this->questionHelper->ask($input, $output, $question)) {
+		if ($yes || $this->questionHelper->ask($input, $output, $question)) {
 			$this->forceSingleUserAndTrashbin();
 
 			try {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Backport of #35575 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/33 // https://github.com/owncloud/enterprise/pull/339

## Motivation

Have fixes in 10.2.1 included