### PR TITLE
Adjust ContactsTest to remove invalid constructor arguments

### DIFF
--- a/tests/lib/PublicNamespace/ContactsTest.php
+++ b/tests/lib/PublicNamespace/ContactsTest.php
@@ -34,7 +34,7 @@ class ContactsTest extends \Test\TestCase {
 
 	public function testEnabledAfterRegister() {
 		// create mock for the addressbook
-		$stub = $this->getMockForAbstractClass("OCP\IAddressBook", ['getKey']);
+		$stub = $this->getMockForAbstractClass("OCP\IAddressBook");
 
 		// we expect getKey to be called twice:
 		// first time on register
@@ -60,7 +60,7 @@ class ContactsTest extends \Test\TestCase {
 
 	public function testAddressBookEnumeration() {
 		// create mock for the addressbook
-		$stub = $this->getMockForAbstractClass("OCP\IAddressBook", ['getKey', 'getDisplayName']);
+		$stub = $this->getMockForAbstractClass("OCP\IAddressBook");
 
 		// setup return for method calls
 		$stub->expects($this->any())
@@ -80,8 +80,8 @@ class ContactsTest extends \Test\TestCase {
 
 	public function testSearchInAddressBook() {
 		// create mock for the addressbook
-		$stub1 = $this->getMockForAbstractClass("OCP\IAddressBook", ['getKey', 'getDisplayName', 'search']);
-		$stub2 = $this->getMockForAbstractClass("OCP\IAddressBook", ['getKey', 'getDisplayName', 'search']);
+		$stub1 = $this->getMockForAbstractClass("OCP\IAddressBook");
+		$stub2 = $this->getMockForAbstractClass("OCP\IAddressBook");
 
 		$searchResult1 = [
 			['id' => 0, 'FN' => 'Frank Karlitschek', 'EMAIL' => 'a@b.c', 'GEO' => '37.386013;-122.082932'],


### PR DESCRIPTION
## Description
PHPunit7 pointed out to me:
https://drone.owncloud.com/owncloud/core/19101/125
```
There were 3 errors:

1) Test\PublicNamespace\ContactsTest::testEnabledAfterRegister
ReflectionException: Class Mock_IAddressBook_89bf1405 does not have a constructor, so you cannot pass any constructor arguments

/drone/src/tests/lib/PublicNamespace/ContactsTest.php:37

2) Test\PublicNamespace\ContactsTest::testAddressBookEnumeration
ReflectionException: Class Mock_IAddressBook_89bf1405 does not have a constructor, so you cannot pass any constructor arguments

/drone/src/tests/lib/PublicNamespace/ContactsTest.php:63

3) Test\PublicNamespace\ContactsTest::testSearchInAddressBook
ReflectionException: Class Mock_IAddressBook_89bf1405 does not have a constructor, so you cannot pass any constructor arguments

/drone/src/tests/lib/PublicNamespace/ContactsTest.php:83
```

PHPunit6 does not complain. But we may as well fix it now, then we do not have to think about it when PHPunit7 happens.

## Motivation and Context
Fix crud in unit tests.

## How Has This Been Tested?
Local PHPunit run:
```
make test-php-unit NOCOVERAGE=true TEST_PHP_SUITE=tests/lib/PublicNamespace/ContactsTest.php 
PHPUNIT="/home/phil/git/owncloud/core/lib/composer/phpunit/phpunit/phpunit" build/autotest.sh sqlite tests/lib/PublicNamespace/ContactsTest.php
Using PHP executable /usr/bin/php
Parsing all files in lib/public for the presence of @since or @deprecated on each method...

Using database oc_autotest
Setup environment for sqlite testing on local storage ...
Installing ....
creating sqlite db
ownCloud was successfully installed
Testing with sqlite ...
No coverage
/home/phil/git/owncloud/core/lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/PublicNamespace/ContactsTest.php 
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.19-1+ubuntu18.04.1+deb.sury.org+1 with Xdebug 2.7.1
Configuration: /home/phil/git/owncloud/core/tests/phpunit-autotest.xml

....                                                                4 / 4 (100%)

Time: 94 ms, Memory: 16.00MB

OK (4 tests, 9 assertions)
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
