### PR TITLE
Remove obsolete contacts_cards_properties table

### DIFF
--- a/lib/private/Repair/DropOldTables.php
+++ b/lib/private/Repair/DropOldTables.php
@@ -99,7 +99,8 @@ class DropOldTables implements IRepairStep {
 			'clndr_share_calendar',
 			'clndr_repeat',
 			'contacts_addressbooks',
-			'contacts_cards'
+			'contacts_cards',
+			'contacts_cards_properties'
 		];
 	}
 }


### PR DESCRIPTION
## Description
https://github.com/owncloud/core/issues/35720, missed by https://github.com/owncloud/core/issues/21889, https://github.com/owncloud/core/pull/24166

## Related Issue
Fixes https://github.com/owncloud/core/issues/35720

## Motivation and Context
cleaning

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
