### PR TITLE
Set default expiration date on public link creation

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -329,15 +329,15 @@ class Manager implements IManager {
 			}
 		}
 
+		// If expiredate is empty and it is a new share, set a default one if there is a default
+		if ($this->isNewShare($share) && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
+			$expirationDate = new \DateTime();
+			$expirationDate->setTime(0, 0, 0);
+			$expirationDate->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));
+		}
+
 		// If we enforce the expiration date check that is does not exceed
 		if ($this->shareApiLinkDefaultExpireDateEnforced()) {
-			// If expiredate is empty and it is a new share, set a default one if there is a default
-			if ($this->isNewShare($share) && $expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
-				$expirationDate = new \DateTime();
-				$expirationDate->setTime(0, 0, 0);
-				$expirationDate->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));
-			}
-
 			if ($expirationDate === null) {
 				throw new \InvalidArgumentException('Expiration date is enforced');
 			}

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -983,7 +983,7 @@ class ManagerTest extends \Test\TestCase {
 		}
 	}
 
-	public function testvalidateExpirationDateEnforceValid() {
+	public function testvalidateExpirationDateNoDefaultEnforceValid() {
 		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P2D'));
@@ -1048,7 +1048,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($share->getExpirationDate());
 	}
 
-	public function testvalidateExpirationDateNoDateDefault() {
+	public function testvalidateExpirationDateNoDateButDefault() {
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P3D'));
 		$future->setTime(0, 0, 0);
@@ -1056,7 +1056,6 @@ class ManagerTest extends \Test\TestCase {
 		$expected = clone $future;
 
 		$share = $this->manager->newShare();
-		$share->setExpirationDate($future);
 
 		$this->config->method('getAppValue')
 			->will($this->returnValueMap([


### PR DESCRIPTION
## Description
Set a default expiration date if a public link is created

## Related Issue
- Fixes #35661 

## Motivation and Context
An API change in 10.2.0 breaks the Desktop Client functionality
This PR restores the original behavior. 

## How Has This Been Tested?
Use Desktop client 2.5.4
- Configure the Server to set a default expiration date of 3 days.
- Configure the Server to **not enforce** an expiration date
- Create a public link in the desktop client
- The public link should have an expiration date set to the maximum time period, in this case 3 days in the future.

## Expected behavior
### Scenario 1:
Given ownCloud is configured to set a default expiration date of 3 days on public links
And a user creates a public link using the api / the desktop client
Then the API response should contain an expiration date 3 days in the future

### Scenario 2
Given ownCloud is configured to set a default expiration date of 3 days on public links
And a user creates a public link using the api / the desktop client
And the user edits the same public link using the api and unsets the expiration date
Then the API response should not contain an expiration date.



## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
