### PR TITLE
use PHPUnit\Framework\Assert in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -114,7 +114,7 @@ trait AppConfiguration {
 	) {
 		$this->theAdministratorGetsCapabilitiesCheckResponse();
 
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedValue,
 			$this->getAppParameter($capabilitiesApp, $capabilitiesPath)
 		);
@@ -161,7 +161,7 @@ trait AppConfiguration {
 	 */
 	public function userGetsCapabilitiesCheckResponse($username) {
 		$this->userGetsCapabilities($username);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -375,12 +375,12 @@ trait AppConfiguration {
 		$this->theUserSendsToOcsApiEndpoint('get', '/cloud/apps?filter=enabled');
 		$this->theHTTPStatusCodeShouldBe('200');
 		if ($enabled) {
-			PHPUnit\Framework\Assert::assertContains(
+			Assert::assertContains(
 				'testing',
 				$this->response->getBody()->getContents()
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertNotContains(
+			Assert::assertNotContains(
 				'testing',
 				$this->response->getBody()->getContents()
 			);

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -22,6 +22,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
@@ -160,7 +161,7 @@ class AppManagementContext implements Context {
 	 * @return void
 	 */
 	public function appPathIs($appId, $dir) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$this->featureContext->getServerRoot() . "/$dir/$appId",
 			\trim($this->cmdOutput)
 		);
@@ -178,7 +179,7 @@ class AppManagementContext implements Context {
 		$cmdOutput = SetupHelper::runOcc(
 			['config:app:get', $appId, 'installed_version', '--no-ansi']
 		)['stdOut'];
-		PHPUnit\Framework\Assert::assertEquals($version, \trim($cmdOutput));
+		Assert::assertEquals($version, \trim($cmdOutput));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -25,6 +25,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Message\ResponseInterface;
+use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\HttpRequestHelper;
@@ -968,12 +969,12 @@ trait BasicStructure {
 		}
 
 		if (\is_array($statusCode)) {
-			PHPUnit\Framework\Assert::assertContains(
+			Assert::assertContains(
 				$this->response->getStatusCode(), $statusCode,
 				$message
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$statusCode, $this->response->getStatusCode(), $message
 			);
 		}
@@ -1003,7 +1004,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theHTTPReasonPhraseShouldBe($reasonPhrase) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$reasonPhrase,
 			$this->getResponse()->getReasonPhrase(),
 			'Unexpected HTTP reason phrase in response'
@@ -1031,7 +1032,7 @@ trait BasicStructure {
 	public function theHTTPReasonPhraseShouldBePyString(
 		PyStringNode $reasonPhrase
 	) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$reasonPhrase->getRaw(),
 			$this->getResponse()->getReasonPhrase(),
 			'Unexpected HTTP reason phrase in response'
@@ -1048,7 +1049,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theXMLKey1Key2ValueShouldBe($key1, $key2, $idText) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$idText,
 			$this->getXMLKey1Key2Value($this->response, $key1, $key2)
 		);
@@ -1067,7 +1068,7 @@ trait BasicStructure {
 	public function theXMLKey1Key2Key3ValueShouldBe(
 		$key1, $key2, $key3, $idText
 	) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$idText,
 			$this->getXMLKey1Key2Key3Value($this->response, $key1, $key2, $key3)
 		);
@@ -1089,7 +1090,7 @@ trait BasicStructure {
 		$value = $this->getXMLKey1Key2Key3AttributeValue(
 			$this->response, $key1, $key2, $key3, $attribute
 		);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			\version_compare($value, '0.0.1') >= 0,
 			"attribute $attribute value $value is not a valid version string"
 		);
@@ -1614,7 +1615,7 @@ trait BasicStructure {
 	public function jsonRespondedShouldMatch(PyStringNode $jsonExpected) {
 		$jsonExpectedEncoded = \json_encode($jsonExpected->getRaw());
 		$jsonRespondedEncoded = \json_encode((string) $this->response->getBody());
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$jsonExpectedEncoded, $jsonRespondedEncoded
 		);
 	}
@@ -1638,7 +1639,7 @@ trait BasicStructure {
 		);
 
 		if (!\strlen($edition)) {
-			PHPUnit\Framework\Assert::fail(
+			Assert::fail(
 				"Cannot get edition from capabilities"
 			);
 		}
@@ -1650,7 +1651,7 @@ trait BasicStructure {
 		);
 
 		if (!\strlen($edition)) {
-			PHPUnit\Framework\Assert::fail(
+			Assert::fail(
 				"Cannot get productname from capabilities"
 			);
 		}
@@ -1662,21 +1663,21 @@ trait BasicStructure {
 		if ($runOccStatus === 0) {
 			$output = \explode("- ", $this->lastStdOut);
 			$version = \explode(": ", $output[3]);
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				"version", $version[0]
 			);
 			$versionString = \explode(": ", $output[4]);
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				"versionstring", $versionString[0]
 			);
 			$jsonExpectedDecoded['version'] = \trim($version[1]);
 			$jsonExpectedDecoded['versionstring'] = \trim($versionString[1]);
 			$jsonExpectedEncoded = \json_encode($jsonExpectedDecoded);
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$jsonExpectedEncoded, $jsonRespondedEncoded
 			);
 		} else {
-			PHPUnit\Framework\Assert::fail(
+			Assert::fail(
 				"Cannot get version variables from occ - status $runOccStatus"
 			);
 		}
@@ -1710,7 +1711,7 @@ trait BasicStructure {
 	 */
 	public function theFileWithContentShouldExistInTheServerRoot($path, $content) {
 		$this->readFileInServerRoot($path);
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			200,
 			$this->getResponse()->getStatusCode(),
 			"Failed to read the file {$path}"
@@ -1720,7 +1721,7 @@ trait BasicStructure {
 		$fileContent = (string)$fileContent->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($fileContent);
 
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			$content,
 			$fileContent,
 			"The content of the file does not match with '{$content}'"
@@ -1748,7 +1749,7 @@ trait BasicStructure {
 	 */
 	public function theFileShouldNotExistInTheServerRoot($path) {
 		$this->readFileInServerRoot($path);
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			404,
 			$this->getResponse()->getStatusCode(),
 			"The file '{$path}' exists in the server root"
@@ -1761,7 +1762,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theResponseBodyShouldBeEmpty() {
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$this->getResponse()->getBody()->getContents()
 		);
 	}
@@ -2081,7 +2082,7 @@ trait BasicStructure {
 			$this->getOcsApiVersion()
 		);
 		$configkeyValue = \json_decode(\json_encode($this->getResponseXml($response)->data[0]->element->value), 1)[0];
-		PHPUnit\Framework\Assert::assertEquals($value, $configkeyValue);
+		Assert::assertEquals($value, $configkeyValue);
 	}
 
 	/**
@@ -2162,9 +2163,9 @@ trait BasicStructure {
 		$should = ($shouldOrNot !== "not");
 
 		if ($should) {
-			PHPUnit\Framework\Assert::assertTrue($this->checkConfigKeyInApp($key, $appID));
+			Assert::assertTrue($this->checkConfigKeyInApp($key, $appID));
 		} else {
-			PHPUnit\Framework\Assert::assertFalse($this->checkConfigKeyInApp($key, $appID));
+			Assert::assertFalse($this->checkConfigKeyInApp($key, $appID));
 		}
 	}
 
@@ -2180,11 +2181,11 @@ trait BasicStructure {
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
 			foreach ($table as $item) {
-				PHPUnit\Framework\Assert::assertTrue($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
+				Assert::assertTrue($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
 			}
 		} else {
 			foreach ($table as $item) {
-				PHPUnit\Framework\Assert::assertFalse($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
+				Assert::assertFalse($this->checkConfigKeyInApp($item['configkey'], $item['appid']));
 			}
 		}
 	}
@@ -2266,7 +2267,7 @@ trait BasicStructure {
 			"/apps/testing/api/v1/lockprovisioning",
 			["global" => "true"]
 		);
-		PHPUnit\Framework\Assert::assertEquals("200", $response->getStatusCode());
+		Assert::assertEquals("200", $response->getStatusCode());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -25,6 +25,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -51,7 +52,7 @@ class CapabilitiesContext implements Context {
 
 		foreach ($formData->getHash() as $row) {
 			$row['value'] = $this->featureContext->substituteInLineCodes($row['value']);
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$row['value'] === "EMPTY" ? '' : $row['value'],
 				$this->featureContext->getParameterValueFromXml(
 					$capabilitiesXML,
@@ -78,7 +79,7 @@ class CapabilitiesContext implements Context {
 			$this->featureContext->getCurrentUser()
 		);
 		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$value === "EMPTY" ? '' : $value,
 			$this->featureContext->getParameterValueFromXml(
 				$capabilitiesXML,
@@ -99,7 +100,7 @@ class CapabilitiesContext implements Context {
 		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
 
 		foreach ($formData->getHash() as $row) {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$this->featureContext->parameterValueExistsInXml(
 					$capabilitiesXML,
 					$row['capability'],

--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 
@@ -134,7 +135,7 @@ class CommentsContext implements Context {
 					break;
 				}
 			}
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$commentFound,
 				"Comment with actorId = '$expectedElement[0]' " .
 				"and message = '$expectedElement[1]' not found"
@@ -173,7 +174,7 @@ class CommentsContext implements Context {
 			$user, $commentsPath, $properties
 		);
 		$messages = $elementList->xpath("//d:prop/oc:message");
-		PHPUnit\Framework\Assert::assertCount(
+		Assert::assertCount(
 			(int) $numberOfComments, $messages
 		);
 	}

--- a/tests/acceptance/features/bootstrap/CorsContext.php
+++ b/tests/acceptance/features/bootstrap/CorsContext.php
@@ -22,6 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 /**
@@ -94,7 +95,7 @@ class CorsContext implements Context {
 			]
 		);
 		$domains = \json_decode($this->featureContext->getStdOutOfOccCommand());
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$domain, $domains, "CORS domain was not added correctly"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\EmailHelper;
 
 require_once 'bootstrap.php';
@@ -60,7 +61,7 @@ class EmailContext implements Context {
 		$expectedContent = $this->featureContext->substituteInLineCodes(
 			$expectedContent
 		);
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$expectedContent,
 			EmailHelper::getBodyOfLastEmail($this->localMailhogUrl, $address)
 		);
@@ -75,7 +76,7 @@ class EmailContext implements Context {
 	 * @return void
 	 */
 	public function theResetEmailSenderEmailAddressShouldBe($receiverAddress, $senderAddress) {
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$senderAddress,
 			EmailHelper::getSenderOfEmail($this->localMailhogUrl, $receiverAddress)
 		);
@@ -90,7 +91,7 @@ class EmailContext implements Context {
 	 * @throws \Exception
 	 */
 	public function assertThatEmailDoesntExistWithTheAddress($address) {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			EmailHelper::emailReceived(
 				EmailHelper::getLocalMailhogUrl(), $address
 			),

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -22,6 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 
@@ -77,7 +78,7 @@ class FilesVersionsContext implements Context {
 		$path, $user, $count
 	) {
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
-		PHPUnit\Framework\Assert::assertNotNull($fileId, "file $path not found");
+		Assert::assertNotNull($fileId, "file $path not found");
 		$this->theVersionFolderOfFileIdShouldContainElements($fileId, $user, $count);
 	}
 
@@ -95,7 +96,7 @@ class FilesVersionsContext implements Context {
 	) {
 		$responseXml = $this->listVersionFolder($user, "/meta/$fileId/v", 1);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getetag");
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$count, \count($xmlPart) - 1,
 			"could not find $count version element(s) in \n" . $responseXml->asXML()
 		);
@@ -119,7 +120,7 @@ class FilesVersionsContext implements Context {
 			$user, "/meta/$fileId/v", 1, ['getcontentlength']
 		);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getcontentlength");
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$length, (int)$xmlPart[$index]
 		);
 	}

--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -21,6 +21,7 @@
  */
 
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\LoggingHelper;
 
 /**
@@ -81,7 +82,7 @@ trait Logging {
 				}
 
 				if ($expectedLogEntry[$attribute] !== "") {
-					PHPUnit\Framework\Assert::assertArrayHasKey(
+					Assert::assertArrayHasKey(
 						$attribute, $logEntry,
 						"could not find attribute: '$attribute' in log entry: '{$logLines[$lineNo]}'"
 					);
@@ -92,17 +93,17 @@ trait Logging {
 						);
 					}
 					if ($comparingMode === 'with') {
-						PHPUnit\Framework\Assert::assertEquals(
+						Assert::assertEquals(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);
 					} elseif ($comparingMode === 'containing') {
-						PHPUnit\Framework\Assert::assertContains(
+						Assert::assertContains(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);
 					} elseif ($comparingMode === 'matching') {
-						PHPUnit\Framework\Assert::assertRegExp(
+						Assert::assertRegExp(
 							$expectedLogEntry[$attribute], $logEntry[$attribute],
 							$message
 						);
@@ -279,7 +280,7 @@ trait Logging {
 		}
 		
 		$notFoundLines = \print_r($expectedLogEntries, true);
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$expectedLogEntries,
 			"could not find these expected line(s):\n $notFoundLines"
 		);
@@ -336,7 +337,7 @@ trait Logging {
 					}
 				}
 			}
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$match,
 				"found a log entry that should not be there\n$logLine\n"
 			);

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Message\ResponseInterface;
+use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 
 require_once 'bootstrap.php';
@@ -94,7 +95,7 @@ class NotificationsCoreContext implements Context {
 		$notifications = $this->getArrayOfNotificationsResponded(
 			$this->featureContext->getResponse()
 		);
-		PHPUnit\Framework\Assert::assertCount(
+		Assert::assertCount(
 			(int) $numNotifications, $notifications
 		);
 
@@ -119,13 +120,13 @@ class NotificationsCoreContext implements Context {
 		$this->ocsContext->userSendsToOcsApiEndpoint(
 			$user, 'GET', '/apps/notifications/api/v1/notifications?format=json'
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			200, $this->featureContext->getResponse()->getStatusCode()
 		);
 
 		$previousNotificationIds = [];
 		if ($missingLast) {
-			PHPUnit\Framework\Assert::assertNotEmpty($this->getNotificationIds());
+			Assert::assertNotEmpty($this->getNotificationIds());
 			$previousNotificationIds = $this->getLastNotificationIds();
 		}
 
@@ -139,7 +140,7 @@ class NotificationsCoreContext implements Context {
 				$now[] = $this->getDeletedNotification();
 			}
 
-			PHPUnit\Framework\Assert::assertEquals($previousNotificationIds, $now);
+			Assert::assertEquals($previousNotificationIds, $now);
 		}
 	}
 
@@ -200,7 +201,7 @@ class NotificationsCoreContext implements Context {
 			'GET',
 			"/apps/notifications/api/v1/notifications/$notificationId?format=json"
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			200, $this->featureContext->getResponse()->getStatusCode()
 		);
 		$response = \json_decode(
@@ -208,20 +209,20 @@ class NotificationsCoreContext implements Context {
 		);
 
 		foreach ($formData->getRowsHash() as $key => $value) {
-			PHPUnit\Framework\Assert::assertArrayHasKey(
+			Assert::assertArrayHasKey(
 				$key, $response['ocs']['data']
 			);
 			if ($regex) {
 				$value = $this->featureContext->substituteInLineCodes(
 					$value, ['preg_quote' => ['/'] ]
 				);
-				PHPUnit\Framework\Assert::assertNotFalse(
+				Assert::assertNotFalse(
 					(bool)\preg_match($value, $response['ocs']['data'][$key]),
 					"'$value' does not match '{$response['ocs']['data'][$key]}'"
 				);
 			} else {
 				$value = $this->featureContext->substituteInLineCodes($value);
-				PHPUnit\Framework\Assert::assertEquals(
+				Assert::assertEquals(
 					$value, $response['ocs']['data'][$key]
 				);
 			}
@@ -254,8 +255,8 @@ class NotificationsCoreContext implements Context {
 			"DELETE",
 			'/apps/testing/api/v1/notifications'
 		);
-		PHPUnit\Framework\Assert::assertEquals(200, $response->getStatusCode());
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(200, $response->getStatusCode());
+		Assert::assertEquals(
 			200, (int) $this->ocsContext->getOCSResponseStatusCode($response)
 		);
 	}

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
+use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 
 require_once 'bootstrap.php';
@@ -356,12 +357,12 @@ class OCSContext implements Context {
 			$this->featureContext->getResponse()
 		);
 		if (\is_array($statusCode)) {
-			PHPUnit\Framework\Assert::assertContains(
+			Assert::assertContains(
 				$responseStatusCode, $statusCode,
 				$message
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$statusCode, $responseStatusCode,
 				$message
 			);
@@ -378,7 +379,7 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theOCSStatusMessageShouldBe($statusMessage) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$statusMessage,
 			$this->getOCSResponseStatusMessage(
 				$this->featureContext->getResponse()
@@ -408,7 +409,7 @@ class OCSContext implements Context {
 	public function theOCSStatusMessageShouldBePyString(
 		PyStringNode $statusMessage
 	) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$statusMessage->getRaw(),
 			$this->getOCSResponseStatusMessage(
 				$this->featureContext->getResponse()

--- a/tests/acceptance/features/bootstrap/OccAppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/OccAppManagementContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -116,7 +117,7 @@ class OccAppManagementContext implements Context {
 	public function theAppNameReturnedByTheOccCommandShouldBe($appName) {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputArray = \json_decode($lastOutput, true);
-		PHPUnit\Framework\Assert::assertEquals($appName, \key($lastOutputArray['apps']));
+		Assert::assertEquals($appName, \key($lastOutputArray['apps']));
 	}
 
 	/**
@@ -166,7 +167,7 @@ class OccAppManagementContext implements Context {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputArray = \json_decode($lastOutput, true);
 		$actualAppEnabledStatus = $lastOutputArray['apps'][$appName]['enabled'];
-		PHPUnit\Framework\Assert::assertEquals($appStatus, $actualAppEnabledStatus);
+		Assert::assertEquals($appStatus, $actualAppEnabledStatus);
 	}
 
 	/**
@@ -184,7 +185,7 @@ class OccAppManagementContext implements Context {
 		$appsSimplified = $this->featureContext->simplifyArray($apps);
 
 		foreach ($appsSimplified as $app) {
-			PHPUnit\Framework\Assert::assertContains($app, $lastOutputApps);
+			Assert::assertContains($app, $lastOutputApps);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';
@@ -210,7 +211,7 @@ class OccContext implements Context {
 			$commandOutput,
 			$text
 		);
-		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
+		Assert::assertGreaterThanOrEqual(
 			1,
 			\count($lines),
 			"The command output did not contain the expected text on stdout '$text'\n" .
@@ -236,7 +237,7 @@ class OccContext implements Context {
 			$commandOutput,
 			$text
 		);
-		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
+		Assert::assertGreaterThanOrEqual(
 			1,
 			\count($lines),
 			"The command output did not contain the expected text on stderr '$text'\n" .
@@ -251,11 +252,11 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function theOccCommandJsonOutputShouldNotReturnAnyData() {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			\trim($this->featureContext->getStdOutOfOccCommand()),
 			"[]"
 		);
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$this->featureContext->getStdErrOfOccCommand()
 		);
 	}
@@ -541,7 +542,7 @@ class OccContext implements Context {
 			"config:app:get core backgroundjobs_mode"
 		);
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit\Framework\Assert::assertEquals($mode, \trim($lastOutput));
+		Assert::assertEquals($mode, \trim($lastOutput));
 	}
 
 	/**
@@ -556,7 +557,7 @@ class OccContext implements Context {
 			"config:app:get core OC_Channel"
 		);
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit\Framework\Assert::assertEquals($value, \trim($lastOutput));
+		Assert::assertEquals($value, \trim($lastOutput));
 	}
 
 	/**
@@ -571,7 +572,7 @@ class OccContext implements Context {
 			"config:system:get loglevel"
 		);
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit\Framework\Assert::assertEquals($logLevel, \trim($lastOutput));
+		Assert::assertEquals($logLevel, \trim($lastOutput));
 	}
 
 	/**
@@ -709,7 +710,7 @@ class OccContext implements Context {
 	public function theLastDeletedJobShouldNotBeListedInTheJobsQueue($job) {
 		$jobId = $this->lastDeletedJobId;
 		$match = $this->getLastJobIdForJob($job);
-		PHPUnit\Framework\Assert::assertNotEquals(
+		Assert::assertNotEquals(
 			$jobId, $match,
 			"job $job with jobId $jobId" .
 			" was not expected to be listed in background queue, but was"
@@ -726,7 +727,7 @@ class OccContext implements Context {
 	 */
 	public function systemConfigKeyShouldHaveValue($key, $value) {
 		$config = \trim($this->featureContext->getSystemConfigValue($key));
-		PHPUnit\Framework\Assert::assertSame($value, $config);
+		Assert::assertSame($value, $config);
 	}
 
 	/**
@@ -743,7 +744,7 @@ class OccContext implements Context {
 				$commandOutput,
 				$row['table_column']
 			);
-			PHPUnit\Framework\Assert::assertNotEmpty(
+			Assert::assertNotEmpty(
 				$lines,
 				"Value: " . $row['table_column'] . " not found"
 			);
@@ -758,7 +759,7 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function systemConfigKeyShouldNotExist($key) {
-		PHPUnit\Framework\Assert::assertEmpty($this->featureContext->getSystemConfig($key)['stdOut']);
+		Assert::assertEmpty($this->featureContext->getSystemConfig($key)['stdOut']);
 	}
 
 	/**
@@ -779,12 +780,12 @@ class OccContext implements Context {
 	 */
 	public function theCommandOutputShouldContainTheAppsConfigs() {
 		$config_list = \json_decode($this->featureContext->getStdOutOfOccCommand(), true);
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			'apps',
 			$config_list,
 			"The occ output does not contain apps configs"
 		);
-		PHPUnit\Framework\Assert::assertNotEmpty(
+		Assert::assertNotEmpty(
 			$config_list['apps'],
 			"The occ output does not contain apps configs"
 		);
@@ -797,12 +798,12 @@ class OccContext implements Context {
 	 */
 	public function theCommandOutputShouldContainTheSystemConfigs() {
 		$config_list = \json_decode($this->featureContext->getStdOutOfOccCommand(), true);
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			'system',
 			$config_list,
 			"The occ output does not contain system configs"
 		);
-		PHPUnit\Framework\Assert::assertNotEmpty(
+		Assert::assertNotEmpty(
 			$config_list['system'],
 			"The occ output does not contain system configs"
 		);
@@ -819,7 +820,7 @@ class OccContext implements Context {
 		$this->invokingTheCommand(
 			"versions:cleanup $user"
 		);
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			"Delete versions of   $user",
 			\trim($this->featureContext->getStdOutOfOccCommand())
 		);
@@ -834,7 +835,7 @@ class OccContext implements Context {
 		$this->invokingTheCommand(
 			"versions:cleanup"
 		);
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			"Delete all versions",
 			\trim($this->featureContext->getStdOutOfOccCommand())
 		);
@@ -891,20 +892,20 @@ class OccContext implements Context {
 				$systemConfig[$key], JSON_UNESCAPED_SLASHES
 			);
 
-			PHPUnit\Framework\Assert::assertThat(
+			Assert::assertThat(
 				$actualKeyValuePair,
-				PHPUnit\Framework\Assert::matchesRegularExpression($value)
+				Assert::matchesRegularExpression($value)
 			);
 			return;
 		}
 
 		if (!\array_key_exists($key, $systemConfig)) {
-			PHPUnit\Framework\Assert::fail(
+			Assert::fail(
 				"system config doesn't contain key: " . $key
 			);
 		}
 
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$value,
 			$systemConfig[$key],
 			"config: $key doesn't contain value: $value"

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -438,7 +439,7 @@ class OccUsersGroupsContext implements Context {
 			"user:setting $username core lang"
 		);
 		$responseLanguage = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit\Framework\Assert::assertEquals($language, \trim($responseLanguage));
+		Assert::assertEquals($language, \trim($responseLanguage));
 	}
 
 	/**
@@ -461,8 +462,8 @@ class OccUsersGroupsContext implements Context {
 			$result = $lastOutputUsers;
 		}
 		foreach ($useridTable as $row) {
-			PHPUnit\Framework\Assert::assertArrayHasKey($row['uid'], $result);
-			PHPUnit\Framework\Assert::assertContains($row['display name'], $result);
+			Assert::assertArrayHasKey($row['uid'], $result);
+			Assert::assertContains($row['display name'], $result);
 		}
 	}
 
@@ -478,10 +479,10 @@ class OccUsersGroupsContext implements Context {
 		$lastOutputGroups = \json_decode($lastOutput, true);
 
 		foreach ($groupTableNode as $row) {
-			PHPUnit\Framework\Assert::assertContains($row['group'], $lastOutputGroups);
+			Assert::assertContains($row['group'], $lastOutputGroups);
 			$lastOutputGroups = \array_diff($lastOutputGroups, [$row['group']]);
 		}
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$lastOutputGroups,
 			"more than the expected groups are returned\n" .
 			\print_r($lastOutputGroups, true)
@@ -499,7 +500,7 @@ class OccUsersGroupsContext implements Context {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputUser = \json_decode($lastOutput, true);
 		$lastOutputDisplayName = \array_column($lastOutputUser, 'displayName')[0];
-		PHPUnit\Framework\Assert::assertEquals($displayName, $lastOutputDisplayName);
+		Assert::assertEquals($displayName, $lastOutputDisplayName);
 	}
 
 	/**
@@ -527,7 +528,7 @@ class OccUsersGroupsContext implements Context {
 	 */
 	public function theCommandOutputOfUserLastSeenShouldBeNever() {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			"has never logged in.",
 			$lastOutput
 		);
@@ -543,7 +544,7 @@ class OccUsersGroupsContext implements Context {
 	public function theTotalUsersReturnedByTheCommandShouldBe($noOfUsers) {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		\preg_match("/\|\s+total users\s+\|\s+(\d+)\s+\|/", $lastOutput, $actualUsers);
-		PHPUnit\Framework\Assert::assertEquals($noOfUsers, $actualUsers[1]);
+		Assert::assertEquals($noOfUsers, $actualUsers[1]);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -20,12 +20,13 @@
  */
 
 use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Client;
 use GuzzleHttp\Message\ResponseInterface;
+use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
 use TestHelpers\HttpRequestHelper;
-use GuzzleHttp\Client;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -446,7 +447,7 @@ trait Provisioning {
 			$failedUser = $e->getRequest()->getBody()->getFields()['userid'];
 			$message = $this->getResponseXml($e->getResponse())->xpath("/ocs/meta/message");
 			if ($message && (string) $message[0] === "User already exists") {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"Could not create user '$failedUser' as it already exists. " .
 					"Please delete the user to run tests again."
 				);
@@ -1089,7 +1090,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldExist($user) {
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$this->userExists($user),
 			"User '$user' should exist but does not exist"
 		);
@@ -1103,7 +1104,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldNotExist($user) {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->userExists($user),
 			"User '$user' should not exist but does exist"
 		);
@@ -1118,7 +1119,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function groupShouldExist($group) {
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$this->groupExists($group),
 			"Group '$group' should exist but does not exist"
 		);
@@ -1132,7 +1133,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function groupShouldNotExist($group) {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->groupExists($group),
 			"Group '$group' should not exist but does exist"
 		);
@@ -1486,7 +1487,7 @@ trait Provisioning {
 					if ($result->getStatusCode() !== 200) {
 						$message = $this->getResponseXml($result)->xpath("/ocs/meta/message");
 						if ($message && (string) $message[0] === "User already exists") {
-							PHPUnit\Framework\Assert::fail(
+							Assert::fail(
 								'Could not create user as it already exists. ' .
 								'Please delete the user to run tests again.'
 							);
@@ -1593,8 +1594,8 @@ trait Provisioning {
 		$this->theAdministratorGetsAllTheGroupsOfUser($user);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 		\sort($respondedArray);
-		PHPUnit\Framework\Assert::assertContains($group, $respondedArray);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertContains($group, $respondedArray);
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -1614,8 +1615,8 @@ trait Provisioning {
 		);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 		\sort($respondedArray);
-		PHPUnit\Framework\Assert::assertNotContains($group, $respondedArray);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertNotContains($group, $respondedArray);
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2304,7 +2305,7 @@ trait Provisioning {
 		$this->adminMakesUserSubadminOfGroupUsingTheProvisioningApi(
 			$user, $group
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2389,7 +2390,7 @@ trait Provisioning {
 			$users = $usersList->getRows();
 			$usersSimplified = $this->simplifyArray($users);
 			$respondedArray = $this->getArrayOfUsersResponded($this->response);
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$usersSimplified, $respondedArray, "", 0.0, 10, true
 			);
 		}
@@ -2407,7 +2408,7 @@ trait Provisioning {
 			$groups = $groupsList->getRows();
 			$groupsSimplified = $this->simplifyArray($groups);
 			$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$groupsSimplified, $respondedArray, "", 0.0, 10, true
 			);
 		}
@@ -2422,7 +2423,7 @@ trait Provisioning {
 	 */
 	public function theGroupsReturnedByTheApiShouldInclude($group) {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		PHPUnit\Framework\Assert::assertContains($group, $respondedArray);
+		Assert::assertContains($group, $respondedArray);
 	}
 
 	/**
@@ -2434,7 +2435,7 @@ trait Provisioning {
 	 */
 	public function theGroupsReturnedByTheApiShouldNotInclude($group) {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		PHPUnit\Framework\Assert::assertNotContains($group, $respondedArray);
+		Assert::assertNotContains($group, $respondedArray);
 	}
 
 	/**
@@ -2446,7 +2447,7 @@ trait Provisioning {
 	 */
 	public function theUsersReturnedByTheApiShouldNotInclude($user) {
 		$respondedArray = $this->getArrayOfUsersResponded($this->response);
-		PHPUnit\Framework\Assert::assertNotContains($user, $respondedArray);
+		Assert::assertNotContains($user, $respondedArray);
 	}
 
 	/**
@@ -2458,7 +2459,7 @@ trait Provisioning {
 		$tableRows = $groupsOrUsersList->getRows();
 		$simplifiedTableRows = $this->simplifyArray($tableRows);
 		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$simplifiedTableRows, $respondedArray, "", 0.0, 10, true
 		);
 	}
@@ -2497,7 +2498,7 @@ trait Provisioning {
 		$appsSimplified = $this->simplifyArray($apps);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
 		foreach ($appsSimplified as $app) {
-			PHPUnit\Framework\Assert::assertContains($app, $respondedArray);
+			Assert::assertContains($app, $respondedArray);
 		}
 	}
 
@@ -2514,7 +2515,7 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
-		PHPUnit\Framework\Assert::assertNotContains($appName, $respondedArray);
+		Assert::assertNotContains($appName, $respondedArray);
 	}
 
 	/**
@@ -2527,11 +2528,11 @@ trait Provisioning {
 	 */
 	public function userShouldBeASubadminOfGroup($user, $group) {
 		$this->theAdministratorGetsAllTheSubadminsOfGroupUsingTheProvisioningApi($group);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 		$listOfSubadmins = $this->getArrayOfSubadminsResponded($this->response);
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$user,
 			$listOfSubadmins
 		);
@@ -2548,7 +2549,7 @@ trait Provisioning {
 	public function userShouldNotBeASubadminOfGroup($user, $group) {
 		$this->theAdministratorGetsAllTheSubadminsOfGroupUsingTheProvisioningApi($group);
 		$listOfSubadmins = $this->getArrayOfSubadminsResponded($this->response);
-		PHPUnit\Framework\Assert::assertNotContains(
+		Assert::assertNotContains(
 			$user,
 			$listOfSubadmins
 		);
@@ -2563,7 +2564,7 @@ trait Provisioning {
 	 */
 	public function theDisplayNameReturnedByTheApiShouldBe($expectedDisplayName) {
 		$responseDisplayName = (string) $this->getResponseXml()->data[0]->displayname;
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedDisplayName,
 			$responseDisplayName
 		);
@@ -2591,7 +2592,7 @@ trait Provisioning {
 	 */
 	public function theEmailAddressReturnedByTheApiShouldBe($expectedEmailAddress) {
 		$responseEmailAddress = (string) $this->getResponseXml()->data[0]->email;
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedEmailAddress,
 			$responseEmailAddress
 		);
@@ -2619,7 +2620,7 @@ trait Provisioning {
 	 */
 	public function theQuotaDefinitionReturnedByTheApiShouldBe($expectedQuotaDefinition) {
 		$responseQuotaDefinition = (string) $this->getResponseXml()->data[0]->quota->definition;
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedQuotaDefinition,
 			$responseQuotaDefinition
 		);
@@ -2727,8 +2728,8 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
-		PHPUnit\Framework\Assert::assertContains($app, $respondedArray);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertContains($app, $respondedArray);
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2746,8 +2747,8 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
-		PHPUnit\Framework\Assert::assertContains($app, $respondedArray);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertContains($app, $respondedArray);
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 	}
@@ -2764,17 +2765,17 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
 		$respondedArray = $this->getArrayOfAppInfoResponded($this->response);
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			'version',
 			$respondedArray,
 			"app info returned for $app app does not have a version"
 		);
 		$appVersion = $respondedArray['version'];
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			\substr_count($appVersion, '.') > 1,
 			"app version '$appVersion' returned in app info is not a valid version string"
 		);
@@ -2793,7 +2794,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			"false", $this->getResponseXml()->data[0]->enabled
 		);
 	}
@@ -2811,7 +2812,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			"true", $this->getResponseXml()->data[0]->enabled
 		);
 	}
@@ -2909,7 +2910,7 @@ trait Provisioning {
 				$data = $data->$field_name;
 			}
 			if ($data != $value) {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"$field has value $data"
 				);
 			}
@@ -2939,7 +2940,7 @@ trait Provisioning {
 	 */
 	public function theApiShouldNotReturnAnyData() {
 		$responseData = $this->getResponseXml()->data[0];
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$responseData,
 			"Response data is not empty but it should be empty"
 		);
@@ -2952,7 +2953,7 @@ trait Provisioning {
 	 */
 	public function theListOfUsersReturnedByTheApiShouldBeEmpty() {
 		$usersList = $this->getResponseXml()->data[0]->users[0];
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$usersList,
 			"Users list is not empty but it should be empty"
 		);
@@ -2965,7 +2966,7 @@ trait Provisioning {
 	 */
 	public function theListOfGroupsReturnedByTheApiShouldBeEmpty() {
 		$groupsList = $this->getResponseXml()->data[0]->groups[0];
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$groupsList,
 			"Groups list is not empty but it should be empty"
 		);

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -22,6 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
 
 require_once 'bootstrap.php';
@@ -406,7 +407,7 @@ class PublicWebDavContext implements Context {
 	public function publiclyUploadingShouldNotWork() {
 		$this->publicUploadContent('whateverfilefortesting.txt', '', 'test');
 		$response = $this->featureContext->getResponse();
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			($response->getStatusCode() == 507)
 			|| (
 				($response->getStatusCode() >= 400)
@@ -427,7 +428,7 @@ class PublicWebDavContext implements Context {
 		$content = 'test';
 		$this->publicUploadContent($path, '', $content);
 		$response = $this->featureContext->getResponse();
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			($response->getStatusCode() == 201),
 			"upload should have passed but failed with code " .
 			$response->getStatusCode()

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';
@@ -97,7 +98,7 @@ class SearchContext implements Context {
 		$fileResult = $this->featureContext->findEntryFromPropfindResponse(
 			$path
 		);
-		PHPUnit\Framework\Assert::assertNotFalse(
+		Assert::assertNotFalse(
 			$fileResult, "could not find file/folder '$path'"
 		);
 		$fileProperties = $fileResult['value'][1]['value'][0]['value'];
@@ -105,14 +106,14 @@ class SearchContext implements Context {
 			$foundProperty = false;
 			foreach ($fileProperties as $fileProperty) {
 				if ($fileProperty['name'] === $property['name']) {
-					PHPUnit\Framework\Assert::assertRegExp(
+					Assert::assertRegExp(
 						"/" . $property['value'] . "/", $fileProperty['value']
 					);
 					$foundProperty = true;
 					break;
 				}
 			}
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$foundProperty, "could not find property '" . $property['name'] . "'"
 			);
 		}

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -26,6 +26,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -96,7 +97,7 @@ class ShareesContext implements Context {
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(), $shareeType
 		);
-		PHPUnit\Framework\Assert::assertEquals($sharees, $respondedArray);
+		Assert::assertEquals($sharees, $respondedArray);
 	}
 
 	/**
@@ -117,7 +118,7 @@ class ShareesContext implements Context {
 			$firstEntry = "";
 		}
 
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$respondedArray,
 			"'$shareeType' array should be empty, but it starts with $firstEntry"
 		);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -23,11 +23,11 @@
  */
 
 use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 use TestHelpers\SharingHelper;
 use TestHelpers\HttpRequestHelper;
-use GuzzleHttp\Message\ResponseInterface;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
+use PHPUnit\Framework\Assert;
 use TestHelpers\TagsHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
@@ -113,26 +114,26 @@ class TagsContext implements Context {
 		$userAssignable = ($userAttributes[1]) ? 'true' : 'false';
 		
 		$tagDisplayName = $tagData->xpath(".//oc:display-name");
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			0, $tagDisplayName, "cannot find 'oc:display-name' property"
 		);
 		$tagDisplayName = $tagDisplayName[0]->__toString();
 		
 		$tagUserVisible = $tagData->xpath(".//oc:user-visible");
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			0, $tagUserVisible, "cannot find 'oc:user-visible' property"
 		);
 		$tagUserVisible = $tagUserVisible[0]->__toString();
 		
 		$tagUserAssignable = $tagData->xpath(".//oc:user-assignable");
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			0, $tagUserAssignable, "cannot find 'oc:user-assignable' property"
 		);
 		$tagUserAssignable = $tagUserAssignable[0]->__toString();
 		if (($tagUserVisible !== $userVisible)
 			|| ($tagUserAssignable !== $userAssignable)
 		) {
-			PHPUnit\Framework\Assert::fail(
+			Assert::fail(
 				"tag $tagDisplayName is not of type $type"
 			);
 		}
@@ -327,7 +328,7 @@ class TagsContext implements Context {
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
 			$tagData = $this->requestTagByDisplayName($user, $rowDisplayName);
 			if ($tagData === null) {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"tag $rowDisplayName is not in propfind answer"
 				);
 			} else {
@@ -346,7 +347,7 @@ class TagsContext implements Context {
 	 */
 	public function tagShouldNotExistForUser($tagDisplayName, $user) {
 		$tagData = $this->requestTagByDisplayName($user, $tagDisplayName);
-		PHPUnit\Framework\Assert::assertNull(
+		Assert::assertNull(
 			$tagData, "tag $tagDisplayName is in propfind answer"
 		);
 	}
@@ -425,7 +426,7 @@ class TagsContext implements Context {
 			);
 		}
 		$canAssign = $tagData->xpath(".//oc:can-assign[text() = '$expected']");
-		PHPUnit\Framework\Assert::assertArrayHasKey(0, $canAssign, $errorMessage);
+		Assert::assertArrayHasKey(0, $canAssign, $errorMessage);
 	}
 
 	/**
@@ -442,15 +443,15 @@ class TagsContext implements Context {
 		$tagData = $this->requestTagByDisplayName(
 			$this->featureContext->getAdminUsername(), $tagName, true
 		);
-		PHPUnit\Framework\Assert::assertNotNull(
+		Assert::assertNotNull(
 			$tagData, "Tag $tagName wasn't found for admin user"
 		);
 		$this->assertTypeOfTag($tagData, $type);
 		$groupsOfTag = $tagData->xpath(".//oc:groups");
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			0, $groupsOfTag, "cannot find oc:groups element"
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$groupsOfTag[0],
 			$groups,
 			"Tag has groups '{$groupsOfTag[0]}' instead of the expected '$groups'"
@@ -793,7 +794,7 @@ class TagsContext implements Context {
 		$user, $fileName, $sharingUser, $status
 	) {
 		$this->requestTagsForFile($user, $fileName, $sharingUser);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$status, $this->featureContext->getResponse()->getStatusCode()
 		);
 	}
@@ -839,7 +840,7 @@ class TagsContext implements Context {
 			$found = false;
 			foreach ($tagList as $tagData) {
 				$displayName = $tagData->xpath(".//oc:display-name");
-				PHPUnit\Framework\Assert::assertArrayHasKey(
+				Assert::assertArrayHasKey(
 					0, $displayName, "cannot find 'oc:display-name' property"
 				);
 				if ($displayName[0]->__toString() === $rowDisplayName) {
@@ -849,7 +850,7 @@ class TagsContext implements Context {
 				}
 			}
 			if ($found === false) {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"tag $rowDisplayName is not in propfind answer"
 				);
 			}
@@ -909,7 +910,7 @@ class TagsContext implements Context {
 		// The array of tags has a single "empty" item at the start.
 		// If there are no tags, then the array should have just this
 		// one entry.
-		PHPUnit\Framework\Assert::assertCount(1, $tagList);
+		Assert::assertCount(1, $tagList);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -21,6 +21,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';
@@ -58,7 +59,7 @@ class TrashbinContext implements Context {
 			'trash-bin'
 		);
 
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			204, $response->getStatusCode()
 		);
 	}
@@ -148,7 +149,7 @@ class TrashbinContext implements Context {
 
 		$firstEntry = $this->findFirstTrashedEntry($user, \trim($sections[0], '/'));
 
-		PHPUnit\Framework\Assert::assertNotNull($firstEntry);
+		Assert::assertNotNull($firstEntry);
 
 		// query was on the main element ?
 		if (\count($sections) === 1) {
@@ -168,7 +169,7 @@ class TrashbinContext implements Context {
 			}
 		}
 
-		PHPUnit\Framework\Assert::assertTrue($found);
+		Assert::assertTrue($found);
 	}
 
 	/**
@@ -258,7 +259,7 @@ class TrashbinContext implements Context {
 	 */
 	public function elementInTrashIsRestored($user, $originalPath) {
 		$this->restoreElement($user, $originalPath);
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath is still in the trashbin"
 		);
@@ -290,7 +291,7 @@ class TrashbinContext implements Context {
 	public function elementIsInTrashCheckingOriginalPath(
 		$user, $originalPath
 	) {
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath wasn't found in the trashbin"
 		);
@@ -307,7 +308,7 @@ class TrashbinContext implements Context {
 	public function elementIsNotInTrashCheckingOriginalPath(
 		$user, $originalPath
 	) {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath was found in the trashbin"
 		);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -25,6 +25,7 @@ use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Ring\Exception\ConnectException;
 use GuzzleHttp\Stream\StreamInterface;
 use Guzzle\Http\Exception\BadResponseException;
+use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
@@ -449,7 +450,7 @@ trait WebDav {
 		$this->response = $this->makeDavRequest(
 			$user, "MOVE", $fileSource, $headers
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			201, $this->response->getStatusCode()
 		);
 	}
@@ -606,10 +607,10 @@ trait WebDav {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
 		$this->downloadFileAsUserUsingPassword($user, $fileName, $password);
-		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
+		Assert::assertGreaterThanOrEqual(
 			400, $this->getResponse()->getStatusCode(), 'download must fail'
 		);
-		PHPUnit\Framework\Assert::assertLessThanOrEqual(
+		Assert::assertLessThanOrEqual(
 			499, $this->getResponse()->getStatusCode(), '4xx error expected'
 		);
 	}
@@ -635,7 +636,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function downloadedContentShouldBe($content) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$content, (string)$this->response->getBody()
 		);
 	}
@@ -986,16 +987,16 @@ trait WebDav {
 		$url = $this->getBaseUrlWithoutPath() . $url;
 		$response = HttpRequestHelper::get($url, $user, $this->getPasswordForUser($user));
 		$result = \json_decode($response->getBody()->getContents(), true);
-		PHPUnit\Framework\Assert::assertNotNull($result, "'$response' is not valid JSON");
+		Assert::assertNotNull($result, "'$response' is not valid JSON");
 		foreach ($table->getTable() as $row) {
 			$expectedKey = $row[0];
-			PHPUnit\Framework\Assert::assertArrayHasKey(
+			Assert::assertArrayHasKey(
 				$expectedKey, $result, "response does not have expected key '$expectedKey'"
 			);
 			$expectedValue = $this->substituteInLineCodes(
 				$row[1], ['preg_quote' => ['/'] ]
 			);
-			PHPUnit\Framework\Assert::assertNotFalse(
+			Assert::assertNotFalse(
 				(bool)\preg_match($expectedValue, $result[$expectedKey]),
 				"'$expectedValue' does not match '$result[$expectedKey]'"
 			);
@@ -1041,7 +1042,7 @@ trait WebDav {
 	public function asFileOrFolderShouldExist($user, $entry, $path) {
 		$path = $this->substituteInLineCodes($path);
 		$this->responseXmlObject = $this->listFolder($user, $path, 0);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$this->isEtagValid(),
 			"$entry '$path' expected to exist but not found"
 		);
@@ -1066,7 +1067,7 @@ trait WebDav {
 				$numEntriesThatExist = $numEntriesThatExist + 1;
 			}
 		}
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			1,
 			$numEntriesThatExist,
 			"exactly one of these $entries should exist but found $numEntriesThatExist $entries"
@@ -1145,12 +1146,12 @@ trait WebDav {
 			if ($expectedToBeListed
 				&& (!isset($element[0]) || $element[0]->__toString() !== $webdavPath)
 			) {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"$webdavPath is not in propfind answer but should"
 				);
 			} elseif (!$expectedToBeListed && isset($element[0])
 			) {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"$webdavPath is in propfind answer but should not be"
 				);
 			}
@@ -1274,7 +1275,7 @@ trait WebDav {
 	public function userUploadsAFileToWithChunks(
 		$user, $source, $destination, $noOfChunks = 2, $chunkingVersion = null, $async = false, $headers = []
 	) {
-		PHPUnit\Framework\Assert::assertGreaterThan(
+		Assert::assertGreaterThan(
 			0, $noOfChunks, "What does it mean to have $noOfChunks chunks?"
 		);
 		//use the chunking version that works with the set dav version
@@ -1286,7 +1287,7 @@ trait WebDav {
 			}
 		}
 		$this->useSpecificChunking($chunkingVersion);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			WebDavHelper::isValidDavChunkingCombination(
 				($this->usingOldDavPath) ? 1 : 2,
 				$this->chunkingToUse
@@ -1397,7 +1398,7 @@ trait WebDav {
 	 */
 	public function theHTTPStatusCodeOfAllUploadResponsesShouldBe($statusCode) {
 		foreach ($this->uploadResponses as $response) {
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$statusCode,
 				$response->getStatusCode(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
@@ -1414,7 +1415,7 @@ trait WebDav {
 	 */
 	public function theHTTPReasonPhraseOfAllUploadResponsesShouldBe($reasonPhrase) {
 		foreach ($this->uploadResponses as $response) {
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				$reasonPhrase,
 				$response->getReasonPhrase(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected reason phrase'
@@ -1462,12 +1463,12 @@ trait WebDav {
 		$minStatusCode, $maxStatusCode
 	) {
 		foreach ($this->uploadResponses as $response) {
-			PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
+			Assert::assertGreaterThanOrEqual(
 				$minStatusCode,
 				$response->getStatusCode(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
 			);
-			PHPUnit\Framework\Assert::assertLessThanOrEqual(
+			Assert::assertLessThanOrEqual(
 				$maxStatusCode,
 				$response->getStatusCode(),
 				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
@@ -1555,7 +1556,7 @@ trait WebDav {
 	public function userUploadsAFileToOfBytes($user, $destination, $bytes) {
 		$filename = "filespecificSize.txt";
 		$this->createLocalFileOfSpecificSize($filename, $bytes);
-		PHPUnit\Framework\Assert::assertFileExists($this->workStorageDirLocation() . $filename);
+		Assert::assertFileExists($this->workStorageDirLocation() . $filename);
 		$this->userUploadsAFileTo(
 			$user,
 			$this->temporaryStorageSubfolderName() . "/$filename",
@@ -2106,7 +2107,7 @@ trait WebDav {
 			$headerValue = $this->response->getHeader($headerName);
 			//Note: according to the documentation of getHeader it must return null
 			//if the header does not exist, but its returning an empty string
-			PHPUnit\Framework\Assert::assertEmpty(
+			Assert::assertEmpty(
 				$headerValue,
 				"header $headerName should not exist " .
 				"but does and is set to $headerValue"
@@ -2131,7 +2132,7 @@ trait WebDav {
 			);
 
 			$returnedHeader = $this->response->getHeader($headerName);
-			PHPUnit\Framework\Assert::assertNotFalse(
+			Assert::assertNotFalse(
 				(bool)\preg_match($expectedHeaderValue, $returnedHeader),
 				"'$expectedHeaderValue' does not match '$returnedHeader'"
 			);
@@ -2201,7 +2202,7 @@ trait WebDav {
 	 */
 	public function userFileShouldHaveStoredId($user, $path) {
 		$currentFileID = $this->getFileIdForPath($user, $path);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$currentFileID, $this->storedFileID
 		);
 	}
@@ -2240,12 +2241,12 @@ trait WebDav {
 				$expectedFile[0]
 			);
 			if ($should) {
-				PHPUnit\Framework\Assert::assertNotEmpty(
+				Assert::assertNotEmpty(
 					$fileFound,
 					"response does not contain the entry '$expectedFile[0]'"
 				);
 			} else {
-				PHPUnit\Framework\Assert::assertFalse(
+				Assert::assertFalse(
 					$fileFound,
 					"response does contain the entry '$expectedFile[0]' but should not"
 				);
@@ -2272,7 +2273,7 @@ trait WebDav {
 		if ($multistatusResults === null) {
 			$multistatusResults = [];
 		}
-		PHPUnit\Framework\Assert::assertEquals((int)$numFiles, \count($multistatusResults));
+		Assert::assertEquals((int)$numFiles, \count($multistatusResults));
 	}
 
 	/**
@@ -2290,7 +2291,7 @@ trait WebDav {
 		$elementRows = $expectedFiles->getRowsHash();
 		$resultEntries = $this->findEntryFromPropfindResponse();
 		foreach ($resultEntries as $resultEntry) {
-			PHPUnit\Framework\Assert::assertArrayHasKey($resultEntry, $elementRows);
+			Assert::assertArrayHasKey($resultEntry, $elementRows);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\ConnectException;
+use PHPUnit\Framework\Assert;
 use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';
@@ -102,7 +103,7 @@ class WebDavLockingContext implements Context {
 			$this->tokenOfLastLock[$user][$file] = (string)$xmlPart[0];
 		} else {
 			if ($expectToSucceed === true) {
-				PHPUnit\Framework\Assert::fail("could not find lock token");
+				Assert::fail("could not find lock token");
 			}
 		}
 	}
@@ -440,7 +441,7 @@ class WebDavLockingContext implements Context {
 		$responseXml = $this->featureContext->getResponseXml($response);
 		$responseXml->registerXPathNamespace('d', 'DAV:');
 		$xmlPart = $responseXml->xpath("//d:response//d:lockdiscovery/d:activelock");
-		PHPUnit\Framework\Assert::assertCount(
+		Assert::assertCount(
 			(int)$count, $xmlPart,
 			"expected $count lock(s) for '$file' but found " . \count($xmlPart)
 		);

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
 use TestHelpers\Asserts\WebDav as WebDavTest;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
@@ -198,10 +199,10 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $responseXmlObject->xpath(
 			"//d:prop/" . "$nameSpacePrefix:$propertyName"
 		);
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			0, $xmlPart, "Cannot find property \"$propertyName\""
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$propertyValue, $xmlPart[0]->__toString(),
 			"\"$propertyName\" has a value \"" .
 			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected"
@@ -224,7 +225,7 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$property/$childProperty"
 		);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find property \"$property/$childProperty\""
 		);
 	}
@@ -262,7 +263,7 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$key"
 		);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find property \"$key\""
 		);
 		$value = $xmlPart[0]->__toString();
@@ -274,7 +275,7 @@ class WebDavPropertiesContext implements Context {
 		if (\preg_match($expectedValue, $value) !== 1
 			&& \preg_match($altExpectedValue, $value) !== 1
 		) {
-			PHPUnit\Framework\Assert::fail(
+			Assert::fail(
 				"Property \"$key\" found with value \"$value\", " .
 				"expected \"$expectedValue\" or \"$altExpectedValue\""
 			);
@@ -292,14 +293,14 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function assertValueOfItemInResponseIs($xpath, $expectedValue) {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find item with xpath \"$xpath\""
 		);
 		$value = $xmlPart[0]->__toString();
 		$expectedValue = $this->featureContext->substituteInLineCodes(
 			$expectedValue
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedValue, $value,
 			"item \"$xpath\" found with value \"$value\", " .
 			"expected \"$expectedValue\""
@@ -317,14 +318,14 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function assertValueOfItemInResponseRegExp($xpath, $pattern) {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find item with xpath \"$xpath\""
 		);
 		$value = $xmlPart[0]->__toString();
 		$pattern = $this->featureContext->substituteInLineCodes(
 			$pattern, ['preg_quote' => ['/'] ]
 		);
-		PHPUnit\Framework\Assert::assertRegExp(
+		Assert::assertRegExp(
 			$pattern, $value,
 			"item \"$xpath\" found with value \"$value\", " .
 			"expected to match regex pattern: \"$pattern\""
@@ -341,7 +342,7 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function assertItemInResponseDoesNotExist($xpath) {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath($xpath);
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			isset($xmlPart[0]),
 			"Found item with xpath \"$xpath\" but it should not exist"
 		);
@@ -402,11 +403,11 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$key"
 		);
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			isset($xmlPart[0]), "Cannot find property \"$key\""
 		);
 		$value = $xmlPart[0]->__toString();
-		PHPUnit\Framework\Assert::assertRegExp(
+		Assert::assertRegExp(
 			$regex, $value,
 			"Property \"$key\" found with value \"$value\", expected \"$regex\""
 		);
@@ -438,10 +439,10 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$property"
 		);
-		PHPUnit\Framework\Assert::assertCount(
+		Assert::assertCount(
 			1, $xmlPart, "Cannot find property \"$property\""
 		);
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$xmlPart[0], "Property \"$property\" is not empty"
 		);
 	}
@@ -491,7 +492,7 @@ class WebDavPropertiesContext implements Context {
 		$this->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$this->storedETAG[$user][$path],
 			$this->featureContext->getEtagFromResponseXmlObject()
 		);
@@ -510,7 +511,7 @@ class WebDavPropertiesContext implements Context {
 		$this->userGetsPropertiesOfFolder(
 			$user, $path, $propertiesTable
 		);
-		PHPUnit\Framework\Assert::assertNotEquals(
+		Assert::assertNotEquals(
 			$this->storedETAG[$user][$path],
 			$this->featureContext->getEtagFromResponseXmlObject()
 		);

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -26,6 +26,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\AdminGeneralSettingsPage;
+use PHPUnit\Framework\Assert;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\SetupHelper;
 
@@ -209,7 +210,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	public function theVersionOfOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
 		$actualVersion = $this->adminGeneralSettingsPage->getOwncloudVersion();
 		$expectedVersion = $this->featureContext->getSystemConfigValue('version');
-		PHPUnit\Framework\Assert::assertEquals(\trim($expectedVersion), $actualVersion);
+		Assert::assertEquals(\trim($expectedVersion), $actualVersion);
 	}
 
 	/**
@@ -220,7 +221,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	public function theVersionStringOfTheOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
 		$actualVersion =  $this->adminGeneralSettingsPage->getOwncloudVersionString();
 		$expectedVersion = SetupHelper::runOcc(['-V'])['stdOut'];
-		PHPUnit\Framework\Assert::assertStringEndsWith($actualVersion, \trim($expectedVersion));
+		Assert::assertStringEndsWith($actualVersion, \trim($expectedVersion));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\AdminSharingSettingsPage;
+use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';
@@ -331,7 +332,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	 */
 	public function aErrorMessageForTrustedServerShouldContain($text) {
 		$msg = $this->adminSharingSettingsPage->getTrustedServerErrorMsg();
-		\PHPUnit\Framework\Assert::assertContains($text, $msg);
+		Assert::assertContains($text, $msg);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\AdminStorageSettingsPage;
+use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';
@@ -175,11 +176,11 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 		);
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$result, "Last created mount was expected to be present but was not"
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$result, "Last created mount was not expected to be present but was"
 			);
 		}
@@ -192,7 +193,7 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	 */
 	public function theExternalStorageFormShouldBeOnTheStorageSettingsPage() {
 		$isDisplayed = $this->adminStorageSettingsPage->externalStorageFormVisible();
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$isDisplayed, "External storage is expected to be visible but is not"
 		);
 	}
@@ -204,7 +205,7 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	 */
 	public function theExternalStorageFormShouldNotBeOnTheStorageSettingsPage() {
 		$isDisplayed = $this->adminStorageSettingsPage->externalStorageFormVisible();
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$isDisplayed, "External storage is not expected to be visible but is"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -323,16 +323,16 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theThumbnailShouldBeVisibleInTheDetailsPanel() {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
 		$thumbnail = $detailsDialog->findThumbnail();
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$thumbnail->isVisible(),
 			"thumbnail is not visible"
 		);
 		$style = $thumbnail->getAttribute("style");
-		PHPUnit\Framework\Assert::assertNotNull(
+		Assert::assertNotNull(
 			$style,
 			'style attribute of details thumbnail is null'
 		);
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$this->getCurrentFolderFilePath(),
 			$style
 		);
@@ -347,7 +347,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theTabNameDetailsPanelShouldBeVisible($tabName) {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$detailsDialog->isDetailsPanelVisible($tabName),
 			"the $tabName panel is not visible in the details panel"
 		);
@@ -362,7 +362,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theTabNameDetailsPanelShouldNotBeVisible($tabName) {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$detailsDialog->isDetailsPanelVisible($tabName),
 			"the $tabName panel is visible in the details panel but should not be"
 		);
@@ -376,7 +376,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theShareWithFieldShouldBeVisibleInTheDetailsPanel() {
 		$sharingDialog = $this->filesPage->getSharingDialog();
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$sharingDialog->isShareWithFieldVisible(),
 			'the share-with field is not visible in the details panel'
 		);
@@ -390,7 +390,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theShareWithFieldShouldNotBeVisibleInTheDetailsPanel() {
 		$sharingDialog = $this->filesPage->getSharingDialog();
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$sharingDialog->isShareWithFieldVisible(),
 			'the share-with field is visible in the details panel'
 		);
@@ -592,7 +592,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function thereShouldBeNoFilesFoldersListedOnTheWebUI() {
 		$pageObject = $this->getCurrentPageObject();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			0,
 			$pageObject->getSizeOfFileFolderList()
 		);
@@ -609,7 +609,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function thereShouldBeCountFilesFoldersListedOnTheWebUI($count) {
 		$pageObject = $this->getCurrentPageObject();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$count,
 			$pageObject->getSizeOfFileFolderList()
 		);
@@ -1355,12 +1355,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$folderIsEmpty = $pageObject->isFolderEmpty($this->getSession());
 
 		if ($should) {
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$folderIsEmpty,
 				"folder contains items but should be empty"
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$folderIsEmpty,
 				"folder is empty but should contain items"
 			);
@@ -1508,11 +1508,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		}
 
 		if ($should) {
-			PHPUnit\Framework\Assert::assertNotNull(
+			Assert::assertNotNull(
 				$fileRow,
 				"could not find $fileLocationText when it should be listed"
 			);
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$fileRow->isVisible(),
 				"file row of $fileLocationText is not visible but should"
 			);
@@ -1521,13 +1521,13 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$name = \implode($name);
 			}
 			if ($fileRow === null) {
-				PHPUnit\Framework\Assert::assertContains(
+				Assert::assertContains(
 					"could not find file with the name '$name'",
 					$exceptionMessage,
 					"found $fileLocationText when it should not be listed"
 				);
 			} else {
-				PHPUnit\Framework\Assert::assertFalse(
+				Assert::assertFalse(
 					$fileRow->isVisible(),
 					"file row of $fileLocationText is visible but should not"
 				);
@@ -1605,7 +1605,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$fileNameParts[] = $namePartsRow['name-parts'];
 			}
 		} else {
-			PHPUnit\Framework\Assert::fail(
+			Assert::fail(
 				'no table of file name parts passed to theFollowingFileFolderShouldBeListed'
 			);
 		}
@@ -1636,7 +1636,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$name,
 		$toolTipText
 	) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$toolTipText,
 			$this->getCurrentPageObject()->getTooltipOfFile($name, $this->getSession())
 		);
@@ -1666,7 +1666,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$tooltiptext
 	) {
 		$createFolderTooltip = $this->getCurrentPageObject()->getCreateFolderTooltip();
-		PHPUnit\Framework\Assert::assertSame($tooltiptext, $createFolderTooltip);
+		Assert::assertSame($tooltiptext, $createFolderTooltip);
 	}
 
 	/**
@@ -1681,7 +1681,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		try {
 			$this->deleteTheFileUsingTheWebUI($name, false);
 		} catch (ElementNotFoundException $e) {
-			PHPUnit\Framework\Assert::assertContains(
+			Assert::assertContains(
 				"could not find button 'Delete' in action Menu",
 				$e->getMessage()
 			);
@@ -1718,9 +1718,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$fileRow = $pageObject->findFileRowByName($name, $session);
 		$action = \ucfirst($action);
 		if ($visible) {
-			PHPUnit\Framework\Assert::assertTrue($fileRow->isActionLabelAvailable($action, $session));
+			Assert::assertTrue($fileRow->isActionLabelAvailable($action, $session));
 		} else {
-			PHPUnit\Framework\Assert::assertFalse($fileRow->isActionLabelAvailable($action, $session));
+			Assert::assertFalse($fileRow->isActionLabelAvailable($action, $session));
 		}
 		$fileRow->clickFileActionButton();
 	}
@@ -1736,9 +1736,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function uploadButtonShouldNotBeVisible($shouldOrNot) {
 		$visible = $shouldOrNot !== "not";
 		if ($visible) {
-			PHPUnit\Framework\Assert::assertTrue($this->getCurrentPageObject()->isUploadButtonAvailable());
+			Assert::assertTrue($this->getCurrentPageObject()->isUploadButtonAvailable());
 		} else {
-			PHPUnit\Framework\Assert::assertFalse($this->getCurrentPageObject()->isUploadButtonAvailable());
+			Assert::assertFalse($this->getCurrentPageObject()->isUploadButtonAvailable());
 		}
 	}
 
@@ -1774,7 +1774,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$currentTime = \microtime(true);
 			}
 
-			PHPUnit\Framework\Assert::assertLessThanOrEqual(
+			Assert::assertLessThanOrEqual(
 				$windowHeight, $deleteBtnCoordinates ["top"]
 			);
 			//this will close the menu again
@@ -2075,7 +2075,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserShouldSeeFileActionTranslatedToOnTheWebui($action_label, $translated_label) {
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			$translated_label,
 			$this->openedFileActionMenu->getActionLabelLocalized($action_label)
 		);
@@ -2115,7 +2115,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theDetailsDialogShouldBeVisibleOnTheWebui() {
-		PHPUnit\Framework\Assert::assertTrue($this->filesPage->getDetailsDialog()->isDialogVisible());
+		Assert::assertTrue($this->filesPage->getDetailsDialog()->isDialogVisible());
 	}
 
 	/**
@@ -2173,12 +2173,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$detailsDialog = $this->getCurrentPageObject()->getDetailsDialog();
 		$detailsDialog->waitTillPageIsLoaded($this->getSession());
 		if ($should) {
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$detailsDialog->isCommentOnUI($text),
 				"Failed to find comment with text $text on the webUI"
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$detailsDialog->isCommentOnUI($text),
 				"The comment with text $text exists on the webUI"
 			);
@@ -2215,7 +2215,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theVersionsListShouldContainEntries($num) {
 		$versionsList = $this->filesPage->getDetailsDialog()->getVersionsList();
 		$versionsCount = \count($versionsList->findAll("xpath", "//li"));
-		PHPUnit\Framework\Assert::assertEquals($num, $versionsCount);
+		Assert::assertEquals($num, $versionsCount);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -27,6 +27,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\LoginPage;
 use Page\OwncloudPage;
+use PHPUnit\Framework\Assert;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\EmailHelper;
@@ -266,7 +267,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		);
 		$matches = [];
 		\preg_match($regexSearch, $content, $matches);
-		PHPUnit\Framework\Assert::assertArrayHasKey(1, $matches, $errorMessage);
+		Assert::assertArrayHasKey(1, $matches, $errorMessage);
 		return $matches[1];
 	}
 
@@ -294,7 +295,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function noNotificationShouldBeDisplayedOnTheWebUI() {
 		try {
 			$notificationText = $this->owncloudPage->getNotificationText();
-			PHPUnit\Framework\Assert::assertEquals(
+			Assert::assertEquals(
 				'',
 				$notificationText,
 				"Expecting no notifications but got $notificationText"
@@ -314,7 +315,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function aNotificationShouldBeDisplayedOnTheWebUIWithTheText(
 		$notificationText
 	) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$notificationText, $this->owncloudPage->getNotificationText()
 		);
 	}
@@ -337,7 +338,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$expectedNotifications = $table->getRows();
 		$numExpectedNotifications = \count($expectedNotifications);
 
-		PHPUnit\Framework\Assert::assertGreaterThanOrEqual(
+		Assert::assertGreaterThanOrEqual(
 			$numExpectedNotifications,
 			$numActualNotifications,
 			"expected at least $numExpectedNotifications notifications but only found $numActualNotifications"
@@ -354,7 +355,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 					);
 				}
 			} else {
-				PHPUnit\Framework\Assert::assertEquals(
+				Assert::assertEquals(
 					$expectedNotificationText,
 					$actualNotificationText
 				);
@@ -390,7 +391,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				$currentTime = \microtime(true);
 				$dialogs = $this->owncloudPage->getOcDialogs();
 			}
-			PHPUnit\Framework\Assert::assertEquals($count, \count($dialogs));
+			Assert::assertEquals($count, \count($dialogs));
 		}
 		if ($table !== null) {
 			$expectedDialogs = $table->getHash();
@@ -412,7 +413,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				}
 			}
 			foreach ($expectedDialogs as $expectedDialog) {
-				PHPUnit\Framework\Assert::assertArrayHasKey(
+				Assert::assertArrayHasKey(
 					"found",
 					$expectedDialog,
 					"could not find dialog with title '{$expectedDialog['title']}' "
@@ -434,7 +435,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$this->owncloudPage->waitForOutstandingAjaxCalls($this->getSession());
 		// Just check that the actual title starts with the expected title.
 		// Theming can have other text following.
-		PHPUnit\Framework\Assert::assertStringStartsWith(
+		Assert::assertStringStartsWith(
 			$title, $this->owncloudPage->getPageTitle()
 		);
 	}
@@ -451,7 +452,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$this->generalErrorPage->waitTillPageIsLoaded($this->getSession());
 		// Just check that the actual title starts with the expected title.
 		// Theming can have other text following.
-		PHPUnit\Framework\Assert::assertStringStartsWith(
+		Assert::assertStringStartsWith(
 			$title, $this->generalErrorPage->getPageTitle()
 		);
 	}
@@ -464,7 +465,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function anErrorShouldBeDisplayedOnTheGeneralErrorPage($error) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$error, $this->generalErrorPage->getErrorMessage()
 		);
 	}
@@ -481,7 +482,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$this->generalExceptionPage->waitTillPageIsLoaded($this->getSession());
 		// Just check that the actual title starts with the expected title.
 		// Theming can have other text following.
-		PHPUnit\Framework\Assert::assertStringStartsWith(
+		Assert::assertStringStartsWith(
 			$title, $this->generalExceptionPage->getPageTitle()
 		);
 	}
@@ -494,7 +495,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function anErrorShouldBeDisplayedOnTheGeneralExceptionPageWithTitle($title) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$title, $this->generalExceptionPage->getExceptionTitle()
 		);
 	}
@@ -507,7 +508,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function anErrorShouldBeDisplayedOnTheGeneralErrorPageContaining($message) {
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$message,
 			$this->generalExceptionPage->getExceptionMessage()
 		);

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\HelpAndTipsPage;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -132,7 +133,7 @@ class WebUIHelpAndTipsContext extends RawMinkContext implements Context {
 	public function theLinkForShouldBeValid($linkTitle) {
 		$linkUrl = $this->generateHelpLinks($this->getLinkID($linkTitle));
 		$linkOnUI = $this->helpAndTipsPage->getLinkUrlByTitle($linkTitle);
-		PHPUnit\Framework\Assert::assertSame($linkUrl, $linkOnUI);
+		Assert::assertSame($linkUrl, $linkOnUI);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\LoginPage;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -403,7 +404,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	public function thisMessageShouldBeDisplayed(PyStringNode $string) {
 		$expectedString = $string->getRaw();
 		$passwordRecoveryMessage = $this->loginPage->getLostPasswordMessage();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedString, $passwordRecoveryMessage
 		);
 	}
@@ -420,7 +421,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	) {
 		$expectedString = $string->getRaw();
 		$setPasswordErrorMessage = $this->loginPage->getSetPasswordErrorMessage();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedString, $setPasswordErrorMessage
 		);
 	}
@@ -437,7 +438,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	) {
 		$expectedString = $string->getRaw();
 		$resetPasswordErrorMessage = $this->loginPage->getLostPasswordResetErrorMessage();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedString, $resetPasswordErrorMessage
 		);
 	}
@@ -451,7 +452,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	public function theImprintUrlOnTheLoginPageShouldLinkTo($expectedImprintUrl) {
 		$actualImprintUrl = $this->loginPage->getLegalUrl("Imprint");
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedImprintUrl,
 			$actualImprintUrl
 		);
@@ -466,7 +467,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	public function thePrivacyPolicyUrlOnTheLoginPageShouldLinkTo($expectedPrivacyPolicyUrl) {
 		$actualPrivacyPolicyUrl = $this->loginPage->getLegalUrl("Privacy Policy");
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedPrivacyPolicyUrl,
 			$actualPrivacyPolicyUrl
 		);
@@ -581,7 +582,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	public function theUserResetConfirmPasswordErrorMessage(PyStringNode $string) {
 		$expectedString = $string->getRaw();
 		$passwordMismatchMessage = $this->loginPage->getRestPasswordConfirmError();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$expectedString, $passwordMismatchMessage
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
@@ -26,6 +26,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Session;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\NotificationsEnabledOwncloudPage;
+use PHPUnit\Framework\Assert;
 
 /**
  * Context for Notifications App
@@ -62,7 +63,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 	) {
 		$notificationsDialog = $this->openNotificationsDialog($this->getSession());
 		$notifications = $notificationsDialog->getAllNotifications();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$number,
 			\count($notifications),
 			"expected $number notifications, found " . \count($notifications)
@@ -84,7 +85,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 				}
 			}
 			if (!$found) {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"could not find expected notification: " .
 					\print_r($expectedNotification, true) .
 					" in viewed notifications: " .

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\PersonalGeneralSettingsPage;
+use PHPUnit\Framework\Assert;
 use TestHelpers\EmailHelper;
 
 require_once 'bootstrap.php';
@@ -167,7 +168,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 			$this->personalGeneralSettingsPage->changeFullname(
 				"anything", $this->getSession()
 			);
-			PHPUnit\Framework\Assert::fail("changing the full name was possible, but should not");
+			Assert::fail("changing the full name was possible, but should not");
 		} catch (Behat\Mink\Exception\ElementNotFoundException $e) {
 		}
 	}
@@ -192,7 +193,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function theOwncloudVersionShouldBeDisplayedOnThePersonalGeneralSettingsPageOnTheWebui() {
-		PHPUnit\Framework\Assert::assertTrue($this->personalGeneralSettingsPage->isVersionDisplayed());
+		Assert::assertTrue($this->personalGeneralSettingsPage->isVersionDisplayed());
 	}
 
 	/**
@@ -204,7 +205,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theFederatedCloudIdForUserShouldBeDisplayedOnThePersonalGeneralSettingsPageOnTheWebui($user) {
 		$userFederatedCloudId = $user . "@" . $this->featureContext->getLocalBaseUrlWithoutScheme();
-		PHPUnit\Framework\Assert::assertEquals($this->personalGeneralSettingsPage->getFederatedCloudID(), $userFederatedCloudId);
+		Assert::assertEquals($this->personalGeneralSettingsPage->getFederatedCloudID(), $userFederatedCloudId);
 	}
 
 	/**
@@ -215,7 +216,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function groupShouldBeDisplayedOnThePersonalGeneralSettingsPageOnTheWebui($groupName) {
-		PHPUnit\Framework\Assert::assertTrue($this->personalGeneralSettingsPage->isGroupNameDisplayed($groupName));
+		Assert::assertTrue($this->personalGeneralSettingsPage->isGroupNameDisplayed($groupName));
 	}
 
 	/**
@@ -236,7 +237,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 			'/Use the following link to confirm your changes to the email address: (http.*)/',
 			$content, $matches
 		);
-		PHPUnit\Framework\Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			1, $matches,
 			"Couldn't find confirmation link in the email"
 		);
@@ -253,7 +254,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	public function aPasswordErrorMessageShouldBeDisplayedOnTheWebUIWithTheText(
 		$wrongPasswordMessageText
 	) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$wrongPasswordMessageText,
 			$this->personalGeneralSettingsPage->getWrongPasswordMessageText()
 		);
@@ -291,11 +292,11 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function thePreviewOfTheProfilePictureShouldBeShownOnTheWebui($shouldOrNot) {
 		if ($shouldOrNot !== "not") {
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
 			);
 		}
@@ -319,7 +320,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theUserHasDeletedAnyExistingProfilePicture() {
 		$this->theUserDeletesTheExistingProfilePicture();
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->personalGeneralSettingsPage->isProfilePicturePreviewDisplayed()
 		);
 	}
@@ -355,11 +356,11 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function theUserShouldBeAbleToUploadTheFileAsTheProfilePicture($shouldOrNot) {
 		if ($shouldOrNot !== "not") {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$this->personalGeneralSettingsPage->isFileUploadErrorMsgVisible()
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$this->personalGeneralSettingsPage->isFileUploadErrorMsgVisible()
 			);
 		}

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\LoginPage;
 use Page\PersonalSecuritySettingsPage;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -91,10 +92,10 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 		$appTr = $this->personalSecuritySettingsPage->getLinkedAppByName(
 			$this->appName
 		);
-		PHPUnit\Framework\Assert::assertNotEmpty($appTr);
+		Assert::assertNotEmpty($appTr);
 		$disconnectButton
 			= $this->personalSecuritySettingsPage->getDisconnectButton($appTr);
-		PHPUnit\Framework\Assert::assertNotEmpty($disconnectButton);
+		Assert::assertNotEmpty($disconnectButton);
 	}
 
 	/**
@@ -104,12 +105,12 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 	 */
 	public function theUserDisplayNameAndAppPasswordShouldBeDisplayedOnTheWebUI() {
 		$result = $this->personalSecuritySettingsPage->getAppPasswordResult();
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$this->featureContext->getCurrentUser(),
 			$result[0]->getValue()
 		);
 
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			1, \preg_match(
 				'/(([A-Z]){5}-){3}([A-Z]){5}/', $result[1]->getValue()
 			)

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -25,6 +25,7 @@ require_once 'bootstrap.php';
 use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\PersonalSharingSettingsPage;
+use PHPUnit\Framework\Assert;
 
 /**
  * steps for personal sharing settings
@@ -100,7 +101,7 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function autoAcceptingCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageOnTheWebui() {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAutoAcceptLocalSharesCheckboxDisplayed()
 		);
 	}
@@ -111,7 +112,7 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function autoAcceptingFederatedCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageOnTheWebui() {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAutoAcceptFederatedSharesCheckboxDisplayed()
 		);
 	}
@@ -122,7 +123,7 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 * @return void
 	 */
 	public function allowFindingYouViaAutocompleteCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPage() {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->personalSharingSettingsPage->isAllowFindingYouViaAutocompleteCheckboxDisplayed()
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -24,18 +24,19 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
+use GuzzleHttp\Message\ResponseInterface;
 use Page\FilesPage;
 use Page\FilesPageElement\SharingDialog;
-use Page\PublicLinkFilesPage;
-use Page\SharedWithYouPage;
-use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
-use TestHelpers\HttpRequestHelper;
-use TestHelpers\EmailHelper;
 use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;
 use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
-use GuzzleHttp\Message\ResponseInterface;
 use Page\GeneralErrorPage;
+use Page\PublicLinkFilesPage;
 use Page\SharedWithOthersPage;
+use Page\SharedWithYouPage;
+use PHPUnit\Framework\Assert;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use TestHelpers\EmailHelper;
+use TestHelpers\HttpRequestHelper;
 
 require_once 'bootstrap.php';
 
@@ -508,7 +509,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$expectedWarningMessage
 	) {
 		$warningMessage = $this->publicShareTab->getWarningMessage();
-		PHPUnit\Framework\Assert::assertEquals($expectedWarningMessage, $warningMessage);
+		Assert::assertEquals($expectedWarningMessage, $warningMessage);
 	}
 
 	/**
@@ -522,7 +523,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		// update public-sharing popup, as it might not have been set previously.
 		$this->publicSharingPopup = $this->publicShareTab->updateSharingPopup($this->getSession());
 		$errormessage = $this->publicSharingPopup->getErrorMessage();
-		PHPUnit\Framework\Assert::assertEquals($message, $errormessage);
+		Assert::assertEquals($message, $errormessage);
 	}
 
 	/**
@@ -534,7 +535,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		try {
 			$this->publicShareTab->getLinkUrl($this->linkName);
 		} catch (Exception $e) {
-			PHPUnit\Framework\Assert::assertContains(
+			Assert::assertContains(
 				"could not find link entry with the given name",
 				$e->getMessage()
 			);
@@ -853,7 +854,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserSendsTheShareNotificationByEmailUsingTheWebui() {
-		PHPUnit\Framework\Assert::assertNotNull(
+		Assert::assertNotNull(
 			$this->sharingDialog, "Sharing Dialog is not open"
 		);
 		$this->sharingDialog->sendShareNotificationByEmail($this->getSession());
@@ -866,7 +867,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theUserShouldNotBeAbleToSendTheShareNotificationByEmailUsingTheWebui() {
 		$errorMessage = "";
-		PHPUnit\Framework\Assert::assertNotNull(
+		Assert::assertNotNull(
 			$this->sharingDialog, "Sharing Dialog is not open"
 		);
 		try {
@@ -874,7 +875,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		} catch (Exception $e) {
 			$errorMessage = $e->getMessage();
 		}
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			"could not find notify by email button",
 			$errorMessage,
 			"User was not expected to be able to send the share notification by email but was"
@@ -888,12 +889,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function thePublicShouldNotGetAccessToPublicShareFile() {
 		$warningMessage = $this->publicLinkFilesPage->getWarningMessage();
-		PHPUnit\Framework\Assert::assertEquals('The password is wrong. Try again.', $warningMessage);
+		Assert::assertEquals('The password is wrong. Try again.', $warningMessage);
 
 		$lastCreatedLink = \end($this->createdPublicLinks);
 		$lastSharePath = $lastCreatedLink['url'] . '/authenticate';
 		$currentPath = $this->getSession()->getCurrentUrl();
-		PHPUnit\Framework\Assert::assertEquals($lastSharePath, $currentPath);
+		Assert::assertEquals($lastSharePath, $currentPath);
 	}
 
 	/**
@@ -935,12 +936,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$autocompleteString
 	) {
 		$autocompleteItems = $this->sharingDialog->getAutocompleteItemsList();
-		PHPUnit\Framework\Assert::assertCount(
+		Assert::assertCount(
 			1,
 			$autocompleteItems,
 			"expected 1 autocomplete item but there are " . \count($autocompleteItems)
 		);
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$autocompleteString,
 			$autocompleteItems,
 			"'$autocompleteString' not in autocomplete list"
@@ -1005,7 +1006,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 					&& ($displayName !== $this->featureContext->getCurrentUser())
 					&& ($displayName !== $this->featureContext->getCurrentUserDisplayName())
 				) {
-					PHPUnit\Framework\Assert::assertContains(
+					Assert::assertContains(
 						$fullDisplayText,
 						$autocompleteItems,
 						"'$fullDisplayText' not in autocomplete list"
@@ -1015,13 +1016,13 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			}
 		}
 
-		PHPUnit\Framework\Assert::assertCount(
+		Assert::assertCount(
 			$numExpectedItems,
 			$autocompleteItems,
 			"expected $numExpectedItems in autocomplete list but there are " . \count($autocompleteItems)
 		);
 
-		PHPUnit\Framework\Assert::assertNotContains(
+		Assert::assertNotContains(
 			$notToBeListed,
 			$this->sharingDialog->getAutocompleteItemsList()
 		);
@@ -1033,7 +1034,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUsersOwnNameShouldNotBeListedInTheAutocompleteList() {
-		PHPUnit\Framework\Assert::assertNotContains(
+		Assert::assertNotContains(
 			$this->sharingDialog->userStringsToMatchAutoComplete(
 				$this->filesPage->getMyDisplayname()
 			),
@@ -1051,7 +1052,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function userShouldBeListedInTheAutocompleteListOnTheWebui($username) {
 		$names = $this->sharingDialog->getAutocompleteItemsList();
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$this->sharingDialog->userStringsToMatchAutoComplete($username),
 			$names,
 			"$username not found in autocomplete list"
@@ -1069,7 +1070,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function userShouldNotBeListedInTheAutocompleteListOnTheWebui($username) {
 		$names = $this->sharingDialog->getAutocompleteItemsList();
 		$userString = $this->sharingDialog->userStringsToMatchAutoComplete($username);
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			\in_array($userString, $names),
 			"$username ($userString) found in autocomplete list but not expected"
 		);
@@ -1085,7 +1086,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function groupShouldNotBeListedInTheAutocompleteListOnTheWebui($groupName) {
 		$names = $this->sharingDialog->getAutocompleteItemsList();
 		$groupName = $this->sharingDialog->groupStringsToMatchAutoComplete($groupName);
-		PHPUnit\Framework\Assert::assertNotContains(
+		Assert::assertNotContains(
 			$groupName,
 			$names,
 			"$groupName found in autocomplete list but not expected"
@@ -1100,7 +1101,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function aTooltipWithTheTextShouldBeShownNearTheShareWithField($text) {
-		PHPUnit\Framework\Assert::assertEquals(
+		Assert::assertEquals(
 			$text,
 			$this->sharingDialog->getShareWithTooltip()
 		);
@@ -1112,7 +1113,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAutocompleteListShouldNotBeDisplayed() {
-		PHPUnit\Framework\Assert::assertEmpty(
+		Assert::assertEmpty(
 			$this->sharingDialog->getAutocompleteItemsList()
 		);
 	}
@@ -1125,7 +1126,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserShouldNotBeInShareWithUserList($username) {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->sharingDialog->isUserPresentInShareWithList($username),
 			"user $username is present in the list"
 		);
@@ -1139,7 +1140,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theGroupShouldNotBeInShareWithGroupList($groupName) {
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$this->sharingDialog->isGroupPresentInShareWithList($groupName),
 			"group $groupName is present in the list"
 		);
@@ -1169,28 +1170,28 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 		$row = $this->filesPage->findFileRowByName($itemName, $this->getSession());
 		$sharingBtn = $row->findSharingButton();
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			$sharerName, $this->filesPage->getTrimmedText($sharingBtn)
 		);
 		$sharingDialog = $this->filesPage->openSharingDialog(
 			$itemName, $this->getSession()
 		);
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			$sharerName, $sharingDialog->getSharerName()
 		);
 		if ($fileOrFolder === "folder") {
-			PHPUnit\Framework\Assert::assertContains(
+			Assert::assertContains(
 				"folder-shared.svg",
 				$row->findThumbnail()->getAttribute("style")
 			);
 			$detailsDialog = $this->filesPage->getDetailsDialog();
-			PHPUnit\Framework\Assert::assertContains(
+			Assert::assertContains(
 				"folder-shared.svg",
 				$detailsDialog->findThumbnail()->getAttribute("style")
 			);
 		}
 		if ($sharedWithGroup !== "") {
-			PHPUnit\Framework\Assert::assertSame(
+			Assert::assertSame(
 				$sharedWithGroup,
 				$sharingDialog->getSharedWithGroupName()
 			);
@@ -1210,7 +1211,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$fileRow = $this->sharedWithYouPage->findFileRowByName(
 			$item, $this->getSession()
 		);
-		PHPUnit\Framework\Assert::assertSame($state, $fileRow->getShareState());
+		Assert::assertSame($state, $fileRow->getShareState());
 	}
 
 	/**
@@ -1236,10 +1237,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				break;
 			}
 		}
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$found, "could not find item called $item shared by $sharedBy"
 		);
-		PHPUnit\Framework\Assert::assertSame($state, $currentState);
+		Assert::assertSame($state, $currentState);
 	}
 
 	/**
@@ -1351,7 +1352,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->generalErrorPage->setPagePath($path);
 		$this->generalErrorPage->open();
 		$actualErrorMsg = $this->generalErrorPage->getErrorMessage();
-		PHPUnit\Framework\Assert::assertContains($errorMsg, $actualErrorMsg);
+		Assert::assertContains($errorMsg, $actualErrorMsg);
 	}
 
 	/**
@@ -1414,7 +1415,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				$settingsArray ['personalMessage']
 			);
 			if ($settingsArray['name'] !== null) {
-				PHPUnit\Framework\Assert::assertSame(
+				Assert::assertSame(
 					$settingsArray ['name'], $linkName,
 					"set and retrieved public link names are not the same"
 				);
@@ -1434,7 +1435,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theTextPreviewOfThePublicLinkShouldContain($content) {
 		$previewText = $this->publicLinkFilesPage->getPreviewText();
-		PHPUnit\Framework\Assert::assertContains(
+		Assert::assertContains(
 			$content, $previewText,
 			__METHOD__ . " file preview does not contain expected content"
 		);
@@ -1449,7 +1450,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theContentOfTheFileSharedByLastPublicLinkShouldBeTheSameAs($originalFile) {
 		$response = $this->thePublicDownloadsAllTheSharedDataUsingTheWebui();
-		PHPUnit\Framework\Assert::assertEquals(200, $response->getStatusCode());
+		Assert::assertEquals(200, $response->getStatusCode());
 		$body = $response->getBody()->getContents();
 
 		$user = $this->featureContext->getCurrentUser();
@@ -1458,7 +1459,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->featureContext->downloadFileAsUserUsingPassword($user, $originalFile, $password);
 		$originalContent = $this->featureContext->getResponse()->getBody()->getContents();
 
-		PHPUnit\Framework\Assert::assertSame($originalContent, $body);
+		Assert::assertSame($originalContent, $body);
 	}
 
 	/**
@@ -1480,7 +1481,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function allThePublicShareDownloadLinkShouldBeSame() {
 		$urls = $this->publicLinkFilesPage->getAllDownloadUrls();
 		$url = \array_unique($urls);
-		PHPUnit\Framework\Assert::assertCount(1, $url, "Download links are not the same");
+		Assert::assertCount(1, $url, "Download links are not the same");
 	}
 
 	/**
@@ -1496,7 +1497,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			$address
 		);
 		$lastCreatedPublicLink = \end($this->createdPublicLinks);
-		PHPUnit\Framework\Assert::assertContains($lastCreatedPublicLink["url"], $content);
+		Assert::assertContains($lastCreatedPublicLink["url"], $content);
 	}
 
 	/**
@@ -1511,7 +1512,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$actualMessage = $sharingDialog->getNoSharingMessage(
 			$this->getSession()
 		);
-		PHPUnit\Framework\Assert::assertEquals($message, $actualMessage);
+		Assert::assertEquals($message, $actualMessage);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUITagsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUITagsContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\FilesPage;
 use Page\TagsPage;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -126,7 +127,7 @@ class WebUITagsContext extends RawMinkContext implements Context {
 	public function allTheTagsStartingWithInTheirNameShouldBeListedInTheDropdownListOnTheWebUI($value) {
 		$results = $this->filesPage->getDetailsDialog()->getDropDownTagsSuggestionResults();
 		foreach ($results as $tagResult) {
-			PHPUnit\Framework\Assert::assertStringStartsWith($value, $tagResult->getText());
+			Assert::assertStringStartsWith($value, $tagResult->getText());
 		}
 
 		// check also that all tags that have been created and starts with $value

--- a/tests/acceptance/features/bootstrap/WebUIUserContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUserContext.php
@@ -23,6 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\OwncloudPage;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -56,7 +57,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	 */
 	public function displayNameOfTheCurrentUserOnTheWebUiShouldBe($displayname) {
 		$actualUserName = $this->owncloudPage->getMyDisplayname();
-		PHPUnit\Framework\Assert::assertSame(
+		Assert::assertSame(
 			$displayname, $actualUserName,
 			"displayed username should be '$displayname' but it is '$actualUserName'"
 		);
@@ -74,12 +75,12 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	) {
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$this->owncloudPage->isDisplaynameVisible(),
 				"displayname should be visible, but is not"
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$this->owncloudPage->isDisplaynameVisible(),
 				"displayname should not be visible, but is"
 			);
@@ -96,12 +97,12 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	public function avatarShouldBeShownOnTheWebUI($shouldOrNot) {
 		$should = ($shouldOrNot !== "no");
 		if ($should) {
-			PHPUnit\Framework\Assert::assertTrue(
+			Assert::assertTrue(
 				$this->owncloudPage->isAvatarVisible(),
 				"avatar should be visible, but is not"
 			);
 		} else {
-			PHPUnit\Framework\Assert::assertFalse(
+			Assert::assertFalse(
 				$this->owncloudPage->isAvatarVisible(),
 				"avatar should not be visible, but is"
 			);

--- a/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\FilesPage;
 use Page\SharedWithYouPage;
+use PHPUnit\Framework\Assert;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 require_once 'bootstrap.php';
@@ -94,7 +95,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 		$this->closeDetailsDialog();
 		$pageObject = $this->webUIGeneralContext->getCurrentPageObject();
 		$fileRow = $pageObject->findFileRowByName($file, $this->getSession());
-		PHPUnit\Framework\Assert::assertTrue(
+		Assert::assertTrue(
 			$fileRow->getLockState(),
 			"'$file' should be marked as locked, but its not"
 		);
@@ -111,7 +112,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 		$this->closeDetailsDialog();
 		$pageObject = $this->webUIGeneralContext->getCurrentPageObject();
 		$fileRow = $pageObject->findFileRowByName($file, $this->getSession());
-		PHPUnit\Framework\Assert::assertFalse(
+		Assert::assertFalse(
 			$fileRow->getLockState(),
 			"'$file' should not be marked as locked, but it is"
 		);
@@ -137,7 +138,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 			$lockDialog = $fileRow->openLockDialog();
 		} catch (ElementNotFoundException $e) {
 			if ($should) {
-				PHPUnit\Framework\Assert::fail(
+				Assert::fail(
 					"looking for a lock set by $lockedBy but no lock dialog exists"
 				);
 			} else {
@@ -153,14 +154,14 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 				if ($should) {
 					return true;
 				} else {
-					PHPUnit\Framework\Assert::fail(
+					Assert::fail(
 						"found a lock set by $lockedBy that should not be listed"
 					);
 				}
 			}
 		}
 		if ($should) {
-			PHPUnit\Framework\Assert::fail("cannot find a lock set by $lockedBy");
+			Assert::fail("cannot find a lock set by $lockedBy");
 		} else {
 			return true;
 		}


### PR DESCRIPTION
## Description
`use PHPUnit\Framework\Assert;` everywhere in acceptance tests.

I modified this last week while doing some other acceptance tests. It will be easier to merge this as a separate refactoring PR.

## Motivation and Context
The acceptance tests sometimes `use PHPUnit\Framework\Assert;` and sometimes directly write `PHPUnit\Framework\Assert` - make it consistently have the `use` statement.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
