### PR TITLE
[stable10] php73 check tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -642,7 +642,7 @@ matrix:
 
   # frontend
     - TEST_SUITE: javascript
-      PHP_VERSION: 7.1
+      PHP_VERSION: 7.3
       COVERAGE: true
 
   # owncloud-coding-standard
@@ -658,7 +658,7 @@ matrix:
       PHP_VERSION: 7.1
 
   # Litmus
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       USE_SERVER: true
       SERVER_PROTOCOL: https
       TEST_SUITE: litmus
@@ -666,34 +666,34 @@ matrix:
       OWNCLOUD_LOG: true
 
   # Unit Tests
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       DB_TYPE: mysql
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       DB_TYPE: mysqlmb4
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       DB_TYPE: postgres
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       DB_TYPE: oracle
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       COVERAGE: true
@@ -752,7 +752,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
   # Files External
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -760,7 +760,7 @@ matrix:
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -768,7 +768,7 @@ matrix:
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    #- PHP_VERSION: 7.1
+    #- PHP_VERSION: 7.3
     #  TEST_SUITE: phpunit
     #  COVERAGE: true
     #  DB_TYPE: sqlite
@@ -776,7 +776,7 @@ matrix:
     #  INSTALL_SERVER: true
     #  INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -794,7 +794,7 @@ matrix:
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -806,7 +806,7 @@ matrix:
 
   # files_primary_s3
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -816,7 +816,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
   # API Acceptance tests
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiMain
       DB_TYPE: mariadb
@@ -827,7 +827,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiAuth
       DB_TYPE: mariadb
@@ -838,7 +838,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiAuthOcs
       DB_TYPE: mariadb
@@ -849,7 +849,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiCapabilities
       DB_TYPE: mariadb
@@ -860,7 +860,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiComments
       DB_TYPE: mariadb
@@ -871,7 +871,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiFavorites
       DB_TYPE: mariadb
@@ -882,7 +882,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiFederation
       DB_TYPE: mariadb
@@ -895,7 +895,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioning-v1
       DB_TYPE: mariadb
@@ -906,7 +906,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioning-v2
       DB_TYPE: mariadb
@@ -917,7 +917,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioningGroups-v1
       DB_TYPE: mariadb
@@ -928,7 +928,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioningGroups-v2
       DB_TYPE: mariadb
@@ -939,7 +939,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiSharees
       DB_TYPE: mariadb
@@ -950,7 +950,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiShareManagement
       DB_TYPE: mariadb
@@ -961,7 +961,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiShareManagementBasic
       DB_TYPE: mariadb
@@ -972,7 +972,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiShareOperations
       DB_TYPE: mariadb
@@ -983,7 +983,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiSharingNotifications
       DB_TYPE: mariadb
@@ -995,7 +995,7 @@ matrix:
       INSTALL_TESTING_APP: true
       INSTALL_NOTIFICATIONS_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiTags
       DB_TYPE: mariadb
@@ -1006,7 +1006,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiTrashbin
       DB_TYPE: mariadb
@@ -1017,7 +1017,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiVersions
       DB_TYPE: mariadb
@@ -1028,7 +1028,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavLocks
       DB_TYPE: mariadb
@@ -1039,7 +1039,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavLocks2
       DB_TYPE: mariadb
@@ -1050,7 +1050,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavMove
       DB_TYPE: mariadb
@@ -1061,7 +1061,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavOperations
       DB_TYPE: mariadb
@@ -1072,7 +1072,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavProperties
       DB_TYPE: mariadb
@@ -1083,7 +1083,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavUpload
       DB_TYPE: mariadb
@@ -1095,7 +1095,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # CLI Provisioning Acceptance tests
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: cli
       BEHAT_SUITE: cliProvisioning
       DB_TYPE: mariadb
@@ -1108,7 +1108,7 @@ matrix:
       USE_EMAIL: true
 
   # CLI Main Acceptance tests
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: cli
       BEHAT_SUITE: cliMain
       DB_TYPE: mariadb
@@ -1120,7 +1120,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
   # CLI Background Acceptance tests
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: cli
       BEHAT_SUITE: cliBackground
       DB_TYPE: mariadb
@@ -1132,7 +1132,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
   # CLI Trashbin Acceptance tests
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: cli
       BEHAT_SUITE: cliTrashbin
       DB_TYPE: mariadb
@@ -1145,7 +1145,7 @@ matrix:
 
   # UI Acceptance tests
   ## Chrome
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIAdminSettings
@@ -1158,7 +1158,7 @@ matrix:
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIComments
@@ -1170,7 +1170,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUICreateDelete
@@ -1182,7 +1182,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIFavorites
@@ -1194,7 +1194,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIFiles
@@ -1206,7 +1206,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUILogin
@@ -1219,7 +1219,7 @@ matrix:
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIMoveFilesFolders
@@ -1231,7 +1231,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIPersonalSettings
@@ -1244,7 +1244,7 @@ matrix:
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIRenameFiles
@@ -1256,7 +1256,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIRenameFolders
@@ -1268,7 +1268,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIRestrictSharing
@@ -1280,7 +1280,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingAcceptShares
@@ -1292,7 +1292,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingAutocompletion
@@ -1304,7 +1304,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingExternal
@@ -1319,7 +1319,7 @@ matrix:
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingInternalGroups
@@ -1332,7 +1332,7 @@ matrix:
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingInternalUsers
@@ -1345,7 +1345,7 @@ matrix:
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingNotifications
@@ -1359,7 +1359,7 @@ matrix:
       USE_EMAIL: true
       INSTALL_NOTIFICATIONS_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingPublic
@@ -1374,7 +1374,7 @@ matrix:
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUITags
@@ -1386,7 +1386,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUITrashbin
@@ -1398,7 +1398,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIUpload
@@ -1411,7 +1411,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # This suite is part of the user_management app in later core versions
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIAddUsers
@@ -1425,7 +1425,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # This suite is part of the user_management app in later core versions
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIManageUsersGroups
@@ -1439,7 +1439,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # This suite is part of the user_management app in later core versions
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIManageQuota
@@ -1452,7 +1452,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # This suite is part of the user_management app in later core versions
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISettingsMenu
@@ -1464,7 +1464,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIWebdavLocks
@@ -1476,7 +1476,7 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIWebdavLockProtection
@@ -1489,7 +1489,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     ## Firefox
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: firefox
       DB_TYPE: mariadb
@@ -1506,7 +1506,7 @@ matrix:
       DIVIDE_INTO_NUM_PARTS: 3
       RUN_PART: 1
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: firefox
       DB_TYPE: mariadb
@@ -1523,7 +1523,7 @@ matrix:
       DIVIDE_INTO_NUM_PARTS: 3
       RUN_PART: 2
 
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: firefox
       DB_TYPE: mariadb
@@ -1541,7 +1541,7 @@ matrix:
       RUN_PART: 3
 
     # caldav test
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: caldav
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1552,7 +1552,7 @@ matrix:
       CALDAV_CARDDAV_JOB: true
 
     # carddav test
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: carddav
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1563,7 +1563,7 @@ matrix:
       CALDAV_CARDDAV_JOB: true
 
     # caldav-old-endpoint test
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: caldav-old-endpoint
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1574,7 +1574,7 @@ matrix:
       CALDAV_CARDDAV_JOB: true
 
     # carddav-old-endpoint test
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: carddav-old-endpoint
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1599,7 +1599,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # This suite is part of the encryption app in later core versions
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
       DB_TYPE: mariadb
@@ -1613,7 +1613,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # This suite is part of the encryption app in later core versions
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIUserKeysType
@@ -1626,7 +1626,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     # This suite is part of the encryption app in later core versions
-    - PHP_VERSION: 7.1
+    - PHP_VERSION: 7.3
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIMasterKeyType

