### PR TITLE
Add acceptance test for enabling auto add server in admin settings

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -258,6 +258,20 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When /^the administrator (enables|disables) add server automatically once a federation share was created successfully using the webUI$/
+	 *
+	 * @param string (enable | disable) $action
+	 *
+	 * @return void
+	 */
+	public function theAdministratorEnablesAddServerAutomatically($action) {
+		$this->adminSharingSettingsPage->toggleAutoAddServer(
+			$this->getSession(),
+			$action
+		);
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -66,6 +66,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $excludeGroupFromSharesFieldXpath = '//div[@id="files_sharing"]//input[contains(@class,"select2-input")]';
 	protected $groupListXpath = '//div[@id="select2-drop"]//li[contains(@class, "select2-result")]';
 	protected $groupListDropDownXpath = "//div[@id='select2-drop']";
+	protected $autoAddServerCheckboxXpath = "//label[@for='autoAddServers']";
+	protected $autoAddServerCheckboxId = "autoAddServers";
 
 	/**
 	 * toggle the Share API
@@ -353,6 +355,23 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 				$group->click();
 			}
 		}
+	}
+
+	/**
+	 * Toggle checkbox to automatically add trusted servers after federation sharing
+	 *
+	 * @param Session $session
+	 * @param string $action
+	 *
+	 * @return void
+	 */
+	public function toggleAutoAddServer(Session $session, $action) {
+		$this->toggleCheckbox(
+			$session,
+			$action,
+			$this->autoAddServerCheckboxXpath,
+			$this->autoAddServerCheckboxId
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -129,3 +129,15 @@ Feature: admin sharing settings
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables restrict users to only share with their group members using the webUI
     Then the "share_with_group_members_only" capability of files sharing app should be "EMPTY"
+
+  Scenario: enable Add server automatically once a federated share was created successfully
+    Given parameter "autoAddServers" of app "federation" has been set to "0"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator enables add server automatically once a federation share was created successfully using the webUI
+    Then the config key "autoAddServers" of app "federation" should have value "1"
+
+  Scenario: disable Add server automatically once a federated share was created successfully
+    Given parameter "autoAddServers" of app "federation" has been set to "1"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables add server automatically once a federation share was created successfully using the webUI
+    Then the config key "autoAddServers" of app "federation" should have value "0"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
add acceptance test for enable/disable auto adding trusted servers in admin sharing settings page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- related issue https://github.com/owncloud/QA/issues/22

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
