### PR TITLE
Remove non-existent deleteHandler.js reference in karma.config.js

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -110,7 +110,6 @@ module.exports = function(config) {
 			{
 				name: 'settings',
 				srcFiles: [
-					'settings/js/users/deleteHandler.js',
 					'settings/js/admin-apps.js'
 				],
 				testFiles: [


### PR DESCRIPTION
## Description
When running JS tests locally (and in drone) there is:
```
17 07 2019 16:02:52.187:WARN [filelist]: Pattern "/home/phil/git/owncloud/core/settings/js/users/deleteHandler.js" does not match any file.
```
That file was moved to the user_management app a long time ago. So remove the mention of it in karma.config.js

This only happened in `master` - so no backport needed.

## Related Issue

## Motivation and Context
Get rid of warning messages. Cleanup crud.

## How Has This Been Tested?
Local `make test-js`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