--- a/.drone.yml
+++ b/.drone.yml
@@ -738,6 +738,19 @@ matrix:
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
+    # PHP 7.3
+    - PHP_VERSION: 7.3
+      DB_TYPE: sqlite
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.3
+      DB_TYPE: mariadb
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
   # Files External
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ pipeline:
         USE_FEDERATED_SERVER: true
 
   configure-federation-server:
-    image: owncloudci/php:${PHP_VERSION}
+    image: owncloudci/php:${FEDERATION_PHP_VERSION}
     pull: true
     commands:
       - cd /drone/fed-server
@@ -41,7 +41,7 @@ pipeline:
         USE_FEDERATED_SERVER: true
 
   fix-permissions-federation-server:
-    image: owncloudci/php:${PHP_VERSION}
+    image: owncloudci/php:${FEDERATION_PHP_VERSION}
     pull: true
     commands:
       - chown www-data /drone/fed-server -R
@@ -563,7 +563,7 @@ services:
         SERVER_PROTOCOL: http
 
   federated-https:
-    image: owncloudci/php:${PHP_VERSION}
+    image: owncloudci/php:${FEDERATION_PHP_VERSION}
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/fed-server/
@@ -578,7 +578,7 @@ services:
         SERVER_PROTOCOL: https
 
   federated-http:
-    image: owncloudci/php:${PHP_VERSION}
+    image: owncloudci/php:${FEDERATION_PHP_VERSION}
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/fed-server/
@@ -643,22 +643,27 @@ matrix:
   # frontend
     - TEST_SUITE: javascript
       PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       COVERAGE: true
 
   # owncloud-coding-standard
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: owncloud-coding-standard
 
   # phan (runs on just PHP 7.0 because that has different dependencies for phan)
     - TEST_SUITE: phan-70
       PHP_VERSION: 7.0
+      FEDERATION_PHP_VERSION: 7.0
 
   # phan (runs multiple PHP v7.1+ to provide syntax checks of each PHP version)
     - TEST_SUITE: phan
       PHP_VERSION: 7.1
+      FEDERATION_PHP_VERSION: 7.1
 
   # Litmus
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       USE_SERVER: true
       SERVER_PROTOCOL: https
       TEST_SUITE: litmus
@@ -667,6 +672,7 @@ matrix:
 
   # Unit Tests
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: mysql
       TEST_SUITE: phpunit
       COVERAGE: true
@@ -674,12 +680,14 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: mysqlmb4
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: postgres
       TEST_SUITE: phpunit
       COVERAGE: true
@@ -687,6 +695,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: oracle
       TEST_SUITE: phpunit
       COVERAGE: true
@@ -694,6 +703,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       COVERAGE: true
@@ -702,24 +712,28 @@ matrix:
 
     # PHP 7.0
     - PHP_VERSION: 7.0
+      FEDERATION_PHP_VERSION: 7.0
       DB_TYPE: mysql
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.0
+      FEDERATION_PHP_VERSION: 7.0
       DB_TYPE: mysqlmb4
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.0
+      FEDERATION_PHP_VERSION: 7.0
       DB_TYPE: postgres
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.0
+      FEDERATION_PHP_VERSION: 7.0
       DB_TYPE: oracle
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
@@ -727,12 +741,14 @@ matrix:
 
     # PHP 7.2
     - PHP_VERSION: 7.2
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.2
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: mariadb
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
@@ -740,12 +756,14 @@ matrix:
 
     # PHP 7.3
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       DB_TYPE: mariadb
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
@@ -753,6 +771,7 @@ matrix:
 
   # Files External
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -761,6 +780,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -777,6 +797,7 @@ matrix:
     #  INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -786,6 +807,7 @@ matrix:
 
   # Primary Objectstorage
     - PHP_VERSION: 7.0
+      FEDERATION_PHP_VERSION: 7.0
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
       OBJECTSTORE: swift
@@ -795,6 +817,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -807,6 +830,7 @@ matrix:
   # files_primary_s3
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: phpunit
       COVERAGE: true
       DB_TYPE: sqlite
@@ -817,6 +841,7 @@ matrix:
 
   # API Acceptance tests
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiMain
       DB_TYPE: mariadb
@@ -828,6 +853,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiAuth
       DB_TYPE: mariadb
@@ -839,6 +865,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiAuthOcs
       DB_TYPE: mariadb
@@ -850,6 +877,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiCapabilities
       DB_TYPE: mariadb
@@ -861,6 +889,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiComments
       DB_TYPE: mariadb
@@ -872,6 +901,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiFavorites
       DB_TYPE: mariadb
@@ -883,6 +913,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiFederation
       DB_TYPE: mariadb
@@ -896,6 +927,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioning-v1
       DB_TYPE: mariadb
@@ -907,6 +939,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioning-v2
       DB_TYPE: mariadb
@@ -918,6 +951,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioningGroups-v1
       DB_TYPE: mariadb
@@ -929,6 +963,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiProvisioningGroups-v2
       DB_TYPE: mariadb
@@ -940,6 +975,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiSharees
       DB_TYPE: mariadb
@@ -951,6 +987,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiShareManagement
       DB_TYPE: mariadb
@@ -962,6 +999,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiShareManagementBasic
       DB_TYPE: mariadb
@@ -973,6 +1011,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiShareOperations
       DB_TYPE: mariadb
@@ -984,6 +1023,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiSharingNotifications
       DB_TYPE: mariadb
@@ -996,6 +1036,7 @@ matrix:
       INSTALL_NOTIFICATIONS_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiTags
       DB_TYPE: mariadb
@@ -1007,6 +1048,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiTrashbin
       DB_TYPE: mariadb
@@ -1018,6 +1060,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiVersions
       DB_TYPE: mariadb
@@ -1029,6 +1072,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavLocks
       DB_TYPE: mariadb
@@ -1040,6 +1084,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavLocks2
       DB_TYPE: mariadb
@@ -1051,6 +1096,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavMove
       DB_TYPE: mariadb
@@ -1062,6 +1108,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavOperations
       DB_TYPE: mariadb
@@ -1073,6 +1120,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavProperties
       DB_TYPE: mariadb
@@ -1084,6 +1132,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: api
       BEHAT_SUITE: apiWebdavUpload
       DB_TYPE: mariadb
@@ -1096,6 +1145,7 @@ matrix:
 
     # CLI Provisioning Acceptance tests
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: cli
       BEHAT_SUITE: cliProvisioning
       DB_TYPE: mariadb
@@ -1109,6 +1159,7 @@ matrix:
 
   # CLI Main Acceptance tests
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: cli
       BEHAT_SUITE: cliMain
       DB_TYPE: mariadb
@@ -1121,6 +1172,7 @@ matrix:
 
   # CLI Background Acceptance tests
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: cli
       BEHAT_SUITE: cliBackground
       DB_TYPE: mariadb
@@ -1133,6 +1185,7 @@ matrix:
 
   # CLI Trashbin Acceptance tests
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: cli
       BEHAT_SUITE: cliTrashbin
       DB_TYPE: mariadb
@@ -1146,6 +1199,7 @@ matrix:
   # UI Acceptance tests
   ## Chrome
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIAdminSettings
@@ -1159,6 +1213,7 @@ matrix:
       USE_EMAIL: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIComments
@@ -1171,6 +1226,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUICreateDelete
@@ -1183,6 +1239,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIFavorites
@@ -1195,6 +1252,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIFiles
@@ -1207,6 +1265,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUILogin
@@ -1220,6 +1279,7 @@ matrix:
       USE_EMAIL: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIMoveFilesFolders
@@ -1232,6 +1292,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIPersonalSettings
@@ -1245,6 +1306,7 @@ matrix:
       USE_EMAIL: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIRenameFiles
@@ -1257,6 +1319,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIRenameFolders
@@ -1269,6 +1332,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIRestrictSharing
@@ -1281,6 +1345,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingAcceptShares
@@ -1293,6 +1358,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingAutocompletion
@@ -1305,6 +1371,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingExternal
@@ -1320,6 +1387,7 @@ matrix:
       USE_EMAIL: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingInternalGroups
@@ -1333,6 +1401,7 @@ matrix:
       USE_EMAIL: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingInternalUsers
@@ -1346,6 +1415,7 @@ matrix:
       USE_EMAIL: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingNotifications
@@ -1360,6 +1430,7 @@ matrix:
       INSTALL_NOTIFICATIONS_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISharingPublic
@@ -1375,6 +1446,7 @@ matrix:
       FEDERATION_OC_VERSION: daily-stable10-qa
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUITags
@@ -1387,6 +1459,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUITrashbin
@@ -1399,6 +1472,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIUpload
@@ -1412,6 +1486,7 @@ matrix:
 
     # This suite is part of the user_management app in later core versions
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIAddUsers
@@ -1426,6 +1501,7 @@ matrix:
 
     # This suite is part of the user_management app in later core versions
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIManageUsersGroups
@@ -1440,6 +1516,7 @@ matrix:
 
     # This suite is part of the user_management app in later core versions
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIManageQuota
@@ -1453,6 +1530,7 @@ matrix:
 
     # This suite is part of the user_management app in later core versions
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUISettingsMenu
@@ -1465,6 +1543,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIWebdavLocks
@@ -1477,6 +1556,7 @@ matrix:
       INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIWebdavLockProtection
@@ -1490,6 +1570,7 @@ matrix:
 
     ## Firefox
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: firefox
       DB_TYPE: mariadb
@@ -1507,6 +1588,7 @@ matrix:
       RUN_PART: 1
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: firefox
       DB_TYPE: mariadb
@@ -1524,6 +1606,7 @@ matrix:
       RUN_PART: 2
 
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: firefox
       DB_TYPE: mariadb
@@ -1542,6 +1625,7 @@ matrix:
 
     # caldav test
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: caldav
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1553,6 +1637,7 @@ matrix:
 
     # carddav test
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: carddav
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1564,6 +1649,7 @@ matrix:
 
     # caldav-old-endpoint test
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: caldav-old-endpoint
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1575,6 +1661,7 @@ matrix:
 
     # carddav-old-endpoint test
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: carddav-old-endpoint
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1586,6 +1673,7 @@ matrix:
 
     # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.0
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
       DB_TYPE: mariadb
@@ -1600,6 +1688,7 @@ matrix:
 
     # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: cli
       BEHAT_SUITE: cliEncryption
       DB_TYPE: mariadb
@@ -1614,6 +1703,7 @@ matrix:
 
     # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIUserKeysType
@@ -1627,6 +1717,7 @@ matrix:
 
     # This suite is part of the encryption app in later core versions
     - PHP_VERSION: 7.3
+      FEDERATION_PHP_VERSION: 7.2
       TEST_SUITE: selenium
       BROWSER: chrome
       BEHAT_SUITE: webUIMasterKeyType

