### PR TITLE
Add tests for extra password combinations

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -47,10 +47,10 @@ Feature: add user
     And user "brand-new-user" should exist
     And user "brand-new-user" should be able to access a skeleton file
     Examples:
-      | password                     | comment                     |
-      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
-      | España                       | special European characters |
-      | नेपाली                       | Unicode                     |
+      | password                     | comment                               |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
+      | España§àôœ€                  | special European and other characters |
+      | नेपाली                       | Unicode                               |
 
   Scenario: admin creates a user and specifies an invalid password, containing just space
     Given user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -47,10 +47,10 @@ Feature: add user
     And user "brand-new-user" should exist
     And user "brand-new-user" should be able to access a skeleton file
     Examples:
-      | password                     | comment                     |
-      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
-      | España                       | special European characters |
-      | नेपाली                       | Unicode                     |
+      | password                     | comment                               |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
+      | España§àôœ€                  | special European and other characters |
+      | नेपाली                       | Unicode                               |
 
   Scenario: admin creates a user and specifies an invalid password, containing just space
     Given user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -14,10 +14,10 @@ Feature: add groups
     And the HTTP status code should be "200"
     And group "<group_id>" should exist
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली        | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: admin creates a group
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -15,10 +15,10 @@ Feature: add users to group
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली        | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -15,10 +15,10 @@ Feature: delete groups
     And the HTTP status code should be "200"
     And group "<group_id>" should not exist
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली        | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: admin deletes a group
     Given group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -17,10 +17,10 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: admin removes a user from a group
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -14,10 +14,10 @@ Feature: add groups
     And the HTTP status code should be "200"
     And group "<group_id>" should exist
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: admin creates a group
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -15,10 +15,10 @@ Feature: add users to group
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -15,10 +15,10 @@ Feature: delete groups
     And the HTTP status code should be "200"
     And group "<group_id>" should not exist
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: admin deletes a group
     Given group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -17,10 +17,10 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
    Scenario Outline: admin removes a user from a group
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -10,10 +10,10 @@ Feature: add group
     And the command output should contain the text 'Created group "<group_id>"'
     And group "<group_id>" should exist
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: group names are case-sensitive, multiple groups can exist with different upper and lower case names
     When the administrator creates group "<group_id1>" using the occ command

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -13,10 +13,10 @@ Feature: add users to group
     And the command output should contain the text 'User "brand-new-user" added to group "<group_id>"'
     And user "brand-new-user" should belong to group "<group_id>"
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -60,7 +60,7 @@ Feature: add a user using the using the occ command
     Examples:
       | password                     | comment                     |
       | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
-      | España                       | special European characters |
+      | España§àôœ€  | special European and other characters       |
       | नेपाली                       | Unicode                     |
       | password with spaces         | password with spaces        |
 

--- a/tests/acceptance/features/cliProvisioning/deleteGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteGroup.feature
@@ -11,10 +11,10 @@ Feature: delete groups
     And the command output should contain the text 'The specified group was deleted'
     And group "<group_id>" should not exist
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: group names are case-sensitive, the correct group is deleted
     Given group "<group_id1>" has been created

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -48,7 +48,7 @@ Feature: edit users
     Examples:
       | password                     | comment                     |
       | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
-      | España                       | special European characters |
+      | España§àôœ€  | special European and other characters       |
       | नेपाली                       | Unicode                     |
       | password with spaces         | password with spaces        |
 

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -13,10 +13,10 @@ Feature: remove a user from a group
     And the command output should contain the text 'Member "brand-new-user" removed from group "<group_id>"'
     And user "brand-new-user" should not belong to group "<group_id>"
     Examples:
-      | group_id    | comment                     |
-      | simplegroup | nothing special here        |
-      | España      | special European characters |
-      | नेपाली      | Unicode group name          |
+      | group_id     | comment                               |
+      | simplegroup  | nothing special here                  |
+      | España§àôœ€  | special European and other characters |
+      | नेपाली       | Unicode group name                    |
 
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -15,6 +15,16 @@ Feature: Change Login Password
     And the user re-logs in with username "user1" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
+  Scenario Outline: Change password to some unusual values
+    When the user changes the password to "<new_password>" using the webUI
+    And the user re-logs in with username "user1" and password "<new_password>" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+    Examples:
+      | new_password                 | comment                               |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
+      | España§àôœ€                  | special European and other characters |
+      | नेपाली                       | Unicode                               |
+
   Scenario: Password change with wrong current password
     When the user changes the password to "%alt3%" entering the wrong current password "%alt2%" using the webUI
     Then a password error message should be displayed on the webUI with the text "Wrong current password"
@@ -22,3 +32,11 @@ Feature: Change Login Password
   Scenario: New password is same as current password
     When the user changes the password to "%alt1%" using the webUI
     Then a password error message should be displayed on the webUI with the text "The new password cannot be the same as the previous one"
+
+  Scenario Outline: Password change with invalid or no new password
+    When the user changes the password to "<new_password>" using the webUI
+    Then a password error message should be displayed on the webUI with the text "<message>"
+    Examples:
+      | new_password | message                        |
+      | 0            | Password cannot be empty       |
+      |              | Unable to change your password |


### PR DESCRIPTION
## Description
Adjust acceptance tests to use some more unusual combinations of characters for passwords.

While we are here, there is a common table of "unusual characters" that is also used for testing group names etc, update that table everywhere so it stays the same, and will test the extra unusual characters for group names... also.

## Related Issue
https://github.com/owncloud/docs/issues/251 mentioned various possible passwords that might be a problem.

## Motivation and Context
"document" existing behaviour in acceptance tests

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
