### PR TITLE
Demonstrate manager test issue 35658

### DIFF
--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -94,7 +94,7 @@ class ManagerTest extends TestCase {
 	public function testAddShare() {
 		$shareData1 = [
 			'remote' => 'http://localhost',
-			'token' => 'token1',
+			'token' => 'token5',
 			'password' => '',
 			'name' => '/SharedFolder',
 			'owner' => 'foobar',
@@ -223,7 +223,7 @@ class ManagerTest extends TestCase {
 	public function testAddShareAccepted() {
 		$shareData1 = [
 			'remote' => 'http://localhost',
-			'token' => 'token1',
+			'token' => 'token6',
 			'password' => '',
 			'name' => '/SharedFolder',
 			'owner' => 'foobar',

--- a/tests/apps.php
+++ b/tests/apps.php
@@ -13,15 +13,14 @@ function loadDirectory($path) {
 	if (\strcasecmp(\basename($path), 'ui') === 0) {
 		return;
 	}
-	if ($dh = \opendir($path)) {
-		while ($name = \readdir($dh)) {
-			if ($name[0] !== '.') {
-				$file = $path . '/' . $name;
-				if (\is_dir($file)) {
-					loadDirectory($file);
-				} elseif (\substr($name, -4, 4) === '.php') {
-					require_once $file;
-				}
+	$dirEntries = \scandir($path);
+	foreach ($dirEntries as $name) {
+		if ($name[0] !== '.') {
+			$file = $path . '/' . $name;
+			if (\is_dir($file)) {
+				loadDirectory($file);
+			} elseif (\substr($name, -4, 4) === '.php') {
+				require_once $file;
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Demonstrate that `apps/files_sharing/tests/External/ManagerTest.php` `testAddShareAccepted` is leaving behind a share entry. That is causing the potential for later unit tests to fail.

## Related Issue
#35658 

## Motivation and Context
Do not leave crud behind from "unit" test cases.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
