### PR TITLE
Revert void return type declarations that are not valid in PHP 7.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -730,6 +730,12 @@ matrix:
 
     # PHP 7.0
     - PHP_VERSION: 7.0
+      DB_TYPE: sqlite
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
       DB_TYPE: mysql
       TEST_SUITE: phpunit
       INSTALL_SERVER: true

--- a/apps/comments/tests/unit/Dav/EntityCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/EntityCollectionTest.php
@@ -66,11 +66,11 @@ class EntityCollectionTest extends \Test\TestCase {
 		);
 	}
 
-	public function testGetId(): void {
+	public function testGetId() {
 		$this->assertSame($this->collection->getId(), '19');
 	}
 
-	public function testGetChild(): void {
+	public function testGetChild() {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('55')
@@ -83,7 +83,7 @@ class EntityCollectionTest extends \Test\TestCase {
 	/**
 	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
-	public function testGetChildException(): void {
+	public function testGetChildException() {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('55')
@@ -92,7 +92,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->collection->getChild('55');
 	}
 
-	public function testGetChildren(): void {
+	public function testGetChildren() {
 		$this->commentsManager->expects($this->once())
 			->method('getForObject')
 			->with('files', '19')
@@ -104,7 +104,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->assertInstanceOf(\OCA\Comments\Dav\CommentNode::class, $result[0]);
 	}
 
-	public function testFindChildren(): void {
+	public function testFindChildren() {
 		$dt = new \DateTime('2016-01-10 18:48:00');
 		$this->commentsManager->expects($this->once())
 			->method('getForObject')
@@ -117,11 +117,11 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->assertInstanceOf(\OCA\Comments\Dav\CommentNode::class, $result[0]);
 	}
 
-	public function testChildExistsTrue(): void {
+	public function testChildExistsTrue() {
 		$this->assertTrue($this->collection->childExists('44'));
 	}
 
-	public function testChildExistsFalse(): void {
+	public function testChildExistsFalse() {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('44')

--- a/tests/lib/AutoLoaderTest.php
+++ b/tests/lib/AutoLoaderTest.php
@@ -21,22 +21,22 @@ class AutoLoaderTest extends TestCase {
 		$this->loader = new AutoLoader();
 	}
 
-	public function testLoadPublicNamespace(): void {
+	public function testLoadPublicNamespace() {
 		$this->assertEquals([], $this->loader->findClass('OCP\Foo\Bar'));
 	}
 
-	public function testLoadAppNamespace(): void {
+	public function testLoadAppNamespace() {
 		$result = $this->loader->findClass('OCA\Files\Foobar');
 		$this->assertCount(2, $result);
 		$this->assertStringEndsWith('apps/files/foobar.php', $result[0]);
 		$this->assertStringEndsWith('apps/files/lib/foobar.php', $result[1]);
 	}
 
-	public function testLoadCoreNamespaceCore(): void {
+	public function testLoadCoreNamespaceCore() {
 		$this->assertEquals([], $this->loader->findClass('OC\Core\Foo\Bar'));
 	}
 
-	public function testLoadCoreNamespaceSettings(): void {
+	public function testLoadCoreNamespaceSettings() {
 		$this->assertEquals([], $this->loader->findClass('OC\Settings\Foo\Bar'));
 	}
 }

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -37,7 +37,7 @@ class MailerTest extends TestCase {
 		$this->mailer = new Mailer($this->config, $this->logger, $this->defaults);
 	}
 
-	public function testGetSendMailInstanceSendMail(): void {
+	public function testGetSendMailInstanceSendMail() {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
@@ -49,7 +49,7 @@ class MailerTest extends TestCase {
 		$this->assertEquals('/usr/sbin/sendmail -bs', $mailer->getCommand());
 	}
 
-	public function testGetSendMailInstanceSendMailQmail(): void {
+	public function testGetSendMailInstanceSendMailQmail() {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
@@ -60,11 +60,11 @@ class MailerTest extends TestCase {
 		$this->assertEquals('/var/qmail/bin/sendmail -bs', $mailer->getCommand());
 	}
 
-	public function testGetInstanceDefault(): void {
+	public function testGetInstanceDefault() {
 		$this->assertInstanceOf(\Swift_Mailer::class, self::invokePrivate($this->mailer, 'getInstance'));
 	}
 
-	public function testGetInstanceSendmail(): void {
+	public function testGetInstanceSendmail() {
 		$this->config
 			->method('getSystemValue')
 			->will($this->returnValue('sendmail'));
@@ -72,14 +72,14 @@ class MailerTest extends TestCase {
 		$this->assertInstanceOf(\Swift_Mailer::class, self::invokePrivate($this->mailer, 'getInstance'));
 	}
 
-	public function testCreateMessage(): void {
+	public function testCreateMessage() {
 		$this->assertInstanceOf(Message::class, $this->mailer->createMessage());
 	}
 
 	/**
 	 * @expectedException \Exception
 	 */
-	public function testSendInvalidMailException(): void {
+	public function testSendInvalidMailException() {
 		/** @var Message | \PHPUnit\Framework\MockObject\MockObject $message */
 		$message = $this->getMockBuilder(Message::class)
 			->disableOriginalConstructor()->getMock();
@@ -108,11 +108,11 @@ class MailerTest extends TestCase {
 	/**
 	 * @dataProvider mailAddressProvider
 	 */
-	public function testValidateMailAddress($email, $expected): void {
+	public function testValidateMailAddress($email, $expected) {
 		$this->assertSame($expected, $this->mailer->validateMailAddress($email));
 	}
 
-	public function testLogEntry(): void {
+	public function testLogEntry() {
 		$this->mailer = $this->getMockBuilder(Mailer::class)
 			->setConstructorArgs([$this->config, $this->logger, $this->defaults])
 			->setMethods(['getInstance'])


### PR DESCRIPTION
## Description
Some `void` return type declarations were backported into the old `stable10` which is still supposed to support PHP 7.0. Now they are in the "new" master that should be PHP 7.0 compatible. 

`tests/drone/test-phpunit.sh` has logic that only runs all the unit tests if the database is `sqlite` or coverage is requested. Otherwise it sets `--group DB` and only about half the unit tests are run. So CI never happens to run these particular tests on PHP 7.0. This was not noticed until now. It caused a problem in `files_primary_s3` when I adjusted the drone test matrix for that app. I have a test matrix entry/entries that runs all these tests on PHP 7.0 and it failed.

- remove the `void` return type declarations.
- add a drone matrix entry for `phpunit` with `sqlite` on PHP 7.0. That makes all the unit tests run.

Note: I will add a revert of this commit to my "drop PHP 7.0" PR, because that will be the time when this stuff can be put back.

## Related Issue
#35777 

## Motivation and Context
Have unit tests that pass on supported PHP 7.0

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
