### PR TITLE
Test scenarios for resharing with various permission bits

### DIFF
--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -6,7 +6,7 @@ Feature: sharing
     And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
-  Scenario Outline: User is not allowed to reshare file
+  Scenario Outline: User is not allowed to reshare file when reshare permission is not given
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions 3
@@ -15,6 +15,20 @@ Feature: sharing
     And the HTTP status code should be "<http_status_code>"
     And as "user2" file "/textfile0.txt" should not exist
     But as "user1" file "/textfile0.txt" should exist
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  Scenario Outline: User is not allowed to reshare folder when reshare permission is not given
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "/FOLDER" with user "user1" with permissions 3
+    When user "user1" shares folder "/FOLDER" with user "user2" with permissions 3 using the sharing API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user2" folder "/FOLDER" should not exist
+    But as "user1" folder "/FOLDER" should exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -33,6 +47,19 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  Scenario Outline: User is allowed to reshare folder with the same permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "/FOLDER" with user "user1" with permissions 17
+    When user "user1" shares folder "/FOLDER" with user "user2" with permissions 17 using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user2" folder "/FOLDER" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
   Scenario Outline: User is allowed to reshare file with less permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
@@ -46,19 +73,169 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: User is not allowed to reshare file with more permissions
+  Scenario Outline: User is allowed to reshare folder with less permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
-    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions 17
-    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions 19 using the sharing API
+    And user "user0" has shared folder "/FOLDER" with user "user1" with permissions 19
+    When user "user1" shares folder "/FOLDER" with user "user2" with permissions 17 using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And as "user2" folder "/FOLDER" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: User is not allowed to reshare file and set more permissions bits
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions <received_permissions>
+    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions <reshare_permissions> using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "user2" file "/textfile0.txt" should not exist
     But as "user1" file "/textfile0.txt" should exist
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | received_permissions | reshare_permissions |
+      # passing on more bits including reshare
+      | 1               | 200              | 17                   | 19                  |
+      | 2               | 404              | 17                   | 19                  |
+      | 1               | 200              | 17                   | 23                  |
+      | 2               | 404              | 17                   | 23                  |
+      | 1               | 200              | 17                   | 31                  |
+      | 2               | 404              | 17                   | 31                  |
+      # passing on more bits but not reshare
+      | 1               | 200              | 17                   | 3                   |
+      | 2               | 404              | 17                   | 3                   |
+      | 1               | 200              | 17                   | 7                   |
+      | 2               | 404              | 17                   | 7                   |
+      | 1               | 200              | 17                   | 15                  |
+      | 2               | 404              | 17                   | 15                  |
+
+  Scenario Outline: User is allowed to reshare file and set create (4) or delete (8) permissions bits, which get ignored
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has shared file "/textfile0.txt" with user "user1" with permissions <received_permissions>
+    When user "user1" shares file "/textfile0.txt" with user "user2" with permissions <reshare_permissions> using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | share_with  | user2                 |
+      | file_target | /textfile0.txt        |
+      | path        | /textfile0.txt        |
+      | permissions | <granted_permissions> |
+      | uid_owner   | user1                 |
+    And as "user2" file "/textfile0.txt" should exist
+    # The receiver of the reshare can always delete their received share, even though they do not have delete permission
+    And user "user2" should be able to delete file "/textfile0.txt"
+    # But the upstream sharers will still have the file
+    But as "user1" file "/textfile0.txt" should exist
+    And as "user0" file "/textfile0.txt" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code | received_permissions | reshare_permissions | granted_permissions |
+      | 1               | 100             | 19                   | 23                  | 19                  |
+      | 2               | 200             | 19                   | 23                  | 19                  |
+      | 1               | 100             | 19                   | 31                  | 19                  |
+      | 2               | 200             | 19                   | 31                  | 19                  |
+      | 1               | 100             | 19                   | 7                   | 3                   |
+      | 2               | 200             | 19                   | 7                   | 3                   |
+      | 1               | 100             | 19                   | 15                  | 3                   |
+      | 2               | 200             | 19                   | 15                  | 3                   |
+      | 1               | 100             | 17                   | 21                  | 17                  |
+      | 2               | 200             | 17                   | 21                  | 17                  |
+      | 1               | 100             | 17                   | 5                   | 1                   |
+      | 2               | 200             | 17                   | 5                   | 1                   |
+      | 1               | 100             | 17                   | 25                  | 17                  |
+      | 2               | 200             | 17                   | 25                  | 17                  |
+      | 1               | 100             | 17                   | 9                   | 1                   |
+      | 2               | 200             | 17                   | 9                   | 1                   |
+
+  Scenario Outline: User is not allowed to reshare folder and set more permissions bits
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "/PARENT" with user "user1" with permissions <received_permissions>
+    When user "user1" shares folder "/PARENT" with user "user2" with permissions <reshare_permissions> using the sharing API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user2" folder "/PARENT" should not exist
+    But as "user1" folder "/PARENT" should exist
+    Examples:
+      | ocs_api_version | http_status_code | received_permissions | reshare_permissions |
+      # try to pass on more bits including reshare
+      | 1               | 200              | 17                   | 19                  |
+      | 2               | 404              | 17                   | 19                  |
+      | 1               | 200              | 17                   | 21                  |
+      | 2               | 404              | 17                   | 21                  |
+      | 1               | 200              | 17                   | 23                  |
+      | 2               | 404              | 17                   | 23                  |
+      | 1               | 200              | 17                   | 31                  |
+      | 2               | 404              | 17                   | 31                  |
+      | 1               | 200              | 19                   | 23                  |
+      | 2               | 404              | 19                   | 23                  |
+      | 1               | 200              | 19                   | 31                  |
+      | 2               | 404              | 19                   | 31                  |
+      # try to pass on more bits but not reshare
+      | 1               | 200              | 17                   | 3                   |
+      | 2               | 404              | 17                   | 3                   |
+      | 1               | 200              | 17                   | 5                   |
+      | 2               | 404              | 17                   | 5                   |
+      | 1               | 200              | 17                   | 7                   |
+      | 2               | 404              | 17                   | 7                   |
+      | 1               | 200              | 17                   | 15                  |
+      | 2               | 404              | 17                   | 15                  |
+      | 1               | 200              | 19                   | 7                   |
+      | 2               | 404              | 19                   | 7                   |
+      | 1               | 200              | 19                   | 15                  |
+      | 2               | 404              | 19                   | 15                  |
+
+  @issue-enterprise-3404
+  Scenario Outline: User is not allowed to reshare folder and add delete permission bit (8)
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "/PARENT" with user "user1" with permissions <received_permissions>
+    When user "user1" shares folder "/PARENT" with user "user2" with permissions <reshare_permissions> using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    #Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+    #And the HTTP status code should be "<http_status_code>"
+    And as "user2" folder "/PARENT" should exist
+    #And as "user2" folder "/PARENT" should not exist
+    # delete the next 2 lines when the issue is fixed
+    And user "user2" should be able to delete file "/PARENT/parent.txt"
+    And as "user2" file "/PARENT/parent.txt" should not exist
+    # keep the following line
+    But as "user1" folder "/PARENT" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code | received_permissions | reshare_permissions |
+      # try to pass on extra delete (including reshare)
+      | 1               | 100             | 17                   | 25                  |
+      | 2               | 200             | 17                   | 25                  |
+      | 1               | 100             | 19                   | 27                  |
+      | 2               | 200             | 19                   | 27                  |
+      | 1               | 100             | 23                   | 31                  |
+      | 2               | 200             | 23                   | 31                  |
+      # try to pass on extra delete (but not reshare)
+      | 1               | 100             | 17                   | 9                   |
+      | 2               | 200             | 17                   | 9                   |
+      | 1               | 100             | 19                   | 11                  |
+      | 2               | 200             | 19                   | 11                  |
+      | 1               | 100             | 23                   | 15                  |
+      | 2               | 200             | 23                   | 15                  |
+      #| ocs_api_version | http_status_code | received_permissions | reshare_permissions |
+      # try to pass on extra delete (including reshare)
+      #| 1               | 200              | 17                   | 25                  |
+      #| 2               | 404              | 17                   | 25                  |
+      #| 1               | 200              | 19                   | 27                  |
+      #| 2               | 404              | 19                   | 27                  |
+      #| 1               | 200              | 23                   | 31                  |
+      #| 2               | 404              | 23                   | 31                  |
+      # try to pass on extra delete (but not reshare)
+      #| 1               | 200              | 17                   | 9                   |
+      #| 2               | 404              | 17                   | 9                   |
+      #| 1               | 200              | 19                   | 11                  |
+      #| 2               | 404              | 19                   | 11                  |
+      #| 1               | 200              | 23                   | 15                  |
+      #| 2               | 404              | 23                   | 15                  |
 
   Scenario Outline: Update of reshare can reduce permissions
     Given using OCS API version "<ocs_api_version>"
