### PR TITLE
Properly clean up `configkey` values from oc_appconfig table when disabling encryption

### DIFF
--- a/changelog/unreleased/35980
+++ b/changelog/unreleased/35980
@@ -1,0 +1,9 @@
+Enhancement: Cleanup encryption config values on disabling encryption
+
+occ encryption:disable command was changed to delete some encryption-specific
+config key-value pairs that made reenabling encryption not possible.
+A safety check was added to prevent disabling encryption until all files are
+decrypted. The occ encryption:disable command exits with an error code and message
+if the system still has any encrypted files.
+
+https://github.com/owncloud/core/pull/35980

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -22,19 +22,24 @@
 namespace OC\Core\Command\Encryption;
 
 use OCP\IConfig;
+use OCP\IDBConnection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Command {
+	/** @var IDBConnection */
+	protected $db;
 	/** @var IConfig */
 	protected $config;
 
 	/**
+	 * @param IDBConnection $db
 	 * @param IConfig $config
 	 */
-	public function __construct(IConfig $config) {
+	public function __construct(IDBConnection $db, IConfig $config) {
 		parent::__construct();
+		$this->db = $db;
 		$this->config = $config;
 	}
 
@@ -46,8 +51,21 @@ class Disable extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->expr()->literal('1'))
+			->from('filecache', 'fc')
+			->where($qb->expr()->gte('fc.encrypted', $qb->expr()->literal('1')))
+			->setMaxResults(1);
+		$results = $qb->execute();
+		$hasEncryptedFiles = (bool) $results->fetchColumn(0);
+		$results->closeCursor();
+		if ($hasEncryptedFiles !== false) {
+			$output->writeln('<info>The system still have encrypted files. Please decrypt them all before disabling encryption.</info>');
+			return 1;
+		}
+
 		/**
-		 * Delete both useMasterKey and userSepecificKey
+		 * Delete both useMasterKey and userSpecificKey
 		 */
 		$this->config->deleteAppValue('encryption', 'useMasterKey');
 		$this->config->deleteAppValue('encryption', 'userSpecificKey');
@@ -56,10 +74,10 @@ class Disable extends Command {
 
 		if ($this->config->getAppValue('core', 'encryption_enabled', 'no') !== 'yes') {
 			$output->writeln('Encryption is already disabled');
-			return 0;
+		} else {
+			$this->config->setAppValue('core', 'encryption_enabled', 'no');
+			$output->writeln('<info>Encryption disabled</info>');
 		}
-
-		$this->config->setAppValue('core', 'encryption_enabled', 'no');
-		$output->writeln('<info>Encryption disabled</info>');
+		return 0;
 	}
 }

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -46,11 +46,20 @@ class Disable extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		/**
+		 * Delete both useMasterKey and userSepecificKey
+		 */
+		$this->config->deleteAppValue('encryption', 'useMasterKey');
+		$this->config->deleteAppValue('encryption', 'userSpecificKey');
+
+		$output->writeln('<info>Cleaned up config</info>');
+
 		if ($this->config->getAppValue('core', 'encryption_enabled', 'no') !== 'yes') {
 			$output->writeln('Encryption is already disabled');
-		} else {
-			$this->config->setAppValue('core', 'encryption_enabled', 'no');
-			$output->writeln('<info>Encryption disabled</info>');
+			return 0;
 		}
+
+		$this->config->setAppValue('core', 'encryption_enabled', 'no');
+		$output->writeln('<info>Encryption disabled</info>');
 	}
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -98,7 +98,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->getDatabaseConnection()));
 
-	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig(), \OC::$server->getEncryptionManager()));
 	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager()));
 	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager()));

--- a/tests/Core/Command/Encryption/DisableTest.php
+++ b/tests/Core/Command/Encryption/DisableTest.php
@@ -50,8 +50,9 @@ class DisableTest extends TestCase {
 
 	public function dataDisable() {
 		return [
-			['yes', true, 'Encryption disabled'],
-			['no', false, 'Encryption is already disabled'],
+			['yes', true, '1', 'Encryption disabled'],
+			['yes', true, '', 'Encryption disabled'],
+			['no', false, false, 'Encryption is already disabled'],
 		];
 	}
 
@@ -60,22 +61,37 @@ class DisableTest extends TestCase {
 	 *
 	 * @param string $oldStatus
 	 * @param bool $isUpdating
+	 * @param bool $masterKeyEnabled
 	 * @param string $expectedString
 	 */
-	public function testDisable($oldStatus, $isUpdating, $expectedString) {
-		$this->config->expects($this->once())
+	public function testDisable($oldStatus, $isUpdating, $masterKeyEnabled, $expectedString) {
+		$this->config->expects($this->exactly(1))
 			->method('getAppValue')
-			->with('core', 'encryption_enabled', $this->anything())
-			->willReturn($oldStatus);
+			->willReturnMap([
+					['core', 'encryption_enabled', 'no', $oldStatus],
+				]
+			);
 
-		$this->consoleOutput->expects($this->once())
+		$this->consoleOutput->expects($this->exactly(2))
 			->method('writeln')
-			->with($this->stringContains($expectedString));
+			->will($this->onConsecutiveCalls([
+				$this->stringContains('<info>Cleaned up config</info>'),
+				$this->stringContains($expectedString),
+			]));
 
 		if ($isUpdating) {
-			$this->config->expects($this->once())
+			$this->config
 				->method('setAppValue')
-				->with('core', 'encryption_enabled', 'no');
+				->willReturnMap([
+						['core', 'encryption_enabled', 'no', true],
+					]
+				);
+			$this->config
+				->method('deleteAppValue')
+				->willReturnMap([
+					['encryption', 'useMasterKey', true],
+					['encryption', 'userSpecificKey', true],
+				]);
 		}
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);


### PR DESCRIPTION
Follow-up of https://github.com/owncloud/core/pull/35756 because of changes in the branching model.

## Description
Currently, we have the problem that we do not correctly clean up the configkey values in the oc_appconfig table when disabling encryption.

Specifically the useMasterKey key for the encryption app, which stays set to 1. This seems to lead to the encryption_enabled key for core to remain set to no so when trying to reenable the encryption app and running encryption:select-encryption-type masterkey, this will fail.

The same has been observed for user-keys encryption. This PR fixes this behavior by properly cleaning up the configkey values and making re-enabling of encryption possible.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3410

## How Has This Been Tested?

- Manually by first activating encryption by running: `occ app:enable encryption`, `occ encryption:enable`, `occ encryption:select-encryption-type masterkey -y` and `encryption:encrypt-all`

- Then disable it with `occ app:disable encryption`, `occ encryption:disable` 

- Re-enabling encryption once again and check that when running `occ encryption:select-encryption-type masterkey`, no error is triggered.

Tested the same with user-keys encryption.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>