### PR TITLE
Adjust 'Unable to create user' exception message text

### DIFF
--- a/lib/private/User/Service/CreateUserService.php
+++ b/lib/private/User/Service/CreateUserService.php
@@ -125,7 +125,7 @@ class CreateUserService {
 			}
 			$user = $this->userManager->createUser($username, $password);
 		} catch (\Exception $exception) {
-			throw new CannotCreateUserException("Unable to create user due to exception: {$exception->getMessage()}");
+			throw new CannotCreateUserException("Unable to create user: {$exception->getMessage()}");
 		}
 
 		if ($user === false) {

--- a/tests/lib/User/Service/CreateUserServiceTest.php
+++ b/tests/lib/User/Service/CreateUserServiceTest.php
@@ -140,7 +140,7 @@ class CreateUserServiceTest extends TestCase {
 	}
 
 	/**
-	 * @expectedExceptionMessage Unable to create user due to exception:
+	 * @expectedExceptionMessage Unable to create user:
 	 * @expectedException  \OCP\User\Exceptions\CannotCreateUserException
 	 */
 	public function testUserCreateException() {


### PR DESCRIPTION
## Description
Adjust the text for when there is an "exception" adding a user from:
```
Unable to create user due to exception:
```
to
```
Unable to create user:
```

The text is emitted in places that could be presented to a user on a UI (e.g. the current webUI for user management, or a future phoenix-style UI for managing users...), and it also goes in the OCS status message text of the Provisioning API. The message text is likely to be displayed by whatever client software is using the provisioning API.

The words `due to exception` give me the impression that there was a "server error" (something like a `500` where the server "exploded"). But actually this is reporting that the user was not created because of some good reason (e.g. the proposed password did not meet the system password policy). Saying `due to exception` might be a bit scary for people who read it.

## Related Issue
#36020  (see item 2)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
