### PR TITLE
Cleanup user share at end of testAddShareAccepted

### DIFF
--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -235,6 +235,7 @@ class ManagerTest extends TestCase {
 		\call_user_func_array([$this->manager, 'addShare'], $shareData1);
 		$this->setupMounts();
 		$this->assertMount($shareData1['name']);
+		$this->manager->removeUserShares($this->uid);
 	}
 
 	/**


### PR DESCRIPTION
## Description
PR #35666 demonstrates that `apps/files_sharing/tests/External/ManagerTest.php` `testAddShareAccepted` is leaving behind a share entry. That is causing the potential for later unit tests to fail.

`OCA\Files_Sharing\Tests\Command\CleanupRemoteStoragesTest::testCleanup` has been failing intermittently. The unit tests in apps are loaded and executed not necessarily in sctrict alphabetical order. The fail happens when `Command/CleanupRemoteStoragesTest` happens to run after `External/ManagerTest.php`. Note: PR #35665 suggests making the unit test loading order deterministic, to help avoid the "random" nature of issues like this in the future.

`apps/files_sharing/tests/External/ManagerTest.php` `testAddShareAccepted` was added by PR #35312 which was merged a few weeks ago. The intermittent problem has been around "for a while" - and I guess has been around for a few weeks.

This PR explicitly removes the share created during `testAddShareAccepted`

## Related Issue
#35658 

## Motivation and Context
Do not leave after-effects at the end of "unit" tests.

Note: lots of these "unit" tests are not really "unit" tests. They are integration tests - they do not mock the known universe, they do real stuff in a real database and have to be careful to clean up the environment so as not to mess up later tests. But that is words, the tests need to happen somewhere.

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
