### PR TITLE
Fix invalid foreach in SharingBlacklist.php

### DIFF
--- a/apps/files_sharing/lib/SharingBlacklist.php
+++ b/apps/files_sharing/lib/SharingBlacklist.php
@@ -75,7 +75,7 @@ class SharingBlacklist {
 	 * @return string[] the list of group ids
 	 */
 	public function getBlacklistedReceiverGroups() {
-		return \json_decode($this->config->getAppValue('files_sharing', 'blacklisted_receiver_groups', '[]'), true);
+		return \array_keys($this->fetchBlacklistedReceiverGroupIds());
 	}
 
 	private function initCache() {
@@ -88,14 +88,27 @@ class SharingBlacklist {
 		}
 	}
 
+	/**
+	 * @return bool[] an array with group ids as the keys, the values do not matter
+	 *                If the blacklisted receiver groups cannot be parsed as valid JSON,
+	 *                then an empty list is returned.
+	 *                Any parsed group ids that are not string, int or float are dropped from the list.
+	 */
 	private function fetchBlacklistedReceiverGroupIds() {
 		$configuredBlacklist = $this->config->getAppValue('files_sharing', 'blacklisted_receiver_groups', '[]');
 		$decodedGroups = \json_decode($configuredBlacklist, true);
-		// expected a plain array here
+
+		if (!\is_array($decodedGroups)) {
+			$decodedGroups = [];
+		}
+
 		$groupSet = [];
 		foreach ($decodedGroups as $group) {
-			$groupSet[$group] = true;
+			if (\is_string($group) || \is_int($group) || \is_float($group)) {
+				$groupSet[(string) $group] = true;
+			}
 		}
+
 		return $groupSet;
 	}
 }

--- a/apps/files_sharing/tests/SharingBlacklistTest.php
+++ b/apps/files_sharing/tests/SharingBlacklistTest.php
@@ -67,6 +67,34 @@ class SharingBlacklistTest extends \Test\TestCase {
 		$this->assertEquals($ids, $this->sharingBlacklist->getBlacklistedReceiverGroups());
 	}
 
+	public function getBlacklistedReceiverGroupsProvider() {
+		return [
+			["", []],
+			["[\"invalid JSON missing right square bracket\"", []],
+			["[]", []],
+			["{\"abc\":\"group1\"}", ["group1"]],
+			["[[\"group1\"]]", []],
+			["[0]", ["0"]],
+			["[1]", ["1"]],
+			["[1.23]", ["1.23"]],
+			["[1.23e-4]", ["1.23e-4"]],
+			["[\"group1\"]", ["group1"]],
+			["[\"group1\", \"group2\", \"group3\"]", ["group1", "group2", "group3"]],
+		];
+	}
+
+	/**
+	 * Test cases for when the admin directly sets blacklisted_receiver_groups,
+	 * e.g. with an occ command, and might not set valid JSON, or might set valid
+	 * JSON but not in the expected structure.
+	 *
+	 * @dataProvider getBlacklistedReceiverGroupsProvider
+	 */
+	public function testGetBlacklistedReceiverGroups($ids, $result) {
+		$this->config->method('getAppValue')->willReturn($ids);
+		$this->assertEquals($result, $this->sharingBlacklist->getBlacklistedReceiverGroups());
+	}
+
 	private function getGroupMock($id, $displayname) {
 		$groupMock = $this->getMockBuilder(IGroup::class)
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Description
The "string" value that it is set to is supposed to be valid JSON representing an array of group ids.

`blacklisted_receiver_groups` can be set "manually" by the administrator using an `occ` command, or by some automated test or... So it can end up being an empty string, or some string that is not valid JSON, or some string that represents a multi-level nested array-of-arrays, or some other weird structure.

1) If the JSON decode does not produce an array, then return an empty list. (JSON decode might have failed, or returned a plain string/int etc)

2) Check the elements of the decoded array. Keep elements that are "string-like" (string, int and float) and cast them to string. Discard other elements (e.g. an array, or boolean). This allows for group names like "0", "1", "1.23", "1.23e-4" that can look like both numbers and strings, while discarding other crud.

## Related Issue
- Fixes #36037 

## How Has This Been Tested?
Local run of acceptance test and observe that the log message no longer happens.
```
make test-acceptance-webui BEHAT_FEATURE=tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature:239
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
