### PR TITLE
[stable10] Remove mock of non-existent getCode from NotificationsTest

### DIFF
--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -236,8 +236,6 @@ class NotificationsTest extends \Test\TestCase {
 		$clientExceptionMock->method('getResponse')->willReturn($responseMock);
 
 		$exceptionMock = $this->createMock(\Exception::class);
-		$exceptionMock->method('getCode')
-			->willReturn(Http::STATUS_NOT_ACCEPTABLE);
 		return [
 			[
 				$clientExceptionMock,


### PR DESCRIPTION
Backport #35766 