### PR TITLE
Refactor share permissions handling

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -348,33 +348,11 @@ class Share20OcsController extends OCSController {
 		if ($permissions === null) {
 			if ($shareType !== Share::SHARE_TYPE_LINK) {
 				$permissions = $this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL);
-				$permissions |= Constants::PERMISSION_READ;
 			} else {
 				$permissions = Constants::PERMISSION_ALL;
 			}
 		} else {
 			$permissions = (int)$permissions;
-		}
-
-		if ($permissions < 0 || $permissions > Constants::PERMISSION_ALL) {
-			$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
-			return new Result(null, 404, 'invalid permissions');
-		}
-
-		if ($permissions === 0) {
-			return new Result(null, 400, $this->l->t('Cannot remove all permissions'));
-		}
-
-		// link shares can have create-only without read (anonymous upload)
-		if ($shareType !== Share::SHARE_TYPE_LINK && $permissions !== Constants::PERMISSION_CREATE) {
-			// Shares always require read permissions
-			$permissions |= Constants::PERMISSION_READ;
-		}
-
-		if ($path instanceof \OCP\Files\File) {
-			// Single file shares should never have delete or create permissions
-			$permissions &= ~Constants::PERMISSION_DELETE;
-			$permissions &= ~Constants::PERMISSION_CREATE;
 		}
 
 		/*

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1083,9 +1083,9 @@ class ApiTest extends TestCase {
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->updateShare($share1->getId());
 
-		//Updating should fail with 400
+		//Updating should fail with 404
 		$this->assertFalse($result->succeeded());
-		$this->assertEquals(400, $result->getStatusCode());
+		$this->assertEquals(404, $result->getStatusCode());
 
 		//Permissions should not have changed!
 		$share1 = $this->shareManager->getShareById('ocinternal:' . $share1->getId());
@@ -1336,8 +1336,6 @@ class ApiTest extends TestCase {
 
 		// logging in will auto-mount the temp storage for user1 as well
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
-
-		$fileInfo = $this->view->getFileInfo($this->folder);
 
 		// user 1 shares the mount point folder with user2
 		$share = $this->share(

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1083,9 +1083,9 @@ class ApiTest extends TestCase {
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->updateShare($share1->getId());
 
-		//Updating should fail with 404
-		$this->assertFalse($result->succeeded());
-		$this->assertEquals(404, $result->getStatusCode());
+		//Redundant bits should be masking out and updating should not fail
+		$this->assertTrue($result->succeeded());
+		$this->assertEquals(100, $result->getStatusCode());
 
 		//Permissions should not have changed!
 		$share1 = $this->shareManager->getShareById('ocinternal:' . $share1->getId());

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -731,15 +731,15 @@ class Share20OcsControllerTest extends TestCase {
 
 		$userFolder = $this->createMock('\OCP\Files\Folder');
 		$this->rootFolder->expects($this->once())
-				->method('getUserFolder')
-				->with('currentUser')
-				->willReturn($userFolder);
+			->method('getUserFolder')
+			->with('currentUser')
+			->willReturn($userFolder);
 
 		$path = $this->createMock('\OCP\Files\File');
 		$userFolder->expects($this->once())
-				->method('get')
-				->with('valid-path')
-				->willReturn($path);
+			->method('get')
+			->with('valid-path')
+			->willReturn($path);
 
 		$path->expects($this->once())
 			->method('lock')
@@ -766,15 +766,15 @@ class Share20OcsControllerTest extends TestCase {
 
 		$userFolder = $this->createMock('\OCP\Files\Folder');
 		$this->rootFolder->expects($this->once())
-				->method('getUserFolder')
-				->with('currentUser')
-				->willReturn($userFolder);
+			->method('getUserFolder')
+			->with('currentUser')
+			->willReturn($userFolder);
 
 		$path = $this->createMock('\OCP\Files\File');
 		$userFolder->expects($this->once())
-				->method('get')
-				->with('valid-path')
-				->willReturn($path);
+			->method('get')
+			->with('valid-path')
+			->willReturn($path);
 
 		$path->expects($this->once())
 			->method('lock')
@@ -1662,43 +1662,6 @@ class Share20OcsControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
-	public function testUpdateLinkHigherPermissions() {
-		$node = $this->createMock(Folder::class);
-		$share = $this->newShare();
-		$share->setPermissions(Constants::PERMISSION_READ)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareType(Share::SHARE_TYPE_LINK)
-			->setNode($node)
-			->setTarget('/foo/bar');
-
-		$node->expects($this->once())
-			->method('lock')
-			->with(ILockingProvider::LOCK_SHARED);
-
-		$this->request
-			->method('getParam')
-			->willReturnMap([
-				['permissions', null, '15'],
-			]);
-
-		$originalNode = $this->createMock(File::class);
-		$originalNode->method('getPermissions')->willReturn(17);
-		$userFolder = $this->createMock(Folder::class);
-		$userFolder->method('getById')->willReturn([$originalNode]);
-		$this->rootFolder
-			->method('getUserFolder')
-			->willReturn($userFolder);
-
-		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
-		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
-
-		$expected = new Result(null, 404, 'Cannot increase permission of /foo/bar');
-		$result = $this->ocs->updateShare(42);
-
-		$this->assertEquals($expected->getMeta(), $result->getMeta());
-		$this->assertEquals($expected->getData(), $result->getData());
-	}
-
 	public function testUpdateLinkShareClear() {
 		$userFolder = $this->createMock(Folder::class);
 		$userFolder->method('getById')->willReturn([]);
@@ -2222,35 +2185,6 @@ class Share20OcsControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
-	public function testUpdateShareZeroPermissions() {
-		$ocs = $this->mockFormatShare();
-
-		$folder = $this->createMock('\OCP\Files\Folder');
-
-		$share = \OC::$server->getShareManager()->newShare();
-		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareOwner($this->currentUser->getUID())
-			->setShareType(Share::SHARE_TYPE_USER)
-			->setSharedWith('anotheruser')
-			->setPermissions(\OCP\Constants::PERMISSION_ALL)
-			->setNode($folder);
-
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap([
-				['permissions', null, '0'],
-			]));
-
-		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
-
-		$expected = new \OC\OCS\Result(null, 400, 'Cannot remove all permissions');
-		$result = $ocs->updateShare(42);
-
-		$this->assertEquals($expected->getMeta(), $result->getMeta());
-		$this->assertEquals($expected->getData(), $result->getData());
-	}
-
 	public function testUpdateOtherPermissions() {
 		$ocs = $this->mockFormatShare();
 
@@ -2280,276 +2214,6 @@ class Share20OcsControllerTest extends TestCase {
 		$this->shareManager->method('getSharedWith')->willReturn([]);
 
 		$expected = new \OC\OCS\Result(null);
-		$result = $ocs->updateShare(42);
-
-		$this->assertEquals($expected->getMeta(), $result->getMeta());
-		$this->assertEquals($expected->getData(), $result->getData());
-	}
-
-	public function testUpdateShareCannotIncreasePermissions() {
-		$ocs = $this->mockFormatShare();
-		$folder = $this->createMock(Folder::class);
-
-		$share = \OC::$server->getShareManager()->newShare();
-		$share
-			->setId(42)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareOwner('anotheruser')
-			->setShareType(Share::SHARE_TYPE_GROUP)
-			->setSharedWith('group1')
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
-			->setNode($folder);
-
-		// note: updateShare will modify the received instance but getSharedWith will reread from the database,
-		// so their values will be different
-		$incomingShare = \OC::$server->getShareManager()->newShare();
-		$incomingShare
-			->setId(42)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareOwner('anotheruser')
-			->setShareType(Share::SHARE_TYPE_GROUP)
-			->setSharedWith('group1')
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setTarget('/folderShare');
-
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap([
-				['permissions', null, '31'],
-			]));
-
-		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
-
-		$this->shareManager->expects($this->any())
-			->method('getSharedWith')
-			->will($this->returnValueMap([
-				['currentUser', Share::SHARE_TYPE_USER, $share->getNode(), -1, 0, []],
-				['currentUser', Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, [$incomingShare]]
-			]));
-
-		$this->shareManager->expects($this->never())->method('updateShare');
-
-		$folderOwner = $this->createMock(IUser::class);
-		$folderOwner->method('getUID')
-			->willReturn('foo1234');
-		$userHomeFolder = $this->createMock(Folder::class);
-		$userNode = $this->createMock(Folder::class);
-		$userNode->method('getOwner')
-			->willReturn($folderOwner);
-		$userNode->method('getPermissions')
-			->willReturn(\OCP\Constants::PERMISSION_READ);
-		$userHomeFolder->method('getById')
-			->willReturn([$userNode]);
-		$this->rootFolder->method('getUserFolder')
-			->willReturn($userHomeFolder);
-
-		$expected = new Result(null, 404, 'Cannot increase permission of ' . $share->getTarget());
-		$result = $ocs->updateShare(42);
-
-		$this->assertEquals($expected->getMeta(), $result->getMeta());
-		$this->assertEquals($expected->getData(), $result->getData());
-	}
-
-	public function providesDataForTestingIncreasePermissionRegularShare() {
-		return [
-			['file', 16, 17],
-			['file', 17, 19],
-			['folder', 17, 19],
-			['folder', 19, 21],
-			['folder', 21, 23],
-		];
-	}
-
-	/**
-	 * @dataProvider providesDataForTestingIncreasePermissionRegularShare
-	 *
-	 * @param string $nodeType
-	 * @param int $currentPermission
-	 * @param string $updatePermissionTo
-	 */
-	public function testRegularShareRecipientCannotIncreasePermission($nodeType, $currentPermission, $updatePermissionTo) {
-		$ocs = $this->mockFormatShare();
-
-		$share = \OC::$server->getShareManager()->newShare();
-		$share
-			->setId(42)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareOwner('anotheruser')
-			->setShareType(Share::SHARE_TYPE_USER)
-			->setSharedWith('user1')
-			->setPermissions($currentPermission);
-
-		if ($nodeType === 'file') {
-			$file = $this->createMock(File::class);
-			$share->setNode($file);
-			$share->setTarget('/testFile');
-		} else {
-			$folder = $this->createMock(Folder::class);
-			$share->setNode($folder);
-			$share->setTarget('/testFolder');
-		}
-
-		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
-
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap([
-				['permissions', null, $updatePermissionTo],
-			]));
-
-		$folderOwner = $this->createMock(IUser::class);
-		$folderOwner->method('getUID')
-			->willReturn('foo1234');
-		$userHomeFolder = $this->createMock(Folder::class);
-		$userNode = $this->createMock(Folder::class);
-		$userNode->method('getOwner')
-			->willReturn($folderOwner);
-		$userNode->method('getPermissions')
-			->willReturn($currentPermission);
-		$userHomeFolder->method('getById')
-			->willReturn([$userNode]);
-		$this->rootFolder->method('getUserFolder')
-			->willReturn($userHomeFolder);
-
-		$result = $ocs->updateShare(42);
-		$this->assertEquals(404, $result->getStatusCode());
-		$this->assertEquals('Cannot increase permission of ' . $share->getTarget(), $result->getMeta()['message']);
-	}
-
-	/**
-	 * @dataProvider publicUploadParamsProvider
-	 */
-	public function testUpdateShareCannotIncreasePermissionsPublicLink($params) {
-		$userFolder = $this->createMock(Folder::class);
-		$userFolder->method('getById')->willReturn([]);
-		$this->rootFolder
-			->method('getUserFolder')
-			->willReturn($userFolder);
-
-		$ocs = $this->mockFormatShare();
-
-		$folder = $this->createMock('\OCP\Files\Folder');
-
-		$share = \OC::$server->getShareManager()->newShare();
-		$share
-			->setId(42)
-			->setSharedBy('anotheruser')
-			->setShareOwner('anotheruser')
-			->setShareType(Share::SHARE_TYPE_USER)
-			->setSharedWith($this->currentUser->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
-			->setNode($folder);
-
-		$linkShare = \OC::$server->getShareManager()->newShare();
-		$linkShare
-			->setId(43)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareOwner('anotheruser')
-			->setShareType(Share::SHARE_TYPE_LINK)
-			->setToken('dummy')
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
-			->setNode($folder);
-
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap($params));
-
-		$this->shareManager->method('getShareById')->with('ocinternal:43')->willReturn($linkShare);
-		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
-
-		$this->shareManager->expects($this->any())
-			->method('getSharedWith')
-			->will($this->returnValueMap([
-				[$this->currentUser->getUID(), Share::SHARE_TYPE_USER, $share->getNode(), -1, 0, [$share]],
-				[$this->currentUser->getUID(), Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, []],
-			]));
-
-		$this->shareManager->expects($this->never())->method('updateShare');
-
-		$expected = new \OC\OCS\Result(null, 404, 'Cannot increase permissions');
-		$result = $ocs->updateShare(43);
-
-		$this->assertEquals($expected->getMeta(), $result->getMeta());
-		$this->assertEquals($expected->getData(), $result->getData());
-	}
-
-	public function canIncreasePermissionsDataProvider() {
-		return [
-			//user is the owner of the share
-			['currentUser', 0],
-			//user not owner, but has enough permission
-			['mockUser', 31]
-		];
-	}
-
-	/**
-	 * @dataProvider canIncreasePermissionsDataProvider
-	 *
-	 * @param string $ownerUID
-	 * @param int $nodePermissions
-	 */
-	public function testUpdateShareCanIncreasePermissions($ownerUID, $nodePermissions) {
-		$ocs = $this->mockFormatShare();
-
-		$folder = $this->createMock(Folder::class);
-
-		$share = \OC::$server->getShareManager()->newShare();
-		$share
-			->setId(42)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareOwner($this->currentUser->getUID())
-			->setShareType(Share::SHARE_TYPE_GROUP)
-			->setSharedWith('group1')
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
-			->setNode($folder);
-
-		// note: updateShare will modify the received instance but getSharedWith will reread from the database,
-		// so their values will be different
-		$incomingShare = \OC::$server->getShareManager()->newShare();
-		$incomingShare
-			->setId(42)
-			->setSharedBy($this->currentUser->getUID())
-			->setShareOwner($this->currentUser->getUID())
-			->setShareType(Share::SHARE_TYPE_GROUP)
-			->setSharedWith('group1')
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
-			->setNode($folder);
-
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap([
-				['permissions', null, '31'],
-			]));
-
-		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
-
-		$this->shareManager->expects($this->any(0))
-			->method('getSharedWith')
-			->will($this->returnValueMap([
-				['currentUser', Share::SHARE_TYPE_USER, $share->getNode(), -1, 0, []],
-				['currentUser', Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, [$incomingShare]]
-			]));
-
-		$this->shareManager->expects($this->once())
-			->method('updateShare')
-			->with($share)
-			->willReturn($share);
-
-		$userHomeFolder = $this->createMock(Folder::class);
-		$nodeOwner = $this->createMock(IUser::class);
-		$nodeOwner->method('getUID')->willReturn($ownerUID);
-		$userNode = $this->createMock(Folder::class);
-		$userNode->method('getOwner')
-			->willReturn($nodeOwner);
-		$userNode->method('getPermissions')
-			->willReturn($nodePermissions);
-		$userHomeFolder->method('getById')
-			->willReturn([$userNode]);
-		$this->rootFolder->method('getUserFolder')
-			->willReturn($userHomeFolder);
-
-		$expected = new Result();
 		$result = $ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
