### PR TITLE
Load PHPunit app tests in alphabetical order

### DIFF
--- a/tests/apps.php
+++ b/tests/apps.php
@@ -13,15 +13,14 @@ function loadDirectory($path) {
 	if (\strcasecmp(\basename($path), 'ui') === 0) {
 		return;
 	}
-	if ($dh = \opendir($path)) {
-		while ($name = \readdir($dh)) {
-			if ($name[0] !== '.') {
-				$file = $path . '/' . $name;
-				if (\is_dir($file)) {
-					loadDirectory($file);
-				} elseif (\substr($name, -4, 4) === '.php') {
-					require_once $file;
-				}
+	$dirEntries = \scandir($path);
+	foreach ($dirEntries as $name) {
+		if ($name[0] !== '.') {
+			$file = $path . '/' . $name;
+			if (\is_dir($file)) {
+				loadDirectory($file);
+			} elseif (\substr($name, -4, 4) === '.php') {
+				require_once $file;
 			}
 		}
 	}


### PR DESCRIPTION
## Description
When finding the unit tests for the built-in core apps, use `scandir()` so that the relevant folders and files are discovered and loaded in a predictable order - in this case it will be alphabetical order.

At least this will mean that the unit test runs will more reliably either pass or fail. There will not be the potential for "random" failures due to the order of test case execution.

## Related Issue
#35658 

## Motivation and Context
We are getting intermittent unit test fails in CI. Actually those fails are because `apps/files_sharing/tests/External/ManagerTest.php` `testAddShareAccepted` is not cleaning up the share that it creates.

If that happens to run before `apps/files_sharing/tests/Commands/CleanupRemoteStoragesTest` then `CleanupRemoteStoragesTest` fails because its environment starts out with an extra unexepected entry in `share_external` table.

`apps/files_sharing/tests/External/ManagerTest.php` can be fixed in a separate PR.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
