### PR TITLE
throw exception in TrashbinContext restoreElement if element not found

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -20,7 +20,8 @@ Feature: Restore deleted files/folders
     And user "user1" has moved file "/shared" to "/renamed_shared"
     And user "user1" has deleted file "/renamed_shared/shared_file.txt"
     When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
-    Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
     And user "user1" should see the following elements
       | /renamed_shared/                |
       | /renamed_shared/shared_file.txt |
@@ -36,7 +37,8 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/textfile0.txt"
     And as "user0" file "/textfile0.txt" should exist in trash
     When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
-    Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the folder with original path "/textfile0.txt" should not exist in trash
     And user "user0" should see the following elements
       | /FOLDER/           |
       | /PARENT/           |
@@ -58,7 +60,8 @@ Feature: Restore deleted files/folders
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
     When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
     And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
@@ -74,7 +77,8 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted folder "/new-folder"
     When user "user0" restores the folder with original path "/new-folder" using the trashbin API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
     And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
@@ -86,7 +90,8 @@ Feature: Restore deleted files/folders
     And user "user0" has been created with default attributes and skeleton files
     And user "user0" has deleted file "<delete-path>"
     When user "user0" restores the file with original path "<delete-path>" to "<restore-path>" using the trashbin API
-    Then as "user0" the file with original path "<delete-path>" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the file with original path "<delete-path>" should not exist in trash
     And as "user0" file "<restore-path>" should exist
     And as "user0" file "<delete-path>" should not exist
     Examples:
@@ -110,7 +115,7 @@ Feature: Restore deleted files/folders
     And as "user0" folder "/shareFolderParent" should exist
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
-    Then the HTTP status code should be "204"
+    Then the HTTP status code should be "201"
     #Then the HTTP status code should be "403"
     And as "user0" the file with original path "/textfile0.txt" should not exist in trash
     #And as "user0" the file with original path "/textfile0.txt" should exist in trash
@@ -136,7 +141,7 @@ Feature: Restore deleted files/folders
     And as "user0" folder "/shareFolderParent/shareFolderChild" should exist
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
-    Then the HTTP status code should be "204"
+    Then the HTTP status code should be "201"
     #Then the HTTP status code should be "403"
     And as "user0" the file with original path "/textfile0.txt" should not exist in trash
     #And as "user0" the file with original path "/textfile0.txt" should exist in trash
@@ -158,7 +163,8 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted folder "/new-folder"
     When user "user0" creates folder "/new-folder" using the WebDAV API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
-    Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
     And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
@@ -177,7 +183,8 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
-    Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And user "user0" should see the following elements
       | /local_storage/                  |
       | /local_storage/tmp/              |
@@ -200,7 +207,8 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
-    Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
 
   @local_storage
@@ -217,5 +225,6 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
-    Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    Then the HTTP status code should be "201"
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -219,6 +219,7 @@ class TrashbinContext implements Context {
 	 * @param string $destinationPath
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	private function restoreElement($user, $originalPath, $destinationPath = null) {
 		$listing = $this->listTrashbinFolder($user, null);
@@ -233,9 +234,16 @@ class TrashbinContext implements Context {
 					$entry['href'],
 					$destinationPath
 				);
-				break;
+				return;
 			}
 		}
+		// The requested element to restore was not even in the trashbin.
+		// Throw an exception, because there was not any API call, and so there
+		// is also no up-to-date response to examine in later test steps.
+		throw new \Exception(
+			__METHOD__
+			. " cannot restore from trashbin because no element was found for user $user at original path $originalPath"
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -211,6 +211,7 @@ class TrashbinContext implements Context {
 		$response = $this->featureContext->makeDavRequest(
 			$user, 'MOVE', $trashItemHRef, $headers, null, 'trash-bin', null, 2
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**


### PR DESCRIPTION
## Description
In `TrashbinContext` `restoreElement()` if the required element is not even found in the trashbin then the method silently exits without making any API  call. If that happens, then there will not be any updated API response data. So later test steps will be examining some old previous response when checking HTTP status etc. That will be misleading and could allow tests to pass when really there is something wrong.

- throw an exception if nothing was found to restore.

`sendUndeleteRequest() ` was not saving the response, so checks of HTTP status were snake oil.

- correctly set response in TrashbinContext sendUndeleteRequest and check HTTP status.

## Motivation and Context
Make tests more robust.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
