### PR TITLE
Add tests for restoring file to a particular destination

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -81,6 +81,74 @@ Feature: Restore deleted files/folders
       | old      |
       | new      |
 
+  Scenario Outline: a file is deleted and restored to a new destination
+    Given using <dav-path> DAV path
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "<delete-path>"
+    When user "user0" restores the file with original path "<delete-path>" to "<restore-path>" using the trashbin API
+    Then as "user0" the file with original path "<delete-path>" should not exist in trash
+    And as "user0" file "<restore-path>" should exist
+    And as "user0" file "<delete-path>" should not exist
+    Examples:
+      | dav-path | delete-path              | restore-path         |
+      | old      | /PARENT/parent.txt       | parent.txt           |
+      | new      | /PARENT/parent.txt       | parent.txt           |
+      | old      | /PARENT/CHILD/child.txt  | child.txt            |
+      | new      | /PARENT/CHILD/child.txt  | child.txt            |
+      | old      | /textfile0.txt           | FOLDER/textfile0.txt |
+      | new      | /textfile0.txt           | FOLDER/textfile0.txt |
+
+  @issue-35900
+  Scenario Outline: restoring a file to a read-only folder
+    Given using <dav-path> DAV path
+    And these users have been created with default attributes and skeleton files:
+    | username |
+    | user0    |
+    | user1    |
+    And user "user1" has created folder "shareFolderParent"
+    And user "user1" has shared folder "shareFolderParent" with user "user0" with permissions "read"
+    And as "user0" folder "/shareFolderParent" should exist
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user0" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "204"
+    #Then the HTTP status code should be "403"
+    And as "user0" the file with original path "/textfile0.txt" should not exist in trash
+    #And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" file "/shareFolderParent/textfile0.txt" should exist
+    #And as "user0" file "/shareFolderParent/textfile0.txt" should not exist
+    And as "user1" file "/shareFolderParent/textfile0.txt" should exist
+    #And as "user1" file "/shareFolderParent/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @issue-35900
+  Scenario Outline: restoring a file to a read-only sub-folder
+    Given using <dav-path> DAV path
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And user "user1" has created folder "shareFolderParent"
+    And user "user1" has created folder "shareFolderParent/shareFolderChild"
+    And user "user1" has shared folder "shareFolderParent" with user "user0" with permissions "read"
+    And as "user0" folder "/shareFolderParent/shareFolderChild" should exist
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user0" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "204"
+    #Then the HTTP status code should be "403"
+    And as "user0" the file with original path "/textfile0.txt" should not exist in trash
+    #And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
+    #And as "user0" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    And as "user1" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
+    #And as "user1" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -51,19 +51,19 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @var FilesPage
 	 */
 	private $filesPage;
-	
+
 	/**
 	 *
 	 * @var TrashbinPage
 	 */
 	private $trashbinPage;
-	
+
 	/**
 	 *
 	 * @var FavoritesPage
 	 */
 	private $favoritesPage;
-	
+
 	/**
 	 *
 	 * @var SharedWithYouPage
@@ -798,7 +798,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 					$this->featureContext->getUserPassword($username),
 					$file['name']
 				);
-				
+
 				if ($response->getStatusCode() >= 200
 					&& $response->getStatusCode() <= 399
 				) {
@@ -813,11 +813,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 						$response->getStatusCode()
 					);
 				}
-				
+
 				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 				$currentTime = \microtime(true);
 			}
-			
+
 			if ($currentTime > $end) {
 				throw new \Exception(
 					__METHOD__ . " timeout deleting files by WebDAV"
@@ -1639,7 +1639,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$this->getCurrentPageObject()->getTooltipOfFile($name, $this->getSession())
 		);
 	}
-	
+
 	/**
 	 * @When the user restores file/folder :fname from the trashbin using the webUI
 	 * @Given the user has restored file/folder :fname from the trashbin using the webUI
@@ -1750,7 +1750,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$actionMenu = $this->filesPage->openFileActionsMenuByNo(
 				$i, $this->getSession()
 			);
-			
+
 			$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC;
 			$currentTime = \microtime(true);
 			$end = $currentTime + ($timeout_msec / 1000);
@@ -1758,7 +1758,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$windowHeight = $this->filesPage->getWindowHeight(
 					$this->getSession()
 				);
-				
+
 				$deleteBtn = $actionMenu->findButton(
 					$actionMenu->getDeleteActionLabel()
 				);
@@ -1771,7 +1771,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 				$currentTime = \microtime(true);
 			}
-			
+
 			PHPUnit\Framework\Assert::assertLessThanOrEqual(
 				$windowHeight, $deleteBtnCoordinates ["top"]
 			);
@@ -1893,7 +1893,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			);
 		}
 	}
-	
+
 	/**
 	 * @When the user unmarks the favorited file/folder :fileOrFolderName using the webUI
 	 * @Given the user has unmarked the favorited file/folder :fileOrFolderName using the webUI
@@ -1953,7 +1953,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		} else {
 			$baseUrl = $this->featureContext->getLocalBaseUrl();
 		}
-		
+
 		$username = $this->featureContext->getCurrentUser();
 		WebDavAssert::assertContentOfRemoteAndLocalFileIsSame(
 			$baseUrl,

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -89,7 +89,7 @@ Feature: Restore deleted files/folders
     And file "data.zip" should be listed on the webUI
     And folder "simple-folder" should be listed on the webUI
 
-  Scenario: Delete a file and then restore it  when a file with the same name already exists
+  Scenario: Delete a file and then restore it when a file with the same name already exists
     Given the user has deleted file "lorem.txt" using the webUI
     And user "user1" has moved file "textfile0.txt" to "lorem.txt"
     And the user has browsed to the trashbin page
@@ -102,4 +102,14 @@ Feature: Restore deleted files/folders
     And the content of file "lorem.txt" for user "user1" should be "ownCloud test text file 0" plus end-of-line
     And the content of "lorem (restored).txt" should be the same as the original "lorem.txt"
 
-
+  Scenario: delete a file inside a folder and then restore the file after the folder has been deleted
+    Given user "user1" has created folder "folder-to-delete"
+    And user "user1" has moved file "lorem.txt" to "folder-to-delete/file-to-delete.txt"
+    And the user has deleted file "folder-to-delete/file-to-delete.txt"
+    And the user has deleted folder "folder-to-delete"
+    And the user has browsed to the trashbin page
+    When the user restores file "file-to-delete.txt" from the trashbin using the webUI
+    Then file "file-to-delete.txt" should not be listed on the webUI
+    When the user browses to the files page
+    Then file "file-to-delete.txt" should be listed on the webUI
+    And folder "folder-to-delete" should not be listed on the webUI


### PR DESCRIPTION
## Description
Add tests for restoring deleted file to a new destination.

This has the code and test scenarios from PR #35809 that pass reliably. Let's get all that committed.

## Related Issue
https://github.com/owncloud/QA/issues/465

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
