### PR TITLE
Add api acceptance tests for auto accept federated share

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -481,3 +481,74 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+  @issue-35839
+  Scenario: "Auto accept from trusted servers" enabled with remote server
+    Given the trusted server list is cleared
+    # Remove this line once the issue is resolved
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    When the administrator adds url "%remote_server%" as trusted server using the testing API
+    And user "user0" from server "REMOTE" shares "/textfile1.txt" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    Then as "user1" file "textfile1 (2).txt" should exist
+    And url "%remote_server%" should be a trusted server
+
+  @issue-35839
+  Scenario: "Auto accept from trusted servers" disabled with remote server
+    Given the trusted server list is cleared
+    # Remove this line once the issue is resolved
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
+    When the administrator adds url "%remote_server%" as trusted server using the testing API
+    And user "user0" from server "REMOTE" shares "/textfile1.txt" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    Then as "user1" file "textfile1 (2).txt" should not exist
+    And url "%remote_server%" should be a trusted server
+
+  Scenario: Federated share with "Auto add server" enabled
+    Given the trusted server list is cleared
+    And using server "LOCAL"
+    And parameter "autoAddServers" of app "federation" has been set to "1"
+    When user "user0" from server "REMOTE" shares "/textfile1.txt" with user "user1" from server "LOCAL" using the sharing API
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    Then as "user1" file "textfile1 (2).txt" should exist
+    And url "%remote_server%" should be a trusted server
+
+  Scenario: Federated share with "Auto add server" disabled
+    Given the trusted server list is cleared
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    When user "user0" from server "REMOTE" shares "/textfile1.txt" with user "user1" from server "LOCAL" using the sharing API
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    Then as "user1" file "textfile1 (2).txt" should exist
+    And url "%remote_server%" should not be a trusted server
+
+  @issue-35839
+  Scenario: enable "Add server automatically" once a federated share was created successfully
+    Given using server "LOCAL"
+    And parameter "autoAddServers" of app "federation" has been set to "1"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    When user "user0" from server "REMOTE" shares "/textfile0.txt" with user "user1" from server "LOCAL" using the sharing API
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    Then url "%remote_server%" should be a trusted server
+    When user "user0" from server "REMOTE" shares "/textfile1.txt" with user "user1" from server "LOCAL" using the sharing API
+    # Uncomment this line once the issue is resolved
+    # Then as "user1" file "textfile1 (2).txt" should exist
+    Then as "user1" file "textfile1 (2).txt" should not exist
+
+  @issue-35839
+  Scenario: disable "Add server automatically" once a federated share was created successfully
+    Given using server "LOCAL"
+    And the trusted server list is cleared
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    When user "user0" from server "REMOTE" shares "/textfile0.txt" with user "user1" from server "LOCAL" using the sharing API
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    Then url "%remote_server%" should not be a trusted server
+    # Remove this line once the issue is resolved
+    When the administrator sets parameter "autoAddServers" of app "federation" to "0"
+    And user "user0" from server "REMOTE" shares "/textfile1.txt" with user "user1" from server "LOCAL" using the sharing API
+    And as "user1" file "textfile1 (2).txt" should not exist

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -401,7 +401,7 @@ trait AppConfiguration {
 			$this->getAdminPassword(),
 			'POST',
 			"/apps/testing/api/v1/trustedservers",
-			['url' => $url]
+			['url' => $this->substituteInLineCodes($url)]
 		);
 		$this->setResponse($response);
 	}
@@ -416,7 +416,7 @@ trait AppConfiguration {
 	public function urlShouldBeATrustedServer($url) {
 		$trustedServers = $this->getTrustedServers();
 		foreach ($trustedServers as $server => $id) {
-			if ($server === $url) {
+			if ($server === $this->substituteInLineCodes($url)) {
 				return;
 			}
 		}
@@ -437,7 +437,7 @@ trait AppConfiguration {
 		foreach ($expected as $server) {
 			$found = false;
 			foreach ($trustedServers as $url => $id) {
-				if ($url === $server['url']) {
+				if ($url === $this->substituteInLineCodes($server['url'])) {
 					$found = true;
 					break;
 				}
@@ -481,7 +481,7 @@ trait AppConfiguration {
 			$this->getAdminPassword(),
 			'DELETE',
 			"/apps/testing/api/v1/trustedservers",
-			['url' => $url]
+			['url' => $this->substituteInLineCodes($url)]
 		);
 		$this->setResponse($response);
 	}
@@ -496,7 +496,7 @@ trait AppConfiguration {
 	public function urlShouldNotBeATrustedServer($url) {
 		$trustedServers = $this->getTrustedServers();
 		foreach ($trustedServers as $server => $id) {
-			if ($server === $url) {
+			if ($server === $this->substituteInLineCodes($url)) {
 				\PHPUnit\Framework\Assert::fail("Given url $url is a trusted server but is not expected to be");
 			}
 		}
@@ -517,6 +517,22 @@ trait AppConfiguration {
 			"/apps/testing/api/v1/trustedservers/all"
 		);
 		$this->setResponse($response);
+	}
+
+	/**
+	 * @Given the trusted server list is cleared
+	 *
+	 * @return void
+	 */
+	public function theTrustedServerListIsCleared() {
+		$this->theAdministratorDeletesAllTrustedServersUsingTheTestingApi();
+		\PHPUnit\Framework\Assert::assertEquals(
+			204,
+			$this->getResponse()->getStatusCode(),
+			__METHOD__
+			. "Failed to clear all trusted servers"
+			. $this->getResponse()->getBody()->getContents()
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add acceptance tests for auto accept trusted servers and auto add server feature of federated sharing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related Issue https://github.com/owncloud/QA/issues/22

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
