### PR TITLE
Revert "Use standalone-chrome-debug:3.141.59-oxygen to get chrome 74"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -539,7 +539,7 @@ services:
         DB_TYPE: oracle
 
   chrome:
-    image: selenium/standalone-chrome-debug:3.141.59-oxygen
+    image: selenium/standalone-chrome-debug:latest
     pull: true
     environment:
       - JAVA_OPTS=-Dselenium.LOGGER.level=WARNING


### PR DESCRIPTION
This reverts commit b81d0e2ee5576728610086fac3b6b9354d8a1e4f.

## Description
See if there is any joy yet with chrome latest for UI tests.

## Related Issue
#35444

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
