### PR TITLE
run litmus tests on new public webdav endpoint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -496,6 +496,8 @@ steps:
   commands:
   - curl -k -s -u user1:123456 -X MKCOL "https://server/remote.php/webdav/new_folder"
   - curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data "path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin"
+  - echo -n "PUBLIC_TOKEN=" > .env
+  - curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data "path=/new_folder&shareType=3&permissions=15&name=new_folder" | grep token | cut -d">" -f2 | cut -d"<" -f1 >> .env
 
 - name: owncloud-logfile
   pull: always
@@ -507,50 +509,86 @@ steps:
 - name: old-endpoint
   pull: always
   image: owncloud/litmus:latest
+  commands:
+  - source .env
+  - export LITMUS_URL='https://server/remote.php/webdav'
+  - /usr/local/bin/litmus-wrapper
   environment:
     LITMUS_PASSWORD: admin
-    LITMUS_URL: https://server/remote.php/webdav
     LITMUS_USERNAME: admin
+    TESTS: basic copymove props locks http
 
 - name: new-endpoint
   pull: always
   image: owncloud/litmus:latest
+  commands:
+  - source .env
+  - export LITMUS_URL='https://server/remote.php/dav/files/admin'
+  - /usr/local/bin/litmus-wrapper
   environment:
     LITMUS_PASSWORD: admin
-    LITMUS_URL: https://server/remote.php/dav/files/admin
     LITMUS_USERNAME: admin
+    TESTS: basic copymove props locks http
 
 - name: new-mount
   pull: always
   image: owncloud/litmus:latest
+  commands:
+  - source .env
+  - export LITMUS_URL='https://server/remote.php/dav/files/admin/local_storage/'
+  - /usr/local/bin/litmus-wrapper
   environment:
     LITMUS_PASSWORD: admin
-    LITMUS_URL: https://server/remote.php/dav/files/admin/local_storage/
     LITMUS_USERNAME: admin
+    TESTS: basic copymove props locks http
 
 - name: old-mount
   pull: always
   image: owncloud/litmus:latest
+  commands:
+  - source .env
+  - export LITMUS_URL='https://server/remote.php/webdav/local_storage/'
+  - /usr/local/bin/litmus-wrapper
   environment:
     LITMUS_PASSWORD: admin
-    LITMUS_URL: https://server/remote.php/webdav/local_storage/
     LITMUS_USERNAME: admin
+    TESTS: basic copymove props locks http
 
 - name: new-shared
   pull: always
   image: owncloud/litmus:latest
+  commands:
+  - source .env
+  - export LITMUS_URL='https://server/remote.php/dav/files/admin/new_folder/'
+  - /usr/local/bin/litmus-wrapper
   environment:
     LITMUS_PASSWORD: admin
-    LITMUS_URL: https://server/remote.php/dav/files/admin/new_folder/
     LITMUS_USERNAME: admin
+    TESTS: basic copymove props locks http
 
 - name: old-shared
   pull: always
   image: owncloud/litmus:latest
+  commands:
+  - source .env
+  - export LITMUS_URL='https://server/remote.php/webdav/new_folder/'
+  - /usr/local/bin/litmus-wrapper
   environment:
     LITMUS_PASSWORD: admin
-    LITMUS_URL: https://server/remote.php/webdav/new_folder/
     LITMUS_USERNAME: admin
+    TESTS: basic copymove props locks http
+
+- name: public-share
+  pull: always
+  image: owncloud/litmus:latest
+  commands:
+  - source .env
+  - export LITMUS_URL='https://server/remote.php/dav/public-files/'$PUBLIC_TOKEN
+  - /usr/local/bin/litmus-wrapper
+  environment:
+    LITMUS_PASSWORD: admin
+    LITMUS_USERNAME: admin
+    TESTS: basic copymove http
 
 services:
 - name: server


### PR DESCRIPTION
## Description
run litmus tests on the new webdav endpoint for public links

## Related Issue
part of #36006

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
