### PR TITLE
Limit the width of the set password button

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -618,7 +618,8 @@ label.infield {
 	float: right;
 }
 #body-login input[type="submit"] {
-	padding: 10px 20px; /* larger log in and installation buttons */
+	padding: 10px 0px; /* larger log in and installation buttons */
+	max-width: 269px;
 }
 #remember_login {
 	margin: 18px 5px 0 16px !important;


### PR DESCRIPTION
## Description
Limit the width of the set password button

## Screenshots:

Before:
<img width="380" alt="before" src="https://user-images.githubusercontent.com/33026403/61087282-7c786e00-a435-11e9-8154-1ca4d1f0c341.png">

After:
<img width="380" alt="after" src="https://user-images.githubusercontent.com/33026403/61087295-84381280-a435-11e9-9129-bf2dee7187e7.png">


## Motivation and Context
Looks better.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual tested in Firefox and Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport
