### PR TITLE
[release-10.2.1] Acceptance test changes from stable10 to 20190701

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1172,18 +1172,6 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: chrome
-      BEHAT_SUITE: webUIUserKeysType
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: https
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: chrome
       BEHAT_SUITE: webUIFavorites
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1583,7 +1571,7 @@ matrix:
       OWNCLOUD_LOG: true
       CALDAV_CARDDAV_JOB: true
 
-    # encryption tests
+    # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.0
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
@@ -1597,6 +1585,7 @@ matrix:
       ENCRYPTION_TYPE: masterkey
       INSTALL_TESTING_APP: true
 
+    # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.1
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
@@ -1610,9 +1599,23 @@ matrix:
       ENCRYPTION_TYPE: masterkey
       INSTALL_TESTING_APP: true
 
-    ## encryption WebUI acceptance tests master-keys encryption
+    # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.1
-      TEST_SUITE: webui
+      TEST_SUITE: selenium
+      BROWSER: chrome
+      BEHAT_SUITE: webUIUserKeysType
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      SERVER_PROTOCOL: https
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    # This suite is part of the encryption app in later core versions
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIMasterKeyType
       DB_TYPE: mariadb
       USE_SERVER: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -174,7 +174,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
-      - git clone https://github.com/owncloud/testing.git $$DRONE_WORKSPACE/apps/testing
+      - git clone https://github.com/owncloud/testing.git $$DRONE_WORKSPACE/apps-external/testing
       - php occ a:l
       - php occ a:e testing
       - php occ a:l

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -21,10 +21,8 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\BatchResults;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Client;
-use GuzzleHttp\Pool;
 
 /**
  * Helper to make requests to the OCS API

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -139,7 +139,18 @@ class UserHelper {
 			);
 		}
 		// Send the array of requests at once in parallel.
-		return HttpRequestHelper::sendBatchRequest($requests, $client);
+		$results =  HttpRequestHelper::sendBatchRequest($requests, $client);
+
+		foreach ($results->getFailures() as $e) {
+			$pathArray = \explode('/', $e->getRequest()->getPath());
+			$failedUser = \end($pathArray);
+			$editData = $e->getRequest()->getBody()->getFields();
+			throw new \Exception(
+				"Could not set '${editData['key']}' to '${editData['value']}' for user '$failedUser' \n"
+				. $e->getResponse()->getStatusCode() . "\n" . $e->getResponse()->getBody()
+			);
+		}
+		return $results;
 	}
 
 	/**

--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -1,33 +1,99 @@
 @api
 Feature: AppManagement
 
-  Background:
-    Given apps have been put in two directories "apps" and "apps2"
-
-  Scenario: Two app instances exist the first is more recent
-    Given app "multidirtest" with version "1.0.1" has been put in dir "apps"
-    And app "multidirtest" with version "1.0.0" has been put in dir "apps2"
+  Scenario: Two apps_path exist by default. The first one is more recent
+    Given app "multidirtest" with version "1.0.2" has been put in dir "apps"
+    And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
     When the administrator gets the path for app "multidirtest" using the occ command
     Then the path to "multidirtest" should be "apps"
 
-  Scenario: Two app instances exist the second is more recent
-    Given app "multidirtest" with version "1.0.0" has been put in dir "apps"
-    And app "multidirtest" with version "1.0.5" has been put in dir "apps2"
+  Scenario: Two apps_path exist by default. The second one is more recent
+    Given app "multidirtest" with version "1.0.2" has been put in dir "apps"
+    And app "multidirtest" with version "1.0.10" has been put in dir "apps-external"
     When the administrator gets the path for app "multidirtest" using the occ command
-    Then the path to "multidirtest" should be "apps2"
+    Then the path to "multidirtest" should be "apps-external"
+
+  Scenario: Three app instances, including apps-external, exist. The first one is more recent
+    Given these apps' path has been configured additionally with following attributes:
+      | dir           | is_writable  |
+      | apps-custom   | true         |
+    And app "multidirtest" with version "1.0.2" has been put in dir "apps"
+    And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
+    And app "multidirtest" with version "1.0.0" has been put in dir "apps-custom"
+    When the administrator gets the path for app "multidirtest" using the occ command
+    Then the path to "multidirtest" should be "apps"
+
+  Scenario: Three app instances, including apps-external, exist. The second one is more recent
+    Given these apps' path has been configured additionally with following attributes:
+      | dir           | is_writable  |
+      | apps-custom   | true         |
+    And app "multidirtest" with version "1.0.2" has been put in dir "apps"
+    And app "multidirtest" with version "1.0.10" has been put in dir "apps-external"
+    And app "multidirtest" with version "1.0.0" has been put in dir "apps-custom"
+    When the administrator gets the path for app "multidirtest" using the occ command
+    Then the path to "multidirtest" should be "apps-external"
+
+  Scenario: Three app instances, including apps-external, exist. The third one is more recent
+    Given these apps' path has been configured additionally with following attributes:
+      | dir           | is_writable  |
+      | apps-custom   | true         |
+    And app "multidirtest" with version "1.0.2" has been put in dir "apps"
+    And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
+    And app "multidirtest" with version "1.0.10" has been put in dir "apps-custom"
+    When the administrator gets the path for app "multidirtest" using the occ command
+    Then the path to "multidirtest" should be "apps-custom"
 
   Scenario: Update of patch version of an app
-    Given app "updatetest" with version "2.0.0" has been put in dir "apps"
+    Given these apps' path has been configured additionally with following attributes:
+      | dir           | is_writable  |
+      | apps-custom   | true         |
+    And app "updatetest" with version "2.0.0" has been put in dir "apps"
     And app "updatetest" has been enabled
     And app "updatetest" has been disabled
     When the administrator puts app "updatetest" with version "2.0.1" in dir "apps"
     And the administrator enables app "updatetest"
     Then the installed version of "updatetest" should be "2.0.1"
 
-  Scenario: Update of patch version of an app but update is put in alternative folder
-    Given app "updatetest" with version "2.0.0" has been put in dir "apps"
+  Scenario: Update of patch version of an app in apps-external, previous version in apps folder
+    Given these apps' path has been configured additionally with following attributes:
+      | dir           | is_writable  |
+      | apps-custom   | true         |
+    And app "updatetest" with version "2.0.0" has been put in dir "apps"
     And app "updatetest" has been enabled
     And app "updatetest" has been disabled
-    When the administrator puts app "updatetest" with version "2.0.1" in dir "apps2"
+    When the administrator puts app "updatetest" with version "2.0.1" in dir "apps-external"
+    And the administrator enables app "updatetest"
+    Then the installed version of "updatetest" should be "2.0.1"
+
+  Scenario: Update of patch version of an app in apps-external
+    Given these apps' path has been configured additionally with following attributes:
+      | dir           | is_writable  |
+      | apps-custom   | true         |
+    And app "updatetest" with version "2.0.0" has been put in dir "apps-external"
+    And app "updatetest" has been enabled
+    And app "updatetest" has been disabled
+    When the administrator puts app "updatetest" with version "2.0.1" in dir "apps-external"
+    And the administrator enables app "updatetest"
+    Then the installed version of "updatetest" should be "2.0.1"
+
+  Scenario: Update of patch version of an app but update is put in alternative folder
+    Given these apps' path has been configured additionally with following attributes:
+      | dir         | is_writable |
+      | apps-custom | true        |
+    And app "updatetest" with version "2.0.0" has been put in dir "apps"
+    And app "updatetest" has been enabled
+    And app "updatetest" has been disabled
+    When the administrator puts app "updatetest" with version "2.0.1" in dir "apps-custom"
+    And the administrator enables app "updatetest"
+    Then the installed version of "updatetest" should be "2.0.1"
+
+  Scenario: Update of patch version of an app previously in apps-external but update is put in alternative folder
+    Given these apps' path has been configured additionally with following attributes:
+      | dir           | is_writable  |
+      | apps-custom   | true         |
+    And app "updatetest" with version "2.0.0" has been put in dir "apps-external"
+    And app "updatetest" has been enabled
+    And app "updatetest" has been disabled
+    When the administrator puts app "updatetest" with version "2.0.1" in dir "apps-custom"
     And the administrator enables app "updatetest"
     Then the installed version of "updatetest" should be "2.0.1"

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -329,8 +329,8 @@ Feature: sharing
     And user "user1" has been created with default attributes and skeleton files
     And group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    When user "user0" shares file "/PARENT" with user "user1" using the sharing API
-    And user "user0" shares file "/PARENT/CHILD" with group "grp4" using the sharing API
+    When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+    And user "user0" shares folder "/PARENT/CHILD" with group "grp4" using the sharing API
     Then user "user1" should see the following elements
       | /FOLDER/                 |
       | /PARENT/                 |
@@ -410,8 +410,8 @@ Feature: sharing
       | user2    |
     And user "user0" has created folder "/foo"
     And user "user1" has created folder "/foo"
-    When user "user0" shares file "/foo" with user "user2" using the sharing API
-    And user "user1" shares file "/foo" with user "user2" using the sharing API
+    When user "user0" shares folder "/foo" with user "user2" using the sharing API
+    And user "user1" shares folder "/foo" with user "user2" using the sharing API
     Then user "user2" should see the following elements
       | /foo/       |
       | /foo%20(2)/ |
@@ -437,8 +437,8 @@ Feature: sharing
     And group "grp1" has been created
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/sub"
-    And user "user0" has shared file "/test" with group "grp1"
-    When user "user0" shares file "/test/sub" with user "user1" using the sharing API
+    And user "user0" has shared folder "/test" with group "grp1"
+    When user "user0" shares folder "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user1" folder "/sub" should exist
@@ -454,8 +454,8 @@ Feature: sharing
     And user "user0" has been added to group "grp1"
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/sub"
-    And user "user0" has shared file "/test" with group "grp1"
-    When user "user0" shares file "/test/sub" with user "user1" using the sharing API
+    And user "user0" has shared folder "/test" with group "grp1"
+    When user "user0" shares folder "/test/sub" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "user1" folder "/sub" should exist
@@ -473,22 +473,22 @@ Feature: sharing
       | user3    |
       | user4    |
     And user "user0" has created folder "/folder1"
-    And user "user0" has shared file "/folder1" with user "user1"
-    And user "user0" has shared file "/folder1" with user "user2"
+    And user "user0" has shared folder "/folder1" with user "user1"
+    And user "user0" has shared folder "/folder1" with user "user2"
     And user "user0" has created folder "/folder1/folder2"
-    And user "user0" has shared file "/folder1/folder2" with user "user3"
-    And user "user0" has shared file "/folder1/folder2" with user "user4"
+    And user "user0" has shared folder "/folder1/folder2" with user "user3"
+    And user "user0" has shared folder "/folder1/folder2" with user "user4"
     And as user "user0"
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the response should contain 4 entries
-    And file "/folder1" should be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     And the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
     And the response should contain 2 entries
-    And file "/folder1" should not be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should not be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -572,7 +572,7 @@ Feature: sharing
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
     And user "user0" has created folder "folderToShare"
-    When user "user0" shares file "folderToShare" with group "anotherGroup" using the sharing API
+    When user "user0" shares folder "folderToShare" with group "anotherGroup" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" file "folderToShare" should not exist

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -566,15 +566,16 @@ Feature: sharing
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
-    And group "excludedFromSharing" has been created
-    And user "user0" has been added to group "excludedFromSharing"
+    And group "grp1" has been created
+    # Note: in user_ldap, user1 is already in grp1
+    And user "user1" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
-    And user "user0" has moved file "welcome.txt" to "fileToShare.txt"
-    When user "user0" shares file "fileToShare.txt" with user "user1" using the sharing API
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
+    And user "user1" has moved file "welcome.txt" to "fileToShare.txt"
+    When user "user1" shares file "fileToShare.txt" with user "user0" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" file "fileToShare.txt" should not exist
+    And as "user0" file "fileToShare.txt" should not exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -582,18 +583,20 @@ Feature: sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes and without skeleton files
-    And group "excludedFromSharing" has been created
-    And group "anotherGroup" has been created
-    And user "user0" has been added to group "excludedFromSharing"
-    And user "user1" has been added to group "anotherGroup"
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And group "grp2" has been created
+    # Note: in user_ldap, user1 is already in grp1, user3 is already in grp2
+    And user "user1" has been added to group "grp1"
+    And user "user3" has been added to group "grp2"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
-    And user "user0" has moved file "welcome.txt" to "fileToShare.txt"
-    When user "user0" shares file "fileToShare.txt" with group "anotherGroup" using the sharing API
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
+    And user "user1" has moved file "welcome.txt" to "fileToShare.txt"
+    When user "user1" shares file "fileToShare.txt" with group "grp2" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" file "fileToShare.txt" should not exist
+    And as "user3" file "fileToShare.txt" should not exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -602,15 +605,16 @@ Feature: sharing
   Scenario Outline: user who is excluded from sharing tries to share a folder with another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
-    And group "excludedFromSharing" has been created
-    And user "user0" has been added to group "excludedFromSharing"
+    And group "grp1" has been created
+    # Note: in user_ldap, user1 is already in grp1
+    And user "user1" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
-    And user "user0" has created folder "folderToShare"
-    When user "user0" shares folder "folderToShare" with user "user1" using the sharing API
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
+    And user "user1" has created folder "folderToShare"
+    When user "user1" shares folder "folderToShare" with user "user0" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" folder "folderToShare" should not exist
+    And as "user0" folder "folderToShare" should not exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -619,17 +623,19 @@ Feature: sharing
   Scenario Outline: user who is excluded from sharing tries to share a folder with a group
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
-    And group "excludedFromSharing" has been created
-    And group "anotherGroup" has been created
-    And user "user0" has been added to group "excludedFromSharing"
-    And user "user1" has been added to group "anotherGroup"
+    And user "user3" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And group "grp2" has been created
+    # Note: in user_ldap, user1 is already in grp1, user3 is already in grp2
+    And user "user1" has been added to group "grp1"
+    And user "user3" has been added to group "grp2"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["excludedFromSharing"]'
-    And user "user0" has created folder "folderToShare"
-    When user "user0" shares folder "folderToShare" with group "anotherGroup" using the sharing API
+    And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
+    And user "user1" has created folder "folderToShare"
+    When user "user1" shares folder "folderToShare" with group "grp2" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" file "folderToShare" should not exist
+    And as "user2" folder "folderToShare" should not exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -901,6 +907,7 @@ Feature: sharing
       | 1               |
       | 2               |
 
+  @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names
     Given using OCS API version "<ocs_api_version>"
     And group "<group_id1>" has been created
@@ -935,6 +942,7 @@ Feature: sharing
       | 2              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             |
       | 2              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             |
 
+  @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with non-existent groups with different upper and lower case names
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -846,3 +846,70 @@ Feature: sharing
       | ocs_api_version |
       | 1               |
       | 2               |
+
+  Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names
+    Given using OCS API version "<ocs_api_version>"
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user1" has been added to group "<group_id1>"
+    And user "user2" has been added to group "<group_id2>"
+    And user "user3" has been added to group "<group_id3>"
+    When user "user0" shares file "textfile1.txt" with group "<group_id1>" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the content of file "textfile1.txt" for user "user1" should be "ownCloud test text file 1" plus end-of-line
+    When user "user0" shares folder "textfile2.txt" with group "<group_id2>" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the content of file "textfile2.txt" for user "user2" should be "ownCloud test text file 2" plus end-of-line
+    When user "user0" shares folder "textfile3.txt" with group "<group_id3>" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the content of file "textfile3.txt" for user "user3" should be "ownCloud test text file 3" plus end-of-line
+    Examples:
+      | ocs_api_version | group_id1           | group_id2            | group_id3            | ocs_status_code |
+      | 1              | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | 100             |
+      | 1              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 100             |
+      | 1              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 100             |
+      | 2              | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | 200             |
+      | 2              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             |
+      | 2              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             |
+
+  Scenario Outline: group names are case-sensitive, sharing with non-existent groups with different upper and lower case names
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And group "<group_id1>" has been created
+    And user "user1" has been added to group "<group_id1>"
+    When user "user0" shares file "textfile1.txt" with group "<group_id1>" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | share_with  | <group_id1>    |
+      | file_target | /textfile1.txt |
+      | path        | /textfile1.txt |
+      | permissions | 19             |
+      | uid_owner   | user0          |
+    And the content of file "textfile1.txt" for user "user1" should be "ownCloud test text file 1" plus end-of-line
+    When user "user0" shares file "textfile2.txt" with group "<group_id2>" using the sharing API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    When user "user0" shares file "textfile3.txt" with group "<group_id3>" using the sharing API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      |ocs_api_version | group_id1            | group_id2            | group_id3            | ocs_status_code | http_status_code |
+      | 1              | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | 100             | 200              |
+      | 1              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 100             | 200              |
+      | 1              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 100             | 200              |
+      | 2              | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | 200             | 404              |
+      | 2              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             | 404              |
+      | 2              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             | 404              |
+

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -7,7 +7,7 @@ Feature: sharing
 
   @smokeTest
   @skipOnEncryptionType:user-keys @issue-32322
-  Scenario Outline: Creating a share of a file with a user
+  Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
@@ -54,7 +54,7 @@ Feature: sharing
       | 1               | 2                     | 3                   | 100             |
       | 2               | 2                     | 3                   | 200             |
 
-  Scenario Outline: Creating a share of a folder with a user
+  Scenario Outline: Creating a share of a folder with a user, the default permissions are all permissions(31)
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     When user "user0" shares folder "/FOLDER" with user "user1" using the sharing API
@@ -71,7 +71,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a share of a file with a group
+  Scenario Outline: Creating a share of a file with a group, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     When user "user0" shares file "/welcome.txt" with group "grp1" using the sharing API
@@ -88,7 +88,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a share of a folder with a group
+  Scenario Outline: Creating a share of a folder with a group, the default permissions are all permissions(31)
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     When user "user0" shares folder "/FOLDER" with group "grp1" using the sharing API
@@ -126,12 +126,24 @@ Feature: sharing
       | 2               | 200             |
 
   @public_link_share-feature-required
-  Scenario Outline: Creating a new public link share of a file
+  Scenario Outline: Creating a new public link share of a file, the default permissions are read (1)
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
       | path | welcome.txt |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | item_type              | file         |
+      | mimetype               | text/plain   |
+      | file_target            | /welcome.txt |
+      | path                   | /welcome.txt |
+      | permissions            | 1            |
+      | share_type             | 3            |
+      | displayname_file_owner | User Zero    |
+      | displayname_owner      | User Zero    |
+      | uid_file_owner         | user0        |
+      | uid_owner              | user0        |
+      | name                   |              |
     And the last public shared file should be able to be downloaded without a password
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -146,7 +158,21 @@ Feature: sharing
       | password | %public%    |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | item_type              | file         |
+      | mimetype               | text/plain   |
+      | file_target            | /welcome.txt |
+      | path                   | /welcome.txt |
+      | permissions            | 1            |
+      | share_type             | 3            |
+      | displayname_file_owner | User Zero    |
+      | displayname_owner      | User Zero    |
+      | uid_file_owner         | user0        |
+      | uid_owner              | user0        |
+      | name                   |              |
     And the last public shared file should be able to be downloaded with password "%public%"
+    But the last public shared file should not be able to be downloaded with password "%regular%"
+    And the last public shared file should not be able to be downloaded without a password
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -161,12 +187,17 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
-      | file_target | /welcome.txt |
-      | path        | /welcome.txt |
-      | item_type   | file         |
-      | share_type  | 3            |
-      | permissions | 1            |
-      | uid_owner   | user0        |
+      | item_type              | file         |
+      | mimetype               | text/plain   |
+      | file_target            | /welcome.txt |
+      | path                   | /welcome.txt |
+      | permissions            | 1            |
+      | share_type             | 3            |
+      | displayname_file_owner | User Zero    |
+      | displayname_owner      | User Zero    |
+      | uid_file_owner         | user0        |
+      | uid_owner              | user0        |
+      | name                   |              |
     And the last public shared file should be able to be downloaded without a password
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -174,14 +205,54 @@ Feature: sharing
       | 2               | 200             |
 
   @public_link_share-feature-required
-  Scenario Outline: Creating a new public link share of a folder
+  Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password
+    Given using OCS API version "<ocs_api_version>"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path     | PARENT   |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | item_type              | folder               |
+      | mimetype               | httpd/unix-directory |
+      | file_target            | /PARENT              |
+      | path                   | /PARENT              |
+      | permissions            | 1                    |
+      | share_type             | 3                    |
+      | displayname_file_owner | User Zero            |
+      | displayname_owner      | User Zero            |
+      | uid_file_owner         | user0                |
+      | uid_owner              | user0                |
+      | name                   |                      |
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%regular%" and the content should be "wnCloud"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario Outline: Creating a new public link share of a folder, with a password
     Given using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
       | password | %public% |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    Then the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+    And the fields of the last response should include
+      | item_type              | folder               |
+      | mimetype               | httpd/unix-directory |
+      | file_target            | /PARENT              |
+      | path                   | /PARENT              |
+      | permissions            | 1                    |
+      | share_type             | 3                    |
+      | displayname_file_owner | User Zero            |
+      | displayname_owner      | User Zero            |
+      | uid_file_owner         | user0                |
+      | uid_owner              | user0                |
+      | name                   |                      |
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+    But the public should not be able to download file "/parent.txt" from inside the last public shared folder without a password
+    And the public should not be able to download file "/parent.txt" from inside the last public shared folder with password "%regular%"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -252,23 +323,6 @@ Feature: sharing
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
-
-  @public_link_share-feature-required
-  Scenario Outline: Creating a link share with no specified permissions defaults to read permissions
-    Given using OCS API version "<ocs_api_version>"
-    And user "user0" has created folder "/afolder"
-    When user "user0" creates a public link share using the sharing API with settings
-      | path | /afolder |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the fields of the last response should include
-      | id          | A_NUMBER |
-      | share_type  | 3        |
-      | permissions | 1        |
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -565,7 +565,7 @@ Feature: sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     # Note: in user_ldap, user1 is already in grp1
     And user "user1" has been added to group "grp1"

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -975,3 +975,20 @@ Feature: sharing
       | 2              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             | 404              |
       | 2              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             | 404              |
 
+  @issue-35550
+  Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path | textfile0.txt |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the OCS status message should be "Expiration date is enforced"
+    And the HTTP status code should be "<http_status_code>"
+#    And the last public shared file should be able to be downloaded without a password
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 403             | 200              |
+#      | 1               | 100             | 100              |
+      | 2               | 403             | 403              |
+#      | 2               | 200             | 200              |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -975,7 +975,7 @@ Feature: sharing
       | 2              | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             | 404              |
       | 2              | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             | 404              |
 
-  @issue-35550
+  @public_link_share-feature-required
   Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -983,12 +983,28 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path | textfile0.txt |
     Then the OCS status code should be "<ocs_status_code>"
-    And the OCS status message should be "Expiration date is enforced"
     And the HTTP status code should be "<http_status_code>"
-#    And the last public shared file should be able to be downloaded without a password
+    And the fields of the last response should include
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | item_type   | file           |
+      | share_type  | 3              |
+      | permissions | 1              |
+      | uid_owner   | user0          |
+      | expiration  | +7 days        |
+    When user "user0" gets the info of the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And the fields of the last response should include
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | item_type   | file           |
+      | share_type  | 3              |
+      | permissions | 1              |
+      | uid_owner   | user0          |
+      | expiration  | +7 days        |
+    And the last public shared file should be able to be downloaded without a password
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 403             | 200              |
-#      | 1               | 100             | 100              |
-      | 2               | 403             | 403              |
-#      | 2               | 200             | 200              |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -62,24 +62,24 @@ Feature: sharing
       | user3    |
       | user4    |
     And user "user0" has created folder "/folder1"
-    And user "user0" has shared file "/folder1" with user "user1"
-    And user "user0" has shared file "/folder1" with user "user2"
+    And user "user0" has shared folder "/folder1" with user "user1"
+    And user "user0" has shared folder "/folder1" with user "user2"
     And user "user0" has created folder "/folder1/folder2"
-    And user "user0" has shared file "/folder1/folder2" with user "user3"
-    And user "user0" has shared file "/folder1/folder2" with user "user4"
+    And user "user0" has shared folder "/folder1/folder2" with user "user3"
+    And user "user0" has shared folder "/folder1/folder2" with user "user4"
     And as user "user0"
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the response should contain 4 entries
-    And file "/folder1" should be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the response should contain 2 entries
-    And file "/folder1" should not be included as path in the response
-    And file "/folder1/folder2" should be included as path in the response
+    And folder "/folder1" should not be included as path in the response
+    And folder "/folder1/folder2" should be included as path in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -21,7 +21,6 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -445,7 +445,18 @@ trait Provisioning {
 		$results = HttpRequestHelper::sendBatchRequest($requests, $client);
 		// Retrieve all failures.
 		foreach ($results->getFailures() as $e) {
-			throw $e;
+			$failedUser = $e->getRequest()->getBody()->getFields()['userid'];
+			$message = $this->getResponseXml($e->getResponse())->xpath("/ocs/meta/message");
+			if ($message && (string) $message[0] === "User already exists") {
+				PHPUnit\Framework\Assert::fail(
+					"Could not create user '$failedUser' as it already exists. " .
+					"Please delete the user to run tests again."
+				);
+			}
+			throw new Exception(
+				"could not create user. "
+				. $e->getResponse()->getStatusCode() . " " . $e->getResponse()->getBody()
+			);
 		}
 
 		// Create requests for setting displayname and email for the newly created users.
@@ -464,15 +475,12 @@ trait Provisioning {
 		}
 		// Edit the users in parallel to make the process faster.
 		if (\count($editData) > 0) {
-			$results = UserHelper::editUserBatch(
+			UserHelper::editUserBatch(
 				$this->getBaseUrl(),
 				$editData,
 				$this->getAdminUsername(),
 				$this->getAdminPassword()
 			);
-			foreach ($results->getFailures() as $e) {
-				throw new \Exception("Could not edit user\n" . $e->getMessage());
-			}
 		}
 
 		// If the users need to be initialized then initialize them in parallel.
@@ -1333,7 +1341,12 @@ trait Provisioning {
 		$response = HttpRequestHelper::sendBatchRequest($requests, $client);
 		// throw an exception if any request fails.
 		foreach ($response->getFailures() as $e) {
-			throw new \Exception("Could not initialize user\n" . $e->getMessage());
+			$pathArray = \explode('/', $e->getRequest()->getPath());
+			$failedUser = \end($pathArray);
+			throw new \Exception(
+				"Could not initialize user $failedUser \n"
+				. $e->getResponse()->getStatusCode() . "\n" . $e->getResponse()->getBody()
+			);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -262,6 +262,21 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder without a password$/
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolder(
+		$path
+	) {
+		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+			"", $path, ""
+		);
+	}
+
+	/**
 	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
@@ -275,6 +290,22 @@ class PublicWebDavContext implements Context {
 	) {
 		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
 			"", $path, $password, $content
+		);
+	}
+
+	/**
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder with password "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
+		$path, $password
+	) {
+		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+			"", $path, $password
 		);
 	}
 
@@ -298,6 +329,24 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder with password "([^"]*)"$/
+	 *
+	 * @param string $range
+	 * @param string $path
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+		$range, $path, $password
+	) {
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
+			$path, $password, $range
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBe(401);
+	}
+
+	/**
 	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder and the content should be "([^"]*)"$/
 	 *
 	 * @param string $range
@@ -311,6 +360,22 @@ class PublicWebDavContext implements Context {
 	) {
 		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
 			$range, $path, "", $content
+		);
+	}
+
+	/**
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder without a password$/
+	 *
+	 * @param string $range
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolder(
+		$range, $path
+	) {
+		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+			$range, $path, ""
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -730,7 +730,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should be included in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $filename
 	 *
@@ -745,7 +745,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should not be included in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $filename
 	 *
@@ -760,7 +760,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should be included as path in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should be included as path in the response$/
 	 *
 	 * @param string $filename
 	 *
@@ -775,7 +775,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should not be included as path in the response$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should not be included as path in the response$/
 	 *
 	 * @param string $filename
 	 *

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -405,6 +405,15 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then the last public shared file should not be able to be downloaded without a password
+	 *
+	 * @return void
+	 */
+	public function theLastPublicSharedFileShouldNotBeAbleToBeDownloadedWithoutAPassword() {
+		$this->theLastPublicSharedFileShouldNotBeAbleToBeDownloadedWithPassword(null);
+	}
+
+	/**
 	 * @Then /^the last public shared file should be able to be downloaded with password "([^"]*)"$/
 	 *
 	 * @param string $password

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -858,7 +858,7 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Then /^file "([^"]*)" should have the following tags for the (administrator|user)$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should have the following tags for the (administrator|user)$/
 	 *
 	 * @param string $fileName
 	 * @param string $adminOrUser
@@ -913,8 +913,9 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Then file :fileName should have no tags for user :user
-	 * @Then /^file "([^"]*)" should have no tags for the (administrator|user)?$/
+	 * @Then file/folder :fileName should have no tags for user :user
+	 * @Then entry :fileName should have no tags for user :user
+	 * @Then /^(?:file|folder|entry) "([^"]*)" should have no tags for the (administrator|user)?$/
 	 *
 	 * @param string $fileName
 	 * @param string $adminOrUser

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -24,7 +24,6 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\PersonalGeneralSettingsPage;
-use PHPUnit\Framework\Assert;
 use TestHelpers\EmailHelper;
 
 require_once 'bootstrap.php';

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -29,7 +29,6 @@ use Page\FilesPageElement\SharingDialog;
 use Page\PublicLinkFilesPage;
 use Page\SharedWithYouPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
-use TestHelpers\AppConfigHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\EmailHelper;
 use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -32,6 +32,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\EmailHelper;
 use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;
+use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
 use GuzzleHttp\Message\ResponseInterface;
 use Page\GeneralErrorPage;
 use Page\SharedWithOthersPage;
@@ -100,7 +101,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	private $oldMinCharactersForAutocomplete = null;
 	private $oldFedSharingFallbackSetting = null;
 
+	/**
+	 * @var PublicLinkTab
+	 */
 	private $publicShareTab;
