### PR TITLE
Do not accidentally disable apps in AppConfiguration.php restoreParameters

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -489,18 +489,22 @@ trait AppConfiguration {
 					&& \array_key_exists($configKey, $this->savedConfigList[$server]['apps'][$appName])
 					&& $this->savedConfigList[$server]['apps'][$appName][$configKey] !== $configValue
 				) {
-					SetupHelper::runOcc(
-						[
-							'config:app:set',
-							$appName,
-							$configKey,
-							"--value=" . $this->savedConfigList[$server]['apps'][$appName][$configKey]
-						],
-						$this->getAdminUsername(),
-						$this->getAdminPassword(),
-						$this->getBaseUrl(),
-						$this->getOcPath()
-					);
+					// Do not accidentally disable apps here (perhaps too early)
+					// That is done in Provisioning.php restoreAppEnabledDisabledState()
+					if ($configKey !== "enabled") {
+						SetupHelper::runOcc(
+							[
+								'config:app:set',
+								$appName,
+								$configKey,
+								"--value=" . $this->savedConfigList[$server]['apps'][$appName][$configKey]
+							],
+							$this->getAdminUsername(),
+							$this->getAdminPassword(),
+							$this->getBaseUrl(),
+							$this->getOcPath()
+						);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

## Related Issue
- Fixes https://github.com/owncloud/testing/issues/103

## Motivation and Context

## How Has This Been Tested?
Local runs of:
```
/git/owncloud/core/apps-external/testing$ make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTestingApp/notifications.feature:11
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
