### PR TITLE
Do not run testing app unit tests in core unit tests

### DIFF
--- a/tests/apps.php
+++ b/tests/apps.php
@@ -45,6 +45,12 @@ foreach ($apps as $app) {
 	if ($app === 'files_external') {
 		continue;
 	}
+	// skip the testing app, it may have been installed to the apps folder
+	// e.g. in a CI environment, but it is a separate app that runs its own
+	// unit tests.
+	if ($app === 'testing') {
+		continue;
+	}
 	$dir = OC_App::getAppPath($app);
 	if (\is_dir($dir . '/tests')) {
 		loadDirectory($dir . '/tests');

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -33,6 +33,7 @@
 				<directory suffix=".php">../apps/files_trashbin/tests</directory>
 				<directory suffix=".php">../apps/files_versions/tests</directory>
 				<directory suffix=".php">../apps/provisioning_api/tests</directory>
+				<directory suffix=".php">../apps/testing/tests</directory>
 				<directory suffix=".php">../apps/updatenotification/tests</directory>
 				<directory suffix=".php">../tests</directory>
 				<directory suffix=".php">../build</directory>


### PR DESCRIPTION
## Description

## Related Issue

## Motivation and Context
While looking into #34375 and rebasing PR #34961 (which has future PHPunit changes) I noticed that the testing app unit tests were being run in core CI. That is because the testing app is getting installed into the `apps` folder, and the PHP unit test script scans the whole `apps` folder looking for tests to run.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
