### PR TITLE
Respect default app config within the TwoFactorChallendeController

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -36,6 +36,7 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\Util;
 
 class TwoFactorChallengeController extends Controller {
 
@@ -73,6 +74,13 @@ class TwoFactorChallengeController extends Controller {
 	 */
 	protected function getLogoutAttribute() {
 		return \OC_User::getLogoutAttribute();
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getDefaultPageUrl() {
+		return \OC_Util::getDefaultPageUrl();
 	}
 
 	/**
@@ -127,7 +135,7 @@ class TwoFactorChallengeController extends Controller {
 		if ($this->session->exists('two_factor_auth_error')) {
 			$this->session->remove('two_factor_auth_error');
 			$error = true;
-			$error_message = $this->session->get("two_factor_auth_error_message");
+			$error_message = $this->session->get('two_factor_auth_error_message');
 			$this->session->remove('two_factor_auth_error_message');
 		} else {
 			$error = false;
@@ -173,7 +181,7 @@ class TwoFactorChallengeController extends Controller {
 				if ($redirect_url !== null) {
 					return new RedirectResponse($this->urlGenerator->getAbsoluteURL(\urldecode($redirect_url)));
 				}
-				return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index'));
+				return new RedirectResponse($this->getDefaultPageUrl());
 			}
 		} catch (TwoFactorException $e) {
 			/*


### PR DESCRIPTION
## Description
Within the TwoFactorChallengeController the default app setting is not respected

## Related Issue
:question: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