@@ -126,16 +303,54 @@ Feature: sharing
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
     And user "user0" has created folder "/TMP/SUB"
-    And user "user0" has shared folder "/TMP" with user "user1" with permissions 17
-    When user "user1" shares folder "/TMP/SUB" with user "user2" with permissions 31 using the sharing API
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions <received_permissions>
+    When user "user1" shares folder "/TMP/SUB" with user "user2" with permissions <reshare_permissions> using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "user2" folder "/SUB" should not exist
     But as "user1" file "/TMP/SUB" should exist
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | received_permissions | reshare_permissions |
+      # try to pass on more bits including reshare
+      | 1               | 200              | 17                   | 19                  |
+      | 2               | 404              | 17                   | 19                  |
+      | 1               | 200              | 17                   | 21                  |
+      | 2               | 404              | 17                   | 21                  |
+      | 1               | 200              | 17                   | 23                  |
+      | 2               | 404              | 17                   | 23                  |
+      | 1               | 200              | 17                   | 31                  |
+      | 2               | 404              | 17                   | 31                  |
+      | 1               | 200              | 19                   | 23                  |
+      | 2               | 404              | 19                   | 23                  |
+      | 1               | 200              | 19                   | 31                  |
+      | 2               | 404              | 19                   | 31                  |
+      # try to pass on more bits but not reshare
+      | 1               | 200              | 17                   | 3                   |
+      | 2               | 404              | 17                   | 3                   |
+      | 1               | 200              | 17                   | 5                   |
+      | 2               | 404              | 17                   | 5                   |
+      | 1               | 200              | 17                   | 7                   |
+      | 2               | 404              | 17                   | 7                   |
+      | 1               | 200              | 17                   | 15                  |
+      | 2               | 404              | 17                   | 15                  |
+      | 1               | 200              | 19                   | 7                   |
+      | 2               | 404              | 19                   | 7                   |
+      | 1               | 200              | 19                   | 15                  |
+      | 2               | 404              | 19                   | 15                  |
+      # try to pass on extra delete (including reshare)
+      | 1               | 200              | 17                   | 25                  |
+      | 2               | 404              | 17                   | 25                  |
+      | 1               | 200              | 19                   | 27                  |
+      | 2               | 404              | 19                   | 27                  |
+      | 1               | 200              | 23                   | 31                  |
+      | 2               | 404              | 23                   | 31                  |
+      # try to pass on extra delete (but not reshare)
+      | 1               | 200              | 17                   | 9                   |
+      | 2               | 404              | 17                   | 9                   |
+      | 1               | 200              | 19                   | 11                  |
+      | 2               | 404              | 19                   | 11                  |
+      | 1               | 200              | 23                   | 15                  |
+      | 2               | 404              | 23                   | 15                  |
 
   Scenario Outline: User is allowed to update reshare of a sub-folder with less permissions
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1613,6 +1613,34 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then user :user should be able to delete file :source
+	 *
+	 * @param string $user
+	 * @param string $source
+	 *
+	 * @return void
+	 */
+	public function userShouldBeAbleToDeleteFile($user, $source) {
+		$this->asFileOrFolderShouldExist($user, "file", $source);
+		$this->userDeletesFile($user, $source);
+		$this->asFileOrFolderShouldNotExist($user, "file", $source);
+	}
+
+	/**
+	 * @Then user :user should not be able to delete file :source
+	 *
+	 * @param string $user
+	 * @param string $source
+	 *
+	 * @return void
+	 */
+	public function theUserShouldNotBeAbleToDeleteFile($user, $source) {
+		$this->asFileOrFolderShouldExist($user, "file", $source);
+		$this->userDeletesFile($user, $source);
+		$this->asFileOrFolderShouldExist($user, "file", $source);
+	}
+
+	/**
 	 * @Given file :file has been deleted for user :user
 	 *
 	 * @param string $file


### PR DESCRIPTION
## Description
- When resharing, check for lots of combinations of received permissions and attempts to reshare with extra permission bit(s).
- Make scenarios that check this for both files and folders

## Related Issue
https://github.com/owncloud/enterprise/issues/3404

## Motivation and Context
Test more combinations of permissions stuff.

## How Has This Been Tested?
Local runs of scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
