### PR TITLE
No max version check for apps when using release channel git or daily

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -412,8 +412,7 @@ class OC {
 		$tmpl->assign('isAppsOnlyUpgrade', $isAppsOnlyUpgrade);
 
 		// get third party apps
-		$ocVersion = \OCP\Util::getVersion();
-		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
+		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade());
 		$tmpl->assign('productName', 'ownCloud'); // for now
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -91,6 +91,8 @@ class AppManager implements IAppManager {
 	 * @var string[][]
 	 */
 	private $appDirs = [];
+	/** @var Platform */
+	private $platform;
 
 	/**
 	 * @param IUserSession $userSession
@@ -99,6 +101,7 @@ class AppManager implements IAppManager {
 	 * @param ICacheFactory $memCacheFactory
 	 * @param EventDispatcherInterface $dispatcher
 	 * @param IConfig $config
+	 * @param Platform $platform
 	 */
 	public function __construct(
 		IUserSession $userSession = null,
@@ -106,7 +109,8 @@ class AppManager implements IAppManager {
 		IGroupManager $groupManager = null,
 		ICacheFactory $memCacheFactory,
 		EventDispatcherInterface $dispatcher,
-		IConfig $config
+		IConfig $config,
+		Platform $platform
 	) {
 		$this->userSession = $userSession;
 		$this->appConfig = $appConfig;
@@ -114,6 +118,7 @@ class AppManager implements IAppManager {
 		$this->memCacheFactory = $memCacheFactory;
 		$this->dispatcher = $dispatcher;
 		$this->config = $config;
+		$this->platform = $platform;
 
 		// TODO we have no public API for this
 		if (\method_exists($this->memCacheFactory, 'createLocal')) {
@@ -360,12 +365,11 @@ class AppManager implements IAppManager {
 	/**
 	 * Returns a list of apps that need upgrade
 	 *
-	 * @param array $ocVersion ownCloud version as array of version components
 	 * @return array list of app info from apps that need an upgrade
 	 *
 	 * @internal
 	 */
-	public function getAppsNeedingUpgrade($ocVersion) {
+	public function getAppsNeedingUpgrade() {
 		$appsToUpgrade = [];
 		$apps = $this->getInstalledApps();
 		foreach ($apps as $appId) {
@@ -374,7 +378,7 @@ class AppManager implements IAppManager {
 			if ($appDbVersion
 				&& isset($appInfo['version'])
 				&& \version_compare($appInfo['version'], $appDbVersion, '>')
-				&& \OC_App::isAppCompatible($ocVersion, $appInfo)
+				&& \OC_App::isAppCompatible($this->platform, $appInfo)
 			) {
 				$appsToUpgrade[] = $appInfo;
 			}
@@ -519,27 +523,6 @@ class AppManager implements IAppManager {
 		$this->appInfo->set($file, $data, 86400);
 
 		return $info;
-	}
-
-	/**
-	 * Returns a list of apps incompatible with the given version
-	 *
-	 * @param array $version ownCloud version as array of version components
-	 *
-	 * @return array list of app info from incompatible apps
-	 *
-	 * @internal
-	 */
-	public function getIncompatibleApps($version) {
-		$apps = $this->getInstalledApps();
-		$incompatibleApps = [];
-		foreach ($apps as $appId) {
-			$info = $this->getAppInfo($appId);
-			if (!\OC_App::isAppCompatible($version, $info)) {
-				$incompatibleApps[] = $info;
-			}
-		}
-		return $incompatibleApps;
 	}
 
 	/**

--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -176,8 +176,8 @@ class DependencyAnalyzer {
 			return $this->getValue($db);
 		}, $supportedDatabases);
 		$currentDatabase = $this->platform->getDatabase();
-		if (!\in_array($currentDatabase, $supportedDatabases)) {
-			$missing[] = (string)$this->l->t('Following databases are supported: %s', \join(', ', $supportedDatabases));
+		if (!\in_array($currentDatabase, $supportedDatabases, true)) {
+			$missing[] = (string)$this->l->t('Following databases are supported: %s', \implode(', ', $supportedDatabases));
 		}
 		return $missing;
 	}
@@ -283,8 +283,8 @@ class DependencyAnalyzer {
 			$oss = [$oss];
 		}
 		$currentOS = $this->platform->getOS();
-		if (!\in_array($currentOS, $oss)) {
-			$missing[] = (string)$this->l->t('Following platforms are supported: %s', \join(', ', $oss));
+		if (!\in_array($currentOS, $oss, true)) {
+			$missing[] = (string)$this->l->t('Following platforms are supported: %s', \implode(', ', $oss));
 		}
 		return $missing;
 	}
@@ -316,7 +316,7 @@ class DependencyAnalyzer {
 				$missing[] = (string)$this->l->t('ownCloud %s or higher is required.', $minVersion);
 			}
 		}
-		if ($maxVersion !== null) {
+		if ($maxVersion !== null && !\in_array($this->platform->getOcChannel(), ['git', 'daily'], true)) {
 			if ($this->compareBigger($this->platform->getOcVersion(), $maxVersion)) {
 				$missing[] = (string)$this->l->t('ownCloud %s or lower is required.', $maxVersion);
 			}

--- a/lib/private/App/Platform.php
+++ b/lib/private/App/Platform.php
@@ -46,29 +46,29 @@ class Platform {
 	/**
 	 * @return string
 	 */
-	public function getPhpVersion() {
+	public function getPhpVersion(): string {
 		return \phpversion();
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getIntSize() {
+	public function getIntSize(): int {
 		return PHP_INT_SIZE;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getOcVersion() {
+	public function getOcVersion(): string {
 		$v = \OCP\Util::getVersion();
-		return \join('.', $v);
+		return \implode('.', $v);
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDatabase() {
+	public function getDatabase(): string {
 		$dbType = $this->config->getSystemValue('dbtype', 'sqlite');
 		if ($dbType === 'sqlite3') {
 			$dbType = 'sqlite';
@@ -80,7 +80,7 @@ class Platform {
 	/**
 	 * @return string
 	 */
-	public function getOS() {
+	public function getOS(): string {
 		return \php_uname('s');
 	}
 
@@ -88,14 +88,17 @@ class Platform {
 	 * @param $command
 	 * @return bool
 	 */
-	public function isCommandKnown($command) {
+	public function isCommandKnown($command): bool {
 		$path = \OC_Helper::findBinaryPath($command);
 		return ($path !== null);
 	}
 
-	public function getLibraryVersion($name) {
+	public function getLibraryVersion($name): ?string {
 		$repo = new PlatformRepository();
-		$lib = $repo->findLibrary($name);
-		return $lib;
+		return $repo->findLibrary($name);
+	}
+
+	public function getOcChannel(): string {
+		return \OCP\Util::getChannel();
 	}
 }

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -39,6 +39,7 @@
 namespace OC;
 
 use Doctrine\DBAL\Exception\TableExistsException;
+use OC\App\Platform;
 use OC\App\CodeChecker\CodeChecker;
 use OC\App\CodeChecker\EmptyCheck;
 use OC\App\CodeChecker\PrivateCheck;
@@ -364,7 +365,7 @@ class Installer {
 		}
 
 		// check if the app is compatible with this version of ownCloud
-		if (!OC_App::isAppCompatible(\OCP\Util::getVersion(), $info)) {
+		if (!OC_App::isAppCompatible(new Platform(\OC::$server->getConfig()), $info)) {
 			OC_Helper::rmdirr($extractDir);
 			throw new \Exception($l->t("App can't be installed because it is not compatible with this version of ownCloud"));
 		}

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -23,6 +23,7 @@ namespace OC\Repair;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use OC\App\Platform;
 use OC\RepairException;
 use OC_App;
 use OCP\App\AppAlreadyInstalledException;
@@ -292,8 +293,7 @@ class Apps implements IRepairStep {
 				$appsToUpgrade[self::KEY_MISSING][] = $appId;
 				continue;
 			}
-			$version = Util::getVersion();
-			$key = (\OC_App::isAppCompatible($version, $info)) ? self::KEY_COMPATIBLE : self::KEY_INCOMPATIBLE;
+			$key = (\OC_App::isAppCompatible(new Platform($this->config), $info)) ? self::KEY_COMPATIBLE : self::KEY_INCOMPATIBLE;
 			$appsToUpgrade[$key][] = $appId;
 		}
 		return $appsToUpgrade;

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -41,6 +41,7 @@
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\App\Platform;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Db\Db;
 use OC\AppFramework\Utility\TimeFactory;
@@ -616,7 +617,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$groupManager,
 				$c->getMemCacheFactory(),
 				$c->getEventDispatcher(),
-				$c->getConfig()
+				$c->getConfig(),
+				new Platform($c->getConfig())
 			);
 		});
 		$this->registerService('DateTimeZone', function (Server $c) {

--- a/tests/Settings/Controller/AppSettingsControllerTest.php
+++ b/tests/Settings/Controller/AppSettingsControllerTest.php
@@ -60,6 +60,7 @@ class AppSettingsControllerTest extends TestCase {
 		$this->appManager = $this->getMockBuilder(IAppManager::class)
 			->disableOriginalConstructor()->getMock();
 
+		$this->config->method('getSystemValue')->willReturnArgument(1);
 		$this->appSettingsController = new AppSettingsController(
 			'settings',
 			$this->request,

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -29,39 +29,43 @@ class DependencyAnalyzerTest extends TestCase {
 		$this->platformMock = $this->getMockBuilder(Platform::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getPhpVersion')
 			->will($this->returnValue('5.4.3'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getIntSize')
 			->will($this->returnValue('4'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getDatabase')
 			->will($this->returnValue('mysql'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getOS')
 			->will($this->returnValue('Linux'));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('isCommandKnown')
 			->will($this->returnCallback(function ($command) {
 				return ($command === 'grep');
 			}));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getLibraryVersion')
 			->will($this->returnCallback(function ($lib) {
 				if ($lib === 'curl') {
-					return "2.3.4";
+					return '2.3.4';
 				}
 				return null;
 			}));
-		$this->platformMock->expects($this->any())
+		$this->platformMock
 			->method('getOcVersion')
 			->will($this->returnValue('8.0.2'));
 
-		$this->l10nMock = $this->getMockBuilder('\OCP\IL10N')
+		$this->platformMock
+			->method('getOcChannel')
+			->will($this->returnValue('production'));
+
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->l10nMock->expects($this->any())
+		$this->l10nMock
 			->method('t')
 			->will($this->returnCallback(function ($text, $parameters = []) {
 				return \vsprintf($text, $parameters);
@@ -78,7 +82,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param string $maxVersion
 	 * @param string $intSize
 	 */
-	public function testPhpVersion($expectedMissing, $minVersion, $maxVersion, $intSize) {
+	public function testPhpVersion($expectedMissing, $minVersion, $maxVersion, $intSize): void {
 		$app = [
 			'dependencies' => [
 				'php' => []
@@ -104,7 +108,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $databases
 	 */
-	public function testDatabases($expectedMissing, $databases) {
+	public function testDatabases($expectedMissing, $databases): void {
 		$app = [
 			'dependencies' => [
 			]
@@ -124,7 +128,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param string $expectedMissing
 	 * @param string|null $commands
 	 */
-	public function testCommand($expectedMissing, $commands) {
+	public function testCommand($expectedMissing, $commands): void {
 		$app = [
 			'dependencies' => [
 			]
@@ -143,7 +147,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $libs
 	 */
-	public function testLibs($expectedMissing, $libs) {
+	public function testLibs($expectedMissing, $libs): void {
 		$app = [
 			'dependencies' => [
 			]
@@ -163,7 +167,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $oss
 	 */
-	public function testOS($expectedMissing, $oss) {
+	public function testOS($expectedMissing, $oss): void {
 		$app = [
 			'dependencies' => []
 		];
@@ -182,7 +186,7 @@ class DependencyAnalyzerTest extends TestCase {
 	 * @param $expectedMissing
 	 * @param $oc
 	 */
-	public function testOC($expectedMissing, $oc) {
+	public function testOC($expectedMissing, $oc): void {
 		$app = [
 			'dependencies' => []
 		];
@@ -199,7 +203,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesOC() {
+	public function providesOC(): array {
 		return [
 			// no version -> no missing dependency
 			[[], null],
@@ -215,7 +219,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesOS() {
+	public function providesOS(): array {
 		return [
 			[[], null],
 			[[], []],
@@ -227,7 +231,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesLibs() {
+	public function providesLibs(): array {
 		return [
 			// we expect curl to exist
 			[[], 'curl'],
@@ -257,7 +261,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesCommands() {
+	public function providesCommands(): array {
 		return [
 			[[], null],
 			// grep is known on linux
@@ -275,7 +279,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesDatabases() {
+	public function providesDatabases(): array {
 		return [
 			// non BC - in case on databases are defined -> all are supported
 			[[], null],
@@ -288,7 +292,7 @@ class DependencyAnalyzerTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function providesPhpVersion() {
+	public function providesPhpVersion(): array {
 		return [
 			[[], null, null, null],
 			[[], '5.4', null, null],

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -10,6 +10,7 @@
 namespace Test\App;
 
 use OC\App\AppManager;
+use OC\App\Platform;
 use OC\Group\Group;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
@@ -47,6 +48,8 @@ class ManagerTest extends TestCase {
 	protected $eventDispatcher;
 	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
+	/** @var Platform | \PHPUnit_Framework_MockObject_MockObject */
+	private $platform;
 
 	/**
 	 * @return IAppConfig | \PHPUnit\Framework\MockObject\MockObject
@@ -57,12 +60,12 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$config->expects($this->any())
+		$config
 			->method('getValue')
 			->will($this->returnCallback(function ($app, $key, $default) use (&$appConfig) {
 				return (isset($appConfig[$app]) and isset($appConfig[$app][$key])) ? $appConfig[$app][$key] : $default;
 			}));
-		$config->expects($this->any())
+		$config
 			->method('setValue')
 			->will($this->returnCallback(function ($app, $key, $value) use (&$appConfig) {
 				if (!isset($appConfig[$app])) {
@@ -70,20 +73,20 @@ class ManagerTest extends TestCase {
 				}
 				$appConfig[$app][$key] = $value;
 			}));
-		$config->expects($this->any())
+		$config
 			->method('getValues')
 			->will($this->returnCallback(function ($app, $key) use (&$appConfig) {
 				if ($app) {
 					return $appConfig[$app];
-				} else {
-					$values = [];
-					foreach ($appConfig as $app => $appData) {
-						if (isset($appData[$key])) {
-							$values[$app] = $appData[$key];
-						}
-					}
-					return $values;
 				}
+
+				$values = [];
+				foreach ($appConfig as $appId => $appData) {
+					if (isset($appData[$key])) {
+						$values[$appId] = $appData[$key];
+					}
+				}
+				return $values;
 			}));
 
 		return $config;
@@ -99,27 +102,29 @@ class ManagerTest extends TestCase {
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->cache = $this->createMock(ICache::class);
 		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-		$this->cacheFactory->expects($this->any())
+		$this->cacheFactory
 			->method('create')
 			->with('settings')
 			->willReturn($this->cache);
+		$this->platform = $this->createMock(Platform::class);
 		$this->manager = new AppManager(
 			$this->userSession,
 			$this->appConfig,
 			$this->groupManager,
 			$this->cacheFactory,
 			$this->eventDispatcher,
-			$this->config
+			$this->config,
+			$this->platform
 		);
 	}
 
-	protected function expectClearCache() {
+	protected function expectClearCache(): void {
 		$this->cache->expects($this->once())
 			->method('clear')
 			->with('listApps');
 	}
 
-	public function testEnableApp() {
+	public function testEnableApp(): void {
 		$this->expectClearCache();
 		// making sure "files_trashbin" is disabled
 		if ($this->manager->isEnabledForUser('files_trashbin')) {
@@ -131,15 +136,16 @@ class ManagerTest extends TestCase {
 
 	/**
 	 */
-	public function testEnableSecondAppTheme() {
+	public function testEnableSecondAppTheme(): void {
 		$this->expectException(\OCP\App\AppManagerException::class);
 
 		$appThemeName = 'theme-one';
+		/** @var AppManager | \PHPUnit_Framework_MockObject_MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setMethods(['isTheme', 'getAppInfo', 'getAppPath'])
 			->setConstructorArgs([$this->userSession, $this->appConfig,
 				$this->groupManager, $this->cacheFactory, $this->eventDispatcher,
-				$this->config])
+				$this->config, $this->platform])
 			->getMock();
 
 		$manager->expects($this->once())
@@ -158,13 +164,13 @@ class ManagerTest extends TestCase {
 		$manager->enableApp($appThemeName);
 	}
 
-	public function testEnableTheSameThemeTwice() {
+	public function testEnableTheSameThemeTwice(): void {
 		$appThemeName = 'theme-one';
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setMethods(['isTheme', 'getAppInfo', 'getAppPath', 'getInstalledApps'])
 			->setConstructorArgs([$this->userSession, $this->appConfig,
 				$this->groupManager, $this->cacheFactory, $this->eventDispatcher,
-				$this->config])
+				$this->config, $this->platform])
 			->getMock();
 
 		$manager->expects($this->once())
@@ -174,7 +180,7 @@ class ManagerTest extends TestCase {
 			->method('getAppInfo')
 			->willReturn(['types'=>['theme']]);
 
-		$manager->expects($this->any())
+		$manager
 			->method('isTheme')
 			->will(
 				$this->returnCallback(
@@ -192,7 +198,7 @@ class ManagerTest extends TestCase {
 		$manager->enableApp($appThemeName);
 	}
 
-	public function testDisableApp() {
+	public function testDisableApp(): void {
 		$this->expectClearCache();
 		$this->manager->disableApp('files_trashbin');
 		$this->assertEquals('no', $this->appConfig->getValue('files_trashbin', 'enabled', 'no'));
@@ -200,7 +206,7 @@ class ManagerTest extends TestCase {
 
 	/**
 	 */
-	public function testNotEnableIfNotInstalled() {
+	public function testNotEnableIfNotInstalled(): void {
 		$this->expectException(\Exception::class);
 
 		$this->manager->enableApp('some_random_name_which_i_hope_is_not_an_app');
@@ -211,7 +217,7 @@ class ManagerTest extends TestCase {
 		));
 	}
 
-	public function testEnableAppForGroups() {
+	public function testEnableAppForGroups(): void {
 		$groups = [
 			new Group('group1', [], null, $this->eventDispatcher),
 			new Group('group2', [], null, $this->eventDispatcher)
@@ -221,7 +227,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals('["group1","group2"]', $this->appConfig->getValue('test', 'enabled', 'no'));
 	}
 
-	public function dataEnableAppForGroupsAllowedTypes() {
+	public function dataEnableAppForGroupsAllowedTypes(): array {
 		return [
 			[[]],
 			[[
@@ -237,8 +243,9 @@ class ManagerTest extends TestCase {
 	 * @dataProvider dataEnableAppForGroupsAllowedTypes
 	 *
 	 * @param array $appInfo
+	 * @throws \Exception
 	 */
-	public function testEnableAppForGroupsAllowedTypes(array $appInfo) {
+	public function testEnableAppForGroupsAllowedTypes(array $appInfo): void {
 		$groups = [
 			new Group('group1', [], null, $this->eventDispatcher),
 			new Group('group2', [], null, $this->eventDispatcher)
@@ -246,10 +253,11 @@ class ManagerTest extends TestCase {
 		$this->expectClearCache();
 
 		/** @var AppManager|\PHPUnit\Framework\MockObject\MockObject $manager */
-		$manager = $this->getMockBuilder('OC\App\AppManager')
+		$manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([
 				$this->userSession, $this->appConfig, $this->groupManager,
-				$this->cacheFactory, $this->eventDispatcher, $this->config
+				$this->cacheFactory, $this->eventDispatcher, $this->config,
+				$this->platform
 			])
 			->setMethods([
 				'getAppInfo'
@@ -265,7 +273,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals('["group1","group2"]', $this->appConfig->getValue('test', 'enabled', 'no'));
 	}
 
-	public function dataEnableAppForGroupsForbiddenTypes() {
+	public function dataEnableAppForGroupsForbiddenTypes(): array {
 		return [
 			['filesystem'],
 			['prelogin'],
@@ -281,7 +289,7 @@ class ManagerTest extends TestCase {
 	 * @param string $type
 	 *
 	 */
-	public function testEnableAppForGroupsForbiddenTypes($type) {
+	public function testEnableAppForGroupsForbiddenTypes($type): void {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('test can\'t be enabled for groups.');
 
@@ -291,10 +299,11 @@ class ManagerTest extends TestCase {
 		];
 
 		/** @var AppManager|\PHPUnit\Framework\MockObject\MockObject $manager */
-		$manager = $this->getMockBuilder('OC\App\AppManager')
+		$manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([
 				$this->userSession, $this->appConfig, $this->groupManager,
-				$this->cacheFactory, $this->eventDispatcher, $this->config
+				$this->cacheFactory, $this->eventDispatcher, $this->config,
+				$this->platform
 			])
 			->setMethods([
 				'getAppInfo'
@@ -311,34 +320,34 @@ class ManagerTest extends TestCase {
 		$manager->enableAppForGroups('test', $groups);
 	}
 
-	public function testIsInstalledEnabled() {
+	public function testIsInstalledEnabled(): void {
 		$this->appConfig->setValue('test', 'enabled', 'yes');
 		$this->assertTrue($this->manager->isInstalled('test'));
 	}
 
-	public function testIsInstalledDisabled() {
+	public function testIsInstalledDisabled(): void {
 		$this->appConfig->setValue('test', 'enabled', 'no');
 		$this->assertFalse($this->manager->isInstalled('test'));
 	}
 
-	public function testIsInstalledEnabledForGroups() {
+	public function testIsInstalledEnabledForGroups(): void {
 		$this->appConfig->setValue('test', 'enabled', '["foo"]');
 		$this->assertTrue($this->manager->isInstalled('test'));
 	}
 
-	public function testIsEnabledForUserEnabled() {
+	public function testIsEnabledForUserEnabled(): void {
 		$this->appConfig->setValue('test', 'enabled', 'yes');
 		$user = $this->createMock(IUser::class);
 		$this->assertTrue($this->manager->isEnabledForUser('test', $user));
 	}
 
-	public function testIsEnabledForUserDisabled() {
+	public function testIsEnabledForUserDisabled(): void {
 		$this->appConfig->setValue('test', 'enabled', 'no');
 		$user = $this->createMock(IUser::class);
 		$this->assertFalse($this->manager->isEnabledForUser('test', $user));
 	}
 
-	public function testIsEnabledForUserEnabledForGroup() {
+	public function testIsEnabledForUserEnabledForGroup(): void {
 		$user = $this->createMock(IUser::class);
 		$this->groupManager->expects($this->once())
 			->method('getUserGroupIds')
@@ -349,7 +358,7 @@ class ManagerTest extends TestCase {
 		$this->assertTrue($this->manager->isEnabledForUser('test', $user));
 	}
 
-	public function testIsEnabledForUserDisabledForGroup() {
+	public function testIsEnabledForUserDisabledForGroup(): void {
 		$user = $this->createMock(IUser::class);
 		$this->groupManager->expects($this->once())
 			->method('getUserGroupIds')
@@ -360,12 +369,12 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($this->manager->isEnabledForUser('test', $user));
 	}
 
-	public function testIsEnabledForUserLoggedOut() {
+	public function testIsEnabledForUserLoggedOut(): void {
 		$this->appConfig->setValue('test', 'enabled', '["foo"]');
-		$this->assertFalse($this->manager->IsEnabledForUser('test'));
+		$this->assertFalse($this->manager->isEnabledForUser('test'));
 	}
 
-	public function testIsEnabledForUserLoggedIn() {
+	public function testIsEnabledForUserLoggedIn(): void {
 		$user = $this->createMock(IUser::class);
 
 		$this->userSession->expects($this->once())
@@ -380,7 +389,7 @@ class ManagerTest extends TestCase {
 		$this->assertTrue($this->manager->isEnabledForUser('test'));
 	}
 
-	public function testGetInstalledApps() {
+	public function testGetInstalledApps(): void {
 		$this->appConfig->setValue('test1', 'enabled', 'yes');
 		$this->appConfig->setValue('test2', 'enabled', 'no');
 		$this->appConfig->setValue('test3', 'enabled', '["foo"]');
@@ -394,9 +403,9 @@ class ManagerTest extends TestCase {
 		], $this->manager->getInstalledApps());
 	}
 
-	public function testGetAppsForUser() {
+	public function testGetAppsForUser(): void {
 		$user = $this->createMock(IUser::class);
-		$this->groupManager->expects($this->any())
+		$this->groupManager
 			->method('getUserGroupIds')
 			->with($user)
 			->will($this->returnValue(['foo', 'bar']));
@@ -415,10 +424,12 @@ class ManagerTest extends TestCase {
 		], $this->manager->getEnabledAppsForUser($user));
 	}
 
-	public function testGetAppsNeedingUpgrade() {
-		$this->manager = $this->getMockBuilder('\OC\App\AppManager')
+	public function testGetAppsNeedingUpgrade(): void {
+		$this->platform->method('getOcVersion')->willReturn('8.2.0');
+		$this->manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([$this->userSession, $this->appConfig,
-				$this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->config])
+				$this->groupManager, $this->cacheFactory, $this->eventDispatcher,
+				$this->config, $this->platform])
 			->setMethods(['getAppInfo'])
 			->getMock();
 
@@ -434,7 +445,7 @@ class ManagerTest extends TestCase {
 			'testnoversion' => ['id' => 'testnoversion', 'requiremin' => '8.2.0'],
 		];
 
-		$this->manager->expects($this->any())
+		$this->manager
 			->method('getAppInfo')
 			->will($this->returnCallback(
 				function ($appId) use ($appInfos) {
@@ -451,7 +462,7 @@ class ManagerTest extends TestCase {
 		$this->appConfig->setValue('test4', 'enabled', 'yes');
 		$this->appConfig->setValue('test4', 'installed_version', '2.4.0');
 
-		$apps = $this->manager->getAppsNeedingUpgrade('8.2.0');
+		$apps = $this->manager->getAppsNeedingUpgrade();
 
 		$this->assertCount(2, $apps);
 		$this->assertEquals('test1', $apps[0]['id']);
@@ -500,12 +511,12 @@ class ManagerTest extends TestCase {
 	 * @param bool $canInstall
 	 * @param string $opsMode
 	 */
-	public function testCanInstall($canInstall, $opsMode) {
+	public function testCanInstall($canInstall, $opsMode): void {
 		$this->config->expects($this->once())->method('getSystemValue')->willReturn($opsMode);
 		$this->assertEquals($canInstall, $this->manager->canInstall());
 	}
 
-	public function providesDataForCanInstall() {
+	public function providesDataForCanInstall(): array {
 		return [
 			[true, 'single-instance'],
 			[false, 'clustered-instance'],
@@ -519,7 +530,7 @@ class ManagerTest extends TestCase {
 	 * @param string $secondDirVersion
 	 * @param bool $isFirstWinner
 	 */
-	public function testTheMostRecentAppIsFound($firstDirVersion, $secondDirVersion, $isFirstWinner) {
+	public function testTheMostRecentAppIsFound($firstDirVersion, $secondDirVersion, $isFirstWinner): void {
 		$appId = 'bogusapp';
 		$appsParentDir = vfsStream::setup();
 		$firstAppDir = vfsStream::newDirectory('apps')->at($appsParentDir);
@@ -532,7 +543,7 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$appManager->expects($this->any())
+		$appManager
 			->method('getAppRoots')
 			->willReturn([
 				[
@@ -545,7 +556,7 @@ class ManagerTest extends TestCase {
 				]
 			]);
 
-		$appManager->expects($this->any())
+		$appManager
 			->method('getAppVersionByPath')
 			->will($this->onConsecutiveCalls($firstDirVersion, $secondDirVersion));
 
@@ -554,14 +565,14 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($expected, $appPath);
 	}
 
-	public function appInfoDataProvider() {
+	public function appInfoDataProvider(): array {
 		return [
 			[ '1.2.3', '3.2.4', false ],
 			[ '2.2.3', '2.2.1', true ]
 		];
 	}
 
-	public function testPathIsNotCachedForNotFoundApp() {
+	public function testPathIsNotCachedForNotFoundApp(): void {
 		$appId = 'notexistingapp';
 
 		$appManager = $this->getMockBuilder(AppManager::class)
@@ -569,7 +580,7 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$appManager->expects($this->any())
+		$appManager
 			->method('getAppRoots')
 			->willReturn([]);
 
@@ -591,7 +602,7 @@ class ManagerTest extends TestCase {
 		$ocWebRoot,
 		$appData,
 		$expectedAppWebPath
-	) {
+	):  void {
 		$appId = 'notexistingapp';
 
 		$appManager = $this->getMockBuilder(AppManager::class)
@@ -599,11 +610,11 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$appManager->expects($this->any())
+		$appManager
 			->method('getOcWebRoot')
 			->willReturn($ocWebRoot);
 
-		$appManager->expects($this->any())
+		$appManager
 			->method('findAppInDirectories')
 			->with($appId)
 			->willReturn($appData);
@@ -612,7 +623,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($expectedAppWebPath, $appWebPath);
 	}
 
-	public function appAboveWebRootDataProvider() {
+	public function appAboveWebRootDataProvider(): array {
 		return [
 			[
 				'/some/host/path',

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -8,6 +8,7 @@
  */
 
 namespace Test;
+use OC\App\Platform;
 use OCP\IAppConfig;
 use Test\Traits\UserTrait;
 
@@ -272,20 +273,10 @@ class AppTest extends \Test\TestCase {
 	 * @dataProvider appVersionsProvider
 	 */
 	public function testIsAppCompatible($ocVersion, $appInfo, $expectedResult) {
-		$this->assertEquals($expectedResult, \OC_App::isAppCompatible($ocVersion, $appInfo));
-	}
-
-	/**
-	 * Test that the isAppCompatible method also supports passing an array
-	 * as $ocVersion
-	 */
-	public function testIsAppCompatibleWithArray() {
-		$ocVersion = [6];
-		$appInfo = [
-			'requiremin' => '6',
-			'requiremax' => '6',
-		];
-		$this->assertTrue(\OC_App::isAppCompatible($ocVersion, $appInfo));
+		$platform = $this->createMock(Platform::class);
+		$platform->method('getOcChannel')->willReturn('production');
+		$platform->method('getOcVersion')->willReturn($ocVersion);
+		$this->assertEquals($expectedResult, \OC_App::isAppCompatible($platform, $appInfo));
 	}
 
 	/**
@@ -513,7 +504,8 @@ class AppTest extends \Test\TestCase {
 				$c->getGroupManager(),
 				$c->getMemCacheFactory(),
 				$c->getEventDispatcher(),
-				$c->getConfig()
+				$c->getConfig(),
+				new Platform($c->getConfig())
 			);
 		});
 	}
@@ -532,7 +524,8 @@ class AppTest extends \Test\TestCase {
 				$c->getGroupManager(),
 				$c->getMemCacheFactory(),
 				$c->getEventDispatcher(),
-				$c->getConfig()
+				$c->getConfig(),
+				new Platform($c->getConfig())
 			);
 		});
 


### PR DESCRIPTION
## Description

Backport #33360 from `archive/master`  to "new" `master`

This was never backported in the past. The tests pass just by removing the return type declarations that are not PHP 7.0. 

From the original PR:

--------
When installing owncloud from git or the daily release tar ball the max version requirement is no longer checked when installing/enabling apps

This will help with the development and release of apps in general

--------

## Related Issue
- fixes #31518 
- fixes https://github.com/owncloud/core/issues/34120