+
 	/**
 	 *
 	 * @var EditPublicLinkPopup
@@ -432,6 +437,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($linkName);
 		$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+
+		$this->featureContext->resetLastShareData();
 	}
 
 	/**
@@ -512,6 +519,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserShouldSeeAnErrorMessageOnThPublicLinkPopupSaying($message) {
+		// update public-sharing popup, as it might not have been set previously.
+		$this->publicSharingPopup = $this->publicShareTab->updateSharingPopup($this->getSession());
 		$errormessage = $this->publicSharingPopup->getErrorMessage();
 		PHPUnit\Framework\Assert::assertEquals($message, $errormessage);
 	}

--- a/tests/acceptance/features/bootstrap/WebUITagsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUITagsContext.php
@@ -25,7 +25,6 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\FilesPage;
 use Page\TagsPage;
-use Behat\Gherkin\Node\TableNode;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -662,4 +662,32 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		$this->usersPage->setSetting('Show email address');
 		$this->usersPage->changeUserEmail($this->getSession(), $username, $email);
 	}
+
+	/**
+	 * @Then /^the user count of group "([^"]*)" should display (\d+) users on the webUI$/
+	 *
+	 * @param string $group
+	 * @param int $count
+	 *
+	 * @return void
+	 */
+	public function theUserCountOfGroupShouldDisplayUsersOnTheWebUI($group, $count) {
+		$expectedCount = (int) $count;
+		$actualCount = $this->usersPage->getUserCountOfGroup($group);
+		PHPUnit\Framework\Assert::assertEquals($expectedCount, $actualCount);
+	}
+
+	/**
+	 * @Then the user count of group :group should not be displayed on the webUI
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function theUserCountOfGroupShouldNotBeDisplayedOnTheWebui($group) {
+		$count = $this->usersPage->getUserCountOfGroup($group);
+		PHPUnit\Framework\Assert::assertNull(
+			$count, "Failed asserting that user count of group $group is not displayed"
+		);
+	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -28,6 +28,7 @@ use Behat\Mink\Session;
 use Exception;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 
 /**
  * The Public link tab of the Sharing Dialog
@@ -50,7 +51,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @var EditPublicLinkPopup
 	 */
 	private $editPublicLinkPopupPageObject;
