### PR TITLE
Test for federated sharing of folders with same name

### DIFF
--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -361,3 +361,14 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user deletes file "textfile.txt" using the webUI
     And using server "LOCAL"
     Then as "user1" file "/simple-folder/simple-empty-folder/textfile.txt" should not exist
+
+  Scenario: delete shared folder and create a folder for federation sharing with same name
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    And user "user1" has deleted folder "simple-folder"
+    And user "user1" has created folder "simple-folder"
+    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+    When user "user1" from server "REMOTE" accepts the last pending share using the sharing API
+    Then using server "REMOTE"
+    And as "user1" folder "simple-folder" should exist
+    And as "user1" folder "simple-folder (3)" should exist


### PR DESCRIPTION


## Description
 When  folders with same name existing both in remote server and local server   is shared from local server to remote server and then deleted from local server  then the folder is not accessible but is still listed in the list of available folders. Hence if folder with same name is created and shared from local to remote server renaming of shared folder is done considering that deleted folder still exists for remote user .




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

