### PR TITLE
Use storages to copy the skeleton files

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -444,7 +444,7 @@ class Session implements IUserSession, Emitter {
 
 			try {
 				// copy skeleton
-				\OC_Util::copySkeleton($user, $userFolder);
+				\OC_Util::copySkeletonUsingStorage($userFolder);
 			} catch (NotPermittedException $ex) {
 				// possible if files directory is in an readonly jail
 				$this->logger->warning(

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -436,6 +436,7 @@ class UtilTest extends \Test\TestCase {
 
 		\OC_Util::$scripts = [];
 		\OC_Util::$styles = [];
+		\OC::$server->getConfig()->deleteSystemValue('skeletondirectory');
 	}
 
 	public function testAddScript() {


### PR DESCRIPTION
Introduce a way to copy the skeleton files.
Here we copy the files using the storage,
instead of old way as in the util file.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Lets say when user created a rule in the firewall: user who belongs to a group & user device is a browser, then first time login users are affected. They are not allowed to login. If the user is already logged in, then they cannot create new files/folders nor read files or download is allowed.

This change would allow the user to login who are logging in for the first time. A small change has been made to the way skeletons are copied to the user folder. This helps to resolve the inconsistency of some users are able to login and some not because of firewall rule mentioned above.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the user is prohibitted to login by a firewall rule, then login should not be blocked, even if its a first time login ( because that's when the skeleton files are copied and necessary folder are created ).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a user, `user1` and assign to a group, `group1`
- Create a User Group rule with group name `group1`
- Create a User Device with `Others (Browsers etc )`
- Now try to login as `user`.
- The user can see the skeleton file after login. But user cannot modify or create new files, because of the rule, which is ok.
- Tested this with encryption (masterkey and user-keys encryption), files_primary_s3 app, as this change modifies the way skeleton is copied.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Requires https://github.com/owncloud/firewall/pull/580

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
