### PR TITLE
Remove stable10 from federated testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /drone
   path: src
 
-branches: [master, stable10, release*]
+branches: [master, release*]
 
 clone:
   git:
@@ -923,7 +923,7 @@ matrix:
       USE_SERVER: true
       SERVER_PROTOCOL: https
       USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-stable10-qa
+      FEDERATION_OC_VERSION: daily-master-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1380,7 +1380,7 @@ matrix:
       USE_SERVER: true
       SERVER_PROTOCOL: https
       USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-stable10-qa
+      FEDERATION_OC_VERSION: daily-master-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1440,7 +1440,7 @@ matrix:
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
       USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-stable10-qa
+      FEDERATION_OC_VERSION: daily-master-qa
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
@@ -1564,7 +1564,7 @@ matrix:
       USE_SERVER: true
       SERVER_PROTOCOL: http
       USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-stable10-qa
+      FEDERATION_OC_VERSION: daily-master-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1581,7 +1581,7 @@ matrix:
       USE_SERVER: true
       SERVER_PROTOCOL: http
       USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-stable10-qa
+      FEDERATION_OC_VERSION: daily-master-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1598,7 +1598,7 @@ matrix:
       USE_SERVER: true
       SERVER_PROTOCOL: http
       USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-stable10-qa
+      FEDERATION_OC_VERSION: daily-master-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ownCloud Core
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/core/status.svg?branch=stable10)](https://drone.owncloud.com/owncloud/core)
+[![Build Status](https://drone.owncloud.com/api/badges/owncloud/core/status.svg?branch=master)](https://drone.owncloud.com/owncloud/core)
 [![codecov.io](https://codecov.io/github/owncloud/core/coverage.svg?branch=master)](https://codecov.io/github/owncloud/core?branch=master)
 
 **[ownCloud](http://ownCloud.org) gives you freedom and control over your own data.

--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -51,7 +51,7 @@ else
   GROUP="--group DB"
 fi
 
-# still required on stable10 to run unit tests for encryption
+# still required to run unit tests for encryption
 php occ app:enable encryption
 
 # show a little debug information


### PR DESCRIPTION
## Description
- use core `master` for the federated server in acceptance tests, not core `stable10`
- fix the build status badge so it does not refer to `stable10`
- remove another comment that talks about `stable10`

## Related Issue
#35777 

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
