### PR TITLE
[stable10] Backport of Remove duplicate events emitted in Config

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -146,16 +146,11 @@ class Config {
 			$oldValue = $this->cache[$key];
 		}
 
-		$this->emittingCall(function () use (&$key, &$value) {
-			if ($this->set($key, $value)) {
-				// Write changes
-				$this->writeData();
-			}
-			return true;
-		}, [
-			'before' => ['key' => $key, 'value' => $value],
-			'after' => ['key' => $key, 'value' => $value, 'update' => $update, 'oldvalue' => $oldValue]
-		], 'config', 'setvalue');
+		if ($this->set($key, $value)) {
+			// Write changes
+			$this->writeData();
+		}
+		return true;
 	}
 
 	/**
@@ -192,19 +187,12 @@ class Config {
 		if ($this->isReadOnly()) {
 			throw new \Exception('Config file is read only.');
 		}
-		$this->emittingCall(function (&$afterArray) use (&$key) {
-			if (isset($this->cache[$key])) {
-				$afterArray['value'] = $this->cache[$key];
-			}
-			if ($this->delete($key)) {
-				// Write changes
-				$this->writeData();
-			}
-			return true;
-		}, [
-			'before' => ['key' => $key, 'value' => null],
-			'after' => ['key' => $key, 'value' => null]
-		], 'config', 'deletevalue');
+
+		if ($this->delete($key)) {
+			// Write changes
+			$this->writeData();
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Remove duplicate events emitted in Config

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The `setvalue` and `deletevalue` are emitted 2 times when the code flows via function `setValue()` or `deleteKey()` in the Config.php. The idea is to restrict to single call.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove duplicate emitting of events.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested with unit test. Its also found that audit logs are duplicated as a result. Hence verified that audit logs are not duplicated now with this change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
