### PR TITLE
test 'restoring a file to an already existing path overrides the file'

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -103,6 +103,31 @@ Feature: Restore deleted files/folders
       | old      | /textfile0.txt           | FOLDER/textfile0.txt |
       | new      | /textfile0.txt           | FOLDER/textfile0.txt |
 
+  @issue-35974
+  Scenario Outline: restoring a file to an already existing path overrides the file
+    Given using <dav-path> DAV path
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has uploaded file with content "file to delete" to "/textfile0.txt"
+    And user "user0" has uploaded file with content "PARENT textfile0 content" to "/PARENT/textfile0.txt"
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user0" restores the file with original path "/textfile0.txt" to "/PARENT/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "204"
+    # Sometimes "/PARENT/textfile0.txt" is found in the trashbin. Should it? Or not?
+    # That seems to be what happens when the restore-overwrite happens properly,
+    # The original /PARENT/textfile0.txt seems to be "deleted" and so goes to the trashbin
+    #And as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in trash
+    And as "user0" file "/PARENT/textfile0.txt" should exist
+    # sometimes the restore from trashbin does overwrite the existing file, but sometimes it does not. That is also surprising.
+    # the current observed behavior is that if the original /PARENT/textfile0.txt ended up in the trashbin,
+    # then the new /PARENT/textfile0.txt has the "file to delete" content.
+    # otherwise /PARENT/textfile0.txt has its old content
+    And the content of file "/PARENT/textfile0.txt" for user "user0" if the file is also in the trashbin should be "file to delete" otherwise "PARENT textfile0 content"
+    #And the content of file "/PARENT/textfile0.txt" for user "user0" should be "file to delete"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
   @issue-35900
   Scenario Outline: restoring a file to a read-only folder
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -249,6 +249,30 @@ class TrashbinContext implements Context {
 	}
 
 	/**
+	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" if the file is also in the trashbin should be "([^"]*)" otherwise "([^"]*)"$/
+	 *
+	 * Note: this is a special step for an unusual bug combination.
+	 *       Delete it when the bug is fixed and the step is no longer needed.
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param string $content
+	 * @param string $alternativeContent
+	 *
+	 * @return void
+	 */
+	public function contentOfFileForUserIfAlsoInTrashShouldBeOtherwise(
+		$fileName, $user, $content, $alternativeContent
+	) {
+		$this->featureContext->downloadFileAsUserUsingPassword($user, $fileName);
+		if ($this->isInTrash($user, $fileName)) {
+			$this->featureContext->downloadedContentShouldBe($content);
+		} else {
+			$this->featureContext->downloadedContentShouldBe($alternativeContent);
+		}
+	}
+
+	/**
 	 * @When /^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" using the trashbin API$/
 	 * @Given /^user "([^"]*)" has restored the (?:file|folder|entry) with original path "([^"]*)"$/
 	 *


### PR DESCRIPTION
## Description
Test scenario to demonstrate the linked issue.

## Related Issue
#35974 

## Motivation and Context

## How Has This Been Tested?
Local acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
