### PR TITLE
Sort out api sharing test group membership to match with user_ldap

### DIFF
--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -13,6 +13,7 @@ Feature: accept/decline shares coming from internal users
       | user1    |
       | user2    |
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
 

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -37,6 +37,7 @@ Feature: sharing
   Scenario Outline: user tries to share a file with group when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
     Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
@@ -50,6 +51,7 @@ Feature: sharing
   Scenario Outline: user tries to share a folder with group when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
     Then user "user0" should not be able to share folder "/FOLDER" with group "grp1" using the sharing API
@@ -87,6 +89,7 @@ Feature: sharing
   Scenario Outline: user tries to share a file with user who is not in their group when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     Then user "user1" should not be able to share file "welcome.txt" with user "user0" using the sharing API
@@ -101,8 +104,9 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has been added to group "grp1"
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     Then user "user2" should be able to share file "welcome.txt" with user "user1" using the sharing API
     And the OCS status code should be "<ocs_status_code>"
@@ -117,8 +121,10 @@ Feature: sharing
     And group "grp2" has been created
     And group "grp1" has been created
     And user "user3" has been created with default attributes and skeleton files
-    And user "user3" has been added to group "grp2"
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
+    # Note: in the user_ldap test environment user3 is in grp2
+    And user "user3" has been added to group "grp2"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     Then user "user3" should be able to share file "welcome.txt" with group "grp1" using the sharing API
     And the OCS status code should be "<ocs_status_code>"
@@ -132,6 +138,7 @@ Feature: sharing
   Scenario Outline: user who is not a member of a group tries to share a file in the group when group sharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
@@ -146,8 +153,9 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has been added to group "grp1"
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     Then user "user2" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
     And the OCS status code should be "404"

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -9,6 +9,7 @@ Feature: sharing
       | user0    |
       | user1    |
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
 
   @smokeTest
@@ -28,6 +29,7 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from outside with two groups
     Given group "grp4" has been created
+    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user0" has created folder "/merge-test-outside-twogroups"
     When user "user0" shares folder "/merge-test-outside-twogroups" with group "grp1" using the sharing API
@@ -37,6 +39,7 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
     Given group "grp4" has been created
+    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user0" has created folder "/merge-test-outside-twogroups-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions 1 using the sharing API
@@ -46,6 +49,7 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from outside with two groups and member
     Given group "grp4" has been created
+    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user0" has created folder "/merge-test-outside-twogroups-member-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions 1 using the sharing API
@@ -62,6 +66,7 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from inside with two groups
     Given group "grp4" has been created
+    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user1" has created folder "/merge-test-inside-twogroups"
     When user "user1" shares folder "/merge-test-inside-twogroups" with group "grp1" using the sharing API
@@ -72,6 +77,7 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from inside with group with less permissions
     Given group "grp4" has been created
