### PR TITLE
[stable10] Fix drone webUIMasterKeyType so it runs the tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1172,18 +1172,6 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: chrome
-      BEHAT_SUITE: webUIUserKeysType
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: https
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: chrome
       BEHAT_SUITE: webUIFavorites
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1583,7 +1571,7 @@ matrix:
       OWNCLOUD_LOG: true
       CALDAV_CARDDAV_JOB: true
 
-    # encryption tests
+    # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.0
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
@@ -1597,6 +1585,7 @@ matrix:
       ENCRYPTION_TYPE: masterkey
       INSTALL_TESTING_APP: true
 
+    # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.1
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
@@ -1610,9 +1599,23 @@ matrix:
       ENCRYPTION_TYPE: masterkey
       INSTALL_TESTING_APP: true
 
-    ## encryption WebUI acceptance tests master-keys encryption
+    # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.1
-      TEST_SUITE: webui
+      TEST_SUITE: selenium
+      BROWSER: chrome
+      BEHAT_SUITE: webUIUserKeysType
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      SERVER_PROTOCOL: https
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    # This suite is part of the encryption app in later core versions
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIMasterKeyType
       DB_TYPE: mariadb
       USE_SERVER: true


### PR DESCRIPTION
## Description
I noticed that the last job in drone, `webUIMasterKeyType`, ran and exited with success but never actually executed the expected acceptance tests

Somewhere in backports or... the line:
```
      TEST_SUITE: webui
```
is now:
```
      TEST_SUITE: selenium
```
and that did not get updated for the sstable10-only `webUIMasterKeyType` encryption suite.

1) fixup the drone job parameters for `webUIMasterKeyType`
2) move the other encryption suite `webUIUserKeysType` down the end also, so they are close together (easier to find)
3) comment all the encryption suites with "This suite is part of the encryption app in later core versions" (consistent with the way it has been done for the `user_management` app)

Note: this is `stable10` only. `encryption` is in a separate repo for core `master`. So no forward-back-port needed.

## Motivation and Context
Actually run tests in CI ;)

## How Has This Been Tested?
Observe the run of CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
