### PR TITLE
Run PHP unit tests on PHP 7.0

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -114,6 +114,21 @@ local pipelines = [
   ),
 ] + [
   #
+  # php 7.0
+  #
+  pipeline.phpunit(
+    php='7.0',
+    db=matrix,
+    coverage=false,
+    trigger=trigger,
+    depends_on=phpunit_deps
+  )
+  for matrix in [
+    'sqlite',
+    'mariadb:10.2',
+  ]
+] + [
+  #
   # php 7.1
   #
   pipeline.phpunit(

--- a/.drone.yml
+++ b/.drone.yml
@@ -1030,6 +1030,211 @@ depends_on:
 
 ---
 kind: pipeline
+name: phpunit-php7.0-sqlite
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: sqlite
+
+- name: owncloud-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown www-data -R /drone/src
+
+- name: owncloud-logfile
+  pull: always
+  image: owncloudci/php:7.0
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: false
+    DB_TYPE: sqlite
+
+trigger:
+  ref:
+  - refs/heads/master
+  - refs/tags/**
+  - refs/pull/**
+
+depends_on:
+- coding-standard
+- phan-php7.1
+- stan-php7.1
+
+---
+kind: pipeline
+name: phpunit-php7.0-mariadb10.2
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: mariadb
+
+- name: owncloud-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown www-data -R /drone/src
+
+- name: owncloud-logfile
+  pull: always
+  image: owncloudci/php:7.0
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: false
+    DB_TYPE: mariadb
+
+services:
+- name: mariadb
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/heads/master
+  - refs/tags/**
+  - refs/pull/**
+
+depends_on:
+- coding-standard
+- phan-php7.1
+- stan-php7.1
+
+---
+kind: pipeline
 name: phpunit-php7.1-sqlite
 
 platform:
@@ -11531,6 +11736,8 @@ depends_on:
 - caldav-old-php7.1-mariadb10.2
 - carddav-new-php7.1-mariadb10.2
 - carddav-old-php7.1-mariadb10.2
+- phpunit-php7.0-sqlite
+- phpunit-php7.0-mariadb10.2
 - phpunit-php7.1-sqlite
 - phpunit-php7.1-mariadb10.2
 - phpunit-php7.1-mysql5.5


### PR DESCRIPTION
## Description
The new drone matrix had been generated a lot from the "old" master, which did not support PHP  7.0. So when the drone script was implemented it was missing unit test runs on PHP 7.0.

Put them back.

Other tests like JavaScript (not PHP anyway) and acceptance tests, are running on PHP 7.1 and that is fine for regular CI. As a separate "thing to do" we can run acceptance tests with PHP 7.0 (and 7.2 7.3) during the release QA process.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
