### PR TITLE
fix phpstan 'Undefined variable: ' reported for togglegroups.php

### DIFF
--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -55,6 +55,7 @@ if (!OC_User::isAdminUser(OC_User::getUser())
 }
 
 if ($targetUserObject === null) {
+	$l = \OC::$server->getL10N('core');
 	OC_JSON::error(['data' => ['message' => $l->t('Unknown user')]]);
 	exit();
 }


### PR DESCRIPTION
## Description
I was looking at `phpstan` in core `stable10` and of course it reports lots of things that would be fixed by backport various commits from `master` #31810 

But this one is a problem in `user_management` code, which is not in core `master`.

It looks easy to fix, so fix it.

## Motivation and Context
Fix random errors.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
forward-port to `user_management` is PR https://github.com/owncloud/user_management/pull/193
