### PR TITLE
[stable10] [OCM] Set unknown remote protocol for remote mounts to https

### DIFF
--- a/apps/files_sharing/lib/External/MountProvider.php
+++ b/apps/files_sharing/lib/External/MountProvider.php
@@ -69,6 +69,12 @@ class MountProvider implements IMountProvider {
 		while ($row = $query->fetch()) {
 			$row['manager'] = $this;
 			$row['token'] = $row['share_token'];
+			/// FIXME: Use \OCA\FederatedFileSharing\Address in external Storage and Cache
+			// Force missing proto to be https
+			if (\strpos($row['remote'], '://') === false) {
+				$row['remote'] = 'https://' .  $row['remote'];
+			}
+
 			$mounts[] = $this->getMount($user, $row, $loader);
 		}
 		return $mounts;

--- a/apps/files_sharing/tests/External/MountProviderTest.php
+++ b/apps/files_sharing/tests/External/MountProviderTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Tests\External;
+
+use Doctrine\DBAL\Driver\Statement;
+use OCA\Files_Sharing\External\Mount;
+use OCA\Files_Sharing\External\MountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IDBConnection;
+use OCP\IUser;
+use Test\TestCase;
+
+/**
+ * Class ManagerTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Sharing\Tests\External
+ */
+class MountProviderTest extends TestCase {
+	/** @var IDBConnection */
+	private $dbConnection;
+
+	/** @var MountProvider */
+	private $mountProvider;
+
+	public function setUp() {
+		parent::setUp();
+		$this->dbConnection = $this->createMock(IDBConnection::class);
+		$this->mountProvider = new MountProvider($this->dbConnection, function () {
+		});
+	}
+
+	public function testCreateMountWithNoProto() {
+		$user = $this->createMock(IUser::class);
+		$storageFactory = $this->createMock(IStorageFactory::class);
+		$statement = $this->createMock(Statement::class);
+		$statement->method('fetch')->willReturnOnConsecutiveCalls(
+			[
+				'remote' => 'domain.tld',
+				'share_token' => 'secret',
+				'mountpoint' => '/mp'
+			],
+			false
+		);
+		$this->dbConnection->method('prepare')->willReturn($statement);
+
+		$mounts = $this->mountProvider->getMountsForUser($user, $storageFactory);
+		$mount = $mounts[0];
+		$this->assertInstanceOf(Mount::class, $mount);
+	}
+}


### PR DESCRIPTION
## Description
Otherwise the external storage and cache will fail

## Related Issue
- Fixes #34633

## Motivation and Context
Not working external storage when the resource was shared from `user@host` instead of `user@proto://host`

## How Has This Been Tested?
by stripping protocol for the `remote` in `oc_share_external` table

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
