### PR TITLE
Roles API + allow setting permissions via share attribues

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -35,6 +35,7 @@ use OC\Core\Controller\CloudController;
 use OC\Core\Controller\CronController;
 use OC\Core\Controller\LoginController;
 use OC\Core\Controller\LostController;
+use OC\Core\Controller\RolesController;
 use OC\Core\Controller\TokenController;
 use OC\Core\Controller\TwoFactorChallengeController;
 use OC\Core\Controller\UserController;
@@ -65,7 +66,7 @@ class Application extends App {
 		/**
 		 * Controllers
 		 */
-		$container->registerService('LostController', function (SimpleContainer $c) {
+		$container->registerService('LostController', static function (SimpleContainer $c) {
 			return new LostController(
 				$c->query('AppName'),
 				$c->query('Request'),
@@ -83,7 +84,7 @@ class Application extends App {
 				$c->query('UserSession')
 			);
 		});
-		$container->registerService('UserController', function (SimpleContainer $c) {
+		$container->registerService('UserController', static function (SimpleContainer $c) {
 			return new UserController(
 				$c->query('AppName'),
 				$c->query('Request'),
@@ -95,7 +96,7 @@ class Application extends App {
 				$c->query('L10N')
 			);
 		});
-		$container->registerService('AvatarController', function (SimpleContainer $c) {
+		$container->registerService('AvatarController', static function (SimpleContainer $c) {
 			/** @var IServerContainer $server */
 			$server = $c->query('ServerContainer');
 			return new AvatarController(
@@ -110,7 +111,7 @@ class Application extends App {
 				$c->query('Logger')
 			);
 		});
-		$container->registerService('LoginController', function (SimpleContainer $c) {
+		$container->registerService('LoginController', static function (SimpleContainer $c) {
 			return new LoginController(
 				$c->query('AppName'),
 				$c->query('Request'),
@@ -122,7 +123,7 @@ class Application extends App {
 				$c->query('TwoFactorAuthManager')
 			);
 		});
-		$container->registerService('TwoFactorChallengeController', function (SimpleContainer $c) {
+		$container->registerService('TwoFactorChallengeController', static function (SimpleContainer $c) {
 			return new TwoFactorChallengeController(
 				$c->query('AppName'),
 				$c->query('Request'),
@@ -131,7 +132,7 @@ class Application extends App {
 				$c->query('Session'),
 				$c->query('URLGenerator'));
 		});
-		$container->registerService('TokenController', function (SimpleContainer $c) {
+		$container->registerService('TokenController', static function (SimpleContainer $c) {
 			return new TokenController(
 				$c->query('AppName'),
 				$c->query('Request'),
@@ -141,13 +142,23 @@ class Application extends App {
 				$c->query('SecureRandom')
 			);
 		});
-		$container->registerService('CloudController', function (SimpleContainer $c) {
+		$container->registerService('CloudController', static function (SimpleContainer $c) {
 			return new CloudController(
 				$c->query('AppName'),
 				$c->query('Request')
 			);
 		});
-		$container->registerService('CronController', function (SimpleContainer $c) {
+		$container->registerService('RolesController', static function (SimpleContainer $c) {
+			/** @var IServerContainer $serverContainer */
+			$serverContainer = $c->query('ServerContainer');
+			return new RolesController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('L10N'),
+				$serverContainer->getEventDispatcher()
+			);
+		});
+		$container->registerService('CronController', static function (SimpleContainer $c) {
 			return new CronController(
 				$c->query('AppName'),
 				$c->query('Request'),
@@ -160,52 +171,52 @@ class Application extends App {
 		/**
 		 * Core class wrappers
 		 */
-		$container->registerService('IsEncryptionEnabled', function (SimpleContainer $c) {
+		$container->registerService('IsEncryptionEnabled', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getEncryptionManager()->isEnabled();
 		});
-		$container->registerService('URLGenerator', function (SimpleContainer $c) {
+		$container->registerService('URLGenerator', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getURLGenerator();
 		});
-		$container->registerService('UserManager', function (SimpleContainer $c) {
+		$container->registerService('UserManager', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getUserManager();
 		});
-		$container->registerService('Config', function (SimpleContainer $c) {
+		$container->registerService('Config', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getConfig();
 		});
-		$container->registerService('L10N', function (SimpleContainer $c) {
+		$container->registerService('L10N', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getL10N('core');
 		});
-		$container->registerService('SecureRandom', function (SimpleContainer $c) {
+		$container->registerService('SecureRandom', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getSecureRandom();
 		});
-		$container->registerService('AvatarManager', function (SimpleContainer $c) {
+		$container->registerService('AvatarManager', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getAvatarManager();
 		});
-		$container->registerService('Session', function (SimpleContainer $c) {
+		$container->registerService('Session', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getSession();
 		});
-		$container->registerService('UserSession', function (SimpleContainer $c) {
+		$container->registerService('UserSession', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getUserSession();
 		});
-		$container->registerService('Cache', function (SimpleContainer $c) {
+		$container->registerService('Cache', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getCache();
 		});
-		$container->registerService('Defaults', function () {
+		$container->registerService('Defaults', static function () {
 			return new OC_Defaults;
 		});
-		$container->registerService('Mailer', function (SimpleContainer $c) {
+		$container->registerService('Mailer', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getMailer();
 		});
-		$container->registerService('Logger', function (SimpleContainer $c) {
+		$container->registerService('Logger', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getLogger();
 		});
-		$container->registerService('TimeFactory', function (SimpleContainer $c) {
+		$container->registerService('TimeFactory', static function (SimpleContainer $c) {
 			return new TimeFactory();
 		});
-		$container->registerService('DefaultEmailAddress', function () {
+		$container->registerService('DefaultEmailAddress', static function () {
 			return Util::getDefaultEmailAddress('lostpassword-noreply');
 		});
-		$container->registerService('TwoFactorAuthManager', function (SimpleContainer $c) {
+		$container->registerService('TwoFactorAuthManager', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getTwoFactorAuthManager();
 		});
 	}

--- a/core/Controller/RolesController.php
+++ b/core/Controller/RolesController.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Controller;
+
+use OCP\AppFramework\OCSController;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\Roles\AddRolesEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class RolesController extends OCSController {
+	/**
+	 * @var IL10N
+	 */
+	private $l10n;
+	/**
+	 * @var EventDispatcherInterface
+	 */
+	private $dispatcher;
+
+	public function __construct($appName, IRequest $request,
+								IL10N $l10n, EventDispatcherInterface $dispatcher) {
+		parent::__construct($appName, $request);
+		$this->l10n = $l10n;
+		$this->dispatcher = $dispatcher;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @return array
+	 */
+	public function getRoles() {
+		// build core roles
+		$roleEvent = new AddRolesEvent();
+		$this->buildCoreRoles($roleEvent);
+
+		// allow apps to register roles
+		$this->dispatcher->dispatch($roleEvent);
+
+		return ['data' => $roleEvent->getRoles()];
+	}
+
+	private function buildCoreRoles(AddRolesEvent $event) {
+		$event->addRole(
+			[
+				'id' => 'core.viewer',
+				'displayName' => $this->l10n->t('Download / View'),
+				'context' => [
+					'publicLinks' => [
+						'displayDescription' => $this->l10n->t('Recipients can view or download contents.'),
+						'order' => 10,
+						'resourceTypes' => [
+							'*'
+						],
+						'permissions' => [
+							'ownCloud' => [
+								'read' => true
+							]
+						]
+					]
+				]
+			]);
+		$event->addRole(
+			[
+				'id' => 'core.editor',
+				'displayName' => $this->l10n->t('Download / View / Edit'),
+				'context' => [
+					'publicLinks' => [
+						'displayDescription' => $this->l10n->t('Recipients can view, download and edit contents.'),
+						'order' => 20,
+						'resourceTypes' => [
+							'httpd/unix-directory'
+						],
+						'permissions' => [
+							'ownCloud' => [
+								'create' => true,
+								'read' => true,
+								'update' => true,
+								'delete' => true,
+							]
+						]
+					]
+				]
+			]);
+		$event->addRole(
+			[
+				'id' => 'core.contributor',
+				'displayName' => $this->l10n->t('Download / View / Upload'),
+				'context' => [
+					'publicLinks' => [
+						'displayDescription' => $this->l10n->t('Recipients can view, download and upload contents.'),
+						'order' => 30,
+						'resourceTypes' => [
+							'httpd/unix-directory'
+						],
+						'permissions' => [
+							'ownCloud' => [
+								'create' => true,
+								'read' => true,
+							]
+						]
+					]
+				]
+
+			]);
+		$event->addRole(
+			[
+				'id' => 'core.uploader',
+				'displayName' => $this->l10n->t('Upload only') . ' (File Drop)',
+				'context' => [
+					'publicLinks' => [
+						'displayDescription' => $this->l10n->t('Receive files from multiple recipients without revealing the contents of the folder.'),
+						'order' => 40,
+						'resourceTypes' => [
+							'httpd/unix-directory'
+						],
+						'permissions' => [
+							'ownCloud' => [
+								'create' => true,
+							]
+						]
+					]
+				]
+			]);
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -59,6 +59,7 @@ $application->registerRoutes($this, [
 	'ocs' => [
 		['root' => '/cloud', 'name' => 'Cloud#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Cloud#getCurrentUser', 'url' => '/user', 'verb' => 'GET'],
+		['root' => '/cloud', 'name' => 'Roles#getRoles', 'url' => '/roles', 'verb' => 'GET'],
 	]
 ]);
 

--- a/lib/public/Roles/AddRolesEvent.php
+++ b/lib/public/Roles/AddRolesEvent.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Roles;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class AddRolesEvent
+ * @since 10.3
+ * @package OCP\Roles
+ */
+class AddRolesEvent extends Event {
+	private $roles;
+
+	/**
+	 * @param array $role
+	 * @since 10.3
+	 */
+	public function addRole(array $role) {
+		if (isset($this->roles[$role['id']])) {
+			throw new \InvalidArgumentException("Role with id {$role['id']} already known");
+		}
+		$this->roles[$role['id']] = $role;
+	}
+
+	/**
+	 * @return array
+	 * @since 10.3
+	 */
+	public function getRoles() {
+		return \array_values($this->roles);
+	}
+}
+

--- a/lib/public/Roles/AddRolesEvent.php
+++ b/lib/public/Roles/AddRolesEvent.php
@@ -50,4 +50,3 @@ class AddRolesEvent extends Event {
 		return \array_values($this->roles);
 	}
 }
-

--- a/tests/Core/Controller/RolesControllerTest.php
+++ b/tests/Core/Controller/RolesControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Controller;
+
+use OC\Core\Controller\RolesController;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\Roles\AddRolesEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Test\TestCase;
+
+/**
+ * Class RolesControllerTest
+ *
+ * @package OC\Core\Controller
+ */
+class RolesControllerTest extends TestCase {
+	public function testGetAvatarNoAvatar() {
+		$request = $this->createMock(IRequest::class);
+		$l10n = $this->createMock(IL10N::class);
+		$eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$controller = new RolesController('core', $request, $l10n, $eventDispatcher);
+
+		$l10n->method('t')->willReturnArgument(0);
+		$eventDispatcher->method('dispatch')->willReturnCallback(function ($event) {
+			$this->assertInstanceOf(AddRolesEvent::class, $event);
+			$event->addRole([
+				'id' => 'test.tester',
+				'displayName' => 'A tester which tests ....'
+			]);
+		});
+
+		$result = $controller->getRoles();
+		$data = $result['data'];
+		$this->assertCount(5, $data);
+		$this->assertEquals('test.tester', $data[4]['id']);
+	}
+}


### PR DESCRIPTION
## Description

The roles api allows clients to ask the server for supported roles.
Currently only roles for public links are implemented.
Apps can listen to the event dispatcher and add their own roles.

The current concept does not reflect any capability for apps to change roles (core or from other apps)

Here is an example on how to submit permissions via the attributes property
![Screenshot from 2019-08-21 10-20-44](https://user-images.githubusercontent.com/1005065/63415134-89f22200-c3fd-11e9-8ce1-5be037b9b6f7.png)


## Related Issue
- refs https://github.com/owncloud/enterprise/issues/3473

## How Has This Been Tested?
- :man_shrugging:

## Screenshots (if appropriate):
```sh
curl http://deepdiver:8080/ocs/v1.php/cloud/roles?format=json  -u admin -H 'Accept-Language: de-DE' | json_pp 
Enter host password for user 'admin':
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1301  100  1301    0     0   1848      0 --:--:-- --:--:-- --:--:--  1845
{
   "ocs" : {
      "data" : [
         {
            "id" : "core.viewer",
            "context" : {
               "publicLinks" : {
                  "order" : 10,
                  "permissions" : {
                     "ownCloud" : {
                        "read" : true
                     }
                  },
                  "displayDescription" : "Empfänger können Inhalte sehen und herunterladen.",
                  "resourceTypes" : [
                     "*"
                  ]
               }
            },
            "displayName" : "Herunterladen / Ansehen"
         },
         {
            "displayName" : "Herunterladen / Ansehen / Bearbeiten",
            "context" : {
               "publicLinks" : {
                  "displayDescription" : "Empfänger können Inhalte sehen, herunterladen und bearbeiten.",
                  "resourceTypes" : [
                     "httpd/unix-directory"
                  ],
                  "order" : 20,
                  "permissions" : {
                     "ownCloud" : {
                        "update" : true,
                        "delete" : true,
                        "read" : true,
                        "create" : true
                     }
                  }
               }
            },
            "id" : "core.editor"
         },
         {
            "context" : {
               "publicLinks" : {
                  "order" : 30,
                  "permissions" : {
                     "ownCloud" : {
                        "read" : true,
                        "create" : true
                     }
                  },
                  "displayDescription" : "Empfänger können Inhalte sehen, herunterladen und hochladen.",
                  "resourceTypes" : [
                     "httpd/unix-directory"
                  ]
               }
            },
            "id" : "core.contributor",
            "displayName" : "Herunterladen / Ansehen / Hochladen"
         },
         {
            "displayName" : "Nur Hochladen (File Drop)",
            "context" : {
               "publicLinks" : {
                  "order" : 40,
                  "permissions" : {
                     "ownCloud" : {
                        "create" : true
                     }
                  },
                  "displayDescription" : "Von mehreren Empfängern Dateien empfangen, ohne den Inhalt des Ordners preiszugeben.",
                  "resourceTypes" : [
                     "httpd/unix-directory"
                  ]
               }
            },
            "id" : "core.uploader"
         }
      ],
      "meta" : {
         "status" : "ok",
         "message" : "OK",
         "statuscode" : 100,
         "totalitems" : "",
         "itemsperpage" : ""
      }
   }
}

```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