+    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user1" has created folder "/merge-test-inside-twogroups-perms"
     When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -12,6 +12,7 @@ Feature: sharing
 
   Scenario: Keep usergroup shares (#22143)
     Given group "grp1" has been created
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And user "user0" has created folder "/TMP"

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -109,6 +109,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "welcome.txt" with group "grp1"
     When user "user0" shares file "/welcome.txt" with user "user1" using the sharing API
@@ -382,6 +383,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and skeleton files
     And group "grp4" has been created
+    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
     And user "user0" shares folder "/PARENT/CHILD" with group "grp4" using the sharing API
@@ -408,6 +410,7 @@ Feature: sharing
       | user1    |
       | user2    |
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -474,6 +477,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user1" has shared file "welcome.txt" with group "grp1"
     And user "user1" has deleted the last share
@@ -504,15 +508,17 @@ Feature: sharing
   Scenario Outline: sharing subfolder when parent already shared with group of sharer
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
+    And user "user3" has been created with default attributes and without skeleton files
     And group "grp1" has been created
-    And user "user0" has been added to group "grp1"
-    And user "user0" has created folder "/test"
-    And user "user0" has created folder "/test/sub"
-    And user "user0" has shared folder "/test" with group "grp1"
-    When user "user0" shares folder "/test/sub" with user "user1" using the sharing API
+    # Note: in the user_ldap test environment user1 is in grp1
+    And user "user1" has been added to group "grp1"
+    And user "user1" has created folder "/test"
+    And user "user1" has created folder "/test/sub"
+    And user "user1" has shared folder "/test" with group "grp1"
+    When user "user1" shares folder "/test/sub" with user "user3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And as "user1" folder "/sub" should exist
+    And as "user3" folder "/sub" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -658,6 +664,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user1" has been created with default attributes and without skeleton files
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with group "grp1" using the sharing API
@@ -687,6 +694,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user1" has been created with default attributes and without skeleton files
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
@@ -754,6 +762,7 @@ Feature: sharing
       | username |
       | user1    |
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "USER1" has been added to group "grp1"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     And user "user0" has shared file "randomfile.txt" with group "grp1"
@@ -770,6 +779,7 @@ Feature: sharing
       | user1    |
       | user2    |
     And group "😀 😁" has been created
+    # Note: in the user_ldap test environment user1 and user2 are already in this group
     And user "user1" has been added to group "😀 😁"
     And user "user2" has been added to group "😀 😁"
     When user "user0" shares folder "/PARENT" with group "😀 😁" using the sharing API
@@ -873,6 +883,7 @@ Feature: sharing
     And these groups have been created:
       | groupname |
       | grp1      |
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has uploaded file with content "some content" to "lorem.txt"
     When user "user0" shares file "lorem.txt" with group "grp1" using the sharing API
@@ -894,6 +905,7 @@ Feature: sharing
     And these groups have been created:
       | groupname |
       | grp1      |
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has uploaded file with content "user0 content" to "lorem.txt"
     And user "user2" has uploaded file with content "user2 content" to "lorem.txt"
@@ -1009,33 +1021,38 @@ Feature: sharing
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-    Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
-      Given using OCS API version "<ocs_api_version>"
-      And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-      And user "user1" has been created with default attributes and skeleton files
-      And group "grp1" has been created
-      And group "grp2" has been created
-      And user "user0" has been added to group "grp1"
-      And user "user1" has been added to group "grp2"
-      When user "user0" shares folder "/PARENT" with group "grp2" using the sharing API
-      Then the OCS status code should be "<ocs_status_code>"
-      And the HTTP status code should be "<http_status_code>"
-      And as "user1" folder "/PARENT (2)" should not exist
-      Examples:
-        | ocs_api_version | ocs_status_code | http_status_code |
-        | 1               | 403             | 200              |
-        | 2               | 403             | 403              |
+  Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and skeleton files
+    And group "grp1" has been created
+    And group "grp2" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
+    And user "user1" has been added to group "grp1"
+    # Note: in the user_ldap test environment user3 is in grp2
+    And user "user3" has been added to group "grp2"
+    When user "user1" shares folder "/PARENT" with group "grp2" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user3" folder "/PARENT (2)" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 403             | 200              |
+      | 2               | 403             | 403              |
 
   Scenario Outline: sharer should be able to share a folder to a user who is not member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user0" has been added to group "grp1"
-    When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+    # Note: in the user_ldap test environment user1 is in grp1, and user3 is not in grp1
+    And user "user1" has been added to group "grp1"
+    When user "user1" shares folder "/PARENT" with user "user3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" folder "/PARENT (2)" should exist
+    And as "user3" folder "/PARENT (2)" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -1045,13 +1062,15 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user0" has been added to group "grp1"
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
-    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "user2" has been added to group "grp1"
+    When user "user1" shares folder "/PARENT" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" folder "/PARENT (2)" should exist
+    And as "user2" folder "/PARENT (2)" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -1061,14 +1080,17 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
-    And user "user0" has been added to group "grp1"
-    And user "user1" has been added to group "grp2"
-    When user "user0" shares file "/textfile0.txt" with group "grp2" using the sharing API
+    # Note: in the user_ldap test environment user1 is in grp1
+    And user "user1" has been added to group "grp1"
+    # Note: in the user_ldap test environment user3 is in grp2
+    And user "user3" has been added to group "grp2"
+    When user "user1" shares file "/textfile0.txt" with group "grp2" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" file "/textfile0 (2).txt" should not exist
+    And as "user3" file "/textfile0 (2).txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |
@@ -1078,13 +1100,15 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user0" has been added to group "grp1"
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
-    When user "user0" shares folder "/textfile0.txt" with group "grp1" using the sharing API
+    And user "user2" has been added to group "grp1"
+    When user "user1" shares folder "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" file "/textfile0 (2).txt" should exist
+    And as "user2" file "/textfile0 (2).txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -1094,12 +1118,14 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files
+    And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user0" has been added to group "grp1"
-    When user "user0" shares folder "/textfile0.txt" with user "user1" using the sharing API
+    # Note: in the user_ldap test environment user1 is in grp1, and user3 is not in grp1
+    And user "user1" has been added to group "grp1"
+    When user "user1" shares folder "/textfile0.txt" with user "user3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "user1" file "/textfile0 (2).txt" should exist
+    And as "user3" file "/textfile0 (2).txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -11,6 +11,7 @@ Feature: sharing
       | user1    |
     And using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "textfile0.txt" with group "grp1"
     And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
@@ -127,8 +128,9 @@ Feature: sharing
       | user0    |
       | user1    |
     And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has been added to group "grp1"
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
     And user "user2" has shared file "/PARENT/parent.txt" with group "grp1"
     And user "user2" has stored etag of element "/PARENT"
     And user "user1" has stored etag of element "/"

--- a/tests/acceptance/features/apiShareReshare/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare/reShare.feature
@@ -452,14 +452,15 @@ Feature: sharing
   Scenario Outline: User should not be able to re-share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "user2" has been created with default attributes and skeleton files
-    And group "grp1" has been created
-    And user "user2" has been added to group "grp1"
+    And user "user3" has been created with default attributes and skeleton files
+    And group "grp2" has been created
+    # Note: in the user_ldap test environment user3 is in grp2
+    And user "user3" has been added to group "grp2"
     And user "user0" has shared folder "/PARENT" with user "user1"
-    When user "user1" shares folder "/PARENT" with group "grp1" using the sharing API
+    When user "user1" shares folder "/PARENT" with group "grp2" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "user2" folder "/PARENT (2)" should not exist
+    And as "user3" folder "/PARENT (2)" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |
@@ -468,14 +469,15 @@ Feature: sharing
   Scenario Outline: User should not be able to re-share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "user2" has been created with default attributes and skeleton files
-    And group "grp1" has been created
-    And user "user2" has been added to group "grp1"
+    And user "user3" has been created with default attributes and skeleton files
+    And group "grp2" has been created
+    # Note: in the user_ldap test environment user3 is in grp2
+    And user "user3" has been added to group "grp2"
     And user "user0" has shared file "/textfile0.txt" with user "user1"
-    When user "user1" shares folder "/textfile0.txt" with group "grp1" using the sharing API
+    When user "user1" shares folder "/textfile0.txt" with group "grp2" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "user2" folder "/textfile0 (2).txt" should not exist
+    And as "user3" folder "/textfile0 (2).txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -247,6 +247,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
+    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "textfile0.txt" with group "grp1"
     And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
@@ -433,8 +434,9 @@ Feature: sharing
     And user "user1" has been created with default attributes and without skeleton files
     And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user2" has been added to group "grp1"
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
     And as user "user2"
     And the user has shared folder "/FOLDER" with group "grp1"
     And the user has updated the last share with


### PR DESCRIPTION
## Description
Reviewed the `has been added to group` steps in the sharing API test scenarios. Sorted them out so that they have group membership that matches what is used in `user_ldap`.

This should make `user_ldap` pass again, and improve some tests that were not really testing quite the right scenario when running in `user_ldap`

## Related Issue
https://github.com/owncloud/user_ldap/issues/433 - fix it for now
https://github.com/owncloud/user_ldap/issues/250 - we should make this better long-term

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
