### PR TITLE
Clone testing app into apps-external

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -165,7 +165,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
-      - git clone https://github.com/owncloud/testing.git $$DRONE_WORKSPACE/apps/testing
+      - git clone https://github.com/owncloud/testing.git $$DRONE_WORKSPACE/apps-external/testing
       - php occ a:l
       - php occ a:e testing
       - php occ a:l

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -33,13 +33,13 @@ class MigrationsTest extends \Test\TestCase {
 
 		$this->db = $this->createMock(Connection::class);
 		$this->db->expects($this->any())->method('getPrefix')->willReturn('test_oc_');
-		$this->migrationService = new MigrationService('testing', $this->db);
+		$this->migrationService = new MigrationService('files_sharing', $this->db);
 	}
 
 	public function testGetters() {
-		$this->assertEquals('testing', $this->migrationService->getApp());
-		$this->assertEquals(\OC::$SERVERROOT . '/apps/testing/appinfo/Migrations', $this->migrationService->getMigrationsDirectory());
-		$this->assertEquals('OCA\testing\Migrations', $this->migrationService->getMigrationsNamespace());
+		$this->assertEquals('files_sharing', $this->migrationService->getApp());
+		$this->assertEquals(\OC::$SERVERROOT . '/apps/files_sharing/appinfo/Migrations', $this->migrationService->getMigrationsDirectory());
+		$this->assertEquals('OCA\files_sharing\Migrations', $this->migrationService->getMigrationsNamespace());
 		$this->assertEquals('test_oc_migrations', $this->migrationService->getMigrationsTableName());
 	}
 
@@ -75,7 +75,7 @@ class MigrationsTest extends \Test\TestCase {
 	public function testExecuteStepWithUnknownClass() {
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['findMigrations'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('findMigrations')->willReturn(
 			['20170130180000' => 'X', '20170130180001' => 'Y', '20170130180002' => 'Z', '20170130180003' => 'A']
@@ -91,7 +91,7 @@ class MigrationsTest extends \Test\TestCase {
 		$step->expects($this->once())->method('changeSchema');
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['createInstance'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('createInstance')->with('20170130180000')->willReturn($step);
 		$this->migrationService->executeStep('20170130180000');
@@ -104,7 +104,7 @@ class MigrationsTest extends \Test\TestCase {
 		$step->expects($this->once())->method('sql')->willReturn(['1', '2', '3']);
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['createInstance'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('createInstance')->with('20170130180000')->willReturn($step);
 		$this->migrationService->executeStep('20170130180000');
@@ -113,7 +113,7 @@ class MigrationsTest extends \Test\TestCase {
 	public function testGetMigration() {
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['getMigratedVersions', 'findMigrations'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('getMigratedVersions')->willReturn(
 			['20170130180000', '20170130180001']
@@ -139,7 +139,7 @@ class MigrationsTest extends \Test\TestCase {
 	public function testMigrate() {
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['getMigratedVersions', 'findMigrations', 'executeStep'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('getMigratedVersions')->willReturn(
 			['20170130180000', '20170130180001']


### PR DESCRIPTION
## Description
Clone the `testing` app into the `apps-external` folder, which is where not-built-in apps should get installed anyway.

Adjust `tests/lib/DB/MigrationsTest.php` so that it does not use the `testing` app as an example app for its tests. Use another one of the built-in apps - I picked `files_sharing`.

## Motivation and Context
The `testing` app was put into a separate repo a few months ago.
At the moment we are cloning it into the `apps` folder of core when running drone CI.
The PHP unit tests scan all code in the `apps` folder looking for PHP unit tests to run - see https://github.com/owncloud/core/blob/master/tests/apps.php `loadDirectory()`
That finds the `apps/testing` folder. So the unit tests in the testing app get run.

When doing core PRs that make non-compatible PHP unit test changes (e.g. bumping to a new major version of PHP unit, and implementing new features of PHP unit etc.), then the `testing` app unit tests sometimes fail, because they are from the separate `testing` app that has not had its unit test code updated yet.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
