### PR TITLE
In case phoenix is configured to be used with this instance - private…

### DIFF
--- a/apps/dav/lib/Meta/MetaPlugin.php
+++ b/apps/dav/lib/Meta/MetaPlugin.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Meta;
+
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\ServerPlugin;
+
+class MetaPlugin extends ServerPlugin {
+
+	// namespace
+	const NS_OWNCLOUD = 'http://owncloud.org/ns';
+	const PATH_FOR_FILEID_PROPERTYNAME = '{http://owncloud.org/ns}meta-path-for-user';
+
+	/**
+	 * Reference to main server object
+	 *
+	 * @var \Sabre\DAV\Server
+	 */
+	private $server;
+	/**
+	 * @var IUserSession
+	 */
+	private $userSession;
+	/**
+	 * @var IRootFolder
+	 */
+	private $rootFolder;
+
+	public function __construct(IUserSession $userSession,
+								IRootFolder $rootFolder
+	) {
+		$this->userSession = $userSession;
+		$this->rootFolder = $rootFolder;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by \Sabre\DAV\Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param \Sabre\DAV\Server $server
+	 * @return void
+	 */
+	public function initialize(\Sabre\DAV\Server $server) {
+		$server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
+		$server->protectedProperties[] = self::PATH_FOR_FILEID_PROPERTYNAME;
+
+		$this->server = $server;
+		$this->server->on('propFind', [$this, 'handleGetProperties']);
+	}
+
+	/**
+	 * Adds all ownCloud-specific properties
+	 *
+	 * @param PropFind $propFind
+	 * @param \Sabre\DAV\INode $node
+	 * @return void
+	 */
+	public function handleGetProperties(PropFind $propFind, INode $node) {
+		if ($node instanceof MetaFolder) {
+			$propFind->handle(self::PATH_FOR_FILEID_PROPERTYNAME, function () use ($node) {
+				$fileId = $node->getName();
+
+				$uid = $this->userSession->getUser()->getUID();
+				$baseFolder = $this->rootFolder->get($uid . '/files/');
+				$files = $baseFolder->getById($fileId);
+				if (!$files) {
+					return null;
+				}
+				$file = \current($files);
+				return $baseFolder->getRelativePath($file->getPath());
+			});
+		}
+	}
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -54,6 +54,7 @@ use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\FileLocksBackend;
 use OCA\DAV\Files\PreviewPlugin;
 use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCA\DAV\Meta\MetaPlugin;
 use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\TrashBin\TrashBinPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
@@ -189,6 +190,10 @@ class Server {
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 		$this->server->addPlugin(new ChunkingPlugin());
 		$this->server->addPlugin(new TrashBinPlugin());
+		$this->server->addPlugin(new MetaPlugin(
+			\OC::$server->getUserSession(),
+			\OC::$server->getLazyRootFolder()
+		));
 
 		// Allow view-only plugin for webdav requests
 		$this->server->addPlugin(new ViewOnlyPlugin(

--- a/apps/dav/tests/unit/Meta/MetaPluginTest.php
+++ b/apps/dav/tests/unit/Meta/MetaPluginTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace OCA\DAV\Tests\Unit\Meta;
+
+use OCA\DAV\Meta\MetaFolder;
+use OCA\DAV\Meta\MetaPlugin;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Test\TestCase;
+
+class MetaPluginTest extends TestCase {
+
+	/** @var MetaPlugin */
+	private $plugin;
+	/**
+	 * @var IRootFolder | MockObject
+	 */
+	private $rootfolder;
+	/**
+	 * @var IUserSession | MockObject
+	 */
+	private $userSession;
+	/**
+	 * @var Server | MockObject
+	 */
+	private $server;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->rootfolder = $this->createMock(IRootFolder::class);
+
+		$uid = 'alice';
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$baseFolder = $this->createMock(Folder::class);
+		$baseFolder->method('getById')->willReturnCallback(function ($fileId) {
+			if ($fileId === '1234') {
+				$matchingFile = $this->createMock(Node::class);
+				$matchingFile->method('getPath')->willReturn('/foo/bar/lorem.txt');
+				return [$matchingFile];
+			}
+			return [];
+		});
+		$baseFolder->method('getRelativePath')->willReturnArgument(0);
+		$this->rootfolder->method('get')->with($uid . '/files/')->willReturn($baseFolder);
+
+		$this->plugin = new MetaPlugin($this->userSession, $this->rootfolder);
+
+		/** @var Server | MockObject $server */
+		$this->server = $this->createMock(Server::class);
+	}
+
+	public function testInit() {
+		$this->server->expects(self::once())->method('on')->with('propFind');
+		$this->plugin->initialize($this->server);
+	}
+
+	/**
+	 * @dataProvider providesMethods
+	 */
+	public function testPropFind($fileId, $filePath) {
+		$prop = MetaPlugin::PATH_FOR_FILEID_PROPERTYNAME;
+		$node = $this->createMock(MetaFolder::class);
+		$node->expects(self::once())->method('getName')->willReturn($fileId);
+		$propFind = new PropFind('', [$prop]);
+		$this->plugin->handleGetProperties($propFind, $node);
+
+		self::assertEquals($filePath, $propFind->get($prop));
+	}
+
+	public function providesMethods() {
+		return [
+			['1234', '/foo/bar/lorem.txt'],
+			['0000', null]
+		];
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -80,7 +80,13 @@ $this->create('core_ajax_update', '/core/ajax/update.php')
 	->actionInclude('core/ajax/update.php');
 
 // File routes
-$this->create('files.viewcontroller.showFile', '/f/{fileId}')->action(function ($urlParams) {
+$this->create('files.viewcontroller.showFile', '/f/{fileId}')->action(static function ($urlParams) {
+	$phoenixBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
+	if ($phoenixBaseUrl) {
+		$fileId = $urlParams['fileId'];
+		\OC_Response::redirect("$phoenixBaseUrl/index.html#/f/$fileId");
+		return;
+	}
 	$app = new \OCA\Files\AppInfo\Application($urlParams);
 	$app->dispatch('ViewController', 'showFile');
 });


### PR DESCRIPTION
… links are redirected

## Description
private links will be redirected to phoenix if configured

## Related Issue
- refs https://github.com/owncloud/phoenix/pull/1264

## How Has This Been Tested?
- add config 	'phoenix.baseUrl' => 'http://172.17.0.1:8300'
- open a private link in the browser
- see it being redirected to phoenix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
