### PR TITLE
only look for unit tests in the primary apps dir

### DIFF
--- a/tests/apps.php
+++ b/tests/apps.php
@@ -45,7 +45,13 @@ foreach ($apps as $app) {
 		continue;
 	}
 	$dir = OC_App::getAppPath($app);
-	if (\is_dir($dir . '/tests')) {
-		loadDirectory($dir . '/tests');
+
+	// only consider the "built-in" apps found in the apps directory
+	// we do not want to automatically run unit tests for extra apps
+	// that might be in a secondary apps dir like apps-external
+	if (\basename(\dirname($dir)) === "apps") {
+		if (\is_dir($dir . '/tests')) {
+			loadDirectory($dir . '/tests');
+		}
 	}
 }


### PR DESCRIPTION
## Description
The "real core" apps are known to be in the `apps` folder. When scanning enabled apps for unit tests, only consider apps found in the `apps` folder.

Note: by convention, developers and other CI scripts... should be installing extra apps in some other folder like `apps-external`

## Motivation and Context
The `testing` app in drone was move from `apps` to `apps-external` by PR #35648 - that was intended to avoid the unit tests o the `testing` app being accidentally run by core unit test jobs.

It turns out that the `testing` app unit tests are still being run in core drone. That is because the testing app is enabled, and the unit test script runs test cases for all enabled apps.

When core unit tests are being run, we really just want to run test cases for the "real core" apps. For other apps from separate repos, that happen to be installed and enabled, we do not want to run their unit test cases. Because those might fail - e.g. we are preparing a PHP unit major version upgrade, or...)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
