### PR TITLE
Do not require a fixed value for storage_id in createShare.feature

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -23,7 +23,7 @@ Feature: sharing
       | displayname_owner          | User Zero         |
       | item_type                  | file              |
       | mimetype                   | text/plain        |
-      | storage_id                 | home::user0       |
+      | storage_id                 | ANY_VALUE         |
       | share_type                 | user              |
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -46,7 +46,7 @@ Feature: sharing
       | displayname_owner          | User Zero             |
       | item_type                  | file                  |
       | mimetype                   | text/plain            |
-      | storage_id                 | home::user0           |
+      | storage_id                 | ANY_VALUE             |
       | share_type                 | user                  |
     Examples:
       | ocs_api_version | requested_permissions | granted_permissions | ocs_status_code |
@@ -82,7 +82,7 @@ Feature: sharing
       | displayname_owner          | User Zero            |
       | item_type                  | folder               |
       | mimetype                   | httpd/unix-directory |
-      | storage_id                 | home::user0          |
+      | storage_id                 | ANY_VALUE            |
       | share_type                 | user                 |
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -105,7 +105,7 @@ Feature: sharing
       | displayname_owner      | User Zero         |
       | item_type              | file              |
       | mimetype               | text/plain        |
-      | storage_id             | home::user0       |
+      | storage_id             | ANY_VALUE         |
       | share_type             | group             |
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -128,7 +128,7 @@ Feature: sharing
       | displayname_owner      | User Zero            |
       | item_type              | folder               |
       | mimetype               | httpd/unix-directory |
-      | storage_id             | home::user0          |
+      | storage_id             | ANY_VALUE            |
       | share_type             | group                |
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -155,7 +155,7 @@ Feature: sharing
       | displayname_owner          | User Zero         |
       | item_type                  | file              |
       | mimetype                   | text/plain        |
-      | storage_id                 | home::user0       |
+      | storage_id                 | ANY_VALUE         |
       | share_type                 | user              |
     Examples:
       | ocs_api_version | ocs_status_code |


### PR DESCRIPTION
## Description
PR #35923 added test steps that check that share create responses contain a `storage_id` field. Those tests specified the exact value of that field - `home::user0`.

When `files_primary_s3` runs those test scenarios with different storage backends, then `storage_id` has different values and the tests fail.

- do not specify a particular value for `storage_id`, we just want to know that it exists in the response.

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
