### PR TITLE
Fix typo in 'Group sharing is not allowed' message

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -435,7 +435,7 @@ class Manager implements IManager {
 	protected function groupCreateChecks(\OCP\Share\IShare $share) {
 		// Verify group shares are allowed
 		if (!$this->allowGroupSharing()) {
-			throw new \Exception('Group sharing is now allowed');
+			throw new \Exception('Group sharing is not allowed');
 		}
 
 		// Verify if the user can share with this group

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1348,7 +1348,7 @@ class ManagerTest extends \Test\TestCase {
 
 	/**
 	 * @expectedException Exception
-	 * @expectedExceptionMessage Group sharing is now allowed
+	 * @expectedExceptionMessage Group sharing is not allowed
 	 */
 	public function testGroupCreateChecksShareWithGroupMembersGroupSharingNotAllowed() {
 		$share = $this->manager->newShare();


### PR DESCRIPTION
## Description
Fix typo/grammar error in group sharing error message.

## Related Issue
Fixes #35913 

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
