### PR TITLE
make notificationsShouldBeDisplayedOnTheWebUIWithTheText more flexible

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -344,23 +344,25 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			"expected at least $numExpectedNotifications notifications but only found $numActualNotifications"
 		);
 
-		$notificationCounter = 0;
 		foreach ($expectedNotifications as $expectedNotification) {
 			$expectedNotificationText = $expectedNotification[0];
-			$actualNotificationText = $actualNotifications[$notificationCounter];
-			if ($matching === "matching") {
-				if (!\preg_match($expectedNotificationText, $actualNotificationText)) {
-					throw new Exception(
-						"$actualNotificationText does not match $expectedNotificationText"
-					);
+			$matchingSucceeded = false;
+			foreach ($actualNotifications as $key => $actualNotificationText) {
+				$latestActualNotificationText = $actualNotificationText;
+				if ((($matching !== "matching") && ($expectedNotificationText === $actualNotificationText))
+					|| (($matching === "matching") && (\preg_match($expectedNotificationText, $actualNotificationText)))
+				) {
+					// it matches, remove this actual entry and go on to look for the next expected notification
+					unset($actualNotifications[$key]);
+					$matchingSucceeded = true;
+					break;
 				}
-			} else {
-				Assert::assertEquals(
-					$expectedNotificationText,
-					$actualNotificationText
+			}
+			if (!$matchingSucceeded) {
+				Assert::fail(
+					"$latestActualNotificationText does not match $expectedNotificationText"
 				);
 			}
-			$notificationCounter++;
 		}
 	}
 


### PR DESCRIPTION
## Description
`notificationsShouldBeDisplayedOnTheWebUIWithTheText` already allows there to be extra notifications in the list after the expected notifications.

Actually, it is quite reasonable that some "async" notification could come during the test setup phase, and be listed before the expected notification(s). And less likely, but possible, some "async" notification could come during the test `When` steps and be in the middle of the notifications list.

Also, there is not really a requirement that the notifications are displayed in some particular order.

The code is modified so that the expected notifications are looked for anywhere in the list of actual notifications. If the expected notifications are all found, then the test passes. It does not matter if there are extra notifications anywhere in the list.

## Related Issue
https://github.com/owncloud/password_policy/issues/239

## Motivation and Context
There can be other notifications that come on the webUI while tests are running. They can come before, during or after the `When`  test steps. So they could be in any order in the list of notifications.

## How Has This Been Tested?
Local testing with temporary scenarios that expect more or less notification messages.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
