### PR TITLE
[stable10] Fix method signature of ExceptionLoggerPlugin::logException to allow …

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -88,7 +88,7 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 	 * Log exception
 	 *
 	 */
-	public function logException(\Exception $ex) {
+	public function logException(\Throwable $ex) {
 		if ($ex->getPrevious() instanceof FileContentNotAllowedException) {
 			//Don't log because its already been logged may be by different
 			//app or so.


### PR DESCRIPTION
…Throwable as argument

## Description
Backport the remaining commit from #32821

The code from the other commits is already in `stable10`

## Related Issue
- https://github.com/owncloud/enterprise/issues/3187
- #34464 

## Motivation and Context
Get all the bits of code that were in PHP  7.3 support PRs in `master` and backport them to `stable10`

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
