### PR TITLE
[stable10] Adjust PHP max version comments

### DIFF
--- a/console.php
+++ b/console.php
@@ -41,7 +41,7 @@ if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
 	exit(1);
 }
 
-// Show warning if PHP 7.3 is used as ownCloud is not compatible with PHP 7.3
+// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
 if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
 	echo 'This version of ownCloud is not compatible with PHP 7.4' . PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '.' . PHP_EOL;

--- a/console.php
+++ b/console.php
@@ -50,13 +50,13 @@ if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
 
 // running oC on Windows is unsupported since 8.1, this has to happen here because
 // is seems that the autoloader on Windows fails later and just throws an exception.
-if (\strtoupper(\substr(PHP_OS, 0, 3)) === 'WIN') {
+if (\stripos(PHP_OS, 'WIN') === 0) {
 	echo 'ownCloud Server does not support Microsoft Windows.';
 	exit(1);
 }
 
 function exceptionHandler($exception) {
-	echo "An unhandled exception has been thrown:" . PHP_EOL;
+	echo 'An unhandled exception has been thrown:' . PHP_EOL;
 	echo $exception;
 	\OC::$server->getLogger()->logException($exception);
 	exit(1);
@@ -77,38 +77,38 @@ try {
 \set_time_limit(0);
 
 if (!OC::$CLI) {
-	echo "This script can be run from the command line only" . PHP_EOL;
+	echo 'This script can be run from the command line only' . PHP_EOL;
 	exit(1);
 }
 
 \set_exception_handler('exceptionHandler');
 
 if (!\function_exists('posix_getuid')) {
-	echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
+	echo 'The posix extensions are required - see http://php.net/manual/en/book.posix.php' . PHP_EOL;
 	exit(1);
 }
 $user = \posix_getpwuid(\posix_getuid());
 $configUser = \posix_getpwuid(\fileowner(OC::$configDir . 'config.php'));
 if ($user['name'] !== $configUser['name']) {
-	echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-	echo "Current user: " . $user['name'] . PHP_EOL;
-	echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
+	echo 'Console has to be executed with the user that owns the file config/config.php' . PHP_EOL;
+	echo 'Current user: ' . $user['name'] . PHP_EOL;
+	echo 'Owner of config.php: ' . $configUser['name'] . PHP_EOL;
 	echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
 	exit(1);
 }
 
 $oldWorkingDir = \getcwd();
 if ($oldWorkingDir === false) {
-	echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+	echo 'This script can be run from the ownCloud root directory only.' . PHP_EOL;
 	echo "Can't determine current working dir - the script will continue to work but be aware of the above fact." . PHP_EOL;
 } elseif ($oldWorkingDir !== __DIR__ && !\chdir(__DIR__)) {
-	echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+	echo 'This script can be run from the ownCloud root directory only.' . PHP_EOL;
 	echo "Can't change to ownCloud root directory." . PHP_EOL;
 	exit(1);
 }
 
-if (!\function_exists('pcntl_signal') && !\in_array('--no-warnings', $argv)) {
-	echo "The process control (PCNTL) extensions are required in case you want to interrupt long running commands - see http://php.net/manual/en/book.pcntl.php" . PHP_EOL;
+if (!\function_exists('pcntl_signal') && !\in_array('--no-warnings', $argv, true)) {
+	echo 'The process control (PCNTL) extensions are required in case you want to interrupt long running commands - see http://php.net/manual/en/book.pcntl.php' . PHP_EOL;
 }
 
 $defaults = new OC_Defaults();

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ if (\version_compare(PHP_VERSION, '7.0.7') === -1) {
 	return;
 }
 
-// Show warning if PHP 7.3 is used as ownCloud is not compatible with PHP 7.3
+// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
 if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
 	echo 'This version of ownCloud is not compatible with PHP 7.4<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '.';

--- a/index.php
+++ b/index.php
@@ -44,7 +44,7 @@ if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
 
 // running oC on Windows is unsupported since 8.1, this has to happen here because
 // is seems that the autoloader on Windows fails later and just throws an exception.
-if (\strtoupper(\substr(PHP_OS, 0, 3)) === 'WIN') {
+if (\stripos(PHP_OS, 'WIN') === 0) {
 	echo 'ownCloud Server does not support Microsoft Windows.';
 	return;
 }


### PR DESCRIPTION
Backport of 2nd commit from #35751 
And other minor string quoting changes from https://github.com/owncloud/core/pull/32821/commits/aaf8c033ccddaf4a37d47f9b41ef86a1cc8bbc32
To get the files in `stable10` more similar to `master`

This is tidy up for issue #34464 