### PR TITLE
Bugfix/not load groups if not necessary

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -243,15 +243,17 @@ class OC_Util {
 			if (!\is_array($readOnlyGroups)) {
 				$readOnlyGroups = [];
 			}
+			$readOnlyGroupMemberships = [];
+			if ($readOnlyGroups) {
+				$userGroups = \array_keys(
+					\OC::$server->getGroupManager()->getUserIdGroups($user)
+				);
 
-			$userGroups = \array_keys(
-				\OC::$server->getGroupManager()->getUserIdGroups($user)
-			);
-
-			$readOnlyGroupMemberships = \array_intersect(
-				$readOnlyGroups,
-				$userGroups
-			);
+				$readOnlyGroupMemberships = \array_intersect(
+					$readOnlyGroups,
+					$userGroups
+				);
+			}
 		}
 
 		if ($isGuest === '1' || !empty($readOnlyGroupMemberships)) {


### PR DESCRIPTION
_please note this targets stable10 already - I will not create PRs for master anymore due to your plans to kill master branch_

## Description
Even if no read only groups are defined (~99,9% of all instance) all groups for the current user will be loaded.
In case of LDAP this means loading the groups from there and this has a major performance impact.

## How Has This Been Tested?
- :hand:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