@@ -3811,32 +3475,5 @@ class Share20OcsControllerTest extends TestCase {
 		$result = $this->ocs->$method(123);
 
 		$this->assertEquals($expected, $result);
-	}
-
-	/**
-	 * @dataProvider strictSubsetOfDataProvider
-	 *
-	 * @param int $allowedPermissions
-	 * @param int $newPermissions
-	 * @param boolean $expected
-	 */
-	public function testStrictSubsetOf($allowedPermissions, $newPermissions, $expected) {
-		$this->assertEquals(
-			$expected,
-			$this->invokePrivate(
-				$this->ocs,
-				'strictSubsetOf',
-				[$allowedPermissions, $newPermissions]
-			)
-		);
-	}
-
-	public function strictSubsetOfDataProvider() {
-		return [
-			[\bindec('11111'), \bindec('0111'), true],
-			[\bindec('01101'), \bindec('01001'), true],
-			[\bindec('01111'), \bindec('11111'), false],
-			[\bindec('10001'), \bindec('01111'), false],
-		];
 	}
 }

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -718,76 +718,6 @@ class Share20OcsControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
-	public function testCreateShareInvalidPermissions() {
-		$share = $this->newShare();
-		$this->shareManager->method('newShare')->willReturn($share);
-
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap([
-				['path', null, 'valid-path'],
-				['permissions', null, 32],
-			]));
-
-		$userFolder = $this->createMock('\OCP\Files\Folder');
-		$this->rootFolder->expects($this->once())
-			->method('getUserFolder')
-			->with('currentUser')
-			->willReturn($userFolder);
-
-		$path = $this->createMock('\OCP\Files\File');
-		$userFolder->expects($this->once())
-			->method('get')
-			->with('valid-path')
-			->willReturn($path);
-
-		$path->expects($this->once())
-			->method('lock')
-			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
-
-		$expected = new \OC\OCS\Result(null, 404, 'invalid permissions');
-
-		$result = $this->ocs->createShare();
-
-		$this->assertEquals($expected->getMeta(), $result->getMeta());
-		$this->assertEquals($expected->getData(), $result->getData());
-	}
-
-	public function testCreateShareZeroPermissions() {
-		$share = $this->newShare();
-		$this->shareManager->method('newShare')->willReturn($share);
-
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap([
-				['path', null, 'valid-path'],
-				['permissions', null, 0],
-			]));
-
-		$userFolder = $this->createMock('\OCP\Files\Folder');
-		$this->rootFolder->expects($this->once())
-			->method('getUserFolder')
-			->with('currentUser')
-			->willReturn($userFolder);
-
-		$path = $this->createMock('\OCP\Files\File');
-		$userFolder->expects($this->once())
-			->method('get')
-			->with('valid-path')
-			->willReturn($path);
-
-		$path->expects($this->once())
-			->method('lock')
-			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
-
-		$expected = new \OC\OCS\Result(null, 400, 'Cannot remove all permissions');
-
-		$result = $this->ocs->createShare();
-
-		$this->assertEquals($expected->getMeta(), $result->getMeta());
-		$this->assertEquals($expected->getData(), $result->getData());
-	}
-
 	public function testCreateShareUserNoShareWith() {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
@@ -918,9 +848,7 @@ class Share20OcsControllerTest extends TestCase {
 			->with($this->callback(function (\OCP\Share\IShare $share) use ($path) {
 				return $share->getNode() === $path &&
 					$share->getPermissions() === (
-						\OCP\Constants::PERMISSION_ALL &
-						~\OCP\Constants::PERMISSION_DELETE &
-						~\OCP\Constants::PERMISSION_CREATE
+						\OCP\Constants::PERMISSION_ALL
 					) &&
 					$share->getShareType() === Share::SHARE_TYPE_USER &&
 					$share->getSharedWith() === 'validUser' &&

--- a/apps/files_sharing/tests/ShareTest.php
+++ b/apps/files_sharing/tests/ShareTest.php
@@ -190,24 +190,21 @@ class ShareTest extends TestCase {
 	}
 
 	/**
-	 * shared files should never have delete permissions
+	 * @param int $permission
+	 * shared files should never have delete and create permissions
 	 * @dataProvider dataProviderTestFileSharePermissions
 	 */
-	public function testFileSharePermissions($permission, $expectedvalid) {
-		$pass = true;
-		try {
-			$this->share(
-				\OCP\Share::SHARE_TYPE_USER,
-				$this->filename,
-				self::TEST_FILES_SHARING_API_USER1,
-				self::TEST_FILES_SHARING_API_USER2,
-				$permission
-			);
-		} catch (\Exception $e) {
-			$pass = false;
-		}
-
-		$this->assertEquals($expectedvalid, $pass);
+	public function testFileSharePermissions($permission) {
+		$share = $this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			$this->filename,
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			$permission
+		);
+		$permission &= ~\OCP\Constants::PERMISSION_DELETE;
+		$permission &= ~\OCP\Constants::PERMISSION_CREATE;
+		$this->assertEquals($share->getPermissions(), $permission);
 	}
 
 	public function dataProviderTestFileSharePermissions() {
@@ -215,14 +212,16 @@ class ShareTest extends TestCase {
 		$permission3 = \OCP\Constants::PERMISSION_READ;
 		$permission4 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE;
 		$permission5 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE;
-		$permission6 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
+		$permission6 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE;
+		$permission7 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
 
 		return [
-			[$permission1, false],
-			[$permission3, true],
-			[$permission4, true],
-			[$permission5, false],
-			[$permission6, false],
+			[$permission1],
+			[$permission3],
+			[$permission4],
+			[$permission5],
+			[$permission6],
+			[$permission7],
 		];
 	}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -339,6 +339,12 @@ class Manager implements IManager {
 	 * @return int
 	 */
 	protected function calculateReshareNodePermissions(IShare $share) {
+		/*
+		 * if it is an incoming federated share, use node permission
+		 */
+		if ($share->getNode()->getStorage()->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
+			return $share->getNode()->getPermissions();
+		}
 		$maxPermissions = 0;
 		$incomingShares = [];
 		$shareTypes = [

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -25,6 +25,7 @@ use OC\User\NoUserException;
 use OCP\Files\Node;
 
 use OCP\Files\NotFoundException;
+use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\TransferSharesException;
 
@@ -41,6 +42,7 @@ interface IManager {
 	 *
 	 * @param IShare $share
 	 * @return IShare The share object
+	 * @throws GenericShareException If $share requirements do not match
 	 * @since 9.0.0
 	 */
 	public function createShare(IShare $share);
@@ -52,6 +54,8 @@ interface IManager {
 	 *
 	 * @param IShare $share
 	 * @return IShare The share object
+	 * @throws \InvalidArgumentException If $share is a link share or the $recipient does not match
+	 * @throws GenericShareException If $share requirements do not match
 	 * @since 9.0.0
 	 */
 	public function updateShare(IShare $share);

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -53,16 +53,16 @@ Feature: Comments
     And the user should have the following comments on file "/myFileToComment.txt"
       | user1 | Comment from sharee |
 
-  Scenario: sharee comments on upload-only shared file
-    Given the user has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
+  Scenario: sharee comments on upload-only shared folder
+    Given the user has created folder "/FOLDER_TO_SHARE"
     And the user has created a share with settings
-      | path        | /myFileToComment.txt |
-      | shareType   | user                 |
-      | shareWith   | user1                |
-      | permissions | create               |
-    When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
+      | path        | /FOLDER_TO_SHARE |
+      | shareType   | user             |
+      | shareWith   | user1            |
+      | permissions | create           |
+    When user "user1" comments with content "Comment from sharee" on folder "/FOLDER_TO_SHARE" using the WebDAV API
     Then the HTTP status code should be "501"
-    And the user should have 0 comments on file "/myFileToComment.txt"
+    And the user should have 0 comments on file "/FOLDER_TO_SHARE"
 
   Scenario: Creating a comment on a folder belonging to myself
     When the user comments with content "My first comment" on folder "/FOLDER" using the WebDAV API

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -53,18 +53,15 @@ Feature: sharing
       # Ask for full permissions. You get share plus read plus update. create and delete do not apply to shares of a file
       | 1               | 31                    | 19                  | 100             |
       | 2               | 31                    | 19                  | 200             |
-      # Ask for share (16), create and delete. You get share plus read
-      | 1               | 28                    | 17                  | 100             |
-      | 2               | 28                    | 17                  | 200             |
+      # Ask for read, share (17), create and delete. You get share plus read
+      | 1               | 29                    | 17                  | 100             |
+      | 2               | 29                    | 17                  | 200             |
       # Ask for read, update, create, delete. You get read plus update.
       | 1               | 15                    | 3                   | 100             |
       | 2               | 15                    | 3                   | 200             |
-      # Ask for create and delete. You get just read.
-      | 1               | 12                    | 1                   | 100             |
-      | 2               | 12                    | 1                   | 200             |
-      # Ask for just update. You get read plus update.
-      | 1               | 2                     | 3                   | 100             |
-      | 2               | 2                     | 3                   | 200             |
+      # Ask for just update. You get exactly update (you do not get read or anything else)
+      | 1               | 2                     | 2                   | 100             |
+      | 2               | 2                     | 2                   | 200             |
 
   Scenario Outline: Creating a share of a folder with a user, the default permissions are all permissions(31)
     Given using OCS API version "<ocs_api_version>"
@@ -612,7 +609,6 @@ Feature: sharing
       | 1               | 404             | 200              | PARENT        | 32          |
       | 2               | 404             | 404              | PARENT        | 32          |
 
-  @issue-35922
   Scenario Outline: Cannot create a share of a file with a user with only create permission
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
@@ -623,23 +619,13 @@ Feature: sharing
       | permissions | create        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    # delete the following step when the issue is fixed. The share should not be created at all.
-    And the fields of the last response should include
-      | share_with  | user1          |
-      | share_type  | user           |
-      | file_target | /textfile0.txt |
-      | path        | /textfile0.txt |
-      | permissions | 0              |
     And as "user1" entry "textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
-      #| 1               | 400             | 200              |
-      #| 2               | 400             | 400              |
+      | 1               | 400             | 200              |
+      | 2               | 400             | 400              |
 
-  @issue-35922
-  Scenario Outline: Cannot create a share of a file with a user with only (create,)delete permission
+  Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     When user "user0" creates a share using the sharing API with settings
@@ -649,27 +635,14 @@ Feature: sharing
       | permissions | <permissions> |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    # delete the following step when the issue is fixed. The share should not be created at all.
-    And the fields of the last response should include
-      | share_with  | user1          |
-      | share_type  | user           |
-      | file_target | /textfile0.txt |
-      | path        | /textfile0.txt |
-      | permissions | 1              |
-    # because the share got created wrongly with read permission, the file exists for the sharee
-    And as "user1" entry "textfile0.txt" should exist
-    #And as "user1" entry "textfile0.txt" should not exist
+    And as "user1" entry "textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | permissions   |
-      | 1               | 100             | 200              | delete        |
-      | 2               | 200             | 200              | delete        |
-      | 1               | 100             | 200              | create,delete |
-      | 2               | 200             | 200              | create,delete |
-      #| 1               | 404             | 200              | delete        |
-      #| 2               | 404             | 404              | delete        |
-      #| 1               | 404             | 200              | create,delete |
-      #| 2               | 404             | 404              | create,delete |
-  @issue-35922
+      | 1               | 400             | 200              | delete        |
+      | 2               | 400             | 400              | delete        |
+      | 1               | 400             | 200              | create,delete |
+      | 2               | 400             | 400              | create,delete |
+
   Scenario Outline: Cannot create a share of a file with a group with only create permission
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
@@ -682,23 +655,13 @@ Feature: sharing
       | permissions | create        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    # delete the following step when the issue is fixed. The share should not be created at all.
-    And the fields of the last response should include
-      | share_with  | grp1           |
-      | share_type  | group          |
-      | file_target | /textfile0.txt |
-      | path        | /textfile0.txt |
-      | permissions | 0              |
     And as "user1" entry "textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
-      #| 1               | 400             | 200              |
-      #| 2               | 400             | 400              |
+      | 1               | 400             | 200              |
+      | 2               | 400             | 400              |
 
-  @issue-35922
-  Scenario Outline: Cannot create a share of a file with a group with only (create,)delete permission
+  Scenario Outline: Cannot create a share of a file with a group with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -710,26 +673,13 @@ Feature: sharing
       | permissions | <permissions> |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    # delete the following step when the issue is fixed. The share should not be created at all.
-    And the fields of the last response should include
-      | share_with  | grp1           |
-      | share_type  | group          |
-      | file_target | /textfile0.txt |
-      | path        | /textfile0.txt |
-      | permissions | 1              |
-    # because the share got created wrongly with read permission, the file exists for the sharee
-    And as "user1" entry "textfile0.txt" should exist
-    #And as "user1" entry "textfile0.txt" should not exist
+    And as "user1" entry "textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | permissions   |
-      | 1               | 100             | 200              | delete        |
-      | 2               | 200             | 200              | delete        |
-      | 1               | 100             | 200              | create,delete |
-      | 2               | 200             | 200              | create,delete |
-      #| 1               | 404             | 200              | delete        |
-      #| 2               | 404             | 404              | delete        |
-      #| 1               | 404             | 200              | create,delete |
-      #| 2               | 404             | 404              | create,delete |
+      | 1               | 400             | 200              | delete        |
+      | 2               | 400             | 400              | delete        |
+      | 1               | 400             | 200              | create,delete |
+      | 2               | 400             | 400              | create,delete |
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
@@ -983,7 +933,7 @@ Feature: sharing
       | file_target | /randomfile.txt |
       | item_type   | file            |
       | permissions | read            |
-    When user "user3" shares file "randomfile.txt" with user "user1" with permissions "update" using the sharing API
+    When user "user3" shares file "randomfile.txt" with user "user1" with permissions "read,update" using the sharing API
     And user "user1" gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | uid_owner   | user3              |
@@ -991,7 +941,6 @@ Feature: sharing
       | file_target | /randomfile (2).txt|
       | item_type   | file               |
       | permissions | read,update        |
-    # Here the last response contains permissions = 3 which is equivalent to permissons: read(1) + update(2)
     And the content of file "randomfile.txt" for user "user1" should be "user2 file"
     And the content of file "randomfile (2).txt" for user "user1" should be "user3 file"
     Examples:
@@ -1010,7 +959,7 @@ Feature: sharing
     And user "user2" has created folder "zzzfolder/user2"
     And user "user3" has created folder "/zzzfolder"
     And user "user3" has created folder "zzzfolder/user3"
-    When user "user2" shares folder "zzzfolder" with user "user1" with permissions "delete" using the sharing API
+    When user "user2" shares folder "zzzfolder" with user "user1" with permissions "read,delete" using the sharing API
     And user "user1" gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | uid_owner   | user2       |
@@ -1018,14 +967,14 @@ Feature: sharing
       | file_target | /zzzfolder  |
       | item_type   | folder      |
       | permissions | read,delete |
-    When user "user3" shares folder "zzzfolder" with user "user1" with permissions "share" using the sharing API
+    When user "user3" shares folder "zzzfolder" with user "user1" with permissions "read,share" using the sharing API
     And user "user1" gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | uid_owner   | user3          |
       | share_with  | user1          |
       | file_target | /zzzfolder (2) |
       | item_type   | folder         |
-      | permissions | share,read     |
+      | permissions | read,share     |
     And as "user1" folder "zzzfolder/user2" should exist
     And as "user1" folder "zzzfolder (2)/user3" should exist
     Examples:

--- a/tests/acceptance/features/apiShareReshare/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare/reShare.feature
@@ -188,54 +188,31 @@ Feature: sharing
       | 1               | 200              | 19                   | 15                  |
       | 2               | 404              | 19                   | 15                  |
 
-  @issue-enterprise-3404
   Scenario Outline: User is not allowed to reshare folder and add delete permission bit (8)
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has shared folder "/PARENT" with user "user1" with permissions <received_permissions>
     When user "user1" shares folder "/PARENT" with user "user2" with permissions <reshare_permissions> using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    #Then the OCS status code should be "404"
-    And the HTTP status code should be "200"
-    #And the HTTP status code should be "<http_status_code>"
-    And as "user2" folder "/PARENT" should exist
-    #And as "user2" folder "/PARENT" should not exist
-    # delete the next 2 lines when the issue is fixed
-    And user "user2" should be able to delete file "/PARENT/parent.txt"
-    And as "user2" file "/PARENT/parent.txt" should not exist
-    # keep the following line
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user2" folder "/PARENT" should not exist
     But as "user1" folder "/PARENT" should exist
     Examples:
-      | ocs_api_version | ocs_status_code | received_permissions | reshare_permissions |
+      | ocs_api_version | http_status_code | received_permissions | reshare_permissions |
       # try to pass on extra delete (including reshare)
-      | 1               | 100             | 17                   | 25                  |
-      | 2               | 200             | 17                   | 25                  |
-      | 1               | 100             | 19                   | 27                  |
-      | 2               | 200             | 19                   | 27                  |
-      | 1               | 100             | 23                   | 31                  |
-      | 2               | 200             | 23                   | 31                  |
+      | 1               | 200              | 17                   | 25                  |
+      | 2               | 404              | 17                   | 25                  |
+      | 1               | 200              | 19                   | 27                  |
+      | 2               | 404              | 19                   | 27                  |
+      | 1               | 200              | 23                   | 31                  |
+      | 2               | 404              | 23                   | 31                  |
       # try to pass on extra delete (but not reshare)
-      | 1               | 100             | 17                   | 9                   |
-      | 2               | 200             | 17                   | 9                   |
-      | 1               | 100             | 19                   | 11                  |
-      | 2               | 200             | 19                   | 11                  |
-      | 1               | 100             | 23                   | 15                  |
-      | 2               | 200             | 23                   | 15                  |
-      #| ocs_api_version | http_status_code | received_permissions | reshare_permissions |
-      # try to pass on extra delete (including reshare)
-      #| 1               | 200              | 17                   | 25                  |
-      #| 2               | 404              | 17                   | 25                  |
-      #| 1               | 200              | 19                   | 27                  |
-      #| 2               | 404              | 19                   | 27                  |
-      #| 1               | 200              | 23                   | 31                  |
-      #| 2               | 404              | 23                   | 31                  |
-      # try to pass on extra delete (but not reshare)
-      #| 1               | 200              | 17                   | 9                   |
-      #| 2               | 404              | 17                   | 9                   |
-      #| 1               | 200              | 19                   | 11                  |
-      #| 2               | 404              | 19                   | 11                  |
-      #| 1               | 200              | 23                   | 15                  |
-      #| 2               | 404              | 23                   | 15                  |
+      | 1               | 200              | 17                   | 9                   |
+      | 2               | 404              | 17                   | 9                   |
+      | 1               | 200              | 19                   | 11                  |
+      | 2               | 404              | 19                   | 11                  |
+      | 1               | 200              | 23                   | 15                  |
+      | 2               | 404              | 23                   | 15                  |
 
   Scenario Outline: Update of reshare can reduce permissions
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -109,7 +109,7 @@ Feature: dav-versions
       | path        | /davtest.txt |
       | shareType   | user         |
       | shareWith   | user1        |
-      | permissions | delete       |
+      | permissions | read         |
     Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element
 
   Scenario: sharer of a file can see the old version information when the sharee changes the content of the file

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -800,8 +800,6 @@ class ManagerTest extends \Test\TestCase {
 		$fileFullPermission->method('getOwner')->willReturn($ownerUser);
 		$fileFullPermission->method('isShareable')->willReturn(true);
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $fileFullPermission, $user0, $user1, $user1, null, null, null), 'A share requires permissions', true];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $fileFullPermission, $user0, $user1, $user1, 25, null, null), 'Files can\'t be shared with delete permissions', true];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $fileFullPermission, $user0, $user1, $user1, 21, null, null), 'Files can\'t be shared with create permissions', true];
 
 		/**
 		 * Normal share (not re-share) with not enough permission input

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -703,7 +703,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->invokePrivate($this->manager, 'verifyPassword', ['password']);
 	}
 
-	public function createShare($id, $type, $path, $sharedWith, $sharedBy, $shareOwner,
+	public function createShare($id, $type, $node, $sharedWith, $sharedBy, $shareOwner,
 		$permissions, $expireDate = null, $password = null, $attributes = null) {
 		$share = $this->createMock(IShare::class);
 
@@ -711,7 +711,7 @@ class ManagerTest extends \Test\TestCase {
 		$share->method('getSharedWith')->willReturn($sharedWith);
 		$share->method('getSharedBy')->willReturn($sharedBy);
 		$share->method('getShareOwner')->willReturn($shareOwner);
-		$share->method('getNode')->willReturn($path);
+		$share->method('getNode')->willReturn($node);
 		$share->method('getPermissions')->willReturn($permissions);
 		$share->method('getAttributes')->willReturn($attributes);
 		$share->method('getExpirationDate')->willReturn($expireDate);
@@ -740,7 +740,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function dataGeneralChecks() {
 		$user0 = 'user0';
-		$user2 = 'user1';
+		$user1 = 'user1';
 		$group0 = 'group0';
 
 		$file = $this->createMock('\OCP\Files\File');
@@ -751,24 +751,24 @@ class ManagerTest extends \Test\TestCase {
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $file, $group0, $user0, $user0, 31, null, null), 'SharedWith is not a valid user', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'SharedWith is not a valid user', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, null, $user0, $user0, 31, null, null), 'SharedWith is not a valid group', true],
-			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, $user2, $user0, $user0, 31, null, null), 'SharedWith is not a valid group', true],
+			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, $user1, $user0, $user0, 31, null, null), 'SharedWith is not a valid group', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'SharedWith is not a valid group', true],
-			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, $user2, $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
+			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, $user1, $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, $group0, $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
 			[$this->createShare(null, -1, $file, null, $user0, $user0, 31, null, null), 'unkown share type', true],
 
-			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $file, $user2, null, $user0, 31, null, null), 'SharedBy should be set', true],
+			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $file, $user1, null, $user0, 31, null, null), 'SharedBy should be set', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, $group0, null, $user0, 31, null, null), 'SharedBy should be set', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, null, null, $user0, 31, null, null), 'SharedBy should be set', true],
 
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $file, $user0, $user0, $user0, 31, null, null), 'Can\'t share with yourself', true],
 
-			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, null, $user2, $user0, $user0, 31, null, null), 'Path should be set', true],
+			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, null, $user1, $user0, $user0, 31, null, null), 'Path should be set', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, null, $group0, $user0, $user0, 31, null, null), 'Path should be set', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, null, null, $user0, $user0, 31, null, null), 'Path should be set', true],
 
-			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $node, $user2, $user0, $user0, 31, null, null), 'Path should be either a file or a folder', true],
+			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $node, $user1, $user0, $user0, 31, null, null), 'Path should be either a file or a folder', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $node, $group0, $user0, $user0, 31, null, null), 'Path should be either a file or a folder', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $node, null, $user0, $user0, 31, null, null), 'Path should be either a file or a folder', true],
 		];
@@ -777,50 +777,41 @@ class ManagerTest extends \Test\TestCase {
 		$nonShareAble->method('isShareable')->willReturn(false);
 		$nonShareAble->method('getPath')->willReturn('path');
 
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $nonShareAble, $user2, $user0, $user0, 31, null, null), 'You are not allowed to share path', true];
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $nonShareAble, $user1, $user0, $user0, 31, null, null), 'You are not allowed to share path', true];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $nonShareAble, $group0, $user0, $user0, 31, null, null), 'You are not allowed to share path', true];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $nonShareAble, null, $user0, $user0, 31, null, null), 'You are not allowed to share path', true];
 
-		$limitedPermssions = $this->createMock('\OCP\Files\File');
-		$limitedPermssions->method('isShareable')->willReturn(true);
-		$limitedPermssions->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_READ);
-		$limitedPermssions->method('getPath')->willReturn('path');
-
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $limitedPermssions, $user2, $user0, $user0, null, null, null), 'A share requires permissions', true];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, null, null, null), 'A share requires permissions', true];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $limitedPermssions, null, $user0, $user0, null, null, null), 'A share requires permissions', true];
-
-		$mount = $this->createMock('OC\Files\Mount\MoveableMount');
-		$limitedPermssions->method('getMountPoint')->willReturn($mount);
-
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $limitedPermssions, $user2, $user0, $user0, 31, null, null), 'Cannot increase permissions of path', true];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, 17, null, null), 'Cannot increase permissions of path', true];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $limitedPermssions, null, $user0, $user0, 3, null, null), 'Cannot increase permissions of path', true];
-
-		$nonMoveableMountPermssions = $this->createMock('\OCP\Files\Folder');
-		$nonMoveableMountPermssions->method('isShareable')->willReturn(true);
-		$nonMoveableMountPermssions->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_READ);
-		$nonMoveableMountPermssions->method('getPath')->willReturn('path');
-
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $nonMoveableMountPermssions, $user2, $user0, $user0, 11, null, null), 'Cannot increase permissions of path', false];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $nonMoveableMountPermssions, $group0, $user0, $user0, 11, null, null), 'Cannot increase permissions of path', false];
-
-		$rootFolder = $this->createMock('\OCP\Files\Folder');
+		$rootFolder = $this->createMock(Folder::class);
 		$rootFolder->method('isShareable')->willReturn(true);
 		$rootFolder->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_ALL);
 		$rootFolder->method('getPath')->willReturn('myrootfolder');
 
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $rootFolder, $user2, $user0, $user0, 30, null, null), 'You can\'t share your root folder', true];
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $rootFolder, $user1, $user0, $user0, 30, null, null), 'You can\'t share your root folder', true];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $rootFolder, $group0, $user0, $user0, 2, null, null), 'You can\'t share your root folder', true];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $rootFolder, null, $user0, $user0, 16, null, null), 'You can\'t share your root folder', true];
 
-		$allPermssions = $this->createMock('\OCP\Files\Folder');
-		$allPermssions->method('isShareable')->willReturn(true);
-		$allPermssions->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_ALL);
+		/**
+		 * Basic share (not re-share) with enough permission inputs
+		 */
+		$ownerUser = $this->createMock(IUser::class);
+		$ownerUser->method('getUID')->willReturn('user1');
+		$fileFullPermission = $this->createMock(File::class);
+		$fileFullPermission->method('getPermissions')->willReturn(31);
+		$fileFullPermission->method('getOwner')->willReturn($ownerUser);
+		$fileFullPermission->method('isShareable')->willReturn(true);
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $fileFullPermission, $user0, $user1, $user1, null, null, null), 'A share requires permissions', true];
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $fileFullPermission, $user0, $user1, $user1, 25, null, null), 'Files can\'t be shared with delete permissions', true];
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $fileFullPermission, $user0, $user1, $user1, 21, null, null), 'Files can\'t be shared with create permissions', true];
 
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $allPermssions, $user2, $user0, $user0, 31, null, null), null, false];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 3, null, null), null, false];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $allPermssions, null, $user0, $user0, 17, null, null), null, false];
+		/**
+		 * Normal share (not re-share) with not enough permission input
+		 */
+		$fileLessPermission = $this->createMock(File::class);
+		$fileLessPermission->method('getPermissions')->willReturn(1);
+		$fileLessPermission->method('getOwner')->willReturn($ownerUser);
+		$fileLessPermission->method('isShareable')->willReturn(true);
+		$fileLessPermission->method('getPath')->willReturn('/user1/sharedfile');
+		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $fileLessPermission, $user0, $user1, $user1, 17, null, null), 'Cannot increase permissions of /user1/sharedfile', true];
 
 		return $data;
 	}
