### PR TITLE
Run all unit tests on PHP 7.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -730,6 +730,12 @@ matrix:
 
     # PHP 7.0
     - PHP_VERSION: 7.0
+      DB_TYPE: sqlite
+      TEST_SUITE: phpunit
+      INSTALL_SERVER: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.0
       DB_TYPE: mysql
       TEST_SUITE: phpunit
       INSTALL_SERVER: true


### PR DESCRIPTION
## Description
`tests/drone/test-phpunit.sh` has logic that only runs all the unit tests if the database is `sqlite` or coverage is requested. Otherwise it sets `--group DB` and only about half the unit tests are run.

For PHP 7.0 there is not currently a drone matrix entry that has `sqlite`. So we are not getting the full set of unit tests run on PHP  7.0

This draft PR adds the needed matrix entry.

Probably the unit test run will fail because of the PHP 7.1-only code that exists (see PR #35958 ). So after demonstrating here, I will add this commit to that PR.

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
