### PR TITLE
Keep DAV properties when file goes to trashbin

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -198,7 +198,8 @@ class ServerFactory {
 						new FileCustomPropertiesBackend(
 							$objectTree,
 							$this->databaseConnection,
-							$this->userSession->getUser()
+							$this->userSession->getUser(),
+							\OC::$server->getRootFolder()
 						)
 					)
 				);

--- a/apps/dav/lib/DAV/AbstractCustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/AbstractCustomPropertiesBackend.php
@@ -21,6 +21,7 @@
 
 namespace OCA\DAV\DAV;
 
+use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
 use OCP\IUser;
 use Sabre\DAV\Exception\Forbidden;
@@ -67,6 +68,11 @@ abstract class AbstractCustomPropertiesBackend implements BackendInterface {
 	protected $user;
 
 	/**
+	 * @var IRootFolder
+	 */
+	protected $rootFolder;
+
+	/**
 	 * Property cache for the filesystem items
 	 * @var array
 	 */
@@ -80,10 +86,12 @@ abstract class AbstractCustomPropertiesBackend implements BackendInterface {
 	public function __construct(
 		Tree $tree,
 		IDBConnection $connection,
-		IUser $user) {
+		IUser $user,
+		IRootFolder $rootFolder) {
 		$this->tree = $tree;
 		$this->connection = $connection;
 		$this->user = $user->getUID();
+		$this->rootFolder = $rootFolder;
 	}
 
 	/**

--- a/apps/dav/lib/DAV/FileCustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/FileCustomPropertiesBackend.php
@@ -105,6 +105,14 @@ class FileCustomPropertiesBackend extends AbstractCustomPropertiesBackend {
 
 		$fileId = $this->deletedItemsCache->get($path);
 		if ($fileId !== null) {
+			$items = $this->rootFolder->getById($fileId);
+			/** @var \OCP\Files\Node $item */
+			foreach ($items as $item) {
+				if ($item->getStorage()->instanceOfStorage(\OCA\Files_Trashbin\Storage::class)) {
+					return;
+				}
+			}
+
 			$statement = $this->connection->prepare(self::DELETE_BY_ID_STMT);
 			$statement->execute([$fileId]);
 			$this->offsetUnset($fileId);

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -228,7 +228,8 @@ class Server {
 						new FileCustomPropertiesBackend(
 							$this->server->tree,
 							\OC::$server->getDatabaseConnection(),
-							\OC::$server->getUserSession()->getUser()
+							\OC::$server->getUserSession()->getUser(),
+							\OC::$server->getRootFolder()
 						)
 					);
 					$this->server->addPlugin($filePropertiesPlugin);
@@ -237,7 +238,8 @@ class Server {
 						new MiscCustomPropertiesBackend(
 							$this->server->tree,
 							\OC::$server->getDatabaseConnection(),
-							\OC::$server->getUserSession()->getUser()
+							\OC::$server->getUserSession()->getUser(),
+							\OC::$server->getRootFolder()
 						)
 					);
 					$this->server->addPlugin($miscPropertiesPlugin);

--- a/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
@@ -87,7 +87,8 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 		$this->backend = new FileCustomPropertiesBackend(
 			$this->tree,
 			\OC::$server->getDatabaseConnection(),
-			$this->user
+			$this->user,
+			\OC::$server->getRootFolder()
 		);
 		$this->plugin = new FileCustomPropertiesPlugin($this->backend);
 		
@@ -436,7 +437,8 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 		$this->backend = new FileCustomPropertiesBackend(
 			$this->tree,
 			$dbConnectionMock,
-			$this->user
+			$this->user,
+			\OC::$server->getRootFolder()
 		);
 
 		$actual = $this->invokePrivate(

--- a/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
@@ -30,6 +30,10 @@ use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\DAV\FileCustomPropertiesBackend;
 use OCA\DAV\DAV\FileCustomPropertiesPlugin;
 use OCA\DAV\Tree;
+use OCA\Files_Trashbin\Storage as TrashbinStorage;
+use OC\Files\Storage\Storage as FileStorage;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\SimpleCollection;
 
@@ -66,7 +70,12 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 	 * @var \OCP\IUser
 	 */
 	private $user;
-	
+
+	/**
+	 * @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject Obj$rootFolder
+	 */
+	private $rootFolder;
+
 	/** @var int */
 	private $maxId;
 
@@ -84,11 +93,12 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 			->method('getUID')
 			->will($this->returnValue($userId));
 
+		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->backend = new FileCustomPropertiesBackend(
 			$this->tree,
 			\OC::$server->getDatabaseConnection(),
 			$this->user,
-			\OC::$server->getRootFolder()
+			$this->rootFolder
 		);
 		$this->plugin = new FileCustomPropertiesPlugin($this->backend);
 		
@@ -348,6 +358,17 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 	public function testDeleteProperty() {
 		$path = '/dummypath';
 		$node = $this->createTestNode(File::class);
+		$nodeAfterDelete = $this->createTestNode(Node::class);
+		$storage = $this->createMock(FileStorage::class);
+		$storage->method('instanceOfStorage')
+			->with(TrashbinStorage::class)
+			->willReturn(false);
+		$nodeAfterDelete->method('getStorage')
+			->willReturn($storage);
+		$this->rootFolder
+			->method('getById')
+			->with($node->getId())
+			->willReturn([$nodeAfterDelete]);
 
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
@@ -384,6 +405,62 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 		);
 		$this->backend->propFind($path, $propFindAfter);
 		$this->assertNull($propFindAfter->get('customprop'));
+	}
+
+	/**
+	 * Test don't delete property if file moved to trashbin
+	 */
+	public function testDontDeletePropertyIfTrashbin() {
+		$path = '/dummypath';
+		$node = $this->createTestNode(File::class);
+		$nodeAfterDelete = $this->createTestNode(Node::class);
+		$storage = $this->createMock(TrashbinStorage::class);
+		$storage->method('instanceOfStorage')
+			->with(TrashbinStorage::class)
+			->willReturn(true);
+		$nodeAfterDelete->method('getStorage')
+			->willReturn($storage);
+
+		$this->rootFolder
+			->method('getById')
+			->with($node->getId())
+			->willReturn([$nodeAfterDelete]);
+
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with($path)
+			->will($this->returnValue($node));
+
+		$this->applyDefaultProps();
+
+		$propPatch = new \Sabre\DAV\PropPatch([
+			'customprop' => 'propvalue',
+		]);
+		$this->backend->propPatch($path, $propPatch);
+		$propPatch->commit();
+		$this->assertEmpty($propPatch->getRemainingMutations());
+
+		$result = $propPatch->getResult();
+		$this->assertEquals(200, $result['customprop']);
+
+		$propFindBefore = new PropFind(
+			$path,
+			[ 'customprop' ],
+			0
+		);
+		$this->backend->propFind($path, $propFindBefore);
+		$this->assertEquals('propvalue', $propFindBefore->get('customprop'));
+
+		$this->plugin->beforeUnbind($path);
+		$this->backend->delete($path);
+
+		$propFindAfter = new PropFind(
+			$path,
+			[ 'customprop' ],
+			0
+		);
+		$this->backend->propFind($path, $propFindAfter);
+		$this->assertEquals('propvalue', $propFindAfter->get('customprop'));
 	}
 
 	public function slicesProvider() {

--- a/apps/dav/tests/unit/DAV/MiscCustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/MiscCustomPropertiesBackendTest.php
@@ -76,7 +76,8 @@ class MiscCustomPropertiesBackendTest extends \Test\TestCase {
 		$this->plugin = new MiscCustomPropertiesBackend(
 			$this->tree,
 			\OC::$server->getDatabaseConnection(),
-			$this->user
+			$this->user,
+			\OC::$server->getRootFolder()
 		);
 		
 		$connection = \OC::$server->getDatabaseConnection();


### PR DESCRIPTION
## Description
Do not delete dav properties when the file is found in the trashbin

## Related Issue

## Motivation and Context
Props are cleaned, files are kept

## How Has This Been Tested?
0. Enable trashbin
1. Upload a file 
2. Add a custom property into `oc_properties` table for it's fileId
3. Put the file into trashbin and restore

### Expected
Property is kept
### Actual
 Property is deleted 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## TODO
- [ ]  deletion from trashbin doesn't go through dav, so when the file is finally deleted it's properties remain