### PR TITLE
[stable10] Backport of Fix path option in the verify checksum cmd

### DIFF
--- a/apps/files/tests/Command/VerifyChecksumsTest.php
+++ b/apps/files/tests/Command/VerifyChecksumsTest.php
@@ -258,7 +258,8 @@ class VerifyChecksumsTest extends TestCase {
 
 		$this->cmd->execute([
 			'-r' => null,
-			'-p' => "{$this->user1}/files/dir/nested"
+			'-u' => $this->user1,
+			'-p' => "dir/nested"
 		]);
 
 		$this->assertChecksumsAreCorrect([
@@ -357,6 +358,16 @@ class VerifyChecksumsTest extends TestCase {
 			VerifyChecksums::EXIT_INVALID_ARGS,
 			$this->cmd->getStatusCode(),
 			'User and path must return invalid args status code when combined'
+		);
+
+		$this->cmd->execute([
+			'-p' => '/some/path/for/testing?'
+		]);
+
+		$this->assertEquals(
+			VerifyChecksums::EXIT_INVALID_ARGS,
+			$this->cmd->getStatusCode(),
+			'User name cannot be omitted when path is provided.'
 		);
 	}
 }


### PR DESCRIPTION
The path option in the verify checksum command
should now be relative to the user folder.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The verify checksum command was failing to fix the checksum when path option is provided as:
- `$user/files/foo` or `/$user/files/foo/bar`

The reason for this is `get()` in the https://github.com/owncloud/core/blob/master/lib/private/Files/Node/Root.php#L180 will add extra entry in the cache. This PR tries to resolve the issue by accepting path which is relative to users folder, instead of datadirectory.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR solves the addition of the file path to the filecache table, when -p option is used with the command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Same tests are applicable as https://github.com/owncloud/core/pull/35483#issuecomment-506329612

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
