### PR TITLE
Add tests to create shares with only create,delete permissions

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -576,6 +576,125 @@ Feature: sharing
       | 1               | 404             | 200              | PARENT        | 32          |
       | 2               | 404             | 404              | PARENT        | 32          |
 
+  @issue-35922
+  Scenario Outline: Cannot create a share of a file with a user with only create permission
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    When user "user0" creates a share using the sharing API with settings
+      | path        | textfile0.txt |
+      | shareWith   | user1         |
+      | shareType   | user          |
+      | permissions | create        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    # delete the following step when the issue is fixed. The share should not be created at all.
+    And the fields of the last response should include
+      | share_with  | user1          |
+      | share_type  | user           |
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | permissions | 0              |
+    And as "user1" entry "textfile0.txt" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |
+      #| 1               | 400             | 200              |
+      #| 2               | 400             | 400              |
+
+  @issue-35922
+  Scenario Outline: Cannot create a share of a file with a user with only (create,)delete permission
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    When user "user0" creates a share using the sharing API with settings
+      | path        | textfile0.txt |
+      | shareWith   | user1         |
+      | shareType   | user          |
+      | permissions | <permissions> |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    # delete the following step when the issue is fixed. The share should not be created at all.
+    And the fields of the last response should include
+      | share_with  | user1          |
+      | share_type  | user           |
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | permissions | 1              |
+    # because the share got created wrongly with read permission, the file exists for the sharee
+    And as "user1" entry "textfile0.txt" should exist
+    #And as "user1" entry "textfile0.txt" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code | permissions   |
+      | 1               | 100             | 200              | delete        |
+      | 2               | 200             | 200              | delete        |
+      | 1               | 100             | 200              | create,delete |
+      | 2               | 200             | 200              | create,delete |
+      #| 1               | 404             | 200              | delete        |
+      #| 2               | 404             | 404              | delete        |
+      #| 1               | 404             | 200              | create,delete |
+      #| 2               | 404             | 404              | create,delete |
+  @issue-35922
+  Scenario Outline: Cannot create a share of a file with a group with only create permission
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When user "user0" creates a share using the sharing API with settings
+      | path        | textfile0.txt |
+      | shareWith   | grp1          |
+      | shareType   | group         |
+      | permissions | create        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    # delete the following step when the issue is fixed. The share should not be created at all.
+    And the fields of the last response should include
+      | share_with  | grp1           |
+      | share_type  | group          |
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | permissions | 0              |
+    And as "user1" entry "textfile0.txt" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |
+      #| 1               | 400             | 200              |
+      #| 2               | 400             | 400              |
+
+  @issue-35922
+  Scenario Outline: Cannot create a share of a file with a group with only (create,)delete permission
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    When user "user0" creates a share using the sharing API with settings
+      | path        | textfile0.txt |
+      | shareWith   | grp1          |
+      | shareType   | group         |
+      | permissions | <permissions> |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    # delete the following step when the issue is fixed. The share should not be created at all.
+    And the fields of the last response should include
+      | share_with  | grp1           |
+      | share_type  | group          |
+      | file_target | /textfile0.txt |
+      | path        | /textfile0.txt |
+      | permissions | 1              |
+    # because the share got created wrongly with read permission, the file exists for the sharee
+    And as "user1" entry "textfile0.txt" should exist
+    #And as "user1" entry "textfile0.txt" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code | permissions   |
+      | 1               | 100             | 200              | delete        |
+      | 2               | 200             | 200              | delete        |
+      | 1               | 100             | 200              | create,delete |
+      | 2               | 200             | 200              | create,delete |
+      #| 1               | 404             | 200              | delete        |
+      #| 2               | 404             | 404              | delete        |
+      #| 1               | 404             | 200              | create,delete |
+      #| 2               | 404             | 404              | create,delete |
+
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -309,6 +309,46 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
+  Scenario Outline: Cannot update a share of a file with a user to have only create and/or delete permission
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | <permissions> |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "<http_status_code>"
+    # user1 should still have at least read access to the shared file
+    And as "user1" entry "textfile0.txt" should exist
+    Examples:
+      | ocs_api_version | http_status_code | permissions   |
+      | 1               | 200              | create        |
+      | 2               | 400              | create        |
+      | 1               | 200              | delete        |
+      | 2               | 400              | delete        |
+      | 1               | 200              | create,delete |
+      | 2               | 400              | create,delete |
+
+  Scenario Outline: Cannot update a share of a file with a group to have only create and/or delete permission
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | <permissions> |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "<http_status_code>"
+    # user1 in grp1 should still have at least read access to the shared file
+    And as "user1" entry "textfile0.txt" should exist
+    Examples:
+      | ocs_api_version | http_status_code | permissions   |
+      | 1               | 200              | create        |
+      | 2               | 400              | create        |
+      | 1               | 200              | delete        |
+      | 2               | 400              | delete        |
+      | 1               | 200              | create,delete |
+      | 2               | 400              | create,delete |
+
   Scenario: Share ownership change after moving a shared file outside of an outer share
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
## Description
- Demonstrate problems from issue #35922 when attempting to create a share of a single file and specifying only create or delete permissions.

- Add scenarios to do similar tests when updating a share. Those work as expected.

## Related Issue
#35922 

## How Has This Been Tested?
Local runs of the acceptance test scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
