### PR TITLE
Check CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ https://owncloud.org/contribute/
 ## Support
 Learn about the different ways you can get support for ownCloud: https://owncloud.org/support/
 
+Check CI
+
 ## Get in touch
 * :clipboard: [Forum](https://central.owncloud.org)
 * :envelope: [Mailing list](https://mailman.owncloud.org/mailman/listinfo)

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -155,6 +155,7 @@ class CleanupRemoteStorages extends Command {
 			$remoteStorages[$row['id']] = $row['numeric_id'];
 		}
 
+		\var_dump($remoteStorages);
 		return $remoteStorages;
 	}
 
@@ -170,6 +171,7 @@ class CleanupRemoteStorages extends Command {
 			$remoteShareIds[$row['id']] = 'shared::' . \md5($row['share_token'] . '@' . $row['remote']);
 		}
 
+		\var_dump($remoteShareIds);
 		return $remoteShareIds;
 	}
 }

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -166,12 +166,15 @@ class CleanupRemoteStorages extends Command {
 		$query = $queryBuilder->execute();
 
 		$remoteShareIds = [];
+		$remoteShareData = [];
 
 		while ($row = $query->fetch()) {
 			$remoteShareIds[$row['id']] = 'shared::' . \md5($row['share_token'] . '@' . $row['remote']);
+			$remoteShareData[$row['id']] = 'shared::' . $row['share_token'] . '@' . $row['remote'];
 		}
 
 		\var_dump($remoteShareIds);
+		\var_dump($remoteShareData);
 		return $remoteShareIds;
 	}
 }

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -94,7 +94,7 @@ class ManagerTest extends TestCase {
 	public function testAddShare() {
 		$shareData1 = [
 			'remote' => 'http://localhost',
-			'token' => 'token1',
+			'token' => 'token5',
 			'password' => '',
 			'name' => '/SharedFolder',
 			'owner' => 'foobar',
@@ -223,7 +223,7 @@ class ManagerTest extends TestCase {
 	public function testAddShareAccepted() {
 		$shareData1 = [
 			'remote' => 'http://localhost',
-			'token' => 'token1',
+			'token' => 'token6',
 			'password' => '',
 			'name' => '/SharedFolder',
 			'owner' => 'foobar',

--- a/lib/private/Shutdown/ShutDownManager.php
+++ b/lib/private/Shutdown/ShutDownManager.php
@@ -55,6 +55,8 @@ class ShutDownManager implements IShutdownManager {
 	}
 
 	public function run(): void {
+		$callbacksCount = \count($this->callbacks);
+		\var_dump($callbacksCount);
 		\ksort($this->callbacks);
 		foreach ($this->callbacks as $callbacks) {
 			foreach ($callbacks as $callback) {

--- a/tests/apps.php
+++ b/tests/apps.php
@@ -13,15 +13,14 @@ function loadDirectory($path) {
 	if (\strcasecmp(\basename($path), 'ui') === 0) {
 		return;
 	}
-	if ($dh = \opendir($path)) {
-		while ($name = \readdir($dh)) {
-			if ($name[0] !== '.') {
-				$file = $path . '/' . $name;
-				if (\is_dir($file)) {
-					loadDirectory($file);
-				} elseif (\substr($name, -4, 4) === '.php') {
-					require_once $file;
-				}
+	$dirEntries = \scandir($path);
+	foreach ($dirEntries as $name) {
+		if ($name[0] !== '.') {
+			$file = $path . '/' . $name;
+			if (\is_dir($file)) {
+				loadDirectory($file);
+			} elseif (\substr($name, -4, 4) === '.php') {
+				require_once $file;
 			}
 		}
 	}


### PR DESCRIPTION
Issue #35658 

I am seeing quite a few PHPunit fails like https://drone.owncloud.com/owncloud/core/18794/146
```
There was 1 failure:

1) OCA\Files_Sharing\Tests\Command\CleanupRemoteStoragesTest::testCleanup
Expectation failed for method name is equal to 'writeln' when invoked at sequence index 1
Parameter 0 for invocation Symfony\Component\Console\Output\OutputInterface::writeln('6 remote share(s) exist', 0) does not match expected value.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'5 remote share(s) exist'
+'6 remote share(s) exist'

/drone/src/apps/files_sharing/lib/Command/CleanupRemoteStorages.php:67
/drone/src/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php:183
```

And they have happened with different databases, CI against both `master` and `stable10` and for different "random" PRs. So it makes me suspicious that this test has some timing/environment problem.

I can run the unit test locally over-and-over with no problem:
```
/home/phil/git/owncloud/core/lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php 
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.19-1+ubuntu18.04.1+deb.sury.org+1 with Xdebug 2.7.1
Configuration: /home/phil/git/owncloud/core/tests/phpunit-autotest.xml

.                                                                   1 / 1 (100%)

Time: 101 ms, Memory: 16.00MB

OK (1 test, 6 assertions)
```