### PR TITLE
Make separate 'given' steps  in AppManagementContext Auth BasicStructure

### DIFF
--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -147,9 +147,18 @@ class AppManagementContext implements Context {
 	 * @return void
 	 */
 	public function adminGetsPathForApp($appId) {
-		$this->cmdOutput = SetupHelper::runOcc(
+		$occStatus = SetupHelper::runOcc(
 			['app:getpath', $appId, '--no-ansi']
-		)['stdOut'];
+		);
+		$this->cmdOutput = $occStatus['stdOut'];
+		// check that the command seems to have executed OK, for both When and Given
+		// step forms. There is no point continuing the scenario if the command itself
+		// has reported an error.
+		Assert::assertEquals(
+			"0",
+			$occStatus['code'],
+			"app:getpath returned error code " . $occStatus['code']
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -19,6 +19,7 @@
  *
  */
 
+use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
 use Behat\Gherkin\Node\TableNode;
 
@@ -86,7 +87,6 @@ trait Auth {
 
 	/**
 	 * @When a user requests :url with :method and no authentication
-	 * @Given a user has requested :url with :method and no authentication
 	 *
 	 * @param string $url
 	 * @param string $method
@@ -95,6 +95,19 @@ trait Auth {
 	 */
 	public function userRequestsURLWith($url, $method) {
 		$this->sendRequest($url, $method);
+	}
+
+	/**
+	 * @Given a user has requested :url with :method and no authentication
+	 *
+	 * @param string $url
+	 * @param string $method
+	 *
+	 * @return void
+	 */
+	public function userHasRequestedURLWith($url, $method) {
+		$this->sendRequest($url, $method);
+		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**
@@ -331,9 +344,10 @@ trait Auth {
 		);
 		$headers = ['Content-Type' => 'application/json'];
 		$url = $this->getBaseUrl() . '/token/generate';
-		$resp = HttpRequestHelper::post($url, null, null, $headers, $body);
+		$this->response = HttpRequestHelper::post($url, null, null, $headers, $body);
+		$this->theHTTPStatusCodeShouldBe("200");
 		$this->clientToken
-			= \json_decode($resp->getBody()->getContents())->token;
+			= \json_decode($this->response->getBody()->getContents())->token;
 	}
 
 	/**
@@ -349,7 +363,6 @@ trait Auth {
 
 	/**
 	 * @When user :user requests :url with :method using basic auth
-	 * @Given user :user has requested :url with :method using basic auth
 	 *
 	 * @param string $user
 	 * @param string $url
@@ -371,6 +384,26 @@ trait Auth {
 	}
 
 	/**
+	 * @Given user :user has requested :url with :method using basic auth
+	 *
+	 * @param string $user
+	 * @param string $url
+	 * @param string $method
+	 * @param string $password
+	 * @param string $body
+	 *
+	 * @return void
+	 */
+	public function userHasRequestedURLWithUsingBasicAuth(
+		$user, $url, $method, $password=null, $body=null
+	) {
+		$this->userRequestsURLWithUsingBasicAuth(
+			$user, $url, $method, $password, $body
+		);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
 	 * @When the administrator requests :url with :method using basic auth
 	 *
 	 * @param string $url
@@ -387,7 +420,6 @@ trait Auth {
 
 	/**
 	 * @When user :user requests :url with :method using basic token auth
-	 * @Given user :user has requested :url with :method using basic token auth
 	 *
 	 * @param string $user
 	 * @param string $url
@@ -404,8 +436,21 @@ trait Auth {
 	}
 
 	/**
+	 * @Given user :user has requested :url with :method using basic token auth
+	 *
+	 * @param string $user
+	 * @param string $url
+	 * @param string $method
+	 *
+	 * @return void
+	 */
+	public function userHasRequestedURLWithUsingBasicTokenAuth($user, $url, $method) {
+		$this->userRequestsURLWithUsingBasicTokenAuth($user, $url, $method);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
 	 * @When the user requests :url with :method using the generated client token
-	 * @Given the user has requested :url with :method using the generated client token
 	 *
 	 * @param string $url
 	 * @param string $method
@@ -417,8 +462,20 @@ trait Auth {
 	}
 
 	/**
+	 * @Given the user has requested :url with :method using the generated client token
+	 *
+	 * @param string $url
+	 * @param string $method
+	 *
+	 * @return void
+	 */
+	public function userHasRequestedURLWithUsingAClientToken($url, $method) {
+		$this->userRequestsURLWithUsingAClientToken($url, $method);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
 	 * @When the user requests :url with :method using the generated app password
-	 * @Given the user has requested :url with :method using the generated app password
 	 *
 	 * @param string $url
 	 * @param string $method
@@ -430,8 +487,20 @@ trait Auth {
 	}
 
 	/**
+	 * @Given the user has requested :url with :method using the generated app password
+	 *
+	 * @param string $url
+	 * @param string $method
+	 *
+	 * @return void
+	 */
+	public function userHasRequestedURLWithUsingAppPassword($url, $method) {
+		$this->userRequestsURLWithUsingAppPassword($url, $method);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
 	 * @When the user requests :url with :method using the browser session
-	 * @Given the user has requested :url with :method using the browser session
 	 *
 	 * @param string $url
 	 * @param string $method
@@ -440,6 +509,19 @@ trait Auth {
 	 */
 	public function userRequestsURLWithBrowserSession($url, $method) {
 		$this->sendRequest($url, $method, null, true);
+	}
+
+	/**
+	 * @Given the user has requested :url with :method using the browser session
+	 *
+	 * @param string $url
+	 * @param string $method
+	 *
+	 * @return void
+	 */
+	public function userHasRequestedURLWithBrowserSession($url, $method) {
+		$this->userRequestsURLWithBrowserSession($url, $method);
+		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**
@@ -452,10 +534,11 @@ trait Auth {
 	public function aNewBrowserSessionForHasBeenStarted($user) {
 		$loginUrl = $this->getBaseUrl() . '/index.php/login';
 		// Request a new session and extract CSRF token
-		$response = HttpRequestHelper::get(
+		$this->response = HttpRequestHelper::get(
 			$loginUrl, null, null, null, null, null, $this->cookieJar
 		);
-		$this->extractRequestTokenFromResponse($response);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+		$this->extractRequestTokenFromResponse($this->response);
 
 		// Login and extract new token
 		$body = [
@@ -463,10 +546,11 @@ trait Auth {
 			'password' => $this->getPasswordForUser($user),
 			'requesttoken' => $this->requestToken
 		];
-		$response = HttpRequestHelper::post(
+		$this->response = HttpRequestHelper::post(
 			$loginUrl, null, null, null, $body, null, $this->cookieJar
 		);
-		$this->extractRequestTokenFromResponse($response);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+		$this->extractRequestTokenFromResponse($this->response);
 	}
 
 	/**
@@ -495,10 +579,15 @@ trait Auth {
 		} else {
 			$value = 'false';
 		}
-		$this->setSystemConfig(
+		$occStatus = $this->setSystemConfig(
 			'token_auth_enforced',
 			$value,
 			'boolean'
+		);
+		Assert::assertEquals(
+			"0",
+			$occStatus['code'],
+			"setSystemConfig token_auth_enforced returned error code " . $occStatus['code']
 		);
 
 		// Remember that we set this value, so it can be removed after the scenario

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -985,7 +985,7 @@ trait BasicStructure {
 	/**
 	 * @Then /^the HTTP status code should be "([^"]*)"$/
 	 *
-	 * @param int|int[] $statusCode
+	 * @param int|int[]|string|string[] $statusCode
 	 * @param string $message
 	 *
 	 * @return void
@@ -1010,8 +1010,8 @@ trait BasicStructure {
 	/**
 	 * @Then /^the HTTP status code should be "([^"]*)" or "([^"]*)"$/
 	 *
-	 * @param int $statusCode1
-	 * @param int $statusCode2
+	 * @param int|string $statusCode1
+	 * @param int|string $statusCode2
 	 *
 	 * @return void
 	 */
@@ -1024,8 +1024,8 @@ trait BasicStructure {
 	/**
 	 * @Then /^the HTTP status code should be between "(\d+)" and "(\d+)"$/
 	 *
-	 * @param int $minStatusCode
-	 * @param int $maxStatusCode
+	 * @param int|string $minStatusCode
+	 * @param int|string $maxStatusCode
 	 *
 	 * @return void
 	 */
@@ -1052,7 +1052,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theHTTPStatusCodeShouldBeSuccess() {
-		$this->theHTTPStatusCodeShouldBeBetween("200", "299");
+		$this->theHTTPStatusCodeShouldBeBetween(200, 299);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -343,7 +343,7 @@ class OCSContext implements Context {
 	/**
 	 * @Then /^the OCS status code should be "([^"]*)"$/
 	 *
-	 * @param int|int[] $statusCode
+	 * @param int|int[]|string|string[] $statusCode
 	 * @param string $message
 	 *
 	 * @return void


### PR DESCRIPTION
## Description
Separate the `Given` steps and check the status of API calls that are done, so that we fail early when `Given` setup goes wrong.

This is "more of the same" like PR #36032 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
