### PR TITLE
acceptance test for attempt to modify group share permissions when group sharing is off

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1566,6 +1566,18 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then the last response should be empty
+	 *
+	 * @return void
+	 */
+	public function theFieldsOfTheLastResponseShouldBeEmpty() {
+		$data = $this->getResponseXml()->data[0];
+		Assert::assertEquals(
+			\count($data->element), 0, "last response contains data"
+		);
+	}
+
+	/**
 	 *
 	 * @return string
 	 *

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -292,14 +292,15 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user deletes share with user :username for the current file
+	 * @When /^the user deletes share with (user|group) ((?:[^']*)|(?:[^"]*)) for the current file$/
 	 *
-	 * @param string $username
+	 * @param string $userOrGroup
+	 * @param string $name
 	 *
 	 * @return void
 	 */
-	public function theUserDeleteShareWithUser($username) {
-		$this->sharingDialog->deleteShareWithUser($this->getSession(), $username);
+	public function theUserDeleteShareWithUser($userOrGroup, $name) {
+		$this->sharingDialog->deleteShareWith($this->getSession(), $userOrGroup, \trim($name, '""'));
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -672,18 +672,22 @@ class SharingDialog extends OwncloudPage {
 	}
 
 	/**
-	 * delete user from shared with list
+	 * delete user/group from shared with list
 	 *
 	 * @param Session $session
+	 * @param string $userOrGroup
 	 * @param string $username
 	 *
 	 * @return void
 	 */
-	public function deleteShareWithUser(Session $session, $username) {
+	public function deleteShareWith(Session $session, $userOrGroup, $username) {
 		$shareWithList = $this->getShareWithList();
-		foreach ($shareWithList as $userOrGroup) {
-			if ($userOrGroup->find('xpath', $this->userOrGroupNameSpanXpath)->getHtml() === $username) {
-				$userOrGroup->find('xpath', $this->unShareTabXpath)->click();
+		foreach ($shareWithList as $item) {
+			if ($userOrGroup == "group") {
+				$username = \sprintf($this->groupFramework, $username);
+			}
+			if ($item->find('xpath', $this->userOrGroupNameSpanXpath)->getHtml() === $username) {
+				$item->find('xpath', $this->unShareTabXpath)->click();
 				$this->waitForAjaxCallsToStartAndFinish($session);
 			}
 		}

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -94,5 +94,5 @@ Feature: restrict Sharing
     And the setting "Allow sharing with groups" in the section "Sharing" has been disabled
     When the user opens the share dialog for folder "simple-folder"
     Then group "grp1" should be listed in the shared with list
-    When the user deletes share with user "grp1 (group)" for the current file
+    When the user deletes share with group "grp1" for the current file
     Then group "grp1" should not be listed in the shared with list


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
Includes api test for group share when group sharing is turned off:
- user tries to create group share
- user tries to edit the permissions of existing shares
- user deletes existing group share
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fix: https://github.com/owncloud/core/issues/35916



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

