### PR TITLE
Add webUI tests for share only with membership groups

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -220,6 +220,17 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When the administrator enables restrict users to only share with groups they are member of using the webUI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorEnablesRestrictUsersToOnlyShareWithGroupsTheyAreMemberOfUsingTheWebui() {
+		$this->adminSharingSettingsPage->restrictUserToOnlyShareWithMembershipGroup(
+			$this->getSession()
+		);
+	}
+
+	/**
 	 * @When the administrator adds group :group to the exclude group from sharing list using the webUI
 	 * @Given the administrator has added group :group to the exclude group from sharing list from the admin sharing settings page
 	 *

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -28,13 +28,13 @@ use Behat\Mink\Session;
  * Admin Sharing Settings page.
  */
 class AdminSharingSettingsPage extends SharingSettingsPage {
-	
+
 	/**
 	 *
 	 * @var string $path
 	 */
 	protected $path = '/index.php/settings/admin?sectionid=sharing';
-	
+
 	protected $shareApiCheckboxXpath = '//label[@for="shareAPIEnabled"]';
 	protected $shareApiCheckboxId = 'shareAPIEnabled';
 	protected $publicShareCheckboxXpath = '//label[@for="allowLinks"]';
@@ -59,8 +59,10 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $onlyShareWithGroupMembersCheckboxId = 'onlyShareWithGroupMembers';
 	protected $excludeGroupFromSharingCheckboxXpath = '//label[@for="shareapiExcludeGroups"]';
 	protected $excludeGroupFromSharingCheckboxId = 'shareapiExcludeGroups';
-
 	protected $excludeGroupsFromSharingListFieldXpath = '//p[@id="selectExcludedGroups"]//input[contains(@class,"select2-input")]';
+
+	protected $onlyShareWithMembershipGroupsCheckboxXpath = '//label[@for="onlyShareWithMembershipGroups"]';
+	protected $onlyShareWithMembershipGroupsCheckboxId = 'onlyShareWithMembershipGroups';
 	protected $excludeGroupFromSharesFieldXpath = '//div[@id="files_sharing"]//input[contains(@class,"select2-input")]';
 	protected $groupListXpath = '//div[@id="select2-drop"]//li[contains(@class, "select2-result")]';
 	protected $groupListDropDownXpath = "//div[@id='select2-drop']";
@@ -273,6 +275,22 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			"enables",
 			$this->excludeGroupFromSharingCheckboxXpath,
 			$this->excludeGroupFromSharingCheckboxId
+		);
+	}
+
+	/**
+	 * enable restrict users to only share with groups they are member of
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function restrictUserToOnlyShareWithMembershipGroup(Session $session) {
+		$this->toggleCheckbox(
+			$session,
+			"enables",
+			$this->onlyShareWithMembershipGroupsCheckboxXpath,
+			$this->onlyShareWithMembershipGroupsCheckboxId
 		);
 	}
 

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -255,3 +255,39 @@ Feature: Sharing files and folders with internal groups
       | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
+
+  Scenario: sharer should not be able to share a folder to a group which he/she is not member of when share with groups they are member of is enabled
+    Given group "grp2" has been created
+    And user "user1" has created folder "/simple-folder"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables restrict users to only share with groups they are member of using the webUI
+    And the user re-logs in as "user1" using the webUI
+    And the user opens the share dialog for folder "simple-folder"
+    And the user types "grp2" in the share-with-field
+    Then a tooltip with the text "No users or groups found for grp2" should be shown near the share-with-field on the webUI
+
+  Scenario: sharer should not be able to share a file to a group which he/she is not member of when share with groups they are member of is enabled
+    Given group "grp2" has been created
+    And user "user1" has uploaded file with content "some content" to "lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables restrict users to only share with groups they are member of using the webUI
+    And the user re-logs in as "user1" using the webUI
+    And the user opens the share dialog for file "lorem.txt"
+    And the user types "grp2" in the share-with-field
+    Then a tooltip with the text "No users or groups found for grp2" should be shown near the share-with-field on the webUI
+
+  Scenario: sharer should be able to share a folder to his/her own group when only share with groups they are member of is enabled
+    Given user "user1" has created folder "/simple-folder"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables restrict users to only share with groups they are member of using the webUI
+    And the user re-logs in as "user1" using the webUI
+    And the user shares folder "simple-folder" with group "grp1" using the webUI
+    Then as "user2" folder "/simple-folder" should exist
+
+  Scenario: sharer should be able to share a file to his/her own group when only share with groups they are member of is enabled
+    Given user "user1" has uploaded file with content "some content" to "lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables restrict users to only share with groups they are member of using the webUI
+    And the user re-logs in as "user1" using the webUI
+    And the user shares file "lorem.txt" with group "grp1" using the webUI
+    Then as "user2" file "/lorem.txt" should exist

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -392,3 +392,31 @@ Feature: Sharing files and folders with internal users
       | Brand-New-User    | brand-new-user | BRAND-NEW-USER |
       | brand-new-user    | BRAND-NEW-USER | Brand-New-User |
       | BRAND-NEW-USER    | Brand-New-User | brand-new-user |
+
+  Scenario: sharer should be able to share a folder to a user when only share with groups they are member of is enabled
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user1" has created folder "/simple-folder"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables restrict users to only share with groups they are member of using the webUI
+    And the user re-logs in as "user1" using the webUI
+    And the user shares folder "simple-folder" with user "User Two" using the webUI
+    Then as "user2" folder "/simple-folder" should exist
+
+  Scenario: sharer should be able to share a file to a user when only share with groups they are member of is enabled
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user1" has uploaded file with content "some content" to "lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables restrict users to only share with groups they are member of using the webUI
+    And the user re-logs in as "user1" using the webUI
+    And the user shares file "lorem.txt" with user "User Two" using the webUI
+    Then as "user2" file "/lorem.txt" should exist


### PR DESCRIPTION
## Description
Add webUI tests for share with only membership groups.

## Related Issue
#35673

## Motivation and Context

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link>