### PR TITLE
sharing permissions for user when admin enables and disables various default share permissions

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -279,6 +279,22 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When /^the administrator (enables|disables) permission (create|change|delete|share) for default user and group share using the webUI$/
+	 *
+	 * @param string (enable | disable) $action
+	 * @param string $permissionValue
+	 *
+	 * @return void
+	 */
+	public function theAdministratorEnablesDefaultSharePermission($action, $permissionValue) {
+		$this->adminSharingSettingsPage->toggleDefaultSharePermissions(
+			$this->getSession(),
+			$action,
+			$permissionValue
+		);
+	}
+
+	/**
 	 * @When the administrator adds :url as a trusted server using the webUI
 	 *
 	 * @param string $url

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -591,6 +591,31 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then the following permissions are seen for :fileName in the sharing dialog for user :userName
+	 *
+	 * @param string $fileName
+	 * @param string $userName
+	 * @param TableNode $permissionsTable table with two columns and no heading
+	 *                                    first column one of the permissions
+	 *                                    (share|edit|create|change|delete)
+	 *                                    second column yes|no
+	 *                                    not mentioned permissions will not be
+	 *                                    touched
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theFollowingPermissionsAreSeenForInTheSharingDialogFor(
+		$fileName, $userName, TableNode $permissionsTable
+	) {
+		$userName = $this->featureContext->substituteInLineCodes($userName);
+		$this->theUserOpensTheShareDialogForFileFolder($fileName);
+		$this->sharingDialog->checkSharingPermissions(
+			$userName, $permissionsTable->getRowsHash(), $this->getSession()
+		);
+	}
+
+	/**
 	 * @When the user accepts the offered remote shares using the webUI
 	 * @Given the user has accepted the offered remote shares
 	 *

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -75,6 +75,10 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $deleteTrustedServerBtnXpath = "//ul[@id='listOfTrustedServers']//li[contains(., '%s')]//span[contains(@class, 'icon-delete')]";
 	protected $trustedServerErrorMsgXpath = "//p[@id='ocFederationAddServer']//span[@class='msg error']";
 
+	protected $createSharePermissionXpath = "//p[@id='shareApiDefaultPermissionsSection']//label[contains(text(),'Create')]";
+	protected $changeSharePermissionXpath = "//p[@id='shareApiDefaultPermissionsSection']//label[contains(text(),'Change')]";
+	protected $deleteSharePermissionXpath = "//p[@id='shareApiDefaultPermissionsSection']//label[contains(text(),'Delete')]";
+	protected $shareSharePermissionXpath = "//p[@id='shareApiDefaultPermissionsSection']//label[contains(text(),'Share')]";
 	/**
 	 * toggle the Share API
 	 *
@@ -88,6 +92,34 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			$session,
 			$action,
 			$this->shareApiCheckboxXpath,
+			$this->shareApiCheckboxId
+		);
+	}
+
+	/**
+	 * toggle the Share API
+	 *
+	 * @param Session $session
+	 * @param string $action "enables|disables"
+	 * @param string $value
+	 *
+	 * @return void
+	 */
+	public function toggleDefaultSharePermissions(Session $session, $action, $value) {
+		$checkboxXpath = null;
+		if ($value == "create") {
+			$checkboxXpath = $this->createSharePermissionXpath;
+		} elseif ($value == "change") {
+			$checkboxXpath = $this->changeSharePermissionXpath;
+		} elseif ($value == "delete") {
+			$checkboxXpath = $this->deleteSharePermissionXpath;
+		} elseif ($value == "share") {
+			$checkboxXpath = $this->shareSharePermissionXpath;
+		}
+		$this->toggleCheckbox(
+			$session,
+			$action,
+			$checkboxXpath,
 			$this->shareApiCheckboxId
 		);
 	}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -409,6 +409,51 @@ class SharingDialog extends OwncloudPage {
 	}
 
 	/**
+	 *
+	 * @param string $shareReceiverName
+	 * @param array $permissions [['permission' => 'yes|no']]
+	 * @param Session $session
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function checkSharingPermissions(
+		$shareReceiverName,
+		$permissions,
+		Session $session
+	) {
+		$xpathLocator = \sprintf(
+			$this->permissionsFieldByUserName, $shareReceiverName
+		);
+		$permissionsField = $this->waitTillElementIsNotNull($xpathLocator);
+		$this->assertElementNotNull(
+			$permissionsField,
+			__METHOD__
+			. " xpath $xpathLocator could not find share permissions field for user "
+			. $shareReceiverName
+		);
+		$showCrudsBtn = $permissionsField->find("xpath", $this->showCrudsXpath);
+		$this->assertElementNotNull(
+			$showCrudsBtn,
+			__METHOD__
+			. " xpath $this->showCrudsXpath could not find show-cruds button for user "
+			. $shareReceiverName
+		);
+		$showCrudsBtn->click();
+		foreach ($permissions as $permission => $value) {
+			$permissionCheckBox = $permissionsField->findField($permission);
+
+			$this->waitForAjaxCallsToStartAndFinish($session);
+
+			if ($value === "yes" && !$permissionCheckBox->isChecked()) {
+				throw new \Exception("The checkbox for permission {$permission} is not enabled.");
+			} elseif ($value === "no" && $permissionCheckBox->isChecked()) {
+				throw new \Exception("The checkbox for permission {$permission} is enabled.");
+			}
+		}
+	}
+
+	/**
 	 * gets the text of the tooltip associated with the "share-with" input
 	 *
 	 * @throws ElementNotFoundException

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -520,13 +520,14 @@ Feature: Sharing files and folders with internal users
     And the user re-logs in as "user1" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI
+    And it should not be possible to share file "lorem.txt" using the webUI
     And the option to delete file "lorem.txt" should be available on the webUI
     And the option to upload file should be available on the webUI
     When the user uploads file "textfile.txt" using the webUI
     Then as "user1" file "simple-folder/textfile.txt" should exist
     And file "textfile.txt" should be listed on the webUI
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
-    Then it should not be possible to share file "textfile.txt" using the webUI
+    And it should not be possible to share file "textfile.txt" using the webUI
 
   @issue-35787
   Scenario: share a skeleton file after changing its content to a user before the user has logged in
@@ -541,3 +542,120 @@ Feature: Sharing files and folders with internal users
     When the user re-logs in as "user1" using the webUI
     Then the content of "lorem.txt" should be the same as the original "lorem.txt"
 #   And the content of file "lorem.txt" for user "user1" should be "edited original content"
+
+  Scenario: Create share when admin disables delete in share permissions
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user2" has created folder "simple-folder"
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables permission delete for default user and group share using the webUI
+    And the user re-logs in as "user2" using the webUI
+    And the user shares folder "simple-folder" with user "User One" using the webUI
+    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+      | change | yes |
+      | create | yes |
+      | delete | no  |
+      | share  | yes |
+    And the user re-logs in as "user1" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then the option to rename file "lorem.txt" should be available on the webUI
+    And the option to delete file "lorem.txt" should not be available on the webUI
+    And the option to upload file should be available on the webUI
+    When the user shares file "lorem.txt" with user "User Three" using the webUI
+    Then as "user3" file "lorem.txt" should exist
+
+  Scenario: Create share when admin disables change in share permissions
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user2" has created folder "simple-folder"
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables permission change for default user and group share using the webUI
+    And the user re-logs in as "user2" using the webUI
+    And the user shares folder "simple-folder" with user "User One" using the webUI
+    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+      | change | no  |
+      | create | yes |
+      | delete | yes |
+      | share  | yes |
+    And the user re-logs in as "user1" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then the option to rename file "lorem.txt" should not be available on the webUI
+    And the option to upload file should be available on the webUI
+    When the user shares file "lorem.txt" with user "User Three" using the webUI
+    Then as "user3" file "lorem.txt" should exist
+    And the option to delete file "lorem.txt" should be available on the webUI
+
+  Scenario: Create share when admin disables create and share in share permissions
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user2" has created folder "simple-folder"
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables permission create for default user and group share using the webUI
+    And the administrator disables permission share for default user and group share using the webUI
+    And the user re-logs in as "user2" using the webUI
+    And the user shares folder "simple-folder" with user "User One" using the webUI
+    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+      | change | yes |
+      | create | no  |
+      | delete | yes |
+      | share  | no  |
+    And the user re-logs in as "user1" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then it should not be possible to share file "lorem.txt" using the webUI
+    And the option to upload file should not be available on the webUI
+    And the option to rename file "lorem.txt" should be available on the webUI
+    And it should be possible to delete file "lorem.txt" using the webUI
+
+  Scenario: Create share when admin disables delete in share permissions but then user enables the permission
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user2" has created folder "simple-folder"
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables permission delete for default user and group share using the webUI
+    And the user re-logs in as "user2" using the webUI
+    And the user shares folder "simple-folder" with user "User One" using the webUI
+    And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
+      | delete | yes |
+    And the user re-logs in as "user1" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then the option to rename file "lorem.txt" should be available on the webUI
+    And the option to upload file should be available on the webUI
+    And it should not be possible to share file "lorem.txt" using the webUI
+    And the option to delete file "lorem.txt" should be available on the webUI
+
+  Scenario: Create share when admin disables multiple default share permissions but then user enables a disabled permission
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user2" has created folder "simple-folder"
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables permission delete for default user and group share using the webUI
+    And the administrator disables permission share for default user and group share using the webUI
+    And the user re-logs in as "user2" using the webUI
+    And the user shares folder "simple-folder" with user "User One" using the webUI
+    And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
+      | share | yes |
+    And the user re-logs in as "user1" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then the option to rename file "lorem.txt" should be available on the webUI
+    And the option to upload file should be available on the webUI
+    And the option to delete file "lorem.txt" should not be available on the webUI
+    When the user shares file "lorem.txt" with user "User Three" using the webUI
+    Then as "user3" file "lorem.txt" should exist


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Includes tests when admin changes default share permissions from admin's sharing settings and :
-  share with user without modifying the share permissions in the sharing dialog
-  share with user modifying the share permissions in the sharing dialog
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/35846


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
