### PR TITLE
Use Throwable as type hint in the exception callback

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -195,9 +195,9 @@ class FilesPlugin extends ServerPlugin {
 	/**
 	 * This sets a cookie to be able to recognize the failure of the download
 	 *
-	 * @param \Exception $ex
+	 * @param \Throwable $ex
 	 */
-	public function handleDownloadFailure(\Exception $ex) {
+	public function handleDownloadFailure(\Throwable $ex) {
 		$queryParams = $this->server->httpRequest->getQueryParameters();
 
 		if (isset($queryParams['downloadStartSecret'])) {

--- a/apps/dav/lib/Files/BrowserErrorPagePlugin.php
+++ b/apps/dav/lib/Files/BrowserErrorPagePlugin.php
@@ -68,9 +68,9 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 	}
 
 	/**
-	 * @param \Exception $ex
+	 * @param \Throwable $ex
 	 */
-	public function logException(\Exception $ex) {
+	public function logException(\Throwable $ex) {
 		if ($ex instanceof Exception) {
 			$httpCode = $ex->getHTTPCode();
 			$headers = $ex->getHTTPHeaders($this->server);
@@ -88,10 +88,10 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 
 	/**
 	 * @codeCoverageIgnore
-	 * @param \Exception $ex
+	 * @param \Throwable $ex
 	 * @return bool|string
 	 */
-	public function generateBody(\Exception $ex) {
+	public function generateBody(\Throwable $ex) {
 		$request = \OC::$server->getRequest();
 		$content = new OC_Template('dav', 'exception', 'guest');
 		$content->assign('title', $this->server->httpResponse->getStatusText());


### PR DESCRIPTION
## Description
Not only exceptions can be thrown at runtime but also Errors. The common interface is \Throwable

## Motivation and Context
Handle Errors properly as well

## How Has This Been Tested?
- add a wrong type declaration in the code which is executed on the webdav endpoint
- see the error page properly popping up

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
