### PR TITLE
Use keywords for share type in acceptance tests

### DIFF
--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -38,6 +38,13 @@ class SharingHelper {
 			'share' => 16,
 	];
 
+	const SHARE_TYPES = [
+			'user' => 0,
+			'group' => 1,
+			'public_link' => 3,
+			'federated' => 6,
+	];
+
 	/**
 	 *
 	 * @param string $baseUrl baseURL of the ownCloud installation without /ocs.
@@ -100,14 +107,6 @@ class SharingHelper {
 			}
 		}
 
-		$validShareTypes
-			= ['user' => 0, 'group' => 1, 'public' => 3, 'federated' => 6];
-		if (isset($validShareTypes[$shareType])) {
-			$shareType = $validShareTypes[$shareType];
-		}
-		if (!\in_array($shareType, $validShareTypes, true)) {
-			throw new \InvalidArgumentException("invalid share type");
-		}
 		if ($permissions !== null) {
 			$fd['permissions'] = self::getPermissionSum($permissions);
 		}
@@ -129,7 +128,7 @@ class SharingHelper {
 		}
 		$fullUrl .= "ocs/v{$ocsApiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
 		$fd['path'] = $path;
-		$fd['shareType'] = $shareType;
+		$fd['shareType'] = self::getShareType($shareType);
 
 		if ($shareWith !== null) {
 			$fd['shareWith'] = $shareWith;
@@ -193,6 +192,32 @@ class SharingHelper {
 			);
 		}
 		return $permissionSum;
+	}
+
+	/**
+	 * returns the share type number corresponding to the share type keyword
+	 *
+	 * @param string|int $shareType a keyword from SHARE_TYPES or a share type number
+	 *
+	 * @return int
+	 * @throws \InvalidArgumentException
+	 *
+	 */
+	public static function getShareType($shareType) {
+		if (\array_key_exists($shareType, self::SHARE_TYPES)) {
+			return self::SHARE_TYPES[$shareType];
+		} else {
+			if (\ctype_digit($shareType)) {
+				$shareType = (int) $shareType;
+			}
+			$key = \array_search($shareType, self::SHARE_TYPES, true);
+			if ($key !== false) {
+				return self::SHARE_TYPES[$key];
+			}
+			throw new \InvalidArgumentException(
+				"invalid share type ($shareType)"
+			);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -45,7 +45,7 @@ Feature: Comments
     Given the user has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And the user has created a share with settings
       | path        | /myFileToComment.txt |
-      | shareType   | 0                    |
+      | shareType   | user                 |
       | shareWith   | user1                |
       | permissions | read                 |
     When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
@@ -57,7 +57,7 @@ Feature: Comments
     Given the user has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And the user has created a share with settings
       | path        | /myFileToComment.txt |
-      | shareType   | 0                    |
+      | shareType   | user                 |
       | shareWith   | user1                |
       | permissions | create               |
     When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -16,7 +16,7 @@ Feature: federated
       | id                     | A_NUMBER          |
       | item_type              | file              |
       | item_source            | A_NUMBER          |
-      | share_type             | 6                 |
+      | share_type             | federated         |
       | file_source            | A_NUMBER          |
       | path                   | /textfile0.txt    |
       | permissions            | share,read,update |
@@ -42,7 +42,7 @@ Feature: federated
       | id                     | A_NUMBER          |
       | item_type              | file              |
       | item_source            | A_NUMBER          |
-      | share_type             | 6                 |
+      | share_type             | federated         |
       | file_source            | A_NUMBER          |
       | path                   | /textfile0.txt    |
       | permissions            | share,read,update |
@@ -167,7 +167,7 @@ Feature: federated
     And using OCS API version "<ocs-api-version>"
     When user "user1" creates a share using the sharing API with settings
       | path        | /textfile0 (2).txt |
-      | shareType   | 0                  |
+      | shareType   | user               |
       | shareWith   | user2              |
       | permissions | share,read,update  |
     Then the OCS status code should be "<ocs-status>"
@@ -176,7 +176,7 @@ Feature: federated
       | id                     | A_NUMBER           |
       | item_type              | file               |
       | item_source            | A_NUMBER           |
-      | share_type             | 0                  |
+      | share_type             | user               |
       | file_source            | A_NUMBER           |
       | path                   | /textfile0 (2).txt |
       | permissions            | share,read,update  |

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -284,7 +284,7 @@ Feature: accept/decline shares coming from internal users
     And the HTTP status code should be "200"
     And the fields of the last response should include
       | id                     | A_NUMBER                   |
-      | share_type             | 0                          |
+      | share_type             | user                       |
       | uid_owner              | user0                      |
       | displayname_owner      | User Zero                  |
       | permissions            | share,read,update          |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -139,7 +139,7 @@ Feature: sharing
       | file_target            | /welcome.txt |
       | path                   | /welcome.txt |
       | permissions            | read         |
-      | share_type             | 3            |
+      | share_type             | public_link  |
       | displayname_file_owner | User Zero    |
       | displayname_owner      | User Zero    |
       | uid_file_owner         | user0        |
@@ -165,7 +165,7 @@ Feature: sharing
       | file_target            | /welcome.txt |
       | path                   | /welcome.txt |
       | permissions            | read         |
-      | share_type             | 3            |
+      | share_type             | public_link  |
       | displayname_file_owner | User Zero    |
       | displayname_owner      | User Zero    |
       | uid_file_owner         | user0        |
@@ -193,7 +193,7 @@ Feature: sharing
       | file_target            | /welcome.txt |
       | path                   | /welcome.txt |
       | permissions            | read         |
-      | share_type             | 3            |
+      | share_type             | public_link  |
       | displayname_file_owner | User Zero    |
       | displayname_owner      | User Zero    |
       | uid_file_owner         | user0        |
@@ -218,7 +218,7 @@ Feature: sharing
       | file_target            | /PARENT              |
       | path                   | /PARENT              |
       | permissions            | read                 |
-      | share_type             | 3                    |
+      | share_type             | public_link          |
       | displayname_file_owner | User Zero            |
       | displayname_owner      | User Zero            |
       | uid_file_owner         | user0                |
@@ -245,7 +245,7 @@ Feature: sharing
       | file_target            | /PARENT              |
       | path                   | /PARENT              |
       | permissions            | read                 |
-      | share_type             | 3                    |
+      | share_type             | public_link          |
       | displayname_file_owner | User Zero            |
       | displayname_owner      | User Zero            |
       | uid_file_owner         | user0                |
@@ -271,7 +271,7 @@ Feature: sharing
       | file_target            | /welcome.txt   |
       | path                   | /welcome.txt   |
       | item_type              | file           |
-      | share_type             | 3              |
+      | share_type             | public_link    |
       | permissions            | read           |
       | uid_owner              | user0          |
       | share_with             | ***redacted*** |
@@ -292,7 +292,7 @@ Feature: sharing
       | file_target            | /welcome.txt   |
       | path                   | /welcome.txt   |
       | item_type              | file           |
-      | share_type             | 3              |
+      | share_type             | public_link    |
       | permissions            | read           |
       | uid_owner              | user0          |
     And the fields of the last response should not include
@@ -335,9 +335,9 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
-      | id          | A_NUMBER |
-      | share_type  | 3        |
-      | permissions | read     |
+      | id          | A_NUMBER    |
+      | share_type  | public_link |
+      | permissions | read        |
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -354,7 +354,7 @@ Feature: sharing
     And the HTTP status code should be "200"
     And the fields of the last response should include
       | id          | A_NUMBER                  |
-      | share_type  | 3                         |
+      | share_type  | public_link               |
       | permissions | read,update,create,delete |
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -372,7 +372,7 @@ Feature: sharing
     And the HTTP status code should be "200"
     And the fields of the last response should include
       | id          | A_NUMBER    |
-      | share_type  | 3           |
+      | share_type  | public_link |
       | permissions | read,create |
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -560,7 +560,7 @@ Feature: sharing
     When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
       | path        | welcome.txt |
       | shareWith   | user1       |
-      | shareType   | 0           |
+      | shareType   | user        |
       | permissions | 0           |
     Then the OCS status code should be "400"
     And the HTTP status code should be "<http_status_code>"
@@ -998,7 +998,7 @@ Feature: sharing
       | file_target | /textfile0.txt |
       | path        | /textfile0.txt |
       | item_type   | file           |
-      | share_type  | 3              |
+      | share_type  | public_link    |
       | permissions | read           |
       | uid_owner   | user0          |
       | expiration  | +7 days        |
@@ -1009,7 +1009,7 @@ Feature: sharing
       | file_target | /textfile0.txt |
       | path        | /textfile0.txt |
       | item_type   | file           |
-      | share_type  | 3              |
+      | share_type  | public_link    |
       | permissions | read           |
       | uid_owner   | user0          |
       | expiration  | +7 days        |

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -39,7 +39,7 @@ Feature: sharing
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has created a share with settings
       | path        | /tmp.txt          |
-      | shareType   | 1                 |
+      | shareType   | group             |
       | permissions | share,update,read |
       | shareWith   | grp1              |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
@@ -69,7 +69,7 @@ Feature: sharing
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has created a share with settings
       | path        | /tmp.txt    |
-      | shareType   | 1           |
+      | shareType   | group       |
       | permissions | update,read |
       | shareWith   | grp1        |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
@@ -99,7 +99,7 @@ Feature: sharing
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has created a share with settings
       | path        | /tmp.txt   |
-      | shareType   | 1          |
+      | shareType   | group      |
       | permissions | share,read |
       | shareWith   | grp1       |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
@@ -139,9 +139,9 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
-      | path      | tmp  |
-      | shareType | 1    |
-      | shareWith | grp1 |
+      | path      | tmp   |
+      | shareType | group |
+      | shareWith | grp1  |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "31"
@@ -169,7 +169,7 @@ Feature: sharing
     And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp                      |
-      | shareType   | 1                        |
+      | shareType   | group                    |
       | shareWith   | grp1                     |
       | permissions | share,delete,create,read |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
@@ -199,7 +199,7 @@ Feature: sharing
     And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp                      |
-      | shareType   | 1                        |
+      | shareType   | group                    |
       | shareWith   | grp1                     |
       | permissions | share,delete,update,read |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
@@ -229,7 +229,7 @@ Feature: sharing
     And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp                        |
-      | shareType   | 1                          |
+      | shareType   | group                      |
       | shareWith   | grp1                       |
       | permissions | share,create,update,read   |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
@@ -259,7 +259,7 @@ Feature: sharing
     And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
       | path        | tmp    |
-      | shareType   | 1      |
+      | shareType   | group  |
       | shareWith   | grp1   |
       | permissions | change |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -105,7 +105,7 @@ Feature: sharing
       | id                     | A_NUMBER           |
       | item_type              | file               |
       | item_source            | A_NUMBER           |
-      | share_type             | 0                  |
+      | share_type             | user               |
       | share_with             | user1              |
       | file_source            | A_NUMBER           |
       | file_target            | /file_to_share.txt |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -41,7 +41,7 @@ Feature: sharing
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
-      | share_type        | 3                    |
+      | share_type        | public_link          |
       | file_source       | A_NUMBER             |
       | file_target       | /FOLDER              |
       | permissions       | read                 |
@@ -92,7 +92,7 @@ Feature: sharing
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
-      | share_type        | 3                    |
+      | share_type        | public_link          |
       | file_source       | A_NUMBER             |
       | file_target       | /FOLDER              |
       | permissions       | read                 |
@@ -126,7 +126,7 @@ Feature: sharing
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
-      | share_type        | 3                    |
+      | share_type        | public_link          |
       | file_source       | A_NUMBER             |
       | file_target       | /FOLDER              |
       | permissions       | read                 |
@@ -159,7 +159,7 @@ Feature: sharing
       | id                | A_NUMBER                  |
       | item_type         | folder                    |
       | item_source       | A_NUMBER                  |
-      | share_type        | 3                         |
+      | share_type        | public_link               |
       | file_source       | A_NUMBER                  |
       | file_target       | /FOLDER                   |
       | permissions       | read,update,create,delete |
@@ -192,7 +192,7 @@ Feature: sharing
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
-      | share_type        | 3                    |
+      | share_type        | public_link          |
       | file_source       | A_NUMBER             |
       | file_target       | /FOLDER              |
       | permissions       | read,update,create   |
@@ -225,7 +225,7 @@ Feature: sharing
       | id                | A_NUMBER                  |
       | item_type         | folder                    |
       | item_source       | A_NUMBER                  |
-      | share_type        | 3                         |
+      | share_type        | public_link               |
       | file_source       | A_NUMBER                  |
       | file_target       | /FOLDER                   |
       | permissions       | read,update,create,delete |
@@ -260,7 +260,7 @@ Feature: sharing
       | id                | A_NUMBER       |
       | item_type         | file           |
       | item_source       | A_NUMBER       |
-      | share_type        | 1              |
+      | share_type        | group          |
       | file_source       | A_NUMBER       |
       | file_target       | /textfile0.txt |
       | permissions       | read           |
@@ -325,7 +325,7 @@ Feature: sharing
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
-      | share_type        | 0                    |
+      | share_type        | user                 |
       | file_source       | A_NUMBER             |
       | file_target       | /folder2             |
       | permissions       | all                  |
@@ -355,7 +355,7 @@ Feature: sharing
       | id                | A_NUMBER             |
       | item_type         | folder               |
       | item_source       | A_NUMBER             |
-      | share_type        | 0                    |
+      | share_type        | user                 |
       | file_source       | A_NUMBER             |
       | file_target       | /user2-folder        |
       | permissions       | all                  |

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -107,7 +107,7 @@ Feature: dav-versions
     And we save it into "FILEID"
     When user "user0" creates a share using the sharing API with settings
       | path        | /davtest.txt |
-      | shareType   | 0            |
+      | shareType   | user         |
       | shareWith   | user1        |
       | permissions | delete       |
     Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -70,7 +70,7 @@ Feature: move (rename) file
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | read      |
       | shareWith   | user0     |
     When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
@@ -88,7 +88,7 @@ Feature: move (rename) file
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | read      |
       | shareWith   | user0     |
     And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"

--- a/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
@@ -88,7 +88,7 @@ Feature: move (rename) file
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | read      |
       | shareWith   | user0     |
     When user "user0" moves file "/textfile0.txt" asynchronously to "/testshare/textfile0.txt" using the WebDAV API
@@ -106,7 +106,7 @@ Feature: move (rename) file
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | read      |
       | shareWith   | user0     |
     And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
@@ -193,7 +193,7 @@ Feature: move (rename) file
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | read      |
       | shareWith   | user0     |
     When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/copyFile.feature
@@ -48,7 +48,7 @@ Feature: copy file
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | read      |
       | shareWith   | user0     |
     When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
@@ -66,7 +66,7 @@ Feature: copy file
     And user "user1" has created folder "/testshare"
     And user "user1" has created a share with settings
       | path        | testshare |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | read      |
       | shareWith   | user0     |
     And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -75,7 +75,7 @@ Feature: get file properties
     And user "user0" has created folder "/test"
     And user "user0" has created a share with settings
       | path        | test  |
-      | shareType   | 0     |
+      | shareType   | user  |
       | permissions | all   |
       | shareWith   | user1 |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
@@ -92,10 +92,10 @@ Feature: get file properties
     And group "grp1" has been created
     And user "user0" has created folder "/test"
     And user "user0" has created a share with settings
-      | path        | test |
-      | shareType   | 1    |
-      | permissions | all  |
-      | shareWith   | grp1 |
+      | path        | test  |
+      | shareType   | group |
+      | permissions | all   |
+      | shareWith   | grp1  |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
       | oc:share-types |
     Then the response should contain a share-types property with
@@ -129,14 +129,14 @@ Feature: get file properties
     And user "user0" has created folder "/test"
     And user "user0" has created a share with settings
       | path        | test  |
-      | shareType   | 0     |
+      | shareType   | user  |
       | permissions | all   |
       | shareWith   | user1 |
     And user "user0" has created a share with settings
-      | path        | test |
-      | shareType   | 1    |
-      | permissions | all  |
-      | shareWith   | grp2 |
+      | path        | test  |
+      | shareType   | group |
+      | permissions | all   |
+      | shareWith   | grp2  |
     And user "user0" has created a public link share with settings
       | path        | test |
       | permissions | all  |

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -35,7 +35,7 @@ Feature: get quota
     And user "user1" has created folder "/testquota"
     And user "user1" has created a share with settings
       | path        | testquota |
-      | shareType   | 0         |
+      | shareType   | user      |
       | permissions | all       |
       | shareWith   | user0     |
     When user "user0" gets the following properties of folder "/testquota" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
@@ -51,7 +51,7 @@ Feature: set file properties
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/testcustompropshared.txt"
     And user "user0" has created a share with settings
       | path        | testcustompropshared.txt |
-      | shareType   | 0                        |
+      | shareType   | user                     |
       | permissions | all                      |
       | shareWith   | user1                    |
     And user "user0" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustompropshared.txt" to "valueForSharetest"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -180,7 +180,7 @@ trait Sharing {
 	 *       | shareWith       | The user or group id with which the file should     |
 	 *       |                 | be shared.                                          |
 	 *       | shareType       | The type of the share. This can be one of:          |
-	 *       |                 |    0 = user, 1 = group, 3 = public (link),          |
+	 *       |                 |    0 = user, 1 = group, 3 = public_link,            |
 	 *       |                 |    6 = federated (cloud share).                     |
 	 *       |                 |    Pass either the number or the keyword.           |
 	 *
@@ -249,7 +249,7 @@ trait Sharing {
 	public function userCreatesAPublicLinkShareWithSettings($user, $body) {
 		$rows = $body->getRows();
 		// A public link share is shareType 3
-		$rows[] = ['shareType', '3'];
+		$rows[] = ['shareType', 'public_link'];
 		$newBody = new TableNode($rows);
 		$this->userCreatesAShareWithSettings($user, $newBody);
 	}
@@ -314,7 +314,7 @@ trait Sharing {
 		$this->createShare(
 			$user,
 			$path,
-			'public',
+			'public_link',
 			null, // shareWith
 			$publicUpload,
 			$sharePassword,
@@ -1198,16 +1198,15 @@ trait Sharing {
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
-	 * @param string $userOrGroup
+	 * @param string $userOrGroupShareType
 	 * @param string $sharee
 	 * @param int|string $permissions
 	 *
 	 * @return void
 	 */
-	public function userTriesToShareFileUsingTheSharingApi($sharer, $filepath, $userOrGroup, $sharee, $permissions = null) {
-		$shareType = ($userOrGroup === "user" ? 0 : 1);
+	public function userTriesToShareFileUsingTheSharingApi($sharer, $filepath, $userOrGroupShareType, $sharee, $permissions = null) {
 		$this->createShare(
-			$sharer, $filepath, $shareType, $sharee, null, null, $permissions
+			$sharer, $filepath, $userOrGroupShareType, $sharee, null, null, $permissions
 		);
 		$statusCode = $this->ocsContext->getOCSResponseStatusCode($this->response);
 		PHPUnit\Framework\Assert::assertTrue(
@@ -1222,18 +1221,17 @@ trait Sharing {
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
-	 * @param string $userOrGroup
+	 * @param string $userOrGroupShareType
 	 * @param string $sharee
 	 * @param int|string $permissions
 	 *
 	 * @return void
 	 */
 	public function userShouldBeAbleToShareUsingTheSharingApi(
-		$sharer, $filepath, $userOrGroup, $sharee, $permissions = null
+		$sharer, $filepath, $userOrGroupShareType, $sharee, $permissions = null
 	) {
-		$shareType = ($userOrGroup === "user" ? 0 : 1);
 		$this->createShare(
-			$sharer, $filepath, $shareType, $sharee, null, null, $permissions
+			$sharer, $filepath, $userOrGroupShareType, $sharee, null, null, $permissions
 		);
 
 		//v1.php returns 100 as success code
@@ -1991,6 +1989,9 @@ trait Sharing {
 				$value = $this->splitPermissionsString($value);
 			}
 			$value = SharingHelper::getPermissionSum($value);
+		}
+		if ($field === "share_type") {
+			$value = SharingHelper::getShareType($value);
 		}
 		return $value;
 	}

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -354,7 +354,7 @@ Feature: Share by public link
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | 14-10-2038  |
-      | shareType  | 3           |
+      | shareType  | public_link |
     And user "user1" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "21-07-2038"
     And the user gets the info of the last share using the sharing API
@@ -367,7 +367,7 @@ Feature: Share by public link
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | 14-10-2038  |
-      | shareType  | 3           |
+      | shareType  | public_link |
     And user "user1" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "14-09-2017"
     And the user gets the info of the last share using the sharing API
@@ -593,7 +593,7 @@ Feature: Share by public link
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | + 5 days    |
-      | shareType  | 3           |
+      | shareType  | public_link |
     And user "user1" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     Then the user should see an error message on the public link popup saying "Expiration date is required"
@@ -608,7 +608,7 @@ Feature: Share by public link
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate |  + 5 days   |
-      | shareType  | 3           |
+      | shareType  | public_link |
     And user "user1" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     And the user gets the info of the last share using the sharing API


### PR DESCRIPTION
## Description
- Use a lookup table to translate the share type keywords `user`  `group` `public_link` `federated` to the "magic" share type numbers.
- modify acceptance test steps to use the share type keywords

## Related Issue
Issue #35886

## Motivation and Context
Helps make the sharing acceptance tests read more consistently as we expand them.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
