### PR TITLE
Don't list files on file drop folders + rename existing files when up…

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
@@ -22,11 +22,11 @@
 namespace OCA\DAV\Files\PublicFiles;
 
 use OCP\Constants;
-use OCP\Files\FileInfo;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\IRequest;
 use OCP\Share\IShare;
 use Sabre\DAV\Collection;
 use Sabre\DAV\Exception\Forbidden;
@@ -42,14 +42,20 @@ class PublicSharedRootNode extends Collection {
 
 	/** @var IShare */
 	private $share;
+	/**
+	 * @var IRequest
+	 */
+	private $request;
 
 	/**
 	 * PublicSharedRootNode constructor.
 	 *
 	 * @param IShare $share
+	 * @param IRequest $request
 	 */
-	public function __construct(IShare $share) {
+	public function __construct(IShare $share, IRequest $request) {
 		$this->share = $share;
+		$this->request = $request;
 	}
 	/**
 	 * Returns an array with all the child nodes
@@ -57,6 +63,11 @@ class PublicSharedRootNode extends Collection {
 	 * @return INode[]
 	 */
 	public function getChildren() {
+		// Within a PROPFIND request we return no listing in case the share is a file drop folder
+		if ($this->isPropfind() && $this->isFileDropFolder()) {
+			return [];
+		}
+
 		if ($this->share->getNodeType() === 'folder') {
 			$nodes = $this->share->getNode()->getDirectoryListing();
 		} else {
@@ -150,5 +161,17 @@ class PublicSharedRootNode extends Collection {
 
 	protected function checkPermissions($permissions) {
 		return ($this->share->getPermissions() & $permissions) === $permissions;
+	}
+
+	private function isPropfind() {
+		return $this->request->getMethod() === 'PROPFIND';
+	}
+
+	/**
+	 * An anonymous upload folder aka file drop folder has only the create permission
+	 * @return bool
+	 */
+	public function isFileDropFolder(): bool {
+		return $this->share->getPermissions() === Constants::PERMISSION_CREATE;
 	}
 }

--- a/apps/dav/lib/Files/PublicFiles/RootCollection.php
+++ b/apps/dav/lib/Files/PublicFiles/RootCollection.php
@@ -52,10 +52,15 @@ class RootCollection extends Collection {
 	 * @var bool
 	 */
 	public $disableListing = false;
+	/**
+	 * @var \OCP\IRequest
+	 */
+	private $request;
 
 	public function __construct() {
 		$this->l10n = \OC::$server->getL10N('dav');
 		$this->shareManager = \OC::$server->getShareManager();
+		$this->request = \OC::$server->getRequest();
 	}
 
 	/**
@@ -71,7 +76,7 @@ class RootCollection extends Collection {
 	public function getChild($name) {
 		try {
 			$share = $this->shareManager->getShareByToken($name);
-			return new PublicSharedRootNode($share);
+			return new PublicSharedRootNode($share, $this->request);
 		} catch (ShareNotFound $ex) {
 			throw new NotFound();
 		}
@@ -86,8 +91,8 @@ class RootCollection extends Collection {
 		}
 
 		$shares = $this->shareManager->getAllSharedWith(null, [Constants::SHARE_TYPE_LINK]);
-		return \array_map(static function (IShare $share) {
-			return new PublicSharedRootNode($share);
+		return \array_map(function (IShare $share) {
+			return new PublicSharedRootNode($share, $this->request);
 		}, $shares);
 	}
 }

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -134,6 +134,7 @@ class Server {
 		if ($this->isRequestForSubtree(['public-files'])) {
 			$authPlugin->addBackend(new PublicSharingAuth($this->server, OC::$server->getShareManager()));
 			$this->server->addPlugin(new PublicLinkEventsPlugin(\OC::$server->getEventDispatcher()));
+			$this->server->addPlugin(new PublicFilesPlugin());
 		}
 		$authPlugin->addBackend(new PublicAuth());
 		$this->server->addPlugin($authPlugin);
@@ -156,7 +157,6 @@ class Server {
 		$this->server->addPlugin(new LockPlugin());
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 		$this->server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory())));
-		$this->server->addPlugin(new PublicFilesPlugin());
 
 		// ACL plugin not used in files subtree, also it causes issues
 		// with performance and locking issues because it will query

--- a/apps/dav/tests/unit/Files/PublicFiles/PublicFilesPluginTest.php
+++ b/apps/dav/tests/unit/Files/PublicFiles/PublicFilesPluginTest.php
@@ -32,7 +32,9 @@ use Test\TestCase;
 class PublicFilesPluginTest extends TestCase {
 	public function testInit() {
 		$server = $this->createMock(Server::class);
-		$server->expects($this->once())->method('on')->with('propFind');
+		$server->expects($this->exactly(2))->method('on')->withConsecutive(
+			['propFind'],
+			['beforeMethod:PUT']);
 
 		$plugin = new PublicFilesPlugin();
 		$plugin->initialize($server);


### PR DESCRIPTION
…loading to file drop folders

## Description
- File drop folders (only share permission CREATE) shall not list folder contents.
- in case an uploaded file already exists the auto renaming will rename the file

## How Has This Been Tested?
- set phoenix.baseUrl in config.php
- create a file drop only share in oc10
- open public link in browser
- see the file drop screen
- upload files

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
