### PR TITLE
read the correct translations

### DIFF
--- a/lib/private/Helper/LocaleHelper.php
+++ b/lib/private/Helper/LocaleHelper.php
@@ -104,7 +104,7 @@ class LocaleHelper {
 
 		$availableCodes = $langFactory->findAvailableLanguages();
 		foreach ($availableCodes as $languageCode) {
-			$l = $langFactory->get('settings', $languageCode);
+			$l = $langFactory->get('lib', $languageCode);
 
 			// TRANSLATORS this is a self-name of your language for the language switcher
 			$endonym = (string)$l->t('__language_name__');


### PR DESCRIPTION
## Description
This language dropdown fix was previously applied to the "old" `master` in PR #32015
It never made it back to `stable10`. So therefore it never made it to the "new" `master`.

After a transifex update, the "new" `master`  was observed to be "broken".

## Related Issue
#32012
#35970 

## How Has This Been Tested?
In a local browser session.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
