### PR TITLE
Document phoenix.baseUrl in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -442,6 +442,15 @@ $CONFIG = array(
 'overwrite.cli.url' => '',
 
 /**
+ * If phoenix.baseUrl is set, public and private links will be redirected to this
+ * url. Phoenix will handle these links accordingly.
+ *
+ * As an example, in case 'phoenix.baseUrl' is set to 'http://phoenix,example.com',
+ * the shared link 'http://ocx.example.com/index.php/s/THoQjwYYMJvXMdW' will be redirected
+ * by ownCloud to 'http://phoenix.example.com/index.html#//s/THoQjwYYMJvXMdW'.
+ */
+'phoenix.baseUrl' => '',
+/**
  * To have clean URLs without `/index.php` this parameter needs to be configured.
  *
  * This parameter will be written as `RewriteBase` on update and installation of


### PR DESCRIPTION
## Description
The new config parameter phoenix.baseUrl is now documented in config.sample.php

## Related Issue
- refs #35932 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
