### PR TITLE
Feature/webdav trash

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CopyEtagHeaderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CopyEtagHeaderPlugin.php
@@ -22,6 +22,7 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use Sabre\DAV\Exception\NotFound;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 
@@ -71,11 +72,15 @@ class CopyEtagHeaderPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @return void
 	 */
 	public function afterMove($source, $destination) {
-		$node = $this->server->tree->getNodeForPath($destination);
-		if ($node instanceof File) {
-			$eTag = $node->getETag();
-			$this->server->httpResponse->setHeader('OC-ETag', $eTag);
-			$this->server->httpResponse->setHeader('ETag', $eTag);
+		try {
+			$node = $this->server->tree->getNodeForPath($destination);
+			if ($node instanceof File) {
+				$eTag = $node->getETag();
+				$this->server->httpResponse->setHeader('OC-ETag', $eTag);
+				$this->server->httpResponse->setHeader('ETag', $eTag);
+			}
+		} catch (NotFound $ex) {
+			// nothing to do then ....
 		}
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -409,7 +409,7 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 	public function moveInto($targetName, $fullSourcePath, INode $sourceNode) {
 		if (!$sourceNode instanceof Node) {
 			if ($sourceNode instanceof ITrashBinNode) {
-				return $sourceNode->restore($targetName);
+				return $sourceNode->restore($this->path . '/' . $targetName);
 			}
 			// it's a file of another kind, like FutureFile
 			if ($sourceNode instanceof IFile) {

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -36,6 +36,7 @@ use OC\Files\Mount\MoveableMount;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\TrashBin\ITrashBinNode;
 use OCA\DAV\Upload\FutureFile;
 use OCA\DAV\Upload\FutureFileZsync;
 use OCP\Files\FileContentNotAllowedException;
@@ -407,6 +408,9 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 	 */
 	public function moveInto($targetName, $fullSourcePath, INode $sourceNode) {
 		if (!$sourceNode instanceof Node) {
+			if ($sourceNode instanceof ITrashBinNode) {
+				return $sourceNode->restore($targetName);
+			}
 			// it's a file of another kind, like FutureFile
 			if ($sourceNode instanceof IFile) {
 				// fallback to default copy+delete handling

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -58,6 +58,8 @@ class RootCollection extends SimpleCollection {
 		$systemPrincipals->disableListing = $disableListing;
 		$filesCollection = new Files\RootCollection($userPrincipalBackend, 'principals/users');
 		$filesCollection->disableListing = $disableListing;
+		$trashBinCollection = new TrashBin\RootCollection($userPrincipalBackend, 'principals/users');
+		$trashBinCollection->disableListing = $disableListing;
 		$caldavBackend = new CalDavBackend($db, $userPrincipalBackend, $groupPrincipalBackend, $random);
 		$calendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users');
 		$calendarRoot->disableListing = $disableListing;
@@ -100,6 +102,7 @@ class RootCollection extends SimpleCollection {
 						$groupPrincipals,
 						$systemPrincipals]),
 				$filesCollection,
+				$trashBinCollection,
 				$calendarRoot,
 				$publicCalendarRoot,
 				new SimpleCollection('addressbooks', [

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -56,6 +56,7 @@ use OCA\DAV\Files\PreviewPlugin;
 use OCA\DAV\Files\ZsyncPlugin;
 use OCA\DAV\JobStatus\Entity\JobStatusMapper;
 use OCA\DAV\SystemTag\SystemTagPlugin;
+use OCA\DAV\TrashBin\TrashBinPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
 use OCA\DAV\Upload\ChunkingPluginZsync;
 use OCP\IRequest;
@@ -189,6 +190,7 @@ class Server {
 
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 		$this->server->addPlugin(new ChunkingPlugin());
+		$this->server->addPlugin(new TrashBinPlugin());
 
 		// Allow view-only plugin for webdav requests
 		$this->server->addPlugin(new ViewOnlyPlugin(
@@ -226,7 +228,7 @@ class Server {
 					)
 				);
 
-				if ($this->isRequestForSubtree(['files', 'uploads'])) {
+				if ($this->isRequestForSubtree(['files', 'uploads', 'trash-bin'])) {
 					//For files only
 					$filePropertiesPlugin = new FileCustomPropertiesPlugin(
 						new FileCustomPropertiesBackend(

--- a/apps/dav/lib/TrashBin/AbstractTrashBinNode.php
+++ b/apps/dav/lib/TrashBin/AbstractTrashBinNode.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\TrashBin;
+
+use OCA\Files_Trashbin\Trashbin;
+use OCP\Files\FileInfo;
+use Sabre\DAV\Exception\Forbidden;
+
+abstract class AbstractTrashBinNode implements ITrashBinNode {
+
+	/**
+	 * @var FileInfo
+	 */
+	protected $fileInfo;
+	/**
+	 * @var TrashBinManager
+	 */
+	protected $trashBinManager;
+	/**
+	 * @var string
+	 */
+	protected $user;
+
+	public function __construct(string $user, FileInfo $fileInfo, TrashBinManager $trashBinManager) {
+		$this->fileInfo = $fileInfo;
+		$this->trashBinManager = $trashBinManager;
+		$this->user = $user;
+	}
+
+	/**
+	 * Returns the name of the node.
+	 *
+	 * This is used to generate the url.
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return (string)$this->fileInfo->getId();
+	}
+
+	/**
+	 * Returns the mime-type for a file
+	 *
+	 * If null is returned, we'll assume application/octet-stream
+	 *
+	 * @return string|null
+	 */
+	public function getContentType() {
+		return $this->fileInfo->getMimetype();
+	}
+
+	public function getETag() {
+		return $this->fileInfo->getEtag();
+	}
+
+	public function getLastModified() {
+		return $this->fileInfo->getMtime();
+	}
+	public function getSize() {
+		return $this->fileInfo->getSize();
+	}
+
+	public function getOriginalFileName() : string {
+		$path = $this->getPathInTrash();
+		if (\count($path) === 1) {
+			$path = \end($path);
+			$pathInfo = \pathinfo($path);
+			return $pathInfo['filename'];
+		}
+		return \end($path);
+	}
+
+	public function getOriginalLocation() : string {
+		$pathElements = $this->getPathInTrash();
+		$path = $pathElements[0];
+		$pathParts = \pathinfo($path);
+		$timestamp = (int)\substr($pathParts['extension'], 1);
+
+		$pathElements[0] = $pathParts['filename'];
+		$originalPath = \implode('/', $pathElements);
+
+		$location = $this->trashBinManager->getLocation($this->user, $pathParts['filename'], $timestamp);
+		if ($location !== '.') {
+			$originalPath = $location . '/' . $originalPath;
+		}
+
+		return $originalPath;
+	}
+
+	public function getDeleteTimestamp() : int {
+		$path = $this->getPathInTrash();
+		$path = $path[0];
+		$pathParts = \pathinfo($path);
+		return (int)\substr($pathParts['extension'], 1);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @param string $targetLocation
+	 * @return bool
+	 */
+	public function restore(string $targetLocation): bool {
+		return $this->trashBinManager->restore($this->user, $this, $targetLocation);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	public function delete() : void {
+		$path = $this->fileInfo->getPath();
+		$path = \explode('/', $path);
+		$user = $path[1];
+		$elements = \array_splice($path, 4);
+		$path = \implode('/', $elements);
+
+		$delimiter = \strrpos($path, '.d');
+		$path = \substr($path, 0, $delimiter);
+
+		Trashbin::delete($path, $user, $this->getDeleteTimestamp());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getPathInTrash() {
+		$path = $this->fileInfo->getPath();
+		$path = \explode('/', $path);
+		return \array_splice($path, 4);
+	}
+
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename this resource');
+	}
+}

--- a/apps/dav/lib/TrashBin/ITrashBinNode.php
+++ b/apps/dav/lib/TrashBin/ITrashBinNode.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -18,41 +18,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+namespace OCA\DAV\TrashBin;
 
-namespace OCA\DAV;
+use Sabre\DAV\INode;
 
-use OCP\Capabilities\ICapability;
-use OCP\IConfig;
-
-class Capabilities implements ICapability {
-	/** @var IConfig */
-	private $config;
+/**
+ * Interface ITrashBinNode
+ *
+ * A common interface for all trash bin items
+ *
+ * @package OCA\DAV\TrashBin
+ */
+interface ITrashBinNode extends INode {
+	/**
+	 * @return string
+	 */
+	public function getOriginalFileName() : string;
+	/**
+	 * @return string
+	 */
+	public function getOriginalLocation() : string;
+	/**
+	 * @return int
+	 */
+	public function getDeleteTimestamp() : int;
 
 	/**
-	 * Capabilities constructor.
-	 *
-	 * @param IConfig $config
+	 * @param string $targetLocation
+	 * @return bool
 	 */
-	public function __construct(IConfig $config) {
-		$this->config = $config;
-	}
-
-	public function getCapabilities() {
-		$cap =  [
-			'dav' => [
-				'chunking' => '1.0',
-				'trashbin' => '1.0',
-				'zsync' => '1.0',
-				'reports' => [
-					'search-files',
-				]
-			]
-		];
-
-		if ($this->config->getSystemValue('dav.enable.async', false)) {
-			$cap['async'] = '1.0';
-		}
-
-		return $cap;
-	}
+	public function restore(string $targetLocation) : bool;
 }

--- a/apps/dav/lib/TrashBin/RootCollection.php
+++ b/apps/dav/lib/TrashBin/RootCollection.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -19,40 +19,27 @@
  *
  */
 
-namespace OCA\DAV;
+namespace OCA\DAV\TrashBin;
 
-use OCP\Capabilities\ICapability;
-use OCP\IConfig;
+use Sabre\DAVACL\AbstractPrincipalCollection;
 
-class Capabilities implements ICapability {
-	/** @var IConfig */
-	private $config;
+class RootCollection extends AbstractPrincipalCollection {
 
 	/**
-	 * Capabilities constructor.
+	 * This method returns a node for a principal.
 	 *
-	 * @param IConfig $config
+	 * The passed array contains principal information, and is guaranteed to
+	 * at least contain a uri item. Other properties may or may not be
+	 * supplied by the authentication backend.
+	 *
+	 * @param array $principalInfo
+	 * @return TrashBinHome
 	 */
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function getChildForPrincipal(array $principalInfo) {
+		return new TrashBinHome($principalInfo, new TrashBinManager());
 	}
 
-	public function getCapabilities() {
-		$cap =  [
-			'dav' => [
-				'chunking' => '1.0',
-				'trashbin' => '1.0',
-				'zsync' => '1.0',
-				'reports' => [
-					'search-files',
-				]
-			]
-		];
-
-		if ($this->config->getSystemValue('dav.enable.async', false)) {
-			$cap['async'] = '1.0';
-		}
-
-		return $cap;
+	public function getName() {
+		return 'trash-bin';
 	}
 }

--- a/apps/dav/lib/TrashBin/TrashBinFile.php
+++ b/apps/dav/lib/TrashBin/TrashBinFile.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -19,40 +19,17 @@
  *
  */
 
-namespace OCA\DAV;
+namespace OCA\DAV\TrashBin;
 
-use OCP\Capabilities\ICapability;
-use OCP\IConfig;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\IFile;
 
-class Capabilities implements ICapability {
-	/** @var IConfig */
-	private $config;
-
-	/**
-	 * Capabilities constructor.
-	 *
-	 * @param IConfig $config
-	 */
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+class TrashBinFile extends AbstractTrashBinNode implements IFile {
+	public function put($data) {
+		throw new Forbidden('Permission denied to write this file');
 	}
 
-	public function getCapabilities() {
-		$cap =  [
-			'dav' => [
-				'chunking' => '1.0',
-				'trashbin' => '1.0',
-				'zsync' => '1.0',
-				'reports' => [
-					'search-files',
-				]
-			]
-		];
-
-		if ($this->config->getSystemValue('dav.enable.async', false)) {
-			$cap['async'] = '1.0';
-		}
-
-		return $cap;
+	public function get() {
+		throw new Forbidden('Permission denied to read this file');
 	}
 }

--- a/apps/dav/lib/TrashBin/TrashBinFolder.php
+++ b/apps/dav/lib/TrashBin/TrashBinFolder.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\TrashBin;
+
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+
+class TrashBinFolder extends AbstractTrashBinNode implements ICollection {
+	public function getChild($name) {
+		return $this->trashBinManager->getChild($this->user, $name);
+	}
+
+	public function getChildren() {
+		return $this->trashBinManager->getChildren($this->user, $this->getName());
+	}
+
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Permission denied to create a file');
+	}
+
+	public function createDirectory($name) {
+		throw new Forbidden('Permission denied to create a folder');
+	}
+
+	public function childExists($name) {
+		try {
+			$ret = $this->getChild($name);
+			return $ret !== null;
+		} catch (NotFound $ex) {
+			return false;
+		} catch (MethodNotAllowed $ex) {
+			return false;
+		}
+	}
+}

--- a/apps/dav/lib/TrashBin/TrashBinHome.php
+++ b/apps/dav/lib/TrashBin/TrashBinHome.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\TrashBin;
+
+use Sabre\DAV\Collection;
+use Sabre\DAV\Exception\Forbidden;
+
+class TrashBinHome extends Collection {
+
+	/** @var TrashBinManager */
+	private $trashBinManager;
+	/** @var string */
+	private $user;
+
+	/**
+	 * TrashBinHome constructor.
+	 *
+	 * @param array $principalInfo
+	 * @param TrashBinManager $trashBinManager
+	 */
+	public function __construct(array $principalInfo, TrashBinManager $trashBinManager) {
+		$this->trashBinManager = $trashBinManager;
+		[, $name] = \Sabre\Uri\split($principalInfo['uri']);
+		$this->user = $name;
+	}
+
+	public function getChild($name) {
+		return $this->trashBinManager->getChild($this->user, $name);
+	}
+
+	public function getChildren() {
+		return $this->trashBinManager->getChildren($this->user);
+	}
+
+	public function delete() {
+		$this->trashBinManager->deleteAll();
+	}
+
+	public function getName() {
+		return $this->user;
+	}
+
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename this folder');
+	}
+
+	public function getLastModified() {
+		return null;
+	}
+}

--- a/apps/dav/lib/TrashBin/TrashBinManager.php
+++ b/apps/dav/lib/TrashBin/TrashBinManager.php
@@ -54,6 +54,9 @@ class TrashBinManager {
 				$path = $view->getPath($fileId);
 			}
 			$fileInfo = $view->getFileInfo($path);
+			if ($fileInfo === false) {
+				throw new NotFound();
+			}
 			if ($fileInfo->getMimetype() !== 'httpd/unix-directory') {
 				throw new InvalidResourceType();
 			}

--- a/apps/dav/lib/TrashBin/TrashBinManager.php
+++ b/apps/dav/lib/TrashBin/TrashBinManager.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\TrashBin;
+
+use OC\Files\FileInfo;
+use OC\Files\View;
+use OCA\Files_Trashbin\Trashbin;
+use OCP\Files\NotFoundException;
+use Sabre\DAV\Exception\InvalidResourceType;
+use Sabre\DAV\Exception\NotFound;
+
+/**
+ * Class TrashBinManager
+ *
+ * @package OCA\DAV\TrashBin
+ * @codeCoverageIgnore
+ */
+class TrashBinManager {
+	public function getChild(string $user, string $id) {
+		try {
+			$view = new View('/' . $user . '/files_trashbin/files');
+			$path = $view->getPath($id);
+			$fileInfo = $view->getFileInfo($path);
+			return $this->nodeFactory($user, $fileInfo);
+		} catch (NotFoundException $ex) {
+			throw new NotFound();
+		}
+	}
+
+	public function getChildren(string $user, string $fileId = null) {
+		try {
+			$view = new View('/' . $user . '/files_trashbin/files');
+			$path = '/';
+			if ($fileId) {
+				$path = $view->getPath($fileId);
+			}
+			$fileInfo = $view->getFileInfo($path);
+			if ($fileInfo->getMimetype() !== 'httpd/unix-directory') {
+				throw new InvalidResourceType();
+			}
+			$files = $view->getDirectoryContent($path);
+			return \array_map(function ($fileInfo) use ($user) {
+				return $this->nodeFactory($user, $fileInfo);
+			}, $files);
+		} catch (\Exception $exception) {
+			return [];
+		}
+	}
+
+	private function nodeFactory(string $user, FileInfo $fileInfo) {
+		if ($fileInfo->getMimetype() === 'httpd/unix-directory') {
+			return new TrashBinFolder($user, $fileInfo, $this);
+		}
+		return new TrashBinFile($user, $fileInfo, $this);
+	}
+
+	public function restore(string $user, AbstractTrashBinNode $trashItem, $targetLocation) {
+		$path = $trashItem->getPathInTrash();
+		$path = \implode('/', $path);
+		return Trashbin::restore($path,
+			$trashItem->getOriginalFileName(), $trashItem->getDeleteTimestamp(), $targetLocation);
+	}
+
+	public function deleteAll() {
+		return Trashbin::deleteAll();
+	}
+
+	public function getLocation(string $user, $filename, int $timestamp) {
+		return Trashbin::getLocation($user, $filename, $timestamp);
+	}
+}

--- a/apps/dav/lib/TrashBin/TrashBinPlugin.php
+++ b/apps/dav/lib/TrashBin/TrashBinPlugin.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\TrashBin;
+
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+
+class TrashBinPlugin extends ServerPlugin {
+	public const TRASHBIN_ORIGINAL_FILENAME = '{http://owncloud.org/ns}trashbin-original-filename';
+	public const TRASHBIN_ORIGINAL_LOCATION = '{http://owncloud.org/ns}trashbin-original-location';
+	public const TRASHBIN_DELETE_TIMESTAMP = '{http://owncloud.org/ns}trashbin-delete-timestamp';
+
+	/** @var Server */
+	private $server;
+
+	public function initialize(Server $server) {
+		$this->server = $server;
+
+		$this->server->on('propFind', [$this, 'propFind']);
+	}
+
+	public function propFind(PropFind $propFind, INode $node) {
+		if (!($node instanceof ITrashBinNode)) {
+			return;
+		}
+
+		$propFind->handle(self::TRASHBIN_ORIGINAL_FILENAME, static function () use ($node) {
+			return $node->getOriginalFileName();
+		});
+
+		$propFind->handle(self::TRASHBIN_ORIGINAL_LOCATION, static function () use ($node) {
+			return $node->getOriginalLocation();
+		});
+
+		$propFind->handle(self::TRASHBIN_DELETE_TIMESTAMP, static function () use ($node) {
+			return $node->getDeleteTimestamp();
+		});
+	}
+}

--- a/apps/dav/lib/TrashBin/TrashBinPlugin.php
+++ b/apps/dav/lib/TrashBin/TrashBinPlugin.php
@@ -25,11 +25,13 @@ use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
+use Sabre\DAV\Xml\Property\GetLastModified;
 
 class TrashBinPlugin extends ServerPlugin {
 	public const TRASHBIN_ORIGINAL_FILENAME = '{http://owncloud.org/ns}trashbin-original-filename';
 	public const TRASHBIN_ORIGINAL_LOCATION = '{http://owncloud.org/ns}trashbin-original-location';
 	public const TRASHBIN_DELETE_TIMESTAMP = '{http://owncloud.org/ns}trashbin-delete-timestamp';
+	public const TRASHBIN_DELETE_DATETIME = '{http://owncloud.org/ns}trashbin-delete-datetime';
 
 	/** @var Server */
 	private $server;
@@ -55,6 +57,10 @@ class TrashBinPlugin extends ServerPlugin {
 
 		$propFind->handle(self::TRASHBIN_DELETE_TIMESTAMP, static function () use ($node) {
 			return $node->getDeleteTimestamp();
+		});
+
+		$propFind->handle(self::TRASHBIN_DELETE_DATETIME, static function () use ($node) {
+			return new GetLastModified($node->getDeleteTimestamp());
 		});
 	}
 }

--- a/apps/dav/tests/unit/TrashBin/RootCollectionTest.php
+++ b/apps/dav/tests/unit/TrashBin/RootCollectionTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\TrashBin;
+
+use OCA\DAV\TrashBin\RootCollection;
+use OCA\DAV\TrashBin\TrashBinHome;
+use Sabre\DAVACL\PrincipalBackend\BackendInterface;
+use Test\TestCase;
+
+class RootCollectionTest extends TestCase {
+	public function testGetName() {
+		$backEnd = $this->createMock(BackendInterface::class);
+		$collection = new RootCollection($backEnd);
+		self::assertEquals('trash-bin', $collection->getName());
+	}
+
+	public function testGetChildForPrincipal() {
+		$backEnd = $this->createMock(BackendInterface::class);
+		$collection = new RootCollection($backEnd);
+		$child = $collection->getChildForPrincipal([
+			'uri' => 'principals/alice'
+		]);
+		self::assertInstanceOf(TrashBinHome::class, $child);
+	}
+}

--- a/apps/dav/tests/unit/TrashBin/TrashBinFileTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinFileTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\TrashBin;
+
+use OCA\DAV\TrashBin\TrashBinFile;
+use OCA\DAV\TrashBin\TrashBinManager;
+use OCP\Files\FileInfo;
+use Test\TestCase;
+
+class TrashBinFileTest extends TestCase {
+	/**
+	 * @var TrashBinFile
+	 */
+	private $trashBinFile;
+
+	protected function setUp() {
+		parent::setUp();
+		$fileInfo = $this->createMock(FileInfo::class);
+		$trashBinManager = $this->createMock(TrashBinManager::class);
+		$this->trashBinFile = new TrashBinFile('alice', $fileInfo, $trashBinManager);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to write this file
+	 */
+	public function testPut() {
+		$this->trashBinFile->put('');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to read this file
+	 */
+	public function testGet() {
+		$this->trashBinFile->get();
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to rename this resource
+	 */
+	public function testSetName() {
+		$this->trashBinFile->setName('');
+	}
+}

--- a/apps/dav/tests/unit/TrashBin/TrashBinFolderTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinFolderTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\TrashBin;
+
+use OCA\DAV\TrashBin\TrashBinFolder;
+use OCA\DAV\TrashBin\TrashBinManager;
+use OCP\Files\FileInfo;
+use Sabre\DAV\Exception\NotFound;
+use Test\TestCase;
+
+class TrashBinFolderTest extends TestCase {
+	/**
+	 * @var TrashBinFolder
+	 */
+	private $trashBinFolder;
+	/**
+	 * @var TrashBinManager | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $trashBinManager;
+	/**
+	 * @var FileInfo | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $fileInfo;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->fileInfo = $this->createMock(FileInfo::class);
+		$this->trashBinManager = $this->createMock(TrashBinManager::class);
+		$this->trashBinFolder = new TrashBinFolder('alice', $this->fileInfo, $this->trashBinManager);
+
+		$this->fileInfo->method('getId')->willReturn(666);
+		$this->fileInfo->method('getMimeType')->willReturn('foo');
+		$this->fileInfo->method('getEtag')->willReturn('abcdefgh');
+		$this->fileInfo->method('getMtime')->willReturn(789123456);
+		$this->fileInfo->method('getSize')->willReturn(12345678);
+		$this->fileInfo->method('getPath')->willReturn('/alice/files_trashbin/files/folder.d1561467869/foo');
+
+		$this->trashBinManager->method('getLocation')->willReturn('.');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to create a file
+	 */
+	public function testCreateFile() {
+		$this->trashBinFolder->createFile('');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to create a folder
+	 */
+	public function testCreateFolder() {
+		$this->trashBinFolder->createDirectory('');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to rename this resource
+	 */
+	public function testSetName() {
+		$this->trashBinFolder->setName('');
+	}
+
+	public function testGetChildren() {
+		$this->trashBinManager->method('getChildren')
+			->with('alice', '666')->willReturn([
+				'dummy string'
+			]);
+		$children = $this->trashBinFolder->getChildren();
+		self::assertEquals(['dummy string'], $children);
+	}
+
+	public function testGetChild() {
+		$this->trashBinManager->method('getChild')
+			->with('alice', '777')->willReturn('dummy string');
+		$child = $this->trashBinFolder->getChild(777);
+		self::assertEquals('dummy string', $child);
+	}
+
+	public function testChildExists() {
+		$this->trashBinManager->method('getChild')
+			->with('alice', '777')->willReturn('dummy string');
+		$exists = $this->trashBinFolder->childExists(777);
+		self::assertTrue($exists);
+	}
+
+	public function testChildDoesNotExists() {
+		$this->trashBinManager->method('getChild')
+			->with('alice', '777')->willThrowException(new NotFound());
+		$exists = $this->trashBinFolder->childExists(777);
+		self::assertFalse($exists);
+	}
+
+	/**
+	 * @dataProvider providesMethods
+	 */
+	public function testGetter($expectedValue, $method) {
+		self::assertEquals($expectedValue, $this->trashBinFolder->$method());
+	}
+
+	public function providesMethods() {
+		return [
+			['666', 'getName'],
+			['foo', 'getContentType'],
+			['abcdefgh', 'getEtag'],
+			[789123456, 'getLastModified'],
+			[12345678, 'getSize'],
+			['foo', 'getOriginalFileName'],
+			['folder/foo', 'getOriginalLocation'],
+			[1561467869, 'getDeleteTimestamp'],
+		];
+	}
+}

--- a/apps/dav/tests/unit/TrashBin/TrashBinHomeTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinHomeTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\TrashBin;
+
+use OCA\DAV\TrashBin\TrashBinHome;
+use OCA\DAV\TrashBin\TrashBinManager;
+use Sabre\DAV\Exception\NotFound;
+use Test\TestCase;
+
+class TrashBinHomeTest extends TestCase {
+	/**
+	 * @var TrashBinHome
+	 */
+	private $trashBinHome;
+	/**
+	 * @var TrashBinManager | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $trashBinManager;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->trashBinManager = $this->createMock(TrashBinManager::class);
+		$this->trashBinHome = new TrashBinHome([
+			'uri' => 'principals/alice'
+		], $this->trashBinManager);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to rename this folder
+	 */
+	public function testSetName() {
+		$this->trashBinHome->setName('');
+	}
+
+	public function testGetName() {
+		self::assertEquals('alice', $this->trashBinHome->getName());
+	}
+
+	public function testGetLastModified() {
+		self::assertNull($this->trashBinHome->getLastModified());
+	}
+
+	public function testGetChildren() {
+		$this->trashBinManager->method('getChildren')
+			->with('alice')->willReturn([
+				'dummy string'
+			]);
+		$children = $this->trashBinHome->getChildren();
+		self::assertEquals(['dummy string'], $children);
+	}
+
+	public function testGetChild() {
+		$this->trashBinManager->method('getChild')
+			->with('alice', '777')->willReturn('dummy string');
+		$child = $this->trashBinHome->getChild(777);
+		self::assertEquals('dummy string', $child);
+	}
+
+	public function testChildExists() {
+		$this->trashBinManager->method('getChild')
+			->with('alice', '777')->willReturn('dummy string');
+		$exists = $this->trashBinHome->childExists(777);
+		self::assertTrue($exists);
+	}
+
+	public function testChildDoesNotExists() {
+		$this->trashBinManager->method('getChild')
+			->with('alice', '777')->willThrowException(new NotFound());
+		$exists = $this->trashBinHome->childExists(777);
+		self::assertFalse($exists);
+	}
+
+	public function testDelete() {
+		$this->trashBinManager
+			->expects($this->once())
+			->method('deleteAll')
+			->willReturn(true);
+		$this->trashBinHome->delete();
+	}
+}

--- a/apps/dav/tests/unit/TrashBin/TrashBinPluginTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinPluginTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\TrashBin;
+
+use OCA\DAV\TrashBin\ITrashBinNode;
+use OCA\DAV\TrashBin\RootCollection;
+use OCA\DAV\TrashBin\TrashBinHome;
+use OCA\DAV\TrashBin\TrashBinPlugin;
+use phpDocumentor\Reflection\Types\This;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Sabre\DAVACL\PrincipalBackend\BackendInterface;
+use Test\TestCase;
+
+class TrashBinPluginTest extends TestCase {
+	public function testInit() {
+		$server = $this->createMock(Server::class);
+		$server->expects($this->once())->method('on')->with('propFind');
+
+		$plugin = new TrashBinPlugin();
+		$plugin->initialize($server);
+	}
+
+	/**
+	 * @dataProvider providesMethods
+	 */
+	public function testPropFind($expectedMethod, $expectedMethodReturn, $prop) {
+		$node = $this->createMock(ITrashBinNode::class);
+		$node->expects(self::once())->method($expectedMethod)->willReturn($expectedMethodReturn);
+		$propFind = new PropFind('', [$prop]);
+		$plugin = new TrashBinPlugin();
+		$plugin->propFind($propFind, $node);
+
+		self::assertEquals($expectedMethodReturn, $propFind->get($prop));
+	}
+
+	public function providesMethods() {
+		return [
+			['getOriginalFileName', 'bar.txt', TrashBinPlugin::TRASHBIN_ORIGINAL_FILENAME],
+			['getOriginalLocation', 'foo/bar.txt', TrashBinPlugin::TRASHBIN_ORIGINAL_LOCATION],
+			['getDeleteTimestamp', 123456, TrashBinPlugin::TRASHBIN_DELETE_TIMESTAMP]
+		];
+	}
+}

--- a/apps/dav/tests/unit/TrashBin/TrashBinPluginTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinPluginTest.php
@@ -28,6 +28,7 @@ use OCA\DAV\TrashBin\TrashBinPlugin;
 use phpDocumentor\Reflection\Types\This;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
+use Sabre\DAV\Xml\Property\GetLastModified;
 use Sabre\DAVACL\PrincipalBackend\BackendInterface;
 use Test\TestCase;
 
@@ -43,9 +44,12 @@ class TrashBinPluginTest extends TestCase {
 	/**
 	 * @dataProvider providesMethods
 	 */
-	public function testPropFind($expectedMethod, $expectedMethodReturn, $prop) {
+	public function testPropFind($expectedMethod, $expectedMethodReturn, $prop, $methodReturnValue = null) {
+		if ($methodReturnValue === null) {
+			$methodReturnValue = $expectedMethodReturn;
+		}
 		$node = $this->createMock(ITrashBinNode::class);
-		$node->expects(self::once())->method($expectedMethod)->willReturn($expectedMethodReturn);
+		$node->expects(self::once())->method($expectedMethod)->willReturn($methodReturnValue);
 		$propFind = new PropFind('', [$prop]);
 		$plugin = new TrashBinPlugin();
 		$plugin->propFind($propFind, $node);
@@ -57,7 +61,8 @@ class TrashBinPluginTest extends TestCase {
 		return [
 			['getOriginalFileName', 'bar.txt', TrashBinPlugin::TRASHBIN_ORIGINAL_FILENAME],
 			['getOriginalLocation', 'foo/bar.txt', TrashBinPlugin::TRASHBIN_ORIGINAL_LOCATION],
-			['getDeleteTimestamp', 123456, TrashBinPlugin::TRASHBIN_DELETE_TIMESTAMP]
+			['getDeleteTimestamp', 123456, TrashBinPlugin::TRASHBIN_DELETE_TIMESTAMP],
+			['getDeleteTimestamp', new GetLastModified(123456), TrashBinPlugin::TRASHBIN_DELETE_DATETIME, 123456]
 		];
 	}
 }

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -130,11 +130,11 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has copied file "/textfile0.txt" to "/folderC/textfile0.txt"
     And user "user0" has copied file "/textfile0.txt" to "/folderD/textfile0.txt"
     When user "user0" deletes these files without delays using the WebDAV API
+      | /textfile0.txt         |
       | /folderA/textfile0.txt |
       | /folderB/textfile0.txt |
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
-      | /textfile0.txt         |
     # When issue-23151 is fixed, uncomment these lines. They should pass reliably.
     #Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
     #And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -19,7 +19,6 @@ Feature: Restore deleted files/folders
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved file "/shared" to "/renamed_shared"
     And user "user1" has deleted file "/renamed_shared/shared_file.txt"
-    And user "user1" has logged in to a web-style session
     When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
     Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
     And user "user1" should see the following elements
@@ -36,7 +35,6 @@ Feature: Restore deleted files/folders
     And user "user0" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     And as "user0" file "/textfile0.txt" should exist in trash
-    And user "user0" has logged in to a web-style session
     When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
     Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
     And user "user0" should see the following elements
@@ -59,26 +57,9 @@ Feature: Restore deleted files/folders
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
-    And user "user0" has logged in to a web-style session
     When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
     And as "user0" file "/new-folder/new-file.txt" should exist
-    Examples:
-      | dav-path |
-      | old      |
-      | new      |
-
-  Scenario Outline: A file deleted from a folder is restored to root if the original folder does not exist
-    Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has created folder "/new-folder"
-    And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-    And user "user0" has deleted file "/new-folder/new-file.txt"
-    And user "user0" has deleted folder "/new-folder"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
-    And as "user0" file "/new-file.txt" should exist
     Examples:
       | dav-path |
       | old      |
@@ -91,7 +72,6 @@ Feature: Restore deleted files/folders
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
     And user "user0" has deleted folder "/new-folder"
-    And user "user0" has logged in to a web-style session
     When user "user0" restores the folder with original path "/new-folder" using the trashbin API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
@@ -108,7 +88,6 @@ Feature: Restore deleted files/folders
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
     And user "user0" has deleted folder "/new-folder"
-    And user "user0" has logged in to a web-style session
     When user "user0" creates folder "/new-folder" using the WebDAV API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
@@ -129,7 +108,6 @@ Feature: Restore deleted files/folders
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-    And user "user0" has logged in to a web-style session
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And user "user0" should see the following elements
@@ -153,7 +131,6 @@ Feature: Restore deleted files/folders
     And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-    And user "user0" has logged in to a web-style session
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
@@ -171,8 +148,6 @@ Feature: Restore deleted files/folders
       | 1 | AA |
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-    And user "user0" has logged in to a web-style session
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
-    


### PR DESCRIPTION
## Description
We want a WebDAV API as discussed in #15646 

This is how it looks like:
- remote.php/dav/trash-bin is the root folder for all trashbins - each user will find their own trahsbin inside
- remote.php/dav/trash-bin/$user is the users root for trashbins - it holds all trahsed items of the user listed by file id
- to restore a trash item use a MOVE operation. In the final implementation the destination can be anything and anywhere: MOVE remote.php/dav/trash-bin/$user/$fileId remote.php/dav/$user/path/to/restore.txt
- to permanently delete an item from the trashbin perform a DELETE remote.php/dav/trash-bin/$user/$fileId
- to delete all items from the trashbin perform a DELETE remote.php/dav/trash-bin/$user/

## Example Requests
### Listing trash items
```sh
$ curl 'http://localhost:8080/remote.php/dav/trash-bin/admin//' -X PROPFIND -H 'authorization: Basic ......' -H 'OCS-APIREQUEST: true' -H 'Content-Type: application/xml; charset=UTF-8' -H 'Depth: 1' --data-binary $'<?xml version="1.0"?>\n<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n  <d:prop>\n    <oc:trashbin-original-filename />\n    <oc:trashbin-original-location />\n    <oc:trashbin-delete-timestamp />\n    <d:getcontentlength />\n    <d:resourcetype />\n  </d:prop>\n</d:propfind>' --compressed | xmllint --format -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1817    0  1533  100   284   8612   1595 --:--:-- --:--:-- --:--:-- 10265
```
```xml
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/remote.php/dav/trash-bin/admin/</d:href>
    <d:propstat>
      <d:prop>
        <d:resourcetype>
          <d:collection/>
        </d:resourcetype>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:trashbin-original-filename/>
        <oc:trashbin-original-location/>
        <oc:trashbin-delete-timestamp/>
        <d:getcontentlength/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/remote.php/dav/trash-bin/admin/2147488234</d:href>
    <d:propstat>
      <d:prop>
        <oc:trashbin-original-filename>Neue Textdatei.txt</oc:trashbin-original-filename>
        <oc:trashbin-original-location>./Neue Textdatei.txt</oc:trashbin-original-location>
        <oc:trashbin-delete-timestamp>1561454917</oc:trashbin-delete-timestamp>
        <d:getcontentlength>17</d:getcontentlength>
        <d:resourcetype/>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/remote.php/dav/trash-bin/admin/2147488238/</d:href>
    <d:propstat>
      <d:prop>
        <oc:trashbin-original-filename>Neuer Ordner</oc:trashbin-original-filename>
        <oc:trashbin-original-location>./Neuer Ordner</oc:trashbin-original-location>
        <oc:trashbin-delete-timestamp>1561454917</oc:trashbin-delete-timestamp>
        <d:resourcetype>
          <d:collection/>
        </d:resourcetype>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <d:getcontentlength/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```

### Restoring a file
```sh
$ curl 'http://localhost:8080/remote.php/dav/trash-bin/admin/2147488234' -X MOVE -H 'authorization: Basic YWRtaW46YWRtaW4=' -H 'OCS-APIREQUEST: true' -H 'Overwrite: F' -H 'Destination: http://localhost:8080/remote.php/dav/files/admin/test.txt' -H 'X-Request-ID: fcff1fa3-60d3-4b6b-b7bd-06598aeb8b1c' -v 
* Expire in 0 ms for 6 (transfer 0x55816f5d8dd0)
* Expire in 1 ms for 1 (transfer 0x55816f5d8dd0)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Expire in 1 ms for 1 (transfer 0x55816f5d8dd0)
* Expire in 1 ms for 1 (transfer 0x55816f5d8dd0)
*   Trying ::1...
* TCP_NODELAY set
* Expire in 149998 ms for 3 (transfer 0x55816f5d8dd0)
* Expire in 200 ms for 4 (transfer 0x55816f5d8dd0)
* Connected to localhost (::1) port 8080 (#0)
> MOVE /remote.php/dav/trash-bin/admin/2147488234 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.64.0
> Accept: */*
> authorization: Basic ......
> OCS-APIREQUEST: true
> Overwrite: F
> Destination: http://localhost:8080/remote.php/dav/files/admin/test.txt
> X-Request-ID: fcff1fa3-60d3-4b6b-b7bd-06598aeb8b1c
> 
  0     0    0     0    0     0      0      0 --:--:--  0:00:42 --:--:--     0< HTTP/1.1 201 Created
< Host: localhost:8080
< Date: Tue, 25 Jun 2019 09:39:11 GMT
< Connection: close
< X-Powered-By: PHP/7.2.19-1+0~20190531112545.22+buster~1.gbp75765b
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate
< Pragma: no-cache
< Set-Cookie: oc_sessionPassphrase=xxxx
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Robots-Tag: none
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Content-Security-Policy: default-src 'none';
< Set-Cookie: xxxx
< Set-Cookie: xxxx
< OC-ETag: "11713caa12b7f721046b55a9d707f86c"
< ETag: "11713caa12b7f721046b55a9d707f86c"
< OC-FileId: 2147488234ocrhbj031xi4
< Content-Length: 0
< Content-type: text/html; charset=UTF-8
< 
  0     0    0     0    0     0      0      0 --:--:--  0:00:42 --:--:--     0
* Closing connection 0
```

## Related Issue
- refs #15646 

## How Has This Been Tested?
- :hand: 
- tests will follow

## Screenshots (if appropriate):
![Screenshot from 2019-06-21 13-25-17](https://user-images.githubusercontent.com/1005065/59919660-50fef680-9428-11e9-9829-2628f54ee414.png)
![Screenshot from 2019-06-21 13-25-28](https://user-images.githubusercontent.com/1005065/59919659-50fef680-9428-11e9-8d20-d566461b5b37.png)
![Screenshot from 2019-06-21 13-25-48](https://user-images.githubusercontent.com/1005065/59919657-50666000-9428-11e9-97b0-bf9723859c78.png)
![Screenshot from 2019-06-21 13-26-48](https://user-images.githubusercontent.com/1005065/59919656-50666000-9428-11e9-9327-b66e83c32b50.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
