### PR TITLE
Handle exception properly when deleting trash items

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Exception/FileLocked.php
+++ b/apps/dav/lib/Connector/Sabre/Exception/FileLocked.php
@@ -28,7 +28,7 @@ namespace OCA\DAV\Connector\Sabre\Exception;
 use Exception;
 
 class FileLocked extends \Sabre\DAV\Exception {
-	public function __construct($message = "", $code = 0, Exception $previous = null) {
+	public function __construct($message = '', $code = 0, Exception $previous = null) {
 		if ($previous instanceof \OCP\Files\LockNotAcquiredException) {
 			$message = \sprintf('Target file %s is locked by another process.', $previous->path);
 		}

--- a/apps/dav/lib/TrashBin/TrashBinManager.php
+++ b/apps/dav/lib/TrashBin/TrashBinManager.php
@@ -24,7 +24,10 @@ namespace OCA\DAV\TrashBin;
 use OC\Files\FileInfo;
 use OC\Files\View;
 use OCA\Files_Trashbin\Trashbin;
+use OCP\Files\ForbiddenException;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
+use OCP\Lock\LockedException;
 use Sabre\DAV\Exception\InvalidResourceType;
 use Sabre\DAV\Exception\NotFound;
 
@@ -76,11 +79,33 @@ class TrashBinManager {
 		return new TrashBinFile($user, $fileInfo, $this);
 	}
 
-	public function restore(string $user, AbstractTrashBinNode $trashItem, $targetLocation) {
+	/**
+	 * @param string $user
+	 * @param AbstractTrashBinNode $trashItem
+	 * @param $targetLocation
+	 * @return bool
+	 * @throws ForbiddenException
+	 * @throws LockedException
+	 * @throws StorageNotAvailableException
+	 */
+	public function restore(string $user, AbstractTrashBinNode $trashItem, $targetLocation) : bool {
 		$path = $trashItem->getPathInTrash();
 		$path = \implode('/', $path);
 		return Trashbin::restore($path,
 			$trashItem->getOriginalFileName(), $trashItem->getDeleteTimestamp(), $targetLocation);
+	}
+
+	/**
+	 * @param string $user
+	 * @param AbstractTrashBinNode $trashItem
+	 * @throws ForbiddenException
+	 * @throws LockedException
+	 * @throws StorageNotAvailableException
+	 */
+	public function delete(string $user, AbstractTrashBinNode $trashItem) {
+		$path = $trashItem->getPathInTrash();
+		$path = \implode('/', $path);
+		Trashbin::delete($path, $user, $trashItem->getDeleteTimestamp());
 	}
 
 	public function deleteAll() {

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -42,7 +42,10 @@ use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Command\Expire;
 use OCP\Encryption\Keys\IStorage;
+use OCP\Files\ForbiddenException;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
+use OCP\Lock\LockedException;
 use OCP\User;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use OCP\Files\Folder;
@@ -473,6 +476,10 @@ class Trashbin {
 	 * @param int $timestamp time when the file/folder was deleted
 	 *
 	 * @return bool true on success, false otherwise
+	 * @throws \OC\DatabaseException
+	 * @throws ForbiddenException
+	 * @throws LockedException
+	 * @throws StorageNotAvailableException
 	 */
 	public static function restore($file, $filename, $timestamp, $targetLocation = null) {
 		$user = User::getUser();
@@ -656,6 +663,10 @@ class Trashbin {
 	 * @param int $timestamp of deletion time
 	 *
 	 * @return int size of deleted files
+	 * @throws \OC\DatabaseException
+	 * @throws ForbiddenException
+	 * @throws LockedException
+	 * @throws StorageNotAvailableException
 	 */
 	public static function delete($filename, $user, $timestamp = null) {
 		$view = new View('/' . $user);


### PR DESCRIPTION
##  Description
Any exception during deletion of an item from trashbin resulted in a 500 response.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/1502

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
