### PR TITLE
[stable10] Adjust createShare scenario to ensure skeleton file welcome.txt is there

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -565,7 +565,7 @@ Feature: sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     # Note: in user_ldap, user1 is already in grp1
     And user "user1" has been added to group "grp1"


### PR DESCRIPTION
Backport #35690 