### PR TITLE
Restrict deletion of share_folder by user

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -100,7 +100,11 @@ class View {
 	/** @var \OC\User\Manager  */
 	private $userManager;
 
+	/** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
 	private $eventDispatcher;
+
+	/** @var \OCP\IConfig */
+	private $config;
 
 	private static $ignorePartFile = false;
 
@@ -121,6 +125,7 @@ class View {
 		$this->lockingEnabled = !($this->lockingProvider instanceof \OC\Lock\NoopLockingProvider);
 		$this->userManager = \OC::$server->getUserManager();
 		$this->eventDispatcher = \OC::$server->getEventDispatcher();
+		$this->config = \OC::$server->getConfig();
 	}
 
 	public function getAbsolutePath($path = '/') {
@@ -347,6 +352,11 @@ class View {
 	 */
 	public function rmdir($path) {
 		return $this->emittingCall(function () use (&$path) {
+			if (($path !== '') &&
+				(\strpos($this->config->getSystemValue('share_folder', '/'), $path) !== false)) {
+				Util::writeLog("core", "The folder $path could not be deleted as it is configured as share_folder in config.", Util::WARN);
+				return false;
+			}
 			$absolutePath = $this->getAbsolutePath($path);
 			$mount = Filesystem::getMountManager()->find($absolutePath);
 			if ($mount->getInternalPath($absolutePath) === '') {


### PR DESCRIPTION
Restrict deletion of share_folder by user

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The idea behind this PR is to restrict user to delete the folder `share_folder` set in the config.php. In this change, I have tried to restrict the deletion from the View and from the dav app (i.e, access via webdav ).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Restrict user to delete folder `share_folder` set in the config.php.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Add `SharedFolder` to the config as `share_folder => 'SharedFolder'`
- Tested by deleting the folder from the UI results in the notification as shown below: 
![sharenoitification](https://user-images.githubusercontent.com/3600427/62678563-78595500-b9cf-11e9-9bcd-ea72776f6c57.png)
- The above test covers testing of webdav request to delete.
- Created a script to access the View of a user which has `SharedFolder` and then called the `rmdir` method of View. Received the return as false.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
