### PR TITLE
Do not try to override JS files from theme when there is no custom th…

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -52,13 +52,20 @@ class JSResourceLocator extends ResourceLocator {
 			if ($found) {
 				return;
 			}
-		} elseif ($this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$fullScript, $webRoot)
-			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$fullScript, $webRoot)
-			|| $this->appendOnceIfExist($this->serverroot, $fullScript)
-			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$fullScript, $webRoot)
-			|| $this->appendOnceIfExist($this->serverroot, 'core/'.$fullScript)
-		) {
-			return;
+		} else {
+			// Search in an active theme first. But only if it is active
+			if (
+				$themeDirectory !== '' && $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$fullScript, $webRoot)
+			) {
+				return;
+			}
+			if ($this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$fullScript, $webRoot)
+				|| $this->appendOnceIfExist($this->serverroot, $fullScript)
+				|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$fullScript, $webRoot)
+				|| $this->appendOnceIfExist($this->serverroot, 'core/'.$fullScript)
+			) {
+				return;
+			}
 		}
 
 		$app = \substr($fullScript, 0, \strpos($fullScript, '/'));

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -101,6 +101,32 @@ class JSResourceLocatorTest extends TestCase {
 		$locator->find(['randomapp/js/script']);
 	}
 
+	public function testFindAppScriptWithNoThemeActive() {
+		$this->themeAppDir = '';
+		/** @var \OC\Template\JSResourceLocator $locator */
+		$locator = $this->getResourceLocator(
+			'',
+			[$this->serverRoot => 'map'],
+			['foo' => 'bar']
+		);
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->with('randomapp')
+			->willReturn('/var/www/apps-external/randomapp');
+
+		$locator->expects($this->exactly(5))
+			->method('appendOnceIfExist')
+			->withConsecutive(
+				['/var/www/apps', '/randomapp/js/script.js', ''],
+				['/var/www/owncloud', 'randomapp/js/script.js', ''],
+				['/var/www/apps', '/core/randomapp/js/script.js', ''],
+				['/var/www/owncloud', 'core/randomapp/js/script.js', ''],
+				['/var/www/apps-external/randomapp', 'js/script.js', '']
+			);
+
+		$locator->find(['randomapp/js/script']);
+	}
+
 	public function testFindL10nScript() {
 		/** @var \OC\Template\JSResourceLocator $locator */
 		$locator = $this->getResourceLocator(


### PR DESCRIPTION
…eme active

## Description
For the multi-appdir installation with no custom theme applied  the `apps` app directory always wins while searching for the js resources
this contradicts the expectation that an appdir with the most recent application version should win

## Related Issue
- Fixes #35640 

## Motivation and Context
Outdated JS  is loaded after update

## How Has This Been Tested?
1. Install 10.2.0+ with two app directories and non-writable `apps` (default installation)
2. Update any app via market - the update will be installed into `apps-external`
3. Use browser dev tools to monitor the origin of JS files for this app

#### Expected
script is loaded from `apps-external`

#### Actual
script is loaded from `apps`

### **Bonus**
Enable a custom theme and put the same script into `app-theme/apps/appid/js`

#### Expected
Script is no longer loaded  from `apps-external` but from the theme

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
