### PR TITLE
Tell the browser not to autofill those password fields

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -734,7 +734,7 @@ $(document).ready(function () {
 		var $td = $(this).closest('td');
 		var $tr = $(this).closest('tr');
 		var uid = UserList.getUID($td);
-		var $input = $('<input type="password">');
+		var $input = $('<input type="password" autocomplete="new-password" autocapitalize="off" autocorrect="off">');
 		var isRestoreDisabled = UserList.getRestoreDisabled($td) === true;
 		if(isRestoreDisabled) {
 			$tr.addClass('row-warning');

--- a/settings/templates/setpassword.php
+++ b/settings/templates/setpassword.php
@@ -31,9 +31,10 @@ script('settings', 'setpassword');
 			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
 			<input type="password" name="password" id="password" value=""
 				   placeholder="<?php p($l->t('New Password')); ?>"
-				   autocomplete="off" autocapitalize="off" autocorrect="off"
+				   autocomplete="new-password" autocapitalize="off" autocorrect="off"
 				   required autofocus />
 			<input type="password" name="retypepassword" id="retypepassword" value=""
+				   autocomplete="new-password" autocapitalize="off" autocorrect="off"
 				   placeholder="<?php p($l->t('Confirm Password')); ?>"/>
 			<span id='message'></span>
 		</p>

--- a/settings/templates/users/part.createuser.php
+++ b/settings/templates/users/part.createuser.php
@@ -6,7 +6,7 @@
 		<input
 			type="password" id="newuserpassword" style="display:none"
 			placeholder="<?php p($l->t('Password'))?>"
-			autocomplete="off" autocapitalize="off" autocorrect="off" />
+			autocomplete="new-password" autocapitalize="off" autocorrect="off" />
 		<input id="newemail" type="text"
 			   placeholder="<?php p($l->t('E-Mail'))?>"
 			   autocomplete="off" autocapitalize="off" autocorrect="off" />


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Both firefox and chrome can autofill some username and password fields in forms without user interaction. This is a problem specially in the users page where the password field is hidden but the browser autocompletes it.

Note that neither safari nor edge have this behaviour. They require user interaction in order to fill the password field. This problem doesn't happen in those browsers.

## Related Issue
no ticket opened as far as I know.

## Motivation and Context
The admin was setting a password without any knowledge.

## How Has This Been Tested?
Checked with firefox, chrome, safari and edge:
1. login as admin.
2. when prompted, save the password in the browser
3. go to the users page
4. at this point the new username and password fields should be empty (this needs to be even if the password field isn't visible)
5. add a new user using the username + email fields
6. in a new browser, check the email sent and reset the password for that user
7. note that the password field for the reset form are also empty.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)

**This should be moved to the user_management app**