### PR TITLE
Fix expire days value in text field

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -391,7 +391,7 @@ table.grid td.date {
 }
 
 #shareAPI input#shareapiExpireAfterNDays {
-	width: 25px;
+	width: 40px;
 }
 
 #shareAPI .nocheckbox {

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -52,8 +52,8 @@ $(document).ready(function(){
 
 	$('#shareapiExpireAfterNDays').change(function() {
 		var value = $(this).val();
-		if (value <= 0) {
-			$(this).val("1");
+		if (isNaN(value) || (parseInt(value) <= 0) || parseInt(value).toString() !== value) {
+			$(this).val('7');
 		}
 	});
 

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -60,7 +60,7 @@
 	p('hidden');
 }?>">
 			<?php p($l->t('Expire after ')); ?>
-			<input type="text" name='shareapi_expire_after_n_days' id="shareapiExpireAfterNDays" placeholder="<?php p('7')?>"
+			<input type="number" name='shareapi_expire_after_n_days' id="shareapiExpireAfterNDays" min="0" placeholder="<?php p('7')?>"
 				   value='<?php p($_['shareExpireAfterNDays']) ?>' />
 			<?php p($l->t('days')); ?><br/>
 			<?php if ($_['shareEnforceExpireDate'] === 'yes'): ?>


### PR DESCRIPTION
Fix the expire days value in the text
field. This change set restricts to
input non-integer value in the input
field.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When `Set default expiration date` was checked and say if we delete the value of `Expire after` input field, was setting value to `1`, when the default value was supposed to be `7`. This change set addresses this issue along with:
- Restrict user to enter non integer value. For example if user sets value to `a`, or `b` it was accepting blindly.
- Restrict user to enter floating numbers. Like "4.13", because according to the description of the input field, it does not make sense to have floating values.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35687
and #35662 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Validate the input of the user and reset the value to `7`, if its not an integer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested with the scenarios described below:
   - [x] Delete the place holder value (i.e, `7` ) and click any where in the page, the nuber is set back to `7`
   - [x] Enter `a` in the input field, the value is reset to `7`
   - [x] Enter `4.0` in the input field the value is reset to `7`
   - [x] Enter `5.3` in the input field the value is reset to `7`
   - [x] Enter alphanumeral like `a12b` in the input field, the value is reset to `7`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