@@ -830,6 +821,7 @@ class ManagerTest extends \Test\TestCase {
 	 *
 	 * @param $share
 	 * @param $exceptionMessage
+	 * @param $exception
 	 */
 	public function testGeneralChecks($share, $exceptionMessage, $exception) {
 		$thrown = null;
@@ -848,7 +840,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
 
 		try {
-			$this->invokePrivate($this->manager, 'generalCreateChecks', [$share]);
+			$this->invokePrivate($this->manager, 'generalChecks', [$share]);
 			$thrown = false;
 		} catch (\OCP\Share\Exceptions\GenericShareException $e) {
 			$this->assertEquals($exceptionMessage, $e->getHint());
@@ -859,32 +851,6 @@ class ManagerTest extends \Test\TestCase {
 		}
 
 		$this->assertSame($exception, $thrown);
-	}
-
-	/**
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessage You can't share your root folder
-	 */
-	public function testGeneralCheckShareRoot() {
-		$thrown = null;
-
-		$this->userManager->method('userExists')->will($this->returnValueMap([
-			['user0', true],
-			['user1', true],
-		]));
-
-		$userFolder = $this->createMock('\OCP\Files\Folder');
-		$userFolder->method('isSubNode')->with($userFolder)->willReturn(false);
-		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
-
-		$share = $this->manager->newShare();
-
-		$share->setShareType(\OCP\Share::SHARE_TYPE_USER)
-			->setSharedWith('user0')
-			->setSharedBy('user1')
-			->setNode($userFolder);
-
-		$this->invokePrivate($this->manager, 'generalCreateChecks', [$share]);
 	}
 
 	/**
@@ -904,7 +870,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException InvalidArgumentException
+	 * @expectedException \InvalidArgumentException
 	 * @expectedExceptionMessage Expiration date is enforced
 	 */
 	public function testvalidateExpirationDateEnforceButNotSet() {
@@ -1766,7 +1732,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->createUser('user1');
 		$this->createUser('user2');
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+			->setMethods(['canShare', 'generalChecks', 'userCreateChecks',
 				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks', 'updateShare'])
 			->getMock();
 
@@ -2025,7 +1991,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testTransferShareNoOldOwner() {
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+			->setMethods(['canShare', 'generalChecks', 'userCreateChecks',
 				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
 			->getMock();
 		$this->userManager->expects($this->once())
@@ -2044,7 +2010,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testTransferShareNoNewOwner() {
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+			->setMethods(['canShare', 'generalChecks', 'userCreateChecks',
 				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
 			->getMock();
 		$this->userManager->method('get')
@@ -2064,7 +2030,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testTransferShareNoSameOwner() {
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+			->setMethods(['canShare', 'generalChecks', 'userCreateChecks',
 				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
 			->getMock();
 		$this->userManager->method('get')
@@ -2083,7 +2049,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testTransferShareNonExistingFinalTarget() {
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+			->setMethods(['canShare', 'generalChecks', 'userCreateChecks',
 				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
 			->getMock();
 		$this->userManager->method('get')
@@ -2102,7 +2068,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testCreateShareUser() {
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks', 'pathCreateChecks'])
+			->setMethods(['canShare', 'generalChecks', 'userCreateChecks', 'pathCreateChecks'])
 			->getMock();
 
 		$shareOwner = $this->createMock('\OCP\IUser');
@@ -2128,7 +2094,7 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn(true);
 		$manager->expects($this->once())
-			->method('generalCreateChecks')
+			->method('generalChecks')
 			->with($share);
 		;
 		$manager->expects($this->once())
@@ -2179,7 +2145,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testCreateShareGroup() {
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'groupCreateChecks', 'pathCreateChecks'])
+			->setMethods(['canShare', 'generalChecks', 'groupCreateChecks', 'pathCreateChecks'])
 			->getMock();
 
 		$shareOwner = $this->createMock('\OCP\IUser');
@@ -2205,7 +2171,7 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn(true);
 		$manager->expects($this->once())
-			->method('generalCreateChecks')
+			->method('generalChecks')
 			->with($share);
 		;
 		$manager->expects($this->once())
@@ -2268,7 +2234,7 @@ class ManagerTest extends \Test\TestCase {
 		$manager = $this->createManagerMock()
 			->setMethods([
 				'canShare',
-				'generalCreateChecks',
+				'generalChecks',
 				'linkCreateChecks',
 				'pathCreateChecks',
 				'validateExpirationDate',
@@ -2306,7 +2272,7 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn(true);
 		$manager->expects($this->once())
-			->method('generalCreateChecks')
+			->method('generalChecks')
 			->with($share);
 		;
 		$manager->expects($this->once())
@@ -2434,7 +2400,7 @@ class ManagerTest extends \Test\TestCase {
 		$manager = $this->createManagerMock()
 			->setMethods([
 				'canShare',
-				'generalCreateChecks',
+				'generalChecks',
 				'userCreateChecks',
 				'pathCreateChecks',
 			])
@@ -2463,7 +2429,7 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn(true);
 		$manager->expects($this->once())
-			->method('generalCreateChecks')
+			->method('generalChecks')
 			->with($share);
 		;
 		$manager->expects($this->once())
@@ -2495,7 +2461,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testCreateShareOfIncomingFederatedShare() {
 		$manager = $this->createManagerMock()
-			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks', 'pathCreateChecks'])
+			->setMethods(['canShare', 'generalChecks', 'userCreateChecks', 'pathCreateChecks'])
 			->getMock();
 
 		$shareOwner = $this->createMock('\OCP\IUser');
@@ -2540,7 +2506,7 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn(true);
 		$manager->expects($this->once())
-			->method('generalCreateChecks')
+			->method('generalChecks')
 			->with($share);
 		;
 		$manager->expects($this->once())
@@ -3133,7 +3099,7 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods([
 				'canShare',
 				'getShareById',
-				'generalCreateChecks',
+				'generalChecks',
 				'userCreateChecks',
 				'pathCreateChecks',
 			])
@@ -3213,7 +3179,7 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods([
 				'canShare',
 				'getShareById',
-				'generalCreateChecks',
+				'generalChecks',
 				'groupCreateChecks',
 				'pathCreateChecks',
 			])
@@ -3262,7 +3228,7 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods([
 				'canShare',
 				'getShareById',
-				'generalCreateChecks',
+				'generalChecks',
 				'linkCreateChecks',
 				'pathCreateChecks',
 				'verifyPassword',
@@ -3360,6 +3326,9 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_allow_public_upload', 'yes', 'yes'],
 			]));
 
+		$user1 = $this->createMock(IUser::class);
+		$user1->method('getUID')->willReturn('user1');
+
 		$this->userManager->method('userExists')
 			->will($this->returnValueMap([
 				['user1', true],
@@ -3374,6 +3343,7 @@ class ManagerTest extends \Test\TestCase {
 		$node->method('getPath')->willReturn('/user1/files/path/to/share');
 		$node->method('isShareable')->willReturn(true);
 		$node->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_ALL);
+		$node->method('getOwner')->willReturn($user1);
 
 		$originalShare = $this->createMock(IShare::class);
 		$originalShare->method('getId')->willReturn(10);
@@ -3427,7 +3397,7 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->will($this->returnArgument(0));
 
-		$updatedShare = $this->manager->updateShare($share);
+		$this->manager->updateShare($share);
 	}
 
 	public function testMoveCallsUpdateShareForRecipient() {
@@ -3495,6 +3465,33 @@ class ManagerTest extends \Test\TestCase {
 		$shares = $this->manager->getAllSharedWith($user, [\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_USER]);
 		$this->assertCount(2, $shares);
 		$this->assertSame($shares, [$share1, $share2]);
+	}
+
+	/**
+	 * @dataProvider strictSubsetOfDataProvider
+	 *
+	 * @param int $allowedPermissions
+	 * @param int $newPermissions
+	 * @param boolean $expected
+	 */
+	public function testStrictSubsetOf($allowedPermissions, $newPermissions, $expected) {
+		$this->assertEquals(
+			$expected,
+			$this->invokePrivate(
+				$this->manager,
+				'strictSubsetOf',
+				[$allowedPermissions, $newPermissions]
+			)
+		);
+	}
+
+	public function strictSubsetOfDataProvider() {
+		return [
+			[\bindec('11111'), \bindec('0111'), true],
+			[\bindec('01101'), \bindec('01001'), true],
+			[\bindec('01111'), \bindec('11111'), false],
+			[\bindec('10001'), \bindec('01111'), false],
+		];
 	}
 }
 


### PR DESCRIPTION
## Description
This PR moves some of the validation on Share20Controlller to the share manager instead and changes permission calculation on re-shares.

Currently, permission handling different for `update` and `create` share operations, also two different classes(`Share20OcsController.php` and `Manager`) are responsible from this permission checks. This situation causes issues such as a scenario that works well in one operation does not work in another. (https://github.com/owncloud/enterprise/issues/3299 only affecting `update` share and the another is only affecting `create` share).

In a clean approach, Share manager should take care of all sorts of validations and logics instead of controller. I unified these logics under Share Manager and applied this unified checks for both `update` and `create` operations.

Also, with this PR re-share permission will be calculated based on share permission of re-share mount point node's.

IMHO, most of the permission exceptions should return `403`. However, to keep acceptance test and behavior changes minimal, I did not touch return codes and I kept them as it is.

I removed many unit tests. Some of them were duplicate and redundant. I will add more unit tests after reviews.

**_Share API, no longer set read permission as default._ Clients should include this permission to their requests. We need to test this behavior on clients to ensure there is no regression.**

## Related Issue
fixes https://github.com/owncloud/enterprise/issues/3299
fixes https://github.com/owncloud/enterprise/issues/3404
fixes #35922 

## Motivation and Context
To get rid of from bugs. To have a cleaner code. Next time we will know where we should look at on a share permission issue.

## How Has This Been Tested?
Acceptance tests, Also it resolves described scenarios in these tickets: 
- https://github.com/owncloud/enterprise/issues/3299 
- https://github.com/owncloud/enterprise/issues/3404
- #35922 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
