### PR TITLE
Allow invalid permission numbers in acceptance tests

### DIFF
--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -168,22 +168,23 @@ class SharingHelper {
 	 */
 	public static function getPermissionSum($permissions) {
 		if (\is_numeric($permissions)) {
-			$permissionSum = (int) $permissions;
-		} else {
-			if (!\is_array($permissions)) {
-				$permissions = [$permissions];
-			}
-			$permissionSum = 0;
-			foreach ($permissions as $permission) {
-				if (\array_key_exists($permission, self::PERMISSION_TYPES)) {
-					$permissionSum += self::PERMISSION_TYPES[$permission];
-				} elseif (\in_array($permission, self::PERMISSION_TYPES, true)) {
-					$permissionSum += (int) $permission;
-				} else {
-					throw new \InvalidArgumentException(
-						"invalid permission type ($permission)"
-					);
-				}
+			// Allow any permission number so that test scenarios can
+			// specifically test invalid permission values
+			return (int) $permissions;
+		}
+		if (!\is_array($permissions)) {
+			$permissions = [$permissions];
+		}
+		$permissionSum = 0;
+		foreach ($permissions as $permission) {
+			if (\array_key_exists($permission, self::PERMISSION_TYPES)) {
+				$permissionSum += self::PERMISSION_TYPES[$permission];
+			} elseif (\in_array($permission, self::PERMISSION_TYPES, true)) {
+				$permissionSum += (int) $permission;
+			} else {
+				throw new \InvalidArgumentException(
+					"invalid permission type ($permission)"
+				);
 			}
 		}
 		if ($permissionSum < 1 || $permissionSum > 31) {

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -554,20 +554,27 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Cannot create share with zero permissions
+  Scenario Outline: Cannot create a share of a file or folder with invalid permissions
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
-    When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
-      | path        | welcome.txt |
-      | shareWith   | user1       |
-      | shareType   | user        |
-      | permissions | 0           |
-    Then the OCS status code should be "400"
+    When user "user0" creates a share using the sharing API with settings
+      | path        | <item>        |
+      | shareWith   | user1         |
+      | shareType   | user          |
+      | permissions | <permissions> |
+    Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
+    And as "user1" entry "<item>" should not exist
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 400              |
+      | ocs_api_version | ocs_status_code | http_status_code | item          | permissions |
+      | 1               | 400             | 200              | textfile0.txt | 0           |
+      | 2               | 400             | 400              | textfile0.txt | 0           |
+      | 1               | 400             | 200              | PARENT        | 0           |
+      | 2               | 400             | 400              | PARENT        | 0           |
+      | 1               | 404             | 200              | textfile0.txt | 32          |
+      | 2               | 404             | 404              | textfile0.txt | 32          |
+      | 1               | 404             | 200              | PARENT        | 32          |
+      | 2               | 404             | 404              | PARENT        | 32          |
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
## Description
- in `getPermissionSum()` allow a permission number that is out of range, so that there can be test scenarios that check for attempts to create shares specifying an invalid permission value.
- modify the `createShare` scenario that currently checks invalid permission `0` so that it uses the normal `user "xyz" creates  a share` step form, and checks that both `0` and `32` are invalid permissions when creating a share of a file or a folder.

## Related Issue
Tidy up after #35886 
I noticed that this test for invalid permissions had the share API endpoint hardcoded etc.

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