-	
+
 	/**
 	 * sets the NodeElement for the current popup
 	 * a little bit like __construct() but as we access this "sub-page-object"
@@ -178,7 +179,7 @@ class PublicLinkTab extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 *
-	 * @return void
+	 * @return EditPublicLinkPopup
 	 */
 	public function updateSharingPopup(Session $session) {
 		$this->editPublicLinkPopupPageObject = $this->getPage(
@@ -187,6 +188,7 @@ class PublicLinkTab extends OwncloudPage {
 		$this->editPublicLinkPopupPageObject->waitTillPageIsLoaded(
 			$session, STANDARD_UI_WAIT_TIMEOUT_MILLISEC, $this->popupXpath
 		);
+		return $this->editPublicLinkPopupPageObject;
 	}
 
 	/**

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -101,6 +101,8 @@ class UsersPage extends OwncloudPage {
 	protected $userGroupsInputXpath = "./div[@class='groupsListContainer multiselect button']";
 	protected $groupLabelInInputXpath = ".//ul[@class='multiselectoptions down']/li/label[@title='%s']";
 	protected $groupInputXpath = ".//ul[@class='multiselectoptions down']/li/input[@id='%s']";
+	protected $activeDropDownXpath = "//div[@class='multiselect button active down']";
+	protected $groupUserCountXpath = "//li[@data-gid='%s']//span[@class='usercount']";
 
 	/**
 	 * @param string $username
@@ -786,6 +788,7 @@ class UsersPage extends OwncloudPage {
 	 * @param boolean $add Boolean value to specify wether to add or remove user from the group
 	 *
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function addOrRemoveUserToGroup(Session $session, $user, $group, $add=true) {
 		$userTr = $this->findUserInTable($user);
@@ -823,6 +826,14 @@ class UsersPage extends OwncloudPage {
 			$groupLabel->click();
 			$this->waitForAjaxCallsToStartAndFinish($session);
 		}
+		$activeDropDown = $this->find('xpath', $this->activeDropDownXpath);
+		$this->assertElementNotNull(
+			$activeDropDown,
+			__METHOD__ .
+			" xpath $this->activeDropDownXpath " .
+			"could not find any active drop down"
+		);
+		$activeDropDown->click();
 	}
 
 	/**
@@ -860,5 +871,27 @@ class UsersPage extends OwncloudPage {
 				__METHOD__ . " timeout waiting for user list to load on users page"
 			);
 		}
+	}
+
+	/**
+	 * @param string $group
+	 *
+	 * @return int|null
+	 * @throws ElementNotFoundException
+	 */
+	public function getUserCountOfGroup($group) {
+		$groupUserCountXpath = \sprintf($this->groupUserCountXpath, $group);
+		$groupUserCount = $this->find('xpath', $groupUserCountXpath);
+		$this->assertElementNotNull(
+			$groupUserCount,
+			__METHOD__ .
+			" xpath $groupUserCountXpath " .
+			"could not find user count for group $group"
+		);
+		$groupUserCount = \trim($groupUserCount->getText());
+		if ($groupUserCount === "") {
+			return null;
+		}
+		return (int) $groupUserCount;
 	}
 }

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -214,8 +214,16 @@ Feature: add users
       | Brand-New-User    | BRAND-NEW-USER | brand-new-user |
       | brand-new-user    | Brand-New-User | BRAND-NEW-USER |
 
-  Scenario: admin tries to create an existing user but with username containing capital letters
-    Given user "user1" has been created with default attributes and without skeleton files
-    When the administrator creates a user with the name "USER1" and the password "password" using the webUI
+  Scenario Outline: user names are not case-sensitive, multiple users can't exist with different upper and lower case names
+    When the administrator creates a user with the name "<user_id1>" and the password "password" using the webUI
+    And the administrator creates a user with the name "<user_id2>" and the password "password" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Error creating user: A user with that name already exists. |
+    When the administrator creates a user with the name "<user_id3>" and the password "password" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | Error creating user: A user with that name already exists. |
+    Examples:
+      | user_id1          | user_id2       | user_id3       |
+      | Brand-New-User    | brand-new-user | BRAND-NEW-USER |
+      | brand-new-user    | BRAND-NEW-USER | Brand-New-User |
+      | BRAND-NEW-USER    | Brand-New-User | brand-new-user |

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -58,3 +58,19 @@ Feature: Add group
       | "✍"                          |
       | "⛷"                           |
       | "⛹"                           |
+
+  Scenario: adding multiple users to a group
+    Given these users have been created without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And the administrator has reloaded the users page
+    When the administrator adds user "user0" to group "grp1" using the webUI
+    And the administrator adds user "user1" to group "grp1" using the webUI
+    Then the user count of group "grp1" should display 2 users on the webUI
+    When the administrator adds user "user2" to group "grp1" using the webUI
+    Then the user count of group "grp1" should display 3 users on the webUI
+    When the administrator reloads the users page
+    Then the user count of group "grp1" should display 3 users on the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -23,3 +23,16 @@ Feature: delete users
   Scenario: use the webUI to cancel deletion of user
     When the administrator deletes user "user1" using the webUI and cancels the deletion using the webUI
     Then user "user1" should exist
+
+  Scenario Outline:  user names are not case-sensitive, deleting users with different upper and lower case names
+    When the administrator creates a user with the name "<user_id1>" and the password "password" using the webUI
+    Then user "<user_id1>" should exist
+    And user "<user_id2>" should exist
+    When the administrator deletes user "<user_id1>" using the webUI and confirms the deletion using the webUI
+    Then user "<user_id1>" should not exist
+    And user "<user_id2>" should not exist
+    Examples:
+      | user_id1          | user_id2       |
+      | Brand-New-User    | brand-new-user |
+      | brand-new-user    | Brand-New-User |
+      | Brand-New-User    | BRAND-NEW-USER |

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -110,3 +110,22 @@ Feature: edit users
       | New-Group | new-group | NEW-GROUP |
       | new-group | NEW-GROUP | New-Group |
       | NEW-GROUP | New-Group | new-group |
+
+  Scenario: removing multiple users from a group
+    Given these users have been created without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And user "user0" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And the administrator has browsed to the users page
+    When the administrator removes user "user0" from group "grp1" using the webUI
+    And the administrator removes user "user1" from group "grp1" using the webUI
+    Then the user count of group "grp1" should display 1 users on the webUI
+    When the administrator removes user "user2" from group "grp1" using the webUI
+    Then the user count of group "grp1" should not be displayed on the webUI
+    When the administrator reloads the users page
+    Then the user count of group "grp1" should not be displayed on the webUI

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -52,6 +52,7 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "other" should not be listed in the autocomplete list on the webUI
 
+  @skipOnLDAP
   Scenario: autocompletion for a pattern that does not match any user or group
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -214,3 +214,44 @@ Feature: Sharing files and folders with internal groups
     And file "lorem (2).txt" should be listed on the webUI
     And file "lorem (2).txt" should be marked as shared with "grp1" by "User One" on the webUI
     And the content of file "lorem (2).txt" for user "user3" should be "some content"
+
+  Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names
+    Given user "some-user" has been created with default attributes and skeleton files
+    And group "<group_id1>" has been created
+    And group "<group_id2>" has been created
+    And group "<group_id3>" has been created
+    And user "user1" has been added to group "<group_id1>"
+    And user "user2" has been added to group "<group_id2>"
+    And user "user3" has been added to group "<group_id3>"
+    And user "some-user" has created folder "/simple-folder"
+    And user "some-user" has logged in using the webUI
+    When the user shares folder "simple-folder" with group "<group_id1>" using the webUI
+    And the user shares folder "simple-folder" with group "<group_id2>" using the webUI
+    And the user shares folder "simple-folder" with group "<group_id3>" using the webUI
+    And the user re-logs in as "user1" using the webUI
+    Then folder "simple-folder" should be marked as shared with "<group_id1>" by "Regular User" on the webUI
+    When the user re-logs in as "user2" using the webUI
+    Then folder "simple-folder" should be marked as shared with "<group_id2>" by "Regular User" on the webUI
+    When the user re-logs in as "user3" using the webUI
+    Then folder "simple-folder (2)" should be marked as shared with "<group_id3>" by "Regular User" on the webUI
+    Examples:
+      | group_id1            | group_id2            | group_id3            |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
+
+  Scenario Outline: group names are case-sensitive, sharing with groups in different case group name fail, if they don't exist
+    Given group "<group_id1>" has been created
+    And user "user2" has created folder "/simple-folder"
+    And user "user2" has logged in using the webUI
+    When the user shares folder "simple-folder" with group "<group_id1>" using the webUI
+    And the user has opened the share dialog for folder "simple-folder"
+    And the user types "<group_id2>" in the share-with-field
+    Then a tooltip with the text "No users or groups found for <group_id2>" should be shown near the share-with-field on the webUI
+    When the user types "<group_id3>" in the share-with-field
+    Then a tooltip with the text "No users or groups found for <group_id3>" should be shown near the share-with-field on the webUI
+    Examples:
+      | group_id1            | group_id2            | group_id3            |
+      | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
+      | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
+      | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -371,3 +371,24 @@ Feature: Sharing files and folders with internal users
     And folder "zzzfolder" should be marked as shared by "User Two" on the webUI
     And folder "zzzfolder (2)" should be listed on the webUI
     And folder "zzzfolder (2)" should be marked as shared by "User Three" on the webUI
+
+  Scenario Outline:  user names are not case-sensitive, sharing same file to user specifying different upper and lower case names
+    Given these users have been created with default attributes and without skeleton files:
+      | username       |
+      | user1          |
+      | brand-new-user |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has shared folder "simple-folder" with user "brand-new-user"
+    And user "user1" has logged in using the webUI
+    And the user has opened the share dialog for folder "simple-folder"
+    When the user types "<user_id1>" in the share-with-field
+    Then a tooltip with the text "No users or groups found for <user_id1>" should be shown near the share-with-field on the webUI
+    When the user types "<user_id2>" in the share-with-field
+    Then a tooltip with the text "No users or groups found for <user_id2>" should be shown near the share-with-field on the webUI
+    When the user types "<user_id3>" in the share-with-field
+    Then a tooltip with the text "No users or groups found for <user_id3>" should be shown near the share-with-field on the webUI
+    Examples:
+      | user_id1          | user_id2       | user_id3       |
+      | Brand-New-User    | brand-new-user | BRAND-NEW-USER |
+      | brand-new-user    | BRAND-NEW-USER | Brand-New-User |
+      | BRAND-NEW-USER    | Brand-New-User | brand-new-user |

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -614,3 +614,33 @@ Feature: Share by public link
     And the user gets the info of the last share using the sharing API
     And the fields of the last response should include
       | expiration   | |
+
+  Scenario: user creates a new public link using webUI without setting expiration date when default expire date is set but not enforced
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "no"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user creates a new public link for file "lorem.txt" using the webUI with
+      | expiration | |
+    And user "user1" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | expiration   | |
+
+  Scenario: user creates a new public link using webUI removing expiration date when default expire date is set and enforced
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user tries to create a new public link for file "lorem.txt" using the webUI
+      | expiration | |
+    Then the user should see an error message on the public link popup saying "Expiration date is required"
+
+  Scenario: user creates a new public link using webUI when default expire date is set and enforced
+    Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user creates a new public link for file "lorem.txt" using the webUI
+    And user "user1" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | expiration | +7 days |

--- a/tests/apps.php
+++ b/tests/apps.php
@@ -13,15 +13,14 @@ function loadDirectory($path) {
 	if (\strcasecmp(\basename($path), 'ui') === 0) {
 		return;
 	}
-	if ($dh = \opendir($path)) {
-		while ($name = \readdir($dh)) {
-			if ($name[0] !== '.') {
-				$file = $path . '/' . $name;
-				if (\is_dir($file)) {
-					loadDirectory($file);
-				} elseif (\substr($name, -4, 4) === '.php') {
-					require_once $file;
-				}
+	$dirEntries = \scandir($path);
+	foreach ($dirEntries as $name) {
+		if ($name[0] !== '.') {
+			$file = $path . '/' . $name;
+			if (\is_dir($file)) {
+				loadDirectory($file);
+			} elseif (\substr($name, -4, 4) === '.php') {
+				require_once $file;
 			}
 		}
 	}

--- a/tests/apps.php
+++ b/tests/apps.php
@@ -45,7 +45,13 @@ foreach ($apps as $app) {
 		continue;
 	}
 	$dir = OC_App::getAppPath($app);
-	if (\is_dir($dir . '/tests')) {
-		loadDirectory($dir . '/tests');
+
+	// only consider the "built-in" apps found in the apps directory
+	// we do not want to automatically run unit tests for extra apps
+	// that might be in a secondary apps dir like apps-external
+	if (\basename(\dirname($dir)) === "apps") {
+		if (\is_dir($dir . '/tests')) {
+			loadDirectory($dir . '/tests');
+		}
 	}
 }

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -33,13 +33,13 @@ class MigrationsTest extends \Test\TestCase {
 
 		$this->db = $this->createMock(Connection::class);
 		$this->db->expects($this->any())->method('getPrefix')->willReturn('test_oc_');
-		$this->migrationService = new MigrationService('testing', $this->db);
+		$this->migrationService = new MigrationService('files_sharing', $this->db);
 	}
 
 	public function testGetters() {
-		$this->assertEquals('testing', $this->migrationService->getApp());
-		$this->assertEquals(\OC::$SERVERROOT . '/apps/testing/appinfo/Migrations', $this->migrationService->getMigrationsDirectory());
-		$this->assertEquals('OCA\testing\Migrations', $this->migrationService->getMigrationsNamespace());
+		$this->assertEquals('files_sharing', $this->migrationService->getApp());
+		$this->assertEquals(\OC::$SERVERROOT . '/apps/files_sharing/appinfo/Migrations', $this->migrationService->getMigrationsDirectory());
+		$this->assertEquals('OCA\files_sharing\Migrations', $this->migrationService->getMigrationsNamespace());
 		$this->assertEquals('test_oc_migrations', $this->migrationService->getMigrationsTableName());
 	}
 
@@ -75,7 +75,7 @@ class MigrationsTest extends \Test\TestCase {
 	public function testExecuteStepWithUnknownClass() {
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['findMigrations'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('findMigrations')->willReturn(
 			['20170130180000' => 'X', '20170130180001' => 'Y', '20170130180002' => 'Z', '20170130180003' => 'A']
@@ -91,7 +91,7 @@ class MigrationsTest extends \Test\TestCase {
 		$step->expects($this->once())->method('changeSchema');
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['createInstance'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('createInstance')->with('20170130180000')->willReturn($step);
 		$this->migrationService->executeStep('20170130180000');
@@ -104,7 +104,7 @@ class MigrationsTest extends \Test\TestCase {
 		$step->expects($this->once())->method('sql')->willReturn(['1', '2', '3']);
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['createInstance'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('createInstance')->with('20170130180000')->willReturn($step);
 		$this->migrationService->executeStep('20170130180000');
@@ -113,7 +113,7 @@ class MigrationsTest extends \Test\TestCase {
 	public function testGetMigration() {
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['getMigratedVersions', 'findMigrations'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('getMigratedVersions')->willReturn(
 			['20170130180000', '20170130180001']
@@ -139,7 +139,7 @@ class MigrationsTest extends \Test\TestCase {
 	public function testMigrate() {
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->setMethods(['getMigratedVersions', 'findMigrations', 'executeStep'])
-			->setConstructorArgs(['testing', $this->db])
+			->setConstructorArgs(['files_sharing', $this->db])
 			->getMock();
 		$this->migrationService->expects($this->any())->method('getMigratedVersions')->willReturn(
 			['20170130180000', '20170130180001']


### PR DESCRIPTION
## Description
Backports of these PRs from `stable10`

[stable10] Remove unused use from acceptance tests #35629
[stable10] Add tests for app management for apps-external path #35631
[stable10] user create and delete scenario case not sensitive #35632
[stable10] test user remove from group #35639
[stable10] sharing with user and groups with different case username and groupname #35651
[stable10] Make consistent file-folder-entry test steps #35657
[stable10] Load PHPunit app tests in alphabetical order #35669
[stable10] Fix drone webUIMasterKeyType so it runs the tests #35659
[stable10] Add Better error handling to batch user create function in acceptance tests #35674
[stable10] api share with users and group case not sensitive #35675
[stable10] clone testing app into apps external #35679
[stable10] clone testing app into apps external #35679
[stable10] Enhance createShare.feature test scenarios #35686
[stable10] Adjust createShare scenario to ensure skeleton file welcome.txt is there #35691
[stable10] only look for unit tests in the primary apps dir #35700
[stable10] Test regression with public link not created when default expiration date set and enforced #35703


## Motivation and Context
Have the latest test code in the `release-10.2.1` branch.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
