### PR TITLE
Make consistent file-folder-entry test steps

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -329,8 +329,8 @@ Feature: sharing
     And user "user1" has been created with default attributes and skeleton files
     And group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    When user "user0" shares file "/PARENT" with user "user1" using the sharing API
-    And user "user0" shares file "/PARENT/CHILD" with group "grp4" using the sharing API
+    When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+    And user "user0" shares folder "/PARENT/CHILD" with group "grp4" using the sharing API
     Then user "user1" should see the following elements
       | /FOLDER/                 |
       | /PARENT/                 |
@@ -410,8 +410,8 @@ Feature: sharing
       | user2    |
     And user "user0" has created folder "/foo"
     And user "user1" has created folder "/foo"
-    When user "user0" shares file "/foo" with user "user2" using the sharing API
-    And user "user1" shares file "/foo" with user "user2" using the sharing API
+    When user "user0" shares folder "/foo" with user "user2" using the sharing API
+    And user "user1" shares folder "/foo" with user "user2" using the sharing API
     Then user "user2" should see the following elements
       | /foo/       |
       | /foo%20(2)/ |
@@ -437,8 +437,8 @@ Feature: sharing
     And group "grp1" has been created
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/sub"
-    And user "user0" has shared file "/test" with group "grp1"
-    When user "user0" shares file "/test/sub" with user "user1" using the sharing API
+    And user "user0" has shared folder "/test" with group "grp1"
+    When user "user0" shares folder "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user1" folder "/sub" should exist
@@ -454,8 +454,8 @@ Feature: sharing
     And user "user0" has been added to group "grp1"
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/sub"
-    And user "user0" has shared file "/test" with group "grp1"
-    When user "user0" shares file "/test/sub" with user "user1" using the sharing API
+    And user "user0" has shared folder "/test" with group "grp1"
+    When user "user0" shares folder "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user1" folder "/sub" should exist
@@ -473,22 +473,22 @@ Feature: sharing
       | user3    |
       | user4    |
     And user "user0" has created folder "/folder1"
-    And user "user0" has shared file "/folder1" with user "user1"
-    And user "user0" has shared file "/folder1" with user "user2"
+    And user "user0" has shared folder "/folder1" with user "user1"
+    And user "user0" has shared folder "/folder1" with user "user2"
     And user "user0" has created folder "/folder1/folder2"
-    And user "user0" has shared file "/folder1/folder2" with user "user3"
-    And user "user0" has shared file "/folder1/folder2" with user "user4"
+    And user "user0" has shared folder "/folder1/folder2" with user "user3"
+    And user "user0" has shared folder "/folder1/folder2" with user "user4"
     And as user "user0"
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the response should contain 4 entries
-    And file "/folder1" should be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     And the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
     And the response should contain 2 entries
-    And file "/folder1" should not be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should not be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -572,7 +572,7 @@ Feature: sharing
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
     And user "user0" has created folder "folderToShare"
-    When user "user0" shares file "folderToShare" with group "anotherGroup" using the sharing API
+    When user "user0" shares folder "folderToShare" with group "anotherGroup" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" file "folderToShare" should not exist

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -62,24 +62,24 @@ Feature: sharing
       | user3    |
       | user4    |
     And user "user0" has created folder "/folder1"
-    And user "user0" has shared file "/folder1" with user "user1"
-    And user "user0" has shared file "/folder1" with user "user2"
+    And user "user0" has shared folder "/folder1" with user "user1"
+    And user "user0" has shared folder "/folder1" with user "user2"
     And user "user0" has created folder "/folder1/folder2"
-    And user "user0" has shared file "/folder1/folder2" with user "user3"
-    And user "user0" has shared file "/folder1/folder2" with user "user4"
+    And user "user0" has shared folder "/folder1/folder2" with user "user3"
+    And user "user0" has shared folder "/folder1/folder2" with user "user4"
     And as user "user0"
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the response should contain 4 entries
-    And file "/folder1" should be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the response should contain 2 entries
-    And file "/folder1" should not be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should not be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -730,7 +730,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should be included in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $filename
 	 *
@@ -745,7 +745,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should not be included in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $filename
 	 *
@@ -760,7 +760,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should be included as path in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should be included as path in the response$/
 	 *
 	 * @param string $filename
 	 *
@@ -775,7 +775,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should not be included as path in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should not be included as path in the response$/
 	 *
 	 * @param string $filename
 	 *

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -858,7 +858,7 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should have the following tags for the (administrator|user)$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should have the following tags for the (administrator|user)$/
 	 *
 	 * @param string $fileName
 	 * @param string $adminOrUser
@@ -913,8 +913,9 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Then file :fileName should have no tags for user :user
-	 * @Then /^file "([^"]*)" should have no tags for the (administrator|user)?$/
+	 * @Then file/folder :fileName should have no tags for user :user
+	 * @Then entry :fileName should have no tags for user :user
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should have no tags for the (administrator|user)?$/
 	 *
 	 * @param string $fileName
 	 * @param string $adminOrUser


### PR DESCRIPTION
## Description
Make all acceptance test steps that talk about `file "some-file-or-folder"` be able to also say `folder "some-file-or-folder"` where the step can just-as-well work with a folder.

Adjust existing test scenarios in feature files so that they say `folder` when the item-in-question is a folder.

I noticed this while making new sharing API acceptance tests. But it will be easier to do the refactoring in this separate PR, then make use of it anywhere.

## Motivation and Context
Some acceptance test steps have been written like:
```
When user "user0" shares file "/test/sub" with user "user1" using the sharing API
```
and actually it is a folder that is being shared.

It works fine, but makes people reading it wonder if something is wrong.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
