### PR TITLE
avoid querying accounts when search string is too short

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -270,9 +270,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return \OC\User\User[]
 	 */
 	public function search($pattern, $limit = null, $offset = null) {
-		$accounts = $this->accountMapper->search('user_id', $pattern, $limit, $offset);
 		$users = [];
 		if ($this->userSearch->isSearchable($pattern)) {
+			$accounts = $this->accountMapper->search('user_id', $pattern, $limit, $offset);
 			foreach ($accounts as $account) {
 				$user = $this->getUserObject($account);
 				$users[$user->getUID()] = $user;
@@ -291,9 +291,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return \OC\User\User[]
 	 */
 	public function find($pattern, $limit = null, $offset = null) {
-		$accounts = $this->accountMapper->find($pattern, $limit, $offset);
 		$users = [];
 		if ($this->userSearch->isSearchable($pattern)) {
+			$accounts = $this->accountMapper->find($pattern, $limit, $offset);
 			foreach ($accounts as $account) {
 				$user = $this->getUserObject($account);
 				$users[$user->getUID()] = $user;


### PR DESCRIPTION
## Description
If the given search string is too short ( not `isSearchable()`) then do not bother calling the `accountMapper` methods to get the matching accounts. That should save some wasted processing if/when short search strings are sent.

## Motivation and Context
Do not do extra processing.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
