### PR TITLE
Read pre-filled app-directories from config.php on install

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -34,7 +34,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 class Install extends Command {
-
 	/**
 	 * @var IConfig
 	 */
@@ -81,6 +80,22 @@ class Install extends Command {
 
 		// validate user input
 		$options = $this->validateInput($input, $output, \array_keys($sysInfo['databases']));
+		$appsRoots = $this->config->getSystemValue(
+			'apps_paths',
+			[
+				0 => [
+					'path' => \OC::$SERVERROOT.'/apps',
+					'url' => '/apps',
+					'writable' => false,
+				],
+				1 => [
+					'path' => \OC::$SERVERROOT.'/apps-external',
+					'url' => '/apps-external',
+					'writable' => true,
+				]
+			]
+		);
+		$options['apps_paths'] = $appsRoots;
 
 		// perform installation
 		$errors = $setupHelper->install($options);

--- a/lib/base.php
+++ b/lib/base.php
@@ -847,7 +847,11 @@ class OC {
 				\OC::$server->getL10N('lib'), new \OC_Defaults(), \OC::$server->getLogger(),
 				\OC::$server->getSecureRandom());
 
-			$controller = new OC\Core\Controller\SetupController($setupHelper);
+			$controller = new OC\Core\Controller\SetupController(
+				$setupHelper,
+				\OC::$server->getConfig(),
+				\OC::$server->getLogger()
+			);
 			$controller->run($_POST);
 			exit();
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -213,6 +213,12 @@ class OC {
 		}
 		$paths = [];
 		foreach (OC::$APPSROOTS as $path) {
+			// if not installed - allow precreating of custom app directories later
+			if (self::$config->getValue('installed', false) === false
+				&& $path['path'] !==  OC::$SERVERROOT . '/apps'
+			) {
+				continue;
+			}
 			$paths[] = $path['path'];
 			if (!\is_dir($path['path'])) {
 				throw new \RuntimeException(\sprintf('App directory "%s" not found! Please put the ownCloud apps folder in the'

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -287,18 +287,19 @@ class Setup {
 		}
 
 		// create the apps-external directory only during installation
-		$appsExternalDir = \OC::$SERVERROOT.'/apps-external';
-		if (!\file_exists($appsExternalDir)) {
-			@\mkdir($appsExternalDir);
-		}
-
-		// validate the apps-external directory
-		if (
-			(!\is_dir($appsExternalDir) and !\mkdir($appsExternalDir)) or
-			!\is_writable($appsExternalDir)
-		) {
-			$htmlAppsExternalDir = \htmlspecialchars_decode($appsExternalDir);
-			$error[] = $l->t("Can't create or write into the apps-external directory %s", $htmlAppsExternalDir);
+		$appsRoots = $options['apps_paths'];
+		foreach ($appsRoots as $appsRoot) {
+			$appDir = $appsRoot['path'];
+			if (\basename($appDir) === 'apps') {
+				continue;
+			}
+			if (
+				(!\is_dir($appDir) && !\mkdir($appDir))
+				|| !\is_writable($appDir)
+			) {
+				$htmlAppsExternalDir = \htmlspecialchars_decode($appDir);
+				$error[] = $l->t("Can't create or write into the custom apps directory %s", $htmlAppsExternalDir);
+			}
 		}
 
 		if (\count($error) != 0) {

--- a/tests/Core/Controller/SetupControllerTest.php
+++ b/tests/Core/Controller/SetupControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Controller;
+
+use OC\Core\Controller\SetupController;
+use OC\Setup;
+use OCP\IConfig;
+use OCP\ILogger;
+
+/**
+ * Class SetupControllerTest
+ *
+ * @package Tests\Core\Controller
+ */
+class SetupControllerTest extends \PHPUnit\Framework\TestCase {
+	/** @var Setup | \PHPUnit\Framework\MockObject\MockObject */
+	private $setupHelper;
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
+	private $config;
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
+	private $logger;
+
+	/** @var SetupController */
+	private $setupController;
+
+	public function setUp() {
+		parent::setUp();
+		$this->setupHelper = $this->createMock(Setup::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->setupController = new SetupController($this->setupHelper, $this->config, $this->logger);
+	}
+
+	public function testEmptyParams() {
+		$post = [];
+		$this->setupHelper->method('getSystemInfo')->willReturn(
+			[
+				'hasSQLite' => true,
+				'hasMySQL' => true,
+				'hasPostgreSQL' => true,
+				'hasOracle' => true,
+				'errors' => []
+			]
+		);
+		$this->setupHelper->expects($this->never())->method('install');
+		$this->setupController->run($post);
+	}
+}


### PR DESCRIPTION
## Description
- [x] drops autoconfig support. Closes #31073 
- [x] allows reading pre-created **config/config.php** instead
- [x] adds **apps_paths** support for those who want to rename **apps-external** out-of-a-box (e.g. docker image)
- [x] some bonuses like dependency injection kung fu

## Related Issue
- Fixes https://github.com/owncloud/core/issues/35304

## Motivation and Context
Kills bad autoconf magic, adds good config.php magic.

## How Has This Been Tested?
Not tested yet

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
- [ ] change documentation 
 at https://doc.owncloud.org/server/10.2/admin_manual/configuration/server/automatic_configuration.html