### PR TITLE
Improve numeric processing of sharing 'expire after days' setting

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -391,7 +391,7 @@ table.grid td.date {
 }
 
 #shareAPI input#shareapiExpireAfterNDays {
-	width: 25px;
+	width: 40px;
 }
 
 #shareAPI .nocheckbox {

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -53,7 +53,7 @@ $(document).ready(function(){
 	$('#shareapiExpireAfterNDays').change(function() {
 		var value = $(this).val();
 		if (value <= 0) {
-			$(this).val("1");
+			$(this).val("7");
 		}
 	});
 

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -60,7 +60,7 @@
 	p('hidden');
 }?>">
 			<?php p($l->t('Expire after ')); ?>
-			<input type="text" name='shareapi_expire_after_n_days' id="shareapiExpireAfterNDays" placeholder="<?php p('7')?>"
+			<input type="number" name='shareapi_expire_after_n_days' id="shareapiExpireAfterNDays" min="0" placeholder="<?php p('7')?>"
 				   value='<?php p($_['shareExpireAfterNDays']) ?>' />
 			<?php p($l->t('days')); ?><br/>
 			<?php if ($_['shareEnforceExpireDate'] === 'yes'): ?>


### PR DESCRIPTION
## Description
1) Make the input box for "expire after n days" wider so it comfortably fits 3 digits (mostly typical values will be 2 digits - 7 days, 14 days, 30 days, 90 days)
2) When a "0" or negative or empty value is attempted, put in "7" (which is also the placeholder value)
3) Make the input type "number". That prevents entry of letters and other crud. (Previously you could enter "a" and it would store "a" as the "number")

## Related Issue
- Fixes #35687 
- Fixes #35662 

## Motivation and Context
Make the UI great.

## How Has This Been Tested?
Viewing UI and trying:
- entering blank, becomes "7"
- entering "0", becomes "7"
- entering "a", becomes "7"
- entering "-1", becomes "7"
- entering "123", becomes "123"

## Screenshots (if appropriate):
![Screenshot_2019-06-27 Settings - ownCloud](https://user-images.githubusercontent.com/1535615/60281601-ee749180-9924-11e9-85be-31b2e3fc49ee.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
