### PR TITLE
Adjust PublicWebDavContext steps

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -179,8 +179,8 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" using the old WebDAV API
-	 * @Given the public has uploaded file ":filename"
+	 * @When the public uploads file :filename using the old WebDAV API
+	 * @Given the public has uploaded file :filename
 	 *
 	 * @param string $source target file name
 	 *
@@ -192,8 +192,8 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with content ":body" with autorename mode using the public WebDAV API
-	 * @Given the public has uploaded file ":filename" with content ":body" with autorename mode
+	 * @When the public uploads file :filename with content :body with autorename mode using the public WebDAV API
+	 * @Given the public has uploaded file :filename with content :body with autorename mode
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
@@ -205,8 +205,8 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with password ":password" and content ":body" using the public WebDAV API
-	 * @Given the public has uploaded file ":filename" with password ":password" and content ":body"
+	 * @When the public uploads file :filename with password :password and content :body using the public WebDAV API
+	 * @Given the public has uploaded file :filename" with password :password and content :body
 	 *
 	 * @param string $filename target file name
 	 * @param string $password
@@ -221,8 +221,8 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public overwrites file ":filename" with content ":body" using the old WebDAV API
-	 * @Given the public has overwritten file ":filename" with content ":body"
+	 * @When the public overwrites file :filename with content :body using the old WebDAV API
+	 * @Given the public has overwritten file :filename with content :body
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
@@ -234,8 +234,8 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with content ":body" using the public WebDAV API
-	 * @Given the public has uploaded file ":filename" with content ":body"
+	 * @When the public uploads file :filename with content :body using the public WebDAV API
+	 * @Given the public has uploaded file :filename with content :body
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload


### PR DESCRIPTION
## Description
In `PublicWebDavContext` remove double-quotes from parameter names in step text declarations.

## Motivation and Context
In PHPstorm IDE it has trouble matching step text like:
```
    And the public has uploaded file "test.txt" with content "This is a test"
```
with the test step implementation.

If I remove the spaces in the last quoted string then it can find it OK.

It seems to be because the step text declaration has parameters like `":body"` - that does work OK when Gherkin parses it, but the IDE has trouble with it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
