### PR TITLE
Improve isFieldInResponse to handle more combinations

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -224,8 +224,8 @@ Feature: sharing
       | permissions            | 1              |
       | uid_owner              | user0          |
     And the fields of the last response should not include
-      | share_with             | ***redacted*** |
-      | share_with_displayname | ***redacted*** |
+      | share_with             | ANY_VALUE |
+      | share_with_displayname | ANY_VALUE |
 
     Examples:
       | ocs_api_version | ocs_status_code |


### PR DESCRIPTION
## Description
Enhance `isFieldInResponse()` acceptance test method so that it:
- knows if the caller is expecting success, and if the field does not exist or has an unexpected value, or... then emit some debug information to help the developer know what the actual value was etc.
- add the special value `ANY_VALUE` so we can test for a field existing (or not existing) and we do not care what the value is.

## Motivation and Context
If I write:
```
    And the fields of the last response should not include
      | share_with | anne |
```
Then if the `share_with` field exists, but has some other value like `bob`, then the test passes.
I want to be able to to test that a field does not exist at all.

If the field is not as expected, then as well as a fail message, I would like to know what value it was set to, or if the field did not exist. That can really help when trying to work out why a test is failing.

## How Has This Been Tested?
Local runs of `createShare.feature` scenarios with different combinations of fields and values in steps for:
```
And the fields of the last response should include
And the fields of the last response should not include
```
to verify that when something is different from expected, that the test does fail, and emits a somewhat-useful message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
