### PR TITLE
[stable10] Bump stable10 to 10.3.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 2, 1, 4];
+$OC_Version = [10, 3, 0, 0];
 
 // The human readable string
-$OC_VersionString = '10.2.1';
+$OC_VersionString = '10.3.0 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
Bump the version in stable10 from 10.2.1 to 10.3 prealpha
For the same reasons as the discussion in PR #34534

## Related Issue
Reasons to bump the minor version include:
#35716 WebDav Trashbin API is a new feature that will require a minor version bump
and that, for example, has acceptance tests that would not run against a 10.2 system.

And there will be other things that are not just bugfixes to 10.2.1

## Motivation and Context
Reflect the truth of what is in stable10 that has been merged since 10.2.* was released.

There are some new acceptance tests and fixes in apps that do not work on 10.2. (those are apps that will get released with 10.3 core) We skip those acceptance tests when running against the 10.2.* core release tarball. We want to run those tests (not skip them) when running the app with the core `stable10` QA tarball. So the core `stable10` QA tarball needs to advertise a later version than 10.2

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
