### PR TITLE
[stable10] commits from release-10.2.1 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+## [10.2.1]
+
+### Fixed
+
+- Handling of "password fields" on public link shares - [#35541](https://github.com/owncloud/core/issues/35541) [#35563](https://github.com/owncloud/core/issues/35563)
+- Error when user was removed from a group - [#35289](https://github.com/owncloud/core/issues/35289) [#35570](https://github.com/owncloud/core/issues/35570)
+- Incorrect avatar storage location - [#35311](https://github.com/owncloud/core/issues/35311) [#35531](https://github.com/owncloud/core/issues/35531)
+- Incorrect rendering of password changed notification email - [#35255](https://github.com/owncloud/core/issues/35255) [#35491](https://github.com/owncloud/core/issues/35491)
+- Performance issue with sharing on masterkey encryption - [#35492](https://github.com/owncloud/core/issues/35492)
+- Permission change handling for share receivers on internal shares - [#35510](https://github.com/owncloud/core/issues/35510) [#35633](https://github.com/owncloud/core/pull/35633)
+- Permission handling of public link shares based upon internal shares [#35600](https://github.com/owncloud/core/pull/35600)
+- Automatically set expiration date on newly created shares [#35550](https://github.com/owncloud/core/issues/35550) [#35593](https://github.com/owncloud/core/pull/35593)
+- Incorrectly sent password reset tokens [#32889](https://github.com/owncloud/core/issues/32889) [#35607](https://github.com/owncloud/core/pull/35607)
+
+### Changed
+
+- Added `-y` option to `encryption:encrypt-all` occ command [encryption#33](https://github.com/owncloud/encryption/issues/33) [#35606](https://github.com/owncloud/core/pull/35606)
+- Updated application revocation list  - [#35506](https://github.com/owncloud/core/issues/35506)
+
 
 ## [10.2.0] - 2019-05-16
 
@@ -1022,6 +1041,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - provisioning API now also returns the user's home path: [#26850](https://github.com/owncloud/core/issues/26850)
 - web updater shows link to changelog in admin page: [#26796](https://github.com/owncloud/core/issues/26796)
 
+[10.2.1]: https://github.com/owncloud/core/compare/v10.2.0...v10.2.1
 [10.2.0]: https://github.com/owncloud/core/compare/v10.1.1...v10.2.0
 [10.1.1]: https://github.com/owncloud/core/compare/v10.1.0...v10.1.1
 [10.1.0]: https://github.com/owncloud/core/compare/v10.0.10...v10.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
-## [10.2.1]
+## [10.2.1]- 2019-07-03
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Permission handling of public link shares based upon internal shares [#35600](https://github.com/owncloud/core/pull/35600)
 - Automatically set expiration date on newly created shares [#35550](https://github.com/owncloud/core/issues/35550) [#35593](https://github.com/owncloud/core/pull/35593)
 - Incorrectly sent password reset tokens [#32889](https://github.com/owncloud/core/issues/32889) [#35607](https://github.com/owncloud/core/pull/35607)
+- Issue with loading javascript files from additional app folders [#35640](https://github.com/owncloud/core/issues/35640) [#35709](https://github.com/owncloud/core/pull/35709)
 
 ### Changed
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 2, 0, 5];
+$OC_Version = [10, 2, 1, 0];
 
 // The human readable string
-$OC_VersionString = '10.2.0';
+$OC_VersionString = '10.2.1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 2, 1, 1];
+$OC_Version = [10, 2, 1, 2];
 
 // The human readable string
-$OC_VersionString = '10.2.1RC1';
+$OC_VersionString = '10.2.1RC2';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 2, 1, 0];
+$OC_Version = [10, 2, 1, 1];
 
 // The human readable string
-$OC_VersionString = '10.2.1';
+$OC_VersionString = '10.2.1RC1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 2, 1, 3];
+$OC_Version = [10, 2, 1, 4];
 
 // The human readable string
-$OC_VersionString = '10.2.1RC3';
+$OC_VersionString = '10.2.1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 2, 1, 2];
+$OC_Version = [10, 2, 1, 3];
 
 // The human readable string
-$OC_VersionString = '10.2.1RC2';
+$OC_VersionString = '10.2.1RC3';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
The only things that are not already in `stable10` are the changelog and version bump.

We are choosing not to take the `l10n` translation changes that were made in `release-10.2.1`. Translations will be updated in `stable10` from Transifex data anyway at an appropriate time before `10.3` release.

## Motivation and Context
Get `stable10` up-to-date with changes that happened in `release-10.2.1` branch.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
