### PR TITLE
Adjust createShare scenario to ensure skeleton file welcome.txt is there

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -565,7 +565,7 @@ Feature: sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     # Note: in user_ldap, user1 is already in grp1
     And user "user1" has been added to group "grp1"


### PR DESCRIPTION
## Description
`user_ldap` CI failed last night with:
https://drone.owncloud.com/owncloud/user_ldap/1615/1019
```
--- Failed scenarios:

    /var/www/owncloud/server/tests/acceptance/features/apiShareManagementBasic/createShare.feature:581
    /var/www/owncloud/server/tests/acceptance/features/apiShareManagementBasic/createShare.feature:582

142 scenarios (140 passed, 2 failed)
1565 steps (1555 passed, 2 failed, 8 skipped)
```

The scenario failed because `welcome.txt` did not exist for `user1`. In the LDAP CI environment we need to make sure that users are initialized (including skeleton files) before we start doing other actions, like renaming files.

I think it was passing in `core` because when we say "without skeleton files" then actually the system ends up falling back to some small skeleton that has `welcome.txt` and a couple of example photos...

Fix it by explictly creating `user1` with skeleton files.


## Related Issue
https://github.com/owncloud/user_ldap/issues/429

## Motivation and Context
Make tests run in LDAP environment also.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