--- a/apps/dav/lib/Avatars/AvatarHome.php
+++ b/apps/dav/lib/Avatars/AvatarHome.php
@@ -26,7 +26,6 @@ use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
-use Sabre\HTTP\URLUtil;
 
 class AvatarHome implements ICollection {
 
@@ -96,7 +95,7 @@ class AvatarHome implements ICollection {
 	}
 
 	public function getName() {
-		list(, $name) = URLUtil::splitPath($this->principalInfo['uri']);
+		list(, $name) = \Sabre\Uri\split($this->principalInfo['uri']);
 		return $name;
 	}
 

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -44,7 +44,6 @@ use Sabre\DAV;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\PropPatch;
-use Sabre\HTTP\URLUtil;
 use Sabre\VObject\DateTimeParser;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Recur\EventIterator;
@@ -235,7 +234,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->execute();
 
 		while ($row = $result->fetch()) {
-			list(, $name) = URLUtil::splitPath($row['principaluri']);
+			list(, $name) = \Sabre\Uri\split($row['principaluri']);
 			$uri = $row['uri'] . '_shared_by_' . $name;
 			$row['displayname'] .= " ($name)";
 			$components = [];
@@ -338,7 +337,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->execute();
 
 		while ($row = $result->fetch()) {
-			list(, $name) = URLUtil::splitPath($row['principaluri']);
+			list(, $name) = \Sabre\Uri\split($row['principaluri']);
 			$row['displayname'] .= "($name)";
 			$components = [];
 			if ($row['components']) {
@@ -402,7 +401,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			throw new NotFound('Node with name \'' . $uri . '\' could not be found');
 		}
 
-		list(, $name) = URLUtil::splitPath($row['principaluri']);
+		list(, $name) = \Sabre\Uri\split($row['principaluri']);
 		$row['displayname'] = $row['displayname'] . ' ' . "($name)";
 		$components = [];
 		if ($row['components']) {
@@ -1660,7 +1659,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 	private function convertPrincipal($principalUri, $toV2 = null) {
 		if ($this->principalBackend->getPrincipalPrefix() === 'principals') {
-			list(, $name) = URLUtil::splitPath($principalUri);
+			list(, $name) = \Sabre\Uri\split($principalUri);
 			$toV2 = $toV2 === null ? !$this->legacyMode : $toV2;
 			if ($toV2) {
 				return "principals/users/$name";

--- a/apps/dav/lib/CalDAV/Plugin.php
+++ b/apps/dav/lib/CalDAV/Plugin.php
@@ -23,7 +23,6 @@ namespace OCA\DAV\CalDAV;
 
 use Sabre\DAV;
 use Sabre\DAV\Xml\Property\ShareAccess;
-use Sabre\HTTP\URLUtil;
 
 class Plugin extends \Sabre\CalDAV\Plugin {
 	public function initialize(DAV\Server $server) {
@@ -45,7 +44,7 @@ class Plugin extends \Sabre\CalDAV\Plugin {
 	 */
 	public function getCalendarHomeForPrincipal($principalUrl) {
 		if (\strrpos($principalUrl, 'principals/users', -\strlen($principalUrl)) !== false) {
-			list(, $principalId) = URLUtil::splitPath($principalUrl);
+			list(, $principalId) = \Sabre\Uri\split($principalUrl);
 			return self::CALENDAR_ROOT .'/' . $principalId;
 		}
 

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -38,7 +38,6 @@ use Sabre\CardDAV\Backend\BackendInterface;
 use Sabre\CardDAV\Backend\SyncSupport;
 use Sabre\CardDAV\Plugin;
 use Sabre\DAV\Exception\BadRequest;
-use Sabre\HTTP\URLUtil;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Reader;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -181,7 +180,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->execute();
 
 		while ($row = $result->fetch()) {
-			list(, $name) = URLUtil::splitPath($row['principaluri']);
+			list(, $name) = \Sabre\Uri\split($row['principaluri']);
 			$uri = $row['uri'] . '_shared_by_' . $name;
 			$displayName = $row['displayname'] . " ($name)";
 			if (!isset($addressBooks[$row['id']])) {
@@ -1035,7 +1034,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 	private function convertPrincipal($principalUri, $toV2 = null) {
 		if ($this->principalBackend->getPrincipalPrefix() === 'principals') {
-			list(, $name) = URLUtil::splitPath($principalUri);
+			list(, $name) = \Sabre\Uri\split($principalUri);
 			$toV2 = $toV2 === null ? !$this->legacyMode : $toV2;
 			if ($toV2) {
 				return "principals/users/$name";

--- a/apps/dav/lib/CardDAV/Plugin.php
+++ b/apps/dav/lib/CardDAV/Plugin.php
@@ -25,7 +25,6 @@ use OCA\DAV\CardDAV\Xml\Groups;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
-use Sabre\HTTP\URLUtil;
 
 class Plugin extends \Sabre\CardDAV\Plugin {
 	public function initialize(Server $server) {
@@ -41,15 +40,15 @@ class Plugin extends \Sabre\CardDAV\Plugin {
 	 */
 	protected function getAddressbookHomeForPrincipal($principal) {
 		if (\strrpos($principal, 'principals/users', -\strlen($principal)) !== false) {
-			list(, $principalId) = URLUtil::splitPath($principal);
+			list(, $principalId) = \Sabre\Uri\split($principal);
 			return self::ADDRESSBOOK_ROOT . '/users/' . $principalId;
 		}
 		if (\strrpos($principal, 'principals/groups', -\strlen($principal)) !== false) {
-			list(, $principalId) = URLUtil::splitPath($principal);
+			list(, $principalId) = \Sabre\Uri\split($principal);
 			return self::ADDRESSBOOK_ROOT . '/groups/' . $principalId;
 		}
 		if (\strrpos($principal, 'principals/system', -\strlen($principal)) !== false) {
-			list(, $principalId) = URLUtil::splitPath($principal);
+			list(, $principalId) = \Sabre\Uri\split($principal);
 			return self::ADDRESSBOOK_ROOT . '/system/' . $principalId;
 		}
 

--- a/apps/dav/lib/Connector/LegacyDAVACL.php
+++ b/apps/dav/lib/Connector/LegacyDAVACL.php
@@ -27,7 +27,6 @@ use OCA\DAV\Connector\Sabre\DavAclPlugin;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAVACL\Xml\Property\Principal;
-use Sabre\HTTP\URLUtil;
 
 class LegacyDAVACL extends DavAclPlugin {
 
@@ -52,7 +51,7 @@ class LegacyDAVACL extends DavAclPlugin {
 	}
 
 	private function convertPrincipal($principal, $toV2) {
-		list(, $name) = URLUtil::splitPath($principal);
+		list(, $name) = \Sabre\Uri\split($principal);
 		if ($toV2) {
 			return "principals/users/$name";
 		}

--- a/apps/dav/lib/Connector/Sabre/AppEnabledPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AppEnabledPlugin.php
@@ -71,7 +71,7 @@ class AppEnabledPlugin extends ServerPlugin {
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
 		$this->server = $server;
-		$this->server->on('beforeMethod', [$this, 'checkAppEnabled'], 30);
+		$this->server->on('beforeMethod:*', [$this, 'checkAppEnabled'], 30);
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/AutorenamePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AutorenamePlugin.php
@@ -96,7 +96,7 @@ class AutorenamePlugin extends ServerPlugin {
 			}
 
 			$view = $this->server->tree->getView();
-			list($nodePath, $nodeName) = \Sabre\HTTP\URLUtil::splitPath($node->getPath());
+			list($nodePath, $nodeName) = \Sabre\Uri\split($node->getPath());
 			$newName = \OC_Helper::buildNotExistingFileNameForView($nodePath, $nodeName, $view);
 
 			$body = $request->getBodyAsStream();

--- a/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
@@ -51,7 +51,7 @@ class BlockLegacyClientPlugin extends ServerPlugin {
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
 		$this->server = $server;
-		$this->server->on('beforeMethod', [$this, 'beforeHandler'], 200);
+		$this->server->on('beforeMethod:*', [$this, 'beforeHandler'], 200);
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/CopyEtagHeaderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CopyEtagHeaderPlugin.php
@@ -44,7 +44,7 @@ class CopyEtagHeaderPlugin extends \Sabre\DAV\ServerPlugin {
 	public function initialize(\Sabre\DAV\Server $server) {
 		$this->server = $server;
 
-		$server->on('afterMethod', [$this, 'afterMethod']);
+		$server->on('afterMethod:*', [$this, 'afterMethod']);
 		$server->on('afterMove', [$this, 'afterMove']);
 	}
 

--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -108,7 +108,7 @@ class CorsPlugin extends ServerPlugin {
 			return;
 		}
 
-		$this->server->on('beforeMethod', [$this, 'setCorsHeaders']);
+		$this->server->on('beforeMethod:*', [$this, 'setCorsHeaders']);
 		$this->server->on('exception', [$this, 'onException']);
 		$this->server->on('beforeMethod:OPTIONS', [$this, 'setOptionsRequestHeaders'], 5);
 	}

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -53,7 +53,6 @@ use Sabre\DAV\IFile;
 use Sabre\DAV\IMoveTarget;
 use Sabre\DAV\INode;
 use Sabre\DAV\IQuota;
-use Sabre\HTTP\URLUtil;
 
 class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 
@@ -434,7 +433,7 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 			throw new SabreForbidden('Could not copy directory ' . $sourceNode->getName() . ', target exists');
 		}
 
-		list($sourceDir, ) = URLUtil::splitPath($sourceNode->getPath());
+		list($sourceDir, ) = \Sabre\Uri\split($sourceNode->getPath());
 		$destinationDir = $this->getPath();
 
 		$sourcePath = $sourceNode->getPath();

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -476,7 +476,7 @@ class File extends Node implements IFile, IFileNode {
 	 * @throws ServiceUnavailable
 	 */
 	private function createFileChunked($data) {
-		list($path, $name) = \Sabre\HTTP\URLUtil::splitPath($this->path);
+		list($path, $name) = \Sabre\Uri\split($this->path);
 
 		$info = \OC_FileChunking::decodeName($name);
 		if (empty($info)) {

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -178,8 +178,8 @@ class FilesPlugin extends ServerPlugin {
 		if (!$sourceNode instanceof Node) {
 			return;
 		}
-		list($sourceDir, ) = \Sabre\HTTP\URLUtil::splitPath($source);
-		list($destinationDir, ) = \Sabre\HTTP\URLUtil::splitPath($destination);
+		list($sourceDir, ) = \Sabre\Uri\split($source);
+		list($destinationDir, ) = \Sabre\Uri\split($destination);
 
 		if ($sourceDir !== $destinationDir) {
 			$sourceNodeFileInfo = $sourceNode->getFileInfo();
@@ -417,7 +417,7 @@ class FilesPlugin extends ServerPlugin {
 	public function sendFileIdHeader($filePath, \Sabre\DAV\INode $node = null) {
 		// chunked upload handling
 		if (\OC_FileChunking::isWebdavChunk()) {
-			list($path, $name) = \Sabre\HTTP\URLUtil::splitPath($filePath);
+			list($path, $name) = \Sabre\Uri\split($filePath);
 			$info = \OC_FileChunking::decodeName($name);
 			if (!empty($info)) {
 				$filePath = $path . '/' . $info['name'];

--- a/apps/dav/lib/Connector/Sabre/LockPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/LockPlugin.php
@@ -48,8 +48,8 @@ class LockPlugin extends ServerPlugin {
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
 		$this->server = $server;
-		$this->server->on('beforeMethod', [$this, 'getLock'], 50);
-		$this->server->on('afterMethod', [$this, 'releaseLock'], 50);
+		$this->server->on('beforeMethod:*', [$this, 'getLock'], 50);
+		$this->server->on('afterMethod:*', [$this, 'releaseLock'], 50);
 		$this->server->on('beforeUnlock', [$this, 'beforeUnlock'], 20);
 	}
 

--- a/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
@@ -64,7 +64,7 @@ class MaintenancePlugin extends ServerPlugin {
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
 		$this->server = $server;
-		$this->server->on('beforeMethod', [$this, 'checkMaintenanceMode'], 1);
+		$this->server->on('beforeMethod:*', [$this, 'checkMaintenanceMode'], 1);
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -132,8 +132,8 @@ abstract class Node implements \Sabre\DAV\INode {
 		// verify path of the source
 		$this->verifyPath();
 
-		list($parentPath, ) = \Sabre\HTTP\URLUtil::splitPath($this->path);
-		list(, $newName) = \Sabre\HTTP\URLUtil::splitPath($name);
+		list($parentPath, ) = \Sabre\Uri\split($this->path);
+		list(, $newName) = \Sabre\Uri\split($name);
 
 		// verify path of target
 		if (\OC\Files\Filesystem::isForbiddenFileOrDir($parentPath . '/' . $newName)) {

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -77,7 +77,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	private function resolveChunkFile($path) {
 		if (\OC_FileChunking::isWebdavChunk()) {
 			// resolve to real file name to find the proper node
-			list($dir, $name) = \Sabre\HTTP\URLUtil::splitPath($path);
+			list($dir, $name) = \Sabre\Uri\split($path);
 			if ($dir == '/' || $dir == '.') {
 				$dir = '';
 			}
@@ -228,7 +228,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		// with that we have covered both source and destination
 		$this->getNodeForPath($source);
 
-		list($destinationDir, $destinationName) = \Sabre\HTTP\URLUtil::splitPath($destination);
+		list($destinationDir, $destinationName) = \Sabre\Uri\split($destination);
 		try {
 			$this->fileView->verifyPath($destinationDir, $destinationName);
 		} catch (\OCP\Files\InvalidPathException $ex) {
@@ -255,7 +255,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
 
-		list($destinationDir, ) = \Sabre\HTTP\URLUtil::splitPath($destination);
+		list($destinationDir, ) = \Sabre\Uri\split($destination);
 		$this->markDirty($destinationDir);
 	}
 

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -36,7 +36,6 @@ use OCP\IUserManager;
 use Sabre\DAV\Exception;
 use Sabre\DAV\PropPatch;
 use Sabre\DAVACL\PrincipalBackend\BackendInterface;
-use Sabre\HTTP\URLUtil;
 
 class Principal implements BackendInterface {
 
@@ -100,7 +99,7 @@ class Principal implements BackendInterface {
 	 * @return array
 	 */
 	public function getPrincipalByPath($path) {
-		list($prefix, $name) = URLUtil::splitPath($path);
+		list($prefix, $name) = \Sabre\Uri\split($path);
 
 		if ($prefix === $this->principalPrefix) {
 			$user = $this->userManager->get($name);
@@ -138,7 +137,7 @@ class Principal implements BackendInterface {
 	 * @throws Exception
 	 */
 	public function getGroupMembership($principal, $needGroups = false) {
-		list($prefix, $name) = URLUtil::splitPath($principal);
+		list($prefix, $name) = \Sabre\Uri\split($principal);
 
 		if ($prefix === $this->principalPrefix) {
 			$user = $this->userManager->get($name);

--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -29,7 +29,6 @@ use OCP\Files\StorageNotAvailableException;
 use Sabre\DAV\Exception\InsufficientStorage;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\INode;
-use Sabre\HTTP\URLUtil;
 
 /**
  * This plugin check user quota and deny creating files when they exceeds the quota.
@@ -146,7 +145,7 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 			$length = $this->getLength();
 		}
 		if ($length) {
-			list($parentPath, $newName) = URLUtil::splitPath($path);
+			list($parentPath, $newName) = \Sabre\Uri\split($path);
 			if ($parentPath === null) {
 				$parentPath = '';
 			}

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -128,7 +128,7 @@ class ServerFactory {
 		}
 
 		// wait with registering these until auth is handled and the filesystem is setup
-		$server->on('beforeMethod', function () use ($server, $objectTree, $viewCallBack) {
+		$server->on('beforeMethod:*', function () use ($server, $objectTree, $viewCallBack) {
 			// ensure the skeleton is copied
 			// Try to obtain User Folder
 			$userFolder = \OC::$server->getUserFolder();

--- a/apps/dav/lib/DAV/SystemPrincipalBackend.php
+++ b/apps/dav/lib/DAV/SystemPrincipalBackend.php
@@ -23,7 +23,6 @@
 namespace OCA\DAV\DAV;
 
 use Sabre\DAVACL\PrincipalBackend\AbstractBackend;
-use Sabre\HTTP\URLUtil;
 
 class SystemPrincipalBackend extends AbstractBackend {
 
@@ -162,7 +161,7 @@ class SystemPrincipalBackend extends AbstractBackend {
 	 * @return array
 	 */
 	public function getGroupMembership($principal) {
-		list($prefix, $name) = URLUtil::splitPath($principal);
+		list($prefix, $name) = \Sabre\Uri\split($principal);
 
 		if ($prefix === 'principals/system') {
 			$principal = $this->getPrincipalByPath($principal);

--- a/apps/dav/lib/Files/FilesHome.php
+++ b/apps/dav/lib/Files/FilesHome.php
@@ -23,7 +23,6 @@ namespace OCA\DAV\Files;
 
 use OCA\DAV\Connector\Sabre\ObjectTree;
 use Sabre\DAV\Exception\Forbidden;
-use Sabre\HTTP\URLUtil;
 use Sabre\DAV\ICollection;
 
 class FilesHome extends ObjectTree implements ICollection {
@@ -80,7 +79,7 @@ class FilesHome extends ObjectTree implements ICollection {
 	}
 
 	public function getName() {
-		list(, $name) = URLUtil::splitPath($this->principalInfo['uri']);
+		list(, $name) = \Sabre\Uri\split($this->principalInfo['uri']);
 		return $name;
 	}
 

--- a/apps/dav/lib/Files/RootCollection.php
+++ b/apps/dav/lib/Files/RootCollection.php
@@ -25,7 +25,6 @@ use OCA\DAV\Connector\Sabre\Directory;
 use Sabre\DAV\INode;
 use Sabre\DAV\SimpleCollection;
 use Sabre\DAVACL\AbstractPrincipalCollection;
-use Sabre\HTTP\URLUtil;
 
 class RootCollection extends AbstractPrincipalCollection {
 
@@ -40,7 +39,7 @@ class RootCollection extends AbstractPrincipalCollection {
 	 * @return INode
 	 */
 	public function getChildForPrincipal(array $principalInfo) {
-		list(, $name) = URLUtil::splitPath($principalInfo['uri']);
+		list(, $name) = \Sabre\Uri\split($principalInfo['uri']);
 		$user = \OC::$server->getUserSession()->getUser();
 		if ($user === null || $name !== $user->getUID()) {
 			// a user is only allowed to see their own home contents, so in case another collection

--- a/apps/dav/lib/Files/Sharing/PublicLinkCheckPlugin.php
+++ b/apps/dav/lib/Files/Sharing/PublicLinkCheckPlugin.php
@@ -51,7 +51,7 @@ class PublicLinkCheckPlugin extends ServerPlugin {
 	 * @return void
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
-		$server->on('beforeMethod', [$this, 'beforeMethod']);
+		$server->on('beforeMethod:*', [$this, 'beforeMethod']);
 	}
 
 	public function beforeMethod(RequestInterface $request, ResponseInterface $response) {

--- a/apps/dav/lib/JobStatus/Home.php
+++ b/apps/dav/lib/JobStatus/Home.php
@@ -20,15 +20,11 @@
  */
 namespace OCA\DAV\JobStatus;
 
-use OCA\DAV\DAV\LazyOpsPlugin;
 use OCA\DAV\JobStatus\Entity\JobStatusMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use Sabre\DAV\Collection;
-use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\Exception\NotFound;
-use Sabre\DAV\SimpleFile;
-use Sabre\HTTP\URLUtil;
 
 class Home extends Collection {
 	/** @var array */
@@ -62,7 +58,7 @@ class Home extends Collection {
 	}
 
 	public function getName() {
-		list(, $name) = URLUtil::splitPath($this->principalInfo['uri']);
+		list(, $name) = \Sabre\Uri\split($this->principalInfo['uri']);
 		return $name;
 	}
 }

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -199,7 +199,7 @@ class Server {
 
 		$this->server->addPlugin(new PreviewPlugin(\OC::$server->getTimeFactory(), \OC::$server->getPreviewManager()));
 		// wait with registering these until auth is handled and the filesystem is setup
-		$this->server->on('beforeMethod', function () use ($root) {
+		$this->server->on('beforeMethod:*', function () use ($root) {
 			// custom properties plugin must be the last one
 			$userSession = \OC::$server->getUserSession();
 			$user = $userSession->getUser();

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
@@ -76,7 +76,7 @@ class PluginTest extends TestCase {
 		$this->book->expects($this->once())->method('setPublishStatus')->with(true);
 
 		// setup request
-		$request = new Request();
+		$request = new Request('POST', '');
 		$request->addHeader('Content-Type', 'application/xml');
 		$request->setUrl('cal1');
 		$request->setBody('<o:publish-calendar xmlns:o="http://calendarserver.org/ns/"/>');
@@ -88,7 +88,7 @@ class PluginTest extends TestCase {
 		$this->book->expects($this->once())->method('setPublishStatus')->with(false);
 
 		// setup request
-		$request = new Request();
+		$request = new Request('POST', '');
 		$request->addHeader('Content-Type', 'application/xml');
 		$request->setUrl('cal1');
 		$request->setBody('<o:unpublish-calendar xmlns:o="http://calendarserver.org/ns/"/>');

--- a/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
@@ -70,7 +70,7 @@ class PluginTest extends TestCase {
 		]], ['mailto:wilfredo@example.com']);
 
 		// setup request
-		$request = new Request();
+		$request = new Request('POST', '');
 		$request->addHeader('Content-Type', 'application/xml');
 		$request->setUrl('addressbook1.vcf');
 		$request->setBody('<?xml version="1.0" encoding="utf-8" ?><CS:share xmlns:D="DAV:" xmlns:CS="http://owncloud.org/ns"><CS:set><D:href>principal:principals/admin</D:href><CS:read-write/></CS:set> <CS:remove><D:href>mailto:wilfredo@example.com</D:href></CS:remove></CS:share>');

--- a/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
@@ -25,6 +25,8 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OCA\DAV\Connector\Sabre\CopyEtagHeaderPlugin;
 use Sabre\DAV\Server;
 use Test\TestCase;
+use OCA\DAV\Connector\Sabre\File;
+use Sabre\DAV\Tree;
 
 /**
  * Copyright (c) 2015 Vincent Petry <pvince81@owncloud.com>
@@ -48,7 +50,7 @@ class CopyEtagHeaderPluginTest extends TestCase {
 	}
 
 	public function testCopyEtag() {
-		$request = new \Sabre\Http\Request();
+		$request = new \Sabre\Http\Request('', '');
 		$response = new \Sabre\Http\Response();
 		$response->setHeader('Etag', 'abcd');
 
@@ -58,7 +60,7 @@ class CopyEtagHeaderPluginTest extends TestCase {
 	}
 
 	public function testNoopWhenEmpty() {
-		$request = new \Sabre\Http\Request();
+		$request = new \Sabre\Http\Request('', '');
 		$response = new \Sabre\Http\Response();
 
 		$this->plugin->afterMethod($request, $response);
@@ -67,13 +69,13 @@ class CopyEtagHeaderPluginTest extends TestCase {
 	}
 
 	public function testAfterMove() {
-		$node = $this->getMockBuilder('OCA\DAV\Connector\Sabre\File')
+		$node = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
 			->method('getETag')
 			->willReturn('123456');
-		$tree = $this->getMockBuilder('Sabre\DAV\Tree')
+		$tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$tree->expects($this->once())

--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -288,7 +288,7 @@ class CorsPluginTest extends TestCase {
 		$this->server->httpRequest->setUrl('/owncloud/remote.php/dav/files/user1/target/path');
 
 		$this->server->addPlugin($this->plugin);
-		$this->server->exec();
+		$this->server->start();
 
 		$this->assertEquals($expectedStatus, $this->server->httpResponse->getStatus());
 

--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -29,6 +29,7 @@ use OCA\DAV\Connector\Sabre\QuotaPlugin;
 use OCA\DAV\Upload\FutureFile;
 use Sabre\DAV\Tree;
 use Test\TestCase;
+use OC\Files\View;
 
 /**
  * Copyright (c) 2013 Thomas Müller <thomas.mueller@tmit.eu>
@@ -47,7 +48,7 @@ class QuotaPluginTest extends TestCase {
 	private function init($quota, $checkedPath = '') {
 		$view = $this->buildFileViewMock($quota, $checkedPath);
 		$this->server = new \Sabre\DAV\Server();
-		$this->plugin = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\QuotaPlugin')
+		$this->plugin = $this->getMockBuilder(QuotaPlugin::class)
 			->setConstructorArgs([$view])
 			->setMethods(['getFileChunking'])
 			->getMock();
@@ -61,7 +62,7 @@ class QuotaPluginTest extends TestCase {
 		$this->init(0);
 		$this->plugin->expects($this->never())
 			->method('getFileChunking');
-		$this->server->httpRequest = new \Sabre\HTTP\Request(null, null, $headers);
+		$this->server->httpRequest = new \Sabre\HTTP\Request('', '', $headers);
 		$length = $this->plugin->getLength();
 		$this->assertEquals($expected, $length);
 	}
@@ -74,7 +75,7 @@ class QuotaPluginTest extends TestCase {
 		$this->plugin->expects($this->never())
 			->method('getFileChunking');
 
-		$this->server->httpRequest = new \Sabre\HTTP\Request(null, null, $headers);
+		$this->server->httpRequest = new \Sabre\HTTP\Request('', '', $headers);
 		$result = $this->plugin->checkQuota('');
 		$this->assertTrue($result);
 	}
@@ -88,7 +89,7 @@ class QuotaPluginTest extends TestCase {
 		$this->plugin->expects($this->never())
 			->method('getFileChunking');
 
-		$this->server->httpRequest = new \Sabre\HTTP\Request(null, null, $headers);
+		$this->server->httpRequest = new \Sabre\HTTP\Request('', '', $headers);
 		$this->plugin->checkQuota('');
 	}
 
@@ -100,7 +101,7 @@ class QuotaPluginTest extends TestCase {
 		$this->plugin->expects($this->never())
 			->method('getFileChunking');
 
-		$this->server->httpRequest = new \Sabre\HTTP\Request(null, null, $headers);
+		$this->server->httpRequest = new \Sabre\HTTP\Request('', '', $headers);
 		$result = $this->plugin->checkQuota('/sub/test.txt');
 		$this->assertTrue($result);
 	}
@@ -180,7 +181,7 @@ class QuotaPluginTest extends TestCase {
 	public function testCheckQuotaChunkedOk($quota, $chunkTotalSize, $headers) {
 		$this->init($quota, 'sub/test.txt');
 
-		$mockChunking = $this->getMockBuilder('\OC_FileChunking')
+		$mockChunking = $this->getMockBuilder(\OC_FileChunking::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$mockChunking->expects($this->once())
@@ -192,7 +193,7 @@ class QuotaPluginTest extends TestCase {
 			->will($this->returnValue($mockChunking));
 
 		$headers['OC-CHUNKED'] = 1;
-		$this->server->httpRequest = new \Sabre\HTTP\Request(null, null, $headers);
+		$this->server->httpRequest = new \Sabre\HTTP\Request('', '', $headers);
 		$result = $this->plugin->checkQuota('/sub/test.txt-chunking-12345-3-1');
 		$this->assertTrue($result);
 	}
@@ -216,7 +217,7 @@ class QuotaPluginTest extends TestCase {
 	public function testCheckQuotaChunkedFail($quota, $chunkTotalSize, $headers) {
 		$this->init($quota, 'sub/test.txt');
 
-		$mockChunking = $this->getMockBuilder('\OC_FileChunking')
+		$mockChunking = $this->getMockBuilder(\OC_FileChunking::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$mockChunking->expects($this->once())
@@ -228,13 +229,13 @@ class QuotaPluginTest extends TestCase {
 			->will($this->returnValue($mockChunking));
 
 		$headers['OC-CHUNKED'] = 1;
-		$this->server->httpRequest = new \Sabre\HTTP\Request(null, null, $headers);
+		$this->server->httpRequest = new \Sabre\HTTP\Request('', '', $headers);
 		$this->plugin->checkQuota('/sub/test.txt-chunking-12345-3-1');
 	}
 
 	private function buildFileViewMock($quota, $checkedPath) {
 		// mock file systen
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['free_space'])
 			->setConstructorArgs([])
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTest.php
@@ -31,6 +31,8 @@ use Sabre\HTTP\Request;
 use Test\TestCase;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
+use OC\Files\Storage\Local;
+use OCP\IRequest;
 
 abstract class RequestTest extends TestCase {
 	use UserTrait;
@@ -60,7 +62,7 @@ abstract class RequestTest extends TestCase {
 			\OC::$server->getUserSession(),
 			\OC::$server->getMountManager(),
 			\OC::$server->getTagManager(),
-			$this->createMock('\OCP\IRequest'),
+			$this->createMock(IRequest::class),
 			\OC::$server->getTimeFactory()
 		);
 	}
@@ -68,7 +70,7 @@ abstract class RequestTest extends TestCase {
 	protected function setupUser($name, $password) {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->registerMount($name, Local::class, '/' . $name, ['datadir' => $tmpFolder]);
 		$this->loginAsUser($name);
 		return new View('/' . $name . '/files');
 	}
@@ -84,7 +86,7 @@ abstract class RequestTest extends TestCase {
 	 * @return \Sabre\HTTP\Response
 	 * @throws \Exception
 	 */
-	protected function request($view, $user, $password, $method, $url, $body = null, $headers = null) {
+	protected function request($view, $user, $password, $method, $url, $body = null, $headers = []) {
 		if (\is_string($body)) {
 			$body = $this->getStream($body);
 		}

--- a/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
@@ -72,7 +72,7 @@ class PluginTest extends TestCase {
 		]], ['mailto:wilfredo@example.com']);
 
 		// setup request
-		$request = new Request();
+		$request = new Request('', '');
 		$request->addHeader('Content-Type', 'application/xml');
 		$request->setUrl('addressbook1.vcf');
 		$request->setBody('<?xml version="1.0" encoding="utf-8" ?><CS:share xmlns:D="DAV:" xmlns:CS="http://owncloud.org/ns"><CS:set><D:href>principal:principals/admin</D:href><CS:read-write/></CS:set> <CS:remove><D:href>mailto:wilfredo@example.com</D:href></CS:remove></CS:share>');

--- a/apps/dav/tests/unit/Files/FilesHomeTest.php
+++ b/apps/dav/tests/unit/Files/FilesHomeTest.php
@@ -125,6 +125,6 @@ class FilesHomeTest extends TestCase {
 			['foo', true, $fileInfo],
 		]);
 		$this->view->expects($this->once())->method('getDirectoryContent')->willReturn([]);
-		$this->assertEquals([], $this->filesHome->getChildren('foo'));
+		$this->assertEquals([], \iterator_to_array($this->filesHome->getChildren('foo')));
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "deepdiver1975/tarstreamer": "v0.1.1",
         "patchwork/jsqueeze": "^2.0",
         "lukasreschke/id3parser": "^0.0.3",
-        "sabre/dav": "^3.2",
+        "sabre/dav": "^4.0",
         "deepdiver/zipstreamer": "^1.1",
         "symfony/translation": "^3.4",
         "zendframework/zend-inputfilter": "^2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b635fc1f39b266bc8fa113fbc5ccea94",
+    "content-hash": "de02856e0fd6ffe69f963cb9118ea729",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1266,7 +1266,7 @@
             "time": "2015-08-01T16:27:37+00:00"
         },
         {
-            "name": "jeremeamia/superclosure",
+            "name": "jeremeamia/SuperClosure",
             "version": "2.4.0",
             "source": {
                 "type": "git",
@@ -2228,16 +2228,16 @@
         },
         {
             "name": "sabre/dav",
-            "version": "3.2.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/dav.git",
-                "reference": "a9780ce4f35560ecbd0af524ad32d9d2c8954b80"
+                "reference": "a4959bf2b9b175aef6fd91c9006b1ca7a56f9bb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/dav/zipball/a9780ce4f35560ecbd0af524ad32d9d2c8954b80",
-                "reference": "a9780ce4f35560ecbd0af524ad32d9d2c8954b80",
+                "url": "https://api.github.com/repos/sabre-io/dav/zipball/a4959bf2b9b175aef6fd91c9006b1ca7a56f9bb0",
+                "reference": "a4959bf2b9b175aef6fd91c9006b1ca7a56f9bb0",
                 "shasum": ""
             },
             "require": {
@@ -2245,27 +2245,28 @@
                 "ext-date": "*",
                 "ext-dom": "*",
                 "ext-iconv": "*",
+                "ext-json": "*",
                 "ext-mbstring": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
                 "ext-spl": "*",
                 "lib-libxml": ">=2.7.0",
-                "php": ">=5.5.0",
+                "php": ">=7.0.0",
                 "psr/log": "^1.0",
-                "sabre/event": ">=2.0.0, <4.0.0",
-                "sabre/http": "^4.2.1",
-                "sabre/uri": "^1.0.1",
-                "sabre/vobject": "^4.1.0",
-                "sabre/xml": "^1.4.0"
+                "sabre/event": "^5.0",
+                "sabre/http": "^5.0",
+                "sabre/uri": "^2.0",
+                "sabre/vobject": "^4.2.0-alpha1",
+                "sabre/xml": "^2.0.1"
             },
             "require-dev": {
                 "evert/phpdoc-md": "~0.1.0",
                 "monolog/monolog": "^1.18",
-                "phpunit/phpunit": "> 4.8, <6.0.0",
-                "sabre/cs": "^1.0.0"
+                "phpunit/phpunit": "^6"
             },
             "suggest": {
                 "ext-curl": "*",
+                "ext-imap": "*",
                 "ext-pdo": "*"
             },
             "bin": [
@@ -2273,11 +2274,6 @@
                 "bin/naturalselection"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Sabre\\DAV\\": "lib/DAV/",
@@ -2307,28 +2303,28 @@
                 "framework",
                 "iCalendar"
             ],
-            "time": "2018-10-19T09:58:27+00:00"
+            "time": "2019-07-01T10:03:18+00:00"
         },
         {
             "name": "sabre/event",
-            "version": "3.0.0",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/event.git",
-                "reference": "831d586f5a442dceacdcf5e9c4c36a4db99a3534"
+                "reference": "f5cf802d240df1257866d8813282b98aee3bc548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/event/zipball/831d586f5a442dceacdcf5e9c4c36a4db99a3534",
-                "reference": "831d586f5a442dceacdcf5e9c4c36a4db99a3534",
+                "url": "https://api.github.com/repos/sabre-io/event/zipball/f5cf802d240df1257866d8813282b98aee3bc548",
+                "reference": "f5cf802d240df1257866d8813282b98aee3bc548",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "*",
-                "sabre/cs": "~0.0.4"
+                "phpunit/phpunit": ">=6",
+                "sabre/cs": "~1.0.0"
             },
             "type": "library",
             "autoload": {
@@ -2358,38 +2354,41 @@
             "keywords": [
                 "EventEmitter",
                 "async",
+                "coroutine",
+                "eventloop",
                 "events",
                 "hooks",
                 "plugin",
                 "promise",
+                "reactor",
                 "signal"
             ],
-            "time": "2015-11-05T20:14:39+00:00"
+            "time": "2018-03-05T13:55:47+00:00"
         },
         {
             "name": "sabre/http",
-            "version": "v4.2.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/http.git",
-                "reference": "acccec4ba863959b2d10c1fa0fb902736c5c8956"
+                "reference": "f91c7d4437dcbc6f89c8b64e855e1544f4b60250"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/http/zipball/acccec4ba863959b2d10c1fa0fb902736c5c8956",
-                "reference": "acccec4ba863959b2d10c1fa0fb902736c5c8956",
+                "url": "https://api.github.com/repos/sabre-io/http/zipball/f91c7d4437dcbc6f89c8b64e855e1544f4b60250",
+                "reference": "f91c7d4437dcbc6f89c8b64e855e1544f4b60250",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-mbstring": "*",
-                "php": ">=5.4",
-                "sabre/event": ">=1.0.0,<4.0.0",
-                "sabre/uri": "~1.0"
+                "php": ">=7.0",
+                "sabre/event": ">=4.0 <6.0",
+                "sabre/uri": "^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.3",
-                "sabre/cs": "~0.0.1"
+                "phpunit/phpunit": ">=6.0.0",
+                "sabre/cs": "~1.0.0"
             },
             "suggest": {
                 "ext-curl": " to make http requests with the Client class"
@@ -2420,28 +2419,27 @@
             "keywords": [
                 "http"
             ],
-            "time": "2018-02-23T11:10:29+00:00"
+            "time": "2018-06-04T21:27:19+00:00"
         },
         {
             "name": "sabre/uri",
-            "version": "1.2.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/uri.git",
-                "reference": "ada354d83579565949d80b2e15593c2371225e61"
+                "reference": "c260a55cbd2083c03484f56f72fe042fee0c17ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/uri/zipball/ada354d83579565949d80b2e15593c2371225e61",
-                "reference": "ada354d83579565949d80b2e15593c2371225e61",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/c260a55cbd2083c03484f56f72fe042fee0c17ed",
+                "reference": "c260a55cbd2083c03484f56f72fe042fee0c17ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.7"
+                "php": ">=7"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=4.0,<6.0",
-                "sabre/cs": "~1.0.0"
+                "phpunit/phpunit": "^6"
             },
             "type": "library",
             "autoload": {
@@ -2471,7 +2469,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-02-20T19:59:28+00:00"
+            "time": "2019-06-25T05:34:33+00:00"
         },
         {
             "name": "sabre/vobject",
@@ -2571,16 +2569,16 @@
         },
         {
             "name": "sabre/xml",
-            "version": "1.5.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/xml.git",
-                "reference": "a367665f1df614c3b8fefc30a54de7cd295e444e"
+                "reference": "e15454e68805e3713271ea58c0b2d6a82dac56b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/xml/zipball/a367665f1df614c3b8fefc30a54de7cd295e444e",
-                "reference": "a367665f1df614c3b8fefc30a54de7cd295e444e",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/e15454e68805e3713271ea58c0b2d6a82dac56b7",
+                "reference": "e15454e68805e3713271ea58c0b2d6a82dac56b7",
                 "shasum": ""
             },
             "require": {
@@ -2588,12 +2586,11 @@
                 "ext-xmlreader": "*",
                 "ext-xmlwriter": "*",
                 "lib-libxml": ">=2.6.20",
-                "php": ">=5.5.5",
+                "php": ">=7.0",
                 "sabre/uri": ">=1.0,<3.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8|~5.7",
-                "sabre/cs": "~1.0.0"
+                "phpunit/phpunit": "*"
             },
             "type": "library",
             "autoload": {
@@ -2630,7 +2627,7 @@
                 "dom",
                 "xml"
             ],
-            "time": "2019-01-09T13:51:57+00:00"
+            "time": "2019-01-09T13:50:52+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -3916,7 +3913,7 @@
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
-            "name": "mikey179/vfsstream",
+            "name": "mikey179/vfsStream",
             "version": "v1.6.6",
             "source": {
                 "type": "git",
@@ -4719,17 +4716,6 @@
         {
             "name": "roave/security-advisories",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a53a6f855cbff7edb078f87c72bb808c89443a00"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a53a6f855cbff7edb078f87c72bb808c89443a00",
-                "reference": "a53a6f855cbff7edb078f87c72bb808c89443a00",
-                "shasum": ""
-            },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<5.20.12",
@@ -5535,7 +5521,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/console.php
+++ b/console.php
@@ -42,8 +42,8 @@ if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
 }
 
 // Show warning if PHP 7.3 is used as ownCloud is not compatible with PHP 7.3
-if (\version_compare(PHP_VERSION, '7.3.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.3' . PHP_EOL;
+if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.4' . PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '.' . PHP_EOL;
 	exit(1);
 }

--- a/index.php
+++ b/index.php
@@ -36,8 +36,8 @@ if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
 }
 
 // Show warning if PHP 7.3 is used as ownCloud is not compatible with PHP 7.3
-if (\version_compare(PHP_VERSION, '7.3.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.3<br/>';
+if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.4<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '.';
 	return;
 }

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -659,17 +659,18 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 				throw new \Exception("The requested uri($requestUri) cannot be processed by the script '$scriptName')");
 			}
 		}
-		if (\strpos($pathInfo, '/'.$name) === 0) {
+		if (\strpos($pathInfo, "/$name") === 0) {
 			$pathInfo = \substr($pathInfo, \strlen($name) + 1);
 		}
-		if (\strpos($pathInfo, $name) === 0) {
+		if (\is_string($name) && \strpos($pathInfo, $name) === 0) {
 			$pathInfo = \substr($pathInfo, \strlen($name));
 		}
+
 		if ($pathInfo === false || $pathInfo === '/') {
 			return '';
-		} else {
-			return $pathInfo;
 		}
+
+		return $pathInfo;
 	}
 
 	/**

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -651,7 +651,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 
 		// strip off the script name's dir and file name
 		// FIXME: Sabre does not really belong here
-		list($path, $name) = \Sabre\HTTP\URLUtil::splitPath($scriptName);
+		list($path, $name) = \Sabre\Uri\split($scriptName);
 		if (!empty($path)) {
 			if ($path === $pathInfo || \strpos($pathInfo, $path.'/') === 0) {
 				$pathInfo = \substr($pathInfo, \strlen($path));

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -343,7 +343,7 @@ class OC_Response {
 		}
 
 		foreach ($allHeaders as $key => $value) {
-			$response->addHeader($key, \implode(",", $value));
+			$response->addHeader($key, \implode(',', $value));
 		}
 
 		return $response;

--- a/remote.php
+++ b/remote.php
@@ -54,7 +54,7 @@ function handleException($e) {
 			// we shall not log on RemoteException
 			$server->addPlugin(new ExceptionLoggerPlugin('webdav', \OC::$server->getLogger()));
 		}
-		$server->on('beforeMethod', function () use ($e) {
+		$server->on('beforeMethod:*', function () use ($e) {
 			if ($e instanceof RemoteException) {
 				switch ($e->getCode()) {
 					case OC_Response::STATUS_SERVICE_UNAVAILABLE:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -11,7 +11,7 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
       | lock-scope |
@@ -25,7 +25,7 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
       | lock-scope |
@@ -39,7 +39,7 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
-    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
       | lock-scope |
@@ -53,7 +53,7 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
-    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
       | lock-scope |
@@ -67,7 +67,7 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
       | lock-scope |
@@ -81,7 +81,7 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD\/child.txt$/"
-    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
       | lock-scope |
@@ -95,7 +95,7 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/child.txt" in the last created public link using the WebDAV API
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
-    And the value of the item "//d:locktoken/d:href" in the response should be "opaquelocktoken:"
+    And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
       | lock-scope |

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -332,6 +332,22 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @Then the item :xpath in the response should not exist
+	 *
+	 * @param string $xpath
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function assertItemInResponseDoesNotExist($xpath) {
+		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
+		PHPUnit\Framework\Assert::assertFalse(
+			isset($xmlPart[0]),
+			"Found item with xpath \"$xpath\" but it should not exist"
+		);
+	}
+
+	/**
 	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)" or with value "([^"]*)"$/
 	 *
 	 * @param string $user

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -127,6 +127,10 @@ abstract class TestCase extends BaseTestCase {
 				\call_user_func([$this, $methodName]);
 			}
 		}
+
+		// necessary pre-set for phpbdg 7.3
+		$_SERVER['REQUEST_URI'] = '';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
 	}
 
 	protected function tearDown() {


### PR DESCRIPTION
Run many of the drone unit and acceptance test jobs with PHP 7.3 to double-check that they pass.

drone had to be adjusted so that the federated server, which runs the `stable10` QA tarball - would run PHP 7.2. Because that QA tarball is the current `stable110` that only officially supports PHP 7.2. Actually that is a good thing to test. We know that a PHP 7.3 system with "newer" code can talk OK to a PHP 7.2 system.