### PR TITLE
[stable10] Test regression with public link not created when default expiration date set and enforced

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -975,3 +975,20 @@ Feature: sharing
       | 2              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             | 404              |
       | 2              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             | 404              |
 
+  @issue-35550
+  Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path | textfile0.txt |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the OCS status message should be "Expiration date is enforced"
+    And the HTTP status code should be "<http_status_code>"
+#    And the last public shared file should be able to be downloaded without a password
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 403             | 200              |
+#      | 1               | 100             | 100              |
+      | 2               | 403             | 403              |
+#      | 2               | 200             | 200              |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -975,7 +975,7 @@ Feature: sharing
       | 2              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             | 404              |
       | 2              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             | 404              |
 
-  @issue-35550
+  @public_link_share-feature-required
   Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -983,12 +983,28 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path | textfile0.txt |
     Then the OCS status code should be "<ocs_status_code>"
-    And the OCS status message should be "Expiration date is enforced"
     And the HTTP status code should be "<http_status_code>"
-#    And the last public shared file should be able to be downloaded without a password
+    And the fields of the last response should include
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | item_type   | file           |
+      | share_type  | 3              |
+      | permissions | 1              |
+      | uid_owner   | user0          |
+      | expiration  | +7 days        |
+    When user "user0" gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And the fields of the last response should include
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | item_type   | file           |
+      | share_type  | 3              |
+      | permissions | 1              |
+      | uid_owner   | user0          |
+      | expiration  | +7 days        |
+    And the last public shared file should be able to be downloaded without a password
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 403             | 200              |
-#      | 1               | 100             | 100              |
-      | 2               | 403             | 403              |
-#      | 2               | 200             | 200              |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -32,6 +32,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\EmailHelper;
 use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;
+use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
 use GuzzleHttp\Message\ResponseInterface;
 use Page\GeneralErrorPage;
 use Page\SharedWithOthersPage;
@@ -100,7 +101,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	private $oldMinCharactersForAutocomplete = null;
 	private $oldFedSharingFallbackSetting = null;
 
+	/**
+	 * @var PublicLinkTab
+	 */
 	private $publicShareTab;
+
 	/**
 	 *
 	 * @var EditPublicLinkPopup
@@ -432,6 +437,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($linkName);
 		$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+
+		$this->featureContext->resetLastShareData();
 	}
 
 	/**
@@ -512,6 +519,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserShouldSeeAnErrorMessageOnThPublicLinkPopupSaying($message) {
+		// update public-sharing popup, as it might not have been set previously.
+		$this->publicSharingPopup = $this->publicShareTab->updateSharingPopup($this->getSession());
 		$errormessage = $this->publicSharingPopup->getErrorMessage();
 		PHPUnit\Framework\Assert::assertEquals($message, $errormessage);
 	}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -28,6 +28,7 @@ use Behat\Mink\Session;
 use Exception;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 
 /**
  * The Public link tab of the Sharing Dialog
@@ -50,7 +51,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @var EditPublicLinkPopup
 	 */
 	private $editPublicLinkPopupPageObject;
-	
+
 	/**
 	 * sets the NodeElement for the current popup
 	 * a little bit like __construct() but as we access this "sub-page-object"
@@ -178,7 +179,7 @@ class PublicLinkTab extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 *
-	 * @return void
+	 * @return EditPublicLinkPopup
 	 */
 	public function updateSharingPopup(Session $session) {
 		$this->editPublicLinkPopupPageObject = $this->getPage(
@@ -187,6 +188,7 @@ class PublicLinkTab extends OwncloudPage {
 		$this->editPublicLinkPopupPageObject->waitTillPageIsLoaded(
 			$session, STANDARD_UI_WAIT_TIMEOUT_MILLISEC, $this->popupXpath
 		);
+		return $this->editPublicLinkPopupPageObject;
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -614,3 +614,33 @@ Feature: Share by public link
     And the user gets the info of the last share using the sharing API
     And the fields of the last response should include
       | expiration   | |
+
+  Scenario: user creates a new public link using webUI without setting expiration date when default expire date is set but not enforced
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "no"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user creates a new public link for file "lorem.txt" using the webUI with
+      | expiration | |
+    And user "user1" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | expiration   | |
+
+  Scenario: user creates a new public link using webUI removing expiration date when default expire date is set and enforced
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user tries to create a new public link for file "lorem.txt" using the webUI
+      | expiration | |
+    Then the user should see an error message on the public link popup saying "Expiration date is required"
+
+  Scenario: user creates a new public link using webUI when default expire date is set and enforced
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user creates a new public link for file "lorem.txt" using the webUI
+    And user "user1" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | expiration | +7 days |


### PR DESCRIPTION
Backport for #35594
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This adds a regression test that public link was not getting created when default expiration date was set and enforced. This also tests the functionality of #34960.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #35550 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
