### PR TITLE
[stable10] Change jakearchibald/es6-promise#2.3.0 to components/es6-promise#v4.2.4

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -18,7 +18,7 @@
     "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.2",
     "@bower_components/clipboard": "zenorocha/clipboard.js#v2.0.4",
     "@bower_components/davclient.js": "owncloud/davclient.js#0.1.3",
-    "@bower_components/es6-promise": "jakearchibald/es6-promise#2.3.0",
+    "@bower_components/es6-promise": "components/es6-promise#4.2.4",
     "@bower_components/handlebars": "components/handlebars.js#v4.1.2",
     "@bower_components/jcrop": "tapmodo/Jcrop#0.9.12",
     "@bower_components/jquery": "jquery/jquery-dist#2.1.4",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -8,7 +8,6 @@
 
 "@bower_components/backbone@jashkenas/backbone#1.4.0":
   version "1.4.0"
-  uid "5de45fc9e1cbe5f61cf459067207bbe73451ac91"
   resolved "https://codeload.github.com/jashkenas/backbone/tar.gz/5de45fc9e1cbe5f61cf459067207bbe73451ac91"
   dependencies:
     underscore ">=1.8.3"
@@ -35,7 +34,6 @@
 
 "@bower_components/clipboard@zenorocha/clipboard.js#v2.0.4":
   version "2.0.4"
-  uid d17eca050e705ae4932fd1be3e96abe38bd3397c
   resolved "https://codeload.github.com/zenorocha/clipboard.js/tar.gz/d17eca050e705ae4932fd1be3e96abe38bd3397c"
   dependencies:
     good-listener "^1.2.2"
@@ -46,13 +44,12 @@
   version "0.1.3"
   resolved "https://codeload.github.com/owncloud/davclient.js/tar.gz/0e5ef1af5d174d9ec10dbe889a415b8f481d5094"
 
-"@bower_components/es6-promise@jakearchibald/es6-promise#2.3.0":
-  version "2.3.0"
-  resolved "https://codeload.github.com/jakearchibald/es6-promise/tar.gz/d3959b5c4c239b604bf95b737a0243ca6e94aa7e"
+"@bower_components/es6-promise@components/es6-promise#4.2.4":
+  version "0.0.0"
+  resolved "https://codeload.github.com/components/es6-promise/tar.gz/c7911b0f272651dca8c3163704fd39628ed4283a"
 
 "@bower_components/handlebars@components/handlebars.js#v4.1.2":
   version "4.1.2"
-  uid "5e52d62e36bc94561cc9b3acdf27ef878df1a5ab"
   resolved "https://codeload.github.com/components/handlebars.js/tar.gz/5e52d62e36bc94561cc9b3acdf27ef878df1a5ab"
 
 "@bower_components/jcrop@tapmodo/Jcrop#0.9.12":

--- a/core/js/core.json
+++ b/core/js/core.json
@@ -9,7 +9,7 @@
 		"blueimp-md5/js/md5.js",
 		"bootstrap/js/tooltip.js",
 		"backbone/backbone.js",
-		"es6-promise/dist/es6-promise.js",
+		"es6-promise/es6-promise.auto.js",
 		"davclient.js/lib/client.js",
 		"clipboard/dist/clipboard.js",
 		"bowser/src/bowser.js"


### PR DESCRIPTION
…. like in master

## Description
This changes from `jakearchibald` to `components` and bumps the version.

The change to `core\js\core.json` was also made to be like `master` - it made the JS tests pass.

## Related Issue
Note:
PR #30026 seems to have done this already in `stable10` merged 2018-01-08
But PR #33665 seems to have put back the `jakearchibald` version of `es6-promise`
But the diffs of that PR are odd, because it looks like the lines were added, not changed.

## Motivation and Context
Make `stable10` like `master`

## How Has This Been Tested?
Local `make test-js`
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
