### PR TITLE
skipOnLDAP for delete group test

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1131,36 +1131,38 @@ Feature: sharing
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-   Scenario Outline: shares shared to deleted group should not be available
-     Given using OCS API version "<ocs_api_version>"
-     And these users have been created with default attributes and without skeleton files:
-       | username |
-       | user1    |
-       | user2    |
-     And group "grp1" has been created
-     And user "user1" has been added to group "grp1"
-     And user "user2" has been added to group "grp1"
-     And user "user0" has shared file "/textfile0.txt" with group "grp1"
-     And as user "user0"
-     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
-     Then the OCS status code should be "<ocs_status_code>"
-     And the HTTP status code should be "200"
-     And the fields of the last response should include
-       | share_with  | grp1                 |
-       | file_target | /textfile0.txt       |
-       | path        | /textfile0.txt       |
-       | uid_owner   | user0                |
-     And as "user1" file "/textfile0.txt" should exist
-     And as "user2" file "/textfile0.txt" should exist
-     When the administrator deletes group "grp1" using the provisioning API
-     And as user "user0"
-     When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
-     Then the OCS status code should be "<ocs_status_code>"
-     And the HTTP status code should be "200"
-     And file "/textfile0.txt" should not be included as path in the response
-     And as "user1" file "/textfile0.txt" should not exist
-     And as "user2" file "/textfile0.txt" should not exist
-     Examples:
-       | ocs_api_version | ocs_status_code |
-       | 1               | 100             |
-       | 2               | 200             |
+  @skipOnLDAP
+  # deleting an LDAP group is not relevant or possible using the provisioning API
+  Scenario Outline: shares shared to deleted group should not be available
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user0" has shared file "/textfile0.txt" with group "grp1"
+    And as user "user0"
+    When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response should include
+      | share_with  | grp1                 |
+      | file_target | /textfile0.txt       |
+      | path        | /textfile0.txt       |
+      | uid_owner   | user0                |
+    And as "user1" file "/textfile0.txt" should exist
+    And as "user2" file "/textfile0.txt" should exist
+    When the administrator deletes group "grp1" using the provisioning API
+    And as user "user0"
+    When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And file "/textfile0.txt" should not be included as path in the response
+    And as "user1" file "/textfile0.txt" should not exist
+    And as "user2" file "/textfile0.txt" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Description
user_ldap tests fail: https://drone.owncloud.com/owncloud/user_ldap/1701/1073
```
--- Failed scenarios:

    /var/www/owncloud/server/tests/acceptance/features/apiShareManagementBasic/createShare.feature:1165
    /var/www/owncloud/server/tests/acceptance/features/apiShareManagementBasic/createShare.feature:1166

134 scenarios (132 passed, 2 failed)
1597 steps (1591 passed, 2 failed, 4 skipped)
```

The test scenario deletes a group using the provisioning API. That is not a relevant or possible thing to do when the group is an LDAP group. So skip the test scenario.

## Motivation and Context
Do not run irrelevant tests with user_ldap.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
