### PR TITLE
Remove mock of non-existent getCode from NotificationsTest

### DIFF
--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -236,8 +236,6 @@ class NotificationsTest extends \Test\TestCase {
 		$clientExceptionMock->method('getResponse')->willReturn($responseMock);
 
 		$exceptionMock = $this->createMock(\Exception::class);
-		$exceptionMock->method('getCode')
-			->willReturn(Http::STATUS_NOT_ACCEPTABLE);
 		return [
 			[
 				$clientExceptionMock,


### PR DESCRIPTION
## Description
PHPunit7 told me about this.

## Motivation and Context
Cleanup unit tests in preparation for PHPunit7 some day.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
