### PR TITLE
Backport of Trigger dav events for the public.php/webdav endpoint

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -55,6 +55,7 @@ $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 $requestUri = \OC::$server->getRequest()->getRequestUri();
 
 $linkCheckPlugin = new \OCA\DAV\Files\Sharing\PublicLinkCheckPlugin();
+$linkEventsPlugin = new \OCA\DAV\Files\Sharing\PublicLinkEventsPlugin(\OC::$server->getEventDispatcher());
 
 $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, function (\Sabre\DAV\Server $server) use ($authBackend, $linkCheckPlugin) {
 	$isAjax = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest');
@@ -98,6 +99,7 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 
 $server->addPlugin(new \OCA\DAV\Connector\Sabre\AutorenamePlugin());
 $server->addPlugin($linkCheckPlugin);
+$server->addPlugin($linkEventsPlugin);
 
 // And off we go!
 $server->exec();

--- a/apps/dav/lib/Files/Sharing/PublicLinkEventsPlugin.php
+++ b/apps/dav/lib/Files/Sharing/PublicLinkEventsPlugin.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgeargroup.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Files\Sharing;
+
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class PublicLinkEventsPlugin extends ServerPlugin {
+	/** @var EventDispatcherInterface */
+	private $dispatcher;
+	/** @var Server */
+	private $server;
+
+	public function __construct(EventDispatcherInterface $dispatcher) {
+		$this->dispatcher = $dispatcher;
+	}
+
+	/**
+	 * Initialize the plugin
+	 * @param Server $server the Sabre server where this plugin will be hooked into
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+
+		$server->on('beforeMethod:*', [$this, 'beforeMethod']);
+		$server->on('afterMethod:*', [$this, 'afterMethod']);
+	}
+
+	/**
+	 * This callback will be called before any method. Note this is a callback
+	 * set during the plugin initialization, so don't call it directly.
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 */
+	public function beforeMethod(RequestInterface $request, ResponseInterface $response) {
+		$path = $request->getPath();
+		$method = $request->getMethod();
+		$lowercaseMethod = \strtolower($method);
+		$token = $request->getRawServerValue('PHP_AUTH_USER');
+
+		if ($method === 'MOVE') {
+			$destination = $this->server->calculateUri($request->getHeader('Destination'));
+			$event = new GenericEvent(null, [
+				'path' => $path,
+				'destination' => $destination,
+				'method' => $method,
+				'token' => $token,
+				'timing' => 'before',
+			]);
+		} else {
+			$event = new GenericEvent(null, [
+				'path' => $path,
+				'method' => $method,
+				'token' => $token,
+				'timing' => 'before',
+			]);
+		}
+
+		/*
+		 * expected events names (for reference):
+		 * dav.public.get.before
+		 * dav.public.put.before
+		 * dav.public.move.before
+		 * dav.public.delete.before
+		 */
+		$eventName = "dav.public.{$lowercaseMethod}.before";
+		$this->dispatcher->dispatch($eventName, $event);
+	}
+
+	/**
+	 * This callback will be called after any method. Note this is a callback
+	 * set during the plugin initialization, so don't call it directly.
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 */
+	public function afterMethod(RequestInterface $request, ResponseInterface $response) {
+		$path = $request->getPath();
+		$method = $request->getMethod();
+		$lowercaseMethod = \strtolower($method);
+		$token = $request->getRawServerValue('PHP_AUTH_USER');
+
+		if ($method === 'MOVE') {
+			$destination = $this->server->calculateUri($request->getHeader('Destination'));
+			$event = new GenericEvent(null, [
+				'path' => $path,
+				'destination' => $destination,
+				'method' => $method,
+				'token' => $token,
+				'timing' => 'after',
+			]);
+		} else {
+			$event = new GenericEvent(null, [
+				'path' => $path,
+				'method' => $method,
+				'token' => $token,
+				'timing' => 'after',
+			]);
+		}
+
+		/*
+		 * expected events names (for reference):
+		 * dav.public.get.after
+		 * dav.public.put.after
+		 * dav.public.move.after
+		 * dav.public.delete.after
+		 */
+		$eventName = "dav.public.{$lowercaseMethod}.after";
+		$this->dispatcher->dispatch($eventName, $event);
+	}
+}

--- a/apps/dav/tests/unit/Files/Sharing/PublicLinkEventsPluginTest.php
+++ b/apps/dav/tests/unit/Files/Sharing/PublicLinkEventsPluginTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgeargroup.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\Files\Sharing;
+
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use OCA\DAV\Files\Sharing\PublicLinkEventsPlugin;
+use Test\TestCase;
+
+class PublicLinkEventsPluginTest extends TestCase {
+	/** @var EventDispatcherInterface */
+	private $dispatcher;
+	/** @var Server */
+	private $server;
+	/** @var PublicLinkEventsPlugin */
+	private $publicLinkEventsPlugin;
+
+	protected function setUp() {
+		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->server = $this->createMock(Server::class);
+
+		$this->publicLinkEventsPlugin = new PublicLinkEventsPlugin($this->dispatcher);
+	}
+
+	public function testInitialize() {
+		$this->server->expects($this->exactly(2))
+			->method('on')
+			->withConsecutive(
+				[$this->equalTo('beforeMethod:*'), $this->equalTo([$this->publicLinkEventsPlugin, 'beforeMethod'])],
+				[$this->equalTo('afterMethod:*'), $this->equalTo([$this->publicLinkEventsPlugin, 'afterMethod'])]
+			);
+		$this->publicLinkEventsPlugin->initialize($this->server);
+	}
+
+	public function methodProvider() {
+		return [
+			['GET'],
+			['PUT'],
+			['MOVE'],
+			['DELETE'],
+			['PROPFIND'],
+		];
+	}
+
+	/**
+	 * @dataProvider methodProvider
+	 */
+	public function testBeforeMethod($method) {
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
+
+		$request->method('getPath')->willReturn('/mypath');
+		$request->expects($this->once())
+			->method('getRawServerValue')
+			->with('PHP_AUTH_USER')
+			->willReturn('ABcdEFgh');
+		$request->method('getMethod')->willReturn($method);
+		$request->method('getHeader')
+			->with($this->equalTo('Destination'))
+			->willReturn('/pub/anotherpath');
+
+		$this->server->method('calculateUri')->willReturn('/anotherpath');
+
+		$lowercaseMethod = \strtolower($method);
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with("dav.public.{$lowercaseMethod}.before", $this->anything());
+
+		$this->publicLinkEventsPlugin->initialize($this->server);  // required to include the server instance
+		$this->publicLinkEventsPlugin->beforeMethod($request, $response);
+	}
+
+	/**
+	 * @dataProvider methodProvider
+	 */
+	public function testAfterMethod($method) {
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
+
+		$request->method('getPath')->willReturn('/mypath');
+		$request->method('getMethod')->willReturn($method);
+		$request->expects($this->once())
+			->method('getRawServerValue')
+			->with('PHP_AUTH_USER')
+			->willReturn('ABcdEFgh');
+		$request->method('getHeader')
+			->with($this->equalTo('Destination'))
+			->willReturn('/pub/anotherpath');
+
+		$this->server->method('calculateUri')->willReturn('/anotherpath');
+
+		$lowercaseMethod = \strtolower($method);
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with("dav.public.{$lowercaseMethod}.after", $this->anything());
+
+		$this->publicLinkEventsPlugin->initialize($this->server);  // required to include the server instance
+		$this->publicLinkEventsPlugin->afterMethod($request, $response);
+	}
+}


### PR DESCRIPTION
Trigger dav events for the public.php/webdav endpoint.
Populate the event args so that recipient of the event
could use them.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Trigger events in order to know when the public.php/webdav endpoint is being accessed. The main goal for this is to know when a download through this public endpoint happens.
Note that these events aren't being listened by anyone for now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Foundation to solve https://github.com/owncloud/admin_audit/issues/162

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will allow us to know when a file is being downloaded through the public.php/webdav endpoint, or when a file is being uploaded through the same endpoint (assuming enough permissions to do so)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual modifications in the code to ensure the events are being triggered

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
