### PR TITLE
testing app is not needed for unit tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -684,91 +684,77 @@ matrix:
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: mysqlmb4
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: postgres
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: oracle
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       COVERAGE: true
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     # PHP 7.0
     - PHP_VERSION: 7.0
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.0
       DB_TYPE: mysql
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.0
       DB_TYPE: mysqlmb4
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.0
       DB_TYPE: postgres
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.0
       DB_TYPE: oracle
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     # PHP 7.2
     - PHP_VERSION: 7.2
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.2
       DB_TYPE: mariadb
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     # PHP 7.3
     - PHP_VERSION: 7.3
       DB_TYPE: sqlite
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.3
       DB_TYPE: mariadb
       TEST_SUITE: phpunit
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
   # Files External
     - PHP_VERSION: 7.1
@@ -777,7 +763,6 @@ matrix:
       DB_TYPE: sqlite
       FILES_EXTERNAL_TYPE: webdav_apache
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit
@@ -785,7 +770,6 @@ matrix:
       DB_TYPE: sqlite
       FILES_EXTERNAL_TYPE: smb_samba
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit
@@ -793,7 +777,6 @@ matrix:
       DB_TYPE: sqlite
       FILES_EXTERNAL_TYPE: smb_windows
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
   # files_primary_s3
 
@@ -804,7 +787,6 @@ matrix:
       OBJECTSTORE: scality
       PRIMARY_OBJECTSTORE: files_primary_s3
       INSTALL_SERVER: true
-      INSTALL_TESTING_APP: true
 
   # API Acceptance tests
     - PHP_VERSION: 7.1

--- a/tests/Core/Command/Apps/AppsDisableTest.php
+++ b/tests/Core/Command/Apps/AppsDisableTest.php
@@ -41,7 +41,7 @@ class AppsDisableTest extends TestCase {
 		$command = new Disable(\OC::$server->getAppManager());
 		$this->commandTester = new CommandTester($command);
 
-		\OC_App::enable('testing');
+		\OC_App::enable('comments');
 	}
 
 	/**
@@ -58,7 +58,7 @@ class AppsDisableTest extends TestCase {
 
 	public function providesAppIds() {
 		return [
-			['testing', 'testing disabled'],
+			['comments', 'comments disabled'],
 			['hui-buh', 'No such app enabled: hui-buh'],
 			['files', 'files can\'t be disabled.'],
 		];

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -60,7 +60,7 @@ class AppsEnableTest extends TestCase {
 
 	public function providesAppIds() {
 		return [
-			['testing', 'testing enabled'],
+			['comments', 'comments enabled'],
 			['hui-buh', 'hui-buh not found'],
 			['updatenotification', 'updatenotification enabled for groups: admin', 'admin'],
 			['hui-buh', 'hui-buh not found', 'admin'],

--- a/tests/Core/Command/Apps/AppsListTest.php
+++ b/tests/Core/Command/Apps/AppsListTest.php
@@ -41,7 +41,7 @@ class AppsListTest extends TestCase {
 		$command = new ListApps(\OC::$server->getAppManager());
 		$this->commandTester = new CommandTester($command);
 
-		\OC_App::enable('testing');
+		\OC_App::enable('comments');
 	}
 
 	/**
@@ -59,7 +59,7 @@ class AppsListTest extends TestCase {
 		return [
 			[[], '- files: 1.5'],
 			[['--shipped' => 'true'], '- dav: 0.4.0'],
-			[['--shipped' => 'false'], '- testing:'],
+			[['--shipped' => 'false'], '- comments:'],
 			[['search-pattern' => 'dav'], '- dav: 0.4.0']
 		];
 	}


### PR DESCRIPTION
## Description
Some app enable/disable/list command unit tests were using the app called "testing" as an example app to enable/disable/list. The `testing` app is no longer in the `core`  repo, so we should not rely on it being there when running "unit "  tests.

Use the `comments` app as the example in the unit tests. I chose it because it is the first app in the list that is in the `core` repo, and it can be enabled/disabled harmlessly.

## Related Issue
- Fixes #35988 

## Motivation and Context
Get rid of ccore test dependencies on non-core apps.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
