### PR TITLE
Adjust PHP 7.3 support in master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "deepdiver1975/tarstreamer": "v0.1.1",
         "patchwork/jsqueeze": "^2.0",
         "lukasreschke/id3parser": "^0.0.3",
-        "sabre/dav": "^4.0.0-alpha5",
+        "sabre/dav": "^4.0",
         "deepdiver/zipstreamer": "^1.1",
         "symfony/translation": "^3.4",
         "zendframework/zend-inputfilter": "^2.8",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,6 @@
             "php": "7.1"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "autoload" : {
         "psr-4": {
             "OC\\": "lib/private",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a10923406d574697f6a671f50bde971",
+    "content-hash": "9784b743e0f0a6cd497b5900a00b9a7f",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -5458,11 +5458,11 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": {
         "roave/security-advisories": 20
     },
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4dad05f538f9cf922397f36db89e10e4",
+    "content-hash": "5a10923406d574697f6a671f50bde971",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",

--- a/console.php
+++ b/console.php
@@ -41,7 +41,7 @@ if (\version_compare(PHP_VERSION, '7.1.0') === -1) {
 	exit(1);
 }
 
-// Show warning if PHP 8 is used as ownCloud is not compatible with PHP 7.4
+// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
 if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
 	echo 'This version of ownCloud is not compatible with PHP 7.4' . PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '.' . PHP_EOL;

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ if (\version_compare(PHP_VERSION, '7.1.0') === -1) {
 	return;
 }
 
-// Show warning if PHP 8 is used as ownCloud is not compatible with PHP 7.4
+// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
 if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
 	echo 'This version of ownCloud is not compatible with PHP 7.4<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '.';


### PR DESCRIPTION
## Description
PR #34559 in `stable10` bumped 
```
"sabre/dav": "^4.0"
```
Do the same here in `master` (i.e. don't have the special `^4.0.0-alpha5` any more)

While sorting out other diffs between PR #34559 and master, I noticed that the comments about the PHP max version check in `console.php` and `index.php` were a bit odd. Those are fixed in the 2nd commit. A similar "backport" of the 2nd commit needs to happen in `stable10` also.

## Related Issue
#34464 

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
