### PR TITLE
[stable10] Fix typo in 'Group sharing is not allowed' message

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -434,7 +434,7 @@ class Manager implements IManager {
 	protected function groupCreateChecks(\OCP\Share\IShare $share) {
 		// Verify group shares are allowed
 		if (!$this->allowGroupSharing()) {
-			throw new \Exception('Group sharing is now allowed');
+			throw new \Exception('Group sharing is not allowed');
 		}
 
 		// Verify if the user can share with this group

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1343,7 +1343,7 @@ class ManagerTest extends \Test\TestCase {
 
 	/**
 	 * @expectedException Exception
-	 * @expectedExceptionMessage Group sharing is now allowed
+	 * @expectedExceptionMessage Group sharing is not allowed
 	 */
 	public function testGroupCreateChecksShareWithGroupMembersGroupSharingNotAllowed() {
 		$share = $this->manager->newShare();


### PR DESCRIPTION
Backport #35915 