### PR TITLE
rename steps to be 'old' public webdav API

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -257,8 +257,8 @@ Feature: sharing
       | uid_file_owner         | user0                |
       | uid_owner              | user0                |
       | name                   |                      |
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%regular%" and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%" and the content should be "wnCloud"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -284,9 +284,9 @@ Feature: sharing
       | uid_file_owner         | user0                |
       | uid_owner              | user0                |
       | name                   |                      |
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
-    But the public should not be able to download file "/parent.txt" from inside the last public shared folder without a password
-    And the public should not be able to download file "/parent.txt" from inside the last public shared folder with password "%regular%"
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
+    But the public should not be able to download file "/parent.txt" from inside the last public shared folder using the old public WebDAV API without a password
+    And the public should not be able to download file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -842,7 +842,7 @@ Feature: sharing
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    Then the public should be able to download the range "bytes=1-6" of file "/welcome.txt" from inside the last public shared folder and the content should be "elcome"
+    Then the public should be able to download the range "bytes=1-6" of file "/welcome.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "elcome"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -1292,7 +1292,7 @@ Feature: sharing
       | displayname_owner      | User Zero            |
       | uid_file_owner         | user0                |
       | uid_owner              | user0                |
-    When the public downloads file "/parent.txt" from inside the last public shared folder using the public WebDAV API
+    When the public downloads file "/parent.txt" from inside the last public shared folder using the old public WebDAV API
     Then the downloaded content should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | ocs_api_version | ocs_status_code |

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -48,7 +48,7 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    And the public deletes file "welcome.txt" from the last public share using the public WebDAV API
+    And the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "user0" file "PARENT/welcome.txt" <should-or-not> exist
     Examples:
@@ -64,7 +64,7 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    And the public renames file "parent.txt" to "newparent.txt" from the last public share using the public WebDAV API
+    And the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
     And as "user0" file "/PARENT/parent.txt" should exist
     And as "user0" file "/PARENT/newparent.txt" should not exist
@@ -79,7 +79,7 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    And the public renames file "parent.txt" to "newparent.txt" from the last public share using the public WebDAV API
+    And the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "201"
     And as "user0" file "/PARENT/parent.txt" should not exist
     And as "user0" file "/PARENT/newparent.txt" should exist
@@ -95,7 +95,7 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    And the public uploads file "lorem.txt" with content "test" using the public WebDAV API
+    And the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "403"
     And as "user0" file "/PARENT/lorem.txt" should not exist
     Examples:
@@ -110,7 +110,7 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    And the public uploads file "lorem.txt" with content "test" using the public WebDAV API
+    And the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "user0" should be "test"
     Examples:

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -58,7 +58,7 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
       | password | %public% |
-    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -86,7 +86,7 @@ Feature: sharing
       | path        | PARENT   |
       | password    | %public% |
       | permissions | change   |
-    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -114,4 +114,4 @@ Feature: sharing
       | path        | PARENT   |
       | password    | %public% |
       | permissions | read     |
-    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
+    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -11,8 +11,8 @@ Feature: sharing
     And the user has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
-    When the public uploads file "test.txt" with content "test" using the public WebDAV API
-    And the public uploads file "test.txt" with content "test2" with autorename mode using the public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
+    And the public uploads file "test.txt" with content "test2" with autorename mode using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
@@ -23,7 +23,7 @@ Feature: sharing
       | path        | FOLDER |
       | permissions | create |
     When user "user0" deletes file "/FOLDER" using the WebDAV API
-    Then publicly uploading a file should not work
+    Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "404"
     Examples:
       | dav-path |
@@ -35,7 +35,7 @@ Feature: sharing
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | read   |
-    Then publicly uploading a file should not work
+    Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
   Scenario: Uploading file to a user read-only share folder does not work
@@ -71,7 +71,7 @@ Feature: sharing
     And the user has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
-    When the public uploads file "test.txt" with content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
   @public_link_share-feature-required
@@ -81,7 +81,7 @@ Feature: sharing
       | path        | FOLDER   |
       | password    | %public% |
       | permissions | create   |
-    When the public uploads file "test.txt" with password "%public%" and content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
   Scenario Outline: Uploading file to a user upload-only share folder works
@@ -123,7 +123,7 @@ Feature: sharing
       | path        | FOLDER   |
       | password    | %public% |
       | permissions | change   |
-    When the public uploads file "test.txt" with password "%public%" and content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
   @smokeTest
@@ -180,7 +180,7 @@ Feature: sharing
       | path        | FOLDER   |
       | password    | %public% |
       | permissions | change   |
-    When the public uploads file "test.txt" with password "%public%" and content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
   Scenario Outline: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
@@ -223,7 +223,7 @@ Feature: sharing
       | path        | FOLDER |
       | permissions | change |
     When the quota of user "user0" has been set to "0"
-    Then publicly uploading a file should not work
+    Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "507"
 
   Scenario Outline: Uploading to a user shared folder with upload-only permission when the sharer has unsufficient quota does not work
@@ -266,7 +266,7 @@ Feature: sharing
       | path        | FOLDER |
       | permissions | create |
     When the quota of user "user0" has been set to "0"
-    Then publicly uploading a file should not work
+    Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "507"
 
   @public_link_share-feature-required
@@ -275,7 +275,7 @@ Feature: sharing
       | path        | FOLDER |
       | permissions | create |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
-    Then publicly uploading a file should not work
+    Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
   @public_link_share-feature-required
@@ -285,7 +285,7 @@ Feature: sharing
       | path        | FOLDER |
       | permissions | all    |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
-    Then publicly uploading a file should not work
+    Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
   @public_link_share-feature-required
@@ -295,7 +295,7 @@ Feature: sharing
       | permissions | create |
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
-    When the public uploads file "test.txt" with content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
   Scenario: Uploading a file in to a shared folder without edit permissions
@@ -318,7 +318,7 @@ Feature: sharing
     And the user has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
-    When the public uploads file "test.txt" with content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
   @smokeTest @public_link_share-feature-required
@@ -327,6 +327,6 @@ Feature: sharing
     And the user has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
-    When the public uploads file "test.txt" with content "test" using the public WebDAV API
-    And the public uploads file "test.txt" with content "test2" using the public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
+    And the public uploads file "test.txt" with content "test2" using the old public WebDAV API
     Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"

--- a/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
@@ -35,8 +35,8 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder and the content should be "some content"
-    But publicly uploading a file should not work
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "some content"
+    But uploading a file should not work using the old public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -84,8 +84,8 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder and the content should be "some content"
-    But publicly uploading a file should not work
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "some content"
+    But uploading a file should not work using the old public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -103,8 +103,8 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder and the content should be "some content"
-    And publicly uploading a file should work
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "some content"
+    And uploading a file should work using the old public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -141,7 +141,7 @@ Feature: reshare as public link
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And publicly uploading a file should not work
+    And uploading a file should not work using the old public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -157,12 +157,12 @@ Feature: reshare as public link
       | path         | /test/sub |
       | permissions  | read      |
       | publicUpload | false     |
-    And publicly uploading a file should not work
+    And uploading a file should not work using the old public WebDAV API
     When user "user1" updates the last share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And publicly uploading a file should not work
+    And uploading a file should not work using the old public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -290,7 +290,7 @@ Feature: sharing
       | publicUpload | true |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And publicly uploading a file should not work
+    And uploading a file should not work using the old public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -423,7 +423,7 @@ Feature: sharing
       | publicUpload | true |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And publicly uploading a file should work
+    And uploading a file should work using the old public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -443,7 +443,7 @@ Feature: sharing
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And publicly uploading a file should not work
+    And uploading a file should not work using the old public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -463,7 +463,7 @@ Feature: sharing
       | permissions | read,update,create,delete |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And publicly uploading a file should work
+    And uploading a file should work using the old public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -504,7 +504,7 @@ Feature: sharing
     When user "user0" gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | permissions | read,update,create |
-    When the public deletes file "CHILD/child.txt" from the last public share using the public WebDAV API
+    When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -524,7 +524,7 @@ Feature: sharing
     When user "user0" gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | permissions | read,update,create,delete |
-    When the public deletes file "CHILD/child.txt" from the last public share using the public WebDAV API
+    When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "204"
     Examples:
       | ocs_api_version | ocs_status_code |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -9,7 +9,7 @@ Feature: persistent-locking in case of a public link
     And user "user0" has created a public link share of folder "FOLDER" with change permission
     When user "user0" locks folder "FOLDER" using the WebDAV API setting following properties
       | lockscope | <lock-scope> |
-    Then publicly uploading a file should not work
+    Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "423"
     Examples:
       | dav-path | lock-scope |
@@ -23,8 +23,8 @@ Feature: persistent-locking in case of a public link
     And user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT/CHILD" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "test.txt" with content "test" using the public WebDAV API
-    And the public uploads file "CHILD/test.txt" with content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
+    And the public uploads file "CHILD/test.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "423"
     And as "user0" file "/PARENT/CHILD/test.txt" should not exist
     But the content of file "/PARENT/test.txt" for user "user0" should be "test"
@@ -40,7 +40,7 @@ Feature: persistent-locking in case of a public link
     And user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "parent.txt" with content "test" using the public WebDAV API
+    When the public uploads file "parent.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "423"
     And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
     Examples:
@@ -55,8 +55,8 @@ Feature: persistent-locking in case of a public link
     And user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT/CHILD" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "parent.txt" with content "changed text" using the public WebDAV API
-    And the public uploads file "CHILD/child.txt" with content "test" using the public WebDAV API
+    When the public uploads file "parent.txt" with content "changed text" using the old public WebDAV API
+    And the public uploads file "CHILD/child.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "423"
     And the content of file "/PARENT/parent.txt" for user "user0" should be "changed text"
     But the content of file "/PARENT/CHILD/child.txt" for user "user0" should be "ownCloud test text file child" plus end-of-line

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -77,7 +77,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
     Given user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "user0" using the public WebDAV API
+    When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "user0" using the old public WebDAV API
     Then the HTTP status code should be "423"
     And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
     Examples:

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -55,7 +55,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "user2" has created a public link share of folder "PARENT (2)" with change permission
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "test.txt" with content "test" using the public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "423"
     And as "user0" file "/PARENT/test.txt" should not exist
     Examples:

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -31,14 +31,14 @@ Feature: download file
   Scenario: download a public shared file with range
     When user "user0" creates a public link share using the sharing API with settings
       | path | welcome.txt |
-    And the public downloads the last public shared file with range "bytes=51-77" using the public WebDAV API
+    And the public downloads the last public shared file with range "bytes=51-77" using the old public WebDAV API
     Then the downloaded content should be "example file for developers"
 
   @public_link_share-feature-required
   Scenario: download a public shared file inside a folder with range
     When user "user0" creates a public link share using the sharing API with settings
       | path | PARENT |
-    And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the public WebDAV API
+    And the public downloads file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with range "bytes=1-7" using the old public WebDAV API
     Then the downloaded content should be "wnCloud"
 
   @smokeTest

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -381,25 +381,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to upload file "([^"]*)" with content "([^"]*)" to the last public shared folder$/
-	 *
-	 * @param string $path
-	 * @param string $content
-	 *
-	 * @return void
-	 */
-	public function shouldBeAbleToUploadFileWithContentToTheLastPublicSharedFolder(
-		$path, $content
-	) {
-		$this->publiclyUploadingContent($path, $content);
-		$this->featureContext->theHTTPStatusCodeShouldBe(
-			"201", "Failed to upload file to public share"
-		);
-		$this->downloadPublicFileInsideAFolder($path);
-		$this->featureContext->downloadedContentShouldBe($content);
-	}
-
-	/**
 	 * @Then uploading a file should not work using the old public WebDAV API
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -38,7 +38,7 @@ class PublicWebDavContext implements Context {
 	private $featureContext;
 
 	/**
-	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the public WebDAV API$/
+	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the old public WebDAV API$/
 	 *
 	 * @param string $range
 	 *
@@ -57,7 +57,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads the last public shared file using the public WebDAV API$/
+	 * @When /^the public downloads the last public shared file using the old public WebDAV API$/
 	 *
 	 * @return void
 	 */
@@ -70,7 +70,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public deletes file "([^"]*)" from the last public share using the public WebDAV API$/
+	 * @When /^the public deletes file "([^"]*)" from the last public share using the old public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 *
@@ -88,7 +88,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public share using the public WebDAV API$/
+	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public share using the old public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $toFileName
@@ -108,7 +108,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API$/
 	 *
 	 * @param string $path
 	 *
@@ -121,7 +121,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" using the public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" using the old public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -137,7 +137,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with range "([^"]*)" using the old public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $range
@@ -151,7 +151,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" with range "([^"]*)" using the public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" with range "([^"]*)" using the old public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -192,7 +192,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :body with autorename mode using the public WebDAV API
+	 * @When the public uploads file :filename with content :body with autorename mode using the old public WebDAV API
 	 * @Given the public has uploaded file :filename with content :body with autorename mode
 	 *
 	 * @param string $filename target file name
@@ -205,7 +205,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with password :password and content :body using the public WebDAV API
+	 * @When the public uploads file :filename with password :password and content :body using the old public WebDAV API
 	 * @Given the public has uploaded file :filename" with password :password and content :body
 	 *
 	 * @param string $filename target file name
@@ -234,7 +234,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :body using the public WebDAV API
+	 * @When the public uploads file :filename with content :body using the old public WebDAV API
 	 * @Given the public has uploaded file :filename with content :body
 	 *
 	 * @param string $filename target file name
@@ -247,7 +247,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $content
@@ -263,7 +263,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder without a password$/
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API without a password$/
 	 *
 	 * @param string $path
 	 *
@@ -278,7 +278,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder with password "([^"]*)" and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -295,7 +295,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder with password "([^"]*)"$/
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -311,7 +311,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder with password "([^"]*)" and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -330,7 +330,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder with password "([^"]*)"$/
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -348,7 +348,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API and the content should be "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -365,7 +365,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder without a password$/
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API without a password$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -400,7 +400,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then publicly uploading a file should not work
+	 * @Then uploading a file should not work using the old public WebDAV API
 	 *
 	 * @return void
 	 */
@@ -419,7 +419,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then publicly uploading a file should work
+	 * @Then uploading a file should work using the old public WebDAV API
 	 *
 	 * @return void
 	 */
@@ -439,7 +439,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * Uploads a file through the public WebDAV API and sets the response in FeatureContext
+	 * Uploads a file through the old public WebDAV API and sets the response in FeatureContext
 	 *
 	 * @param string $filename
 	 * @param string $password

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -379,7 +379,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :content sending the locktoken of file :itemToUseLockOf of user :lockOwner using the public WebDAV API
+	 * @When the public uploads file :filename with content :content sending the locktoken of file :itemToUseLockOf of user :lockOwner using the old public WebDAV API
 	 *
 	 * @param string $filename
 	 * @param string $content
@@ -401,7 +401,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :content sending the locktoken of :itemToUseLockOf of the public using the public WebDAV API
+	 * @When the public uploads file :filename with content :content sending the locktoken of :itemToUseLockOf of the public using the old public WebDAV API
 	 *
 	 * @param string $filename
 	 * @param string $content


### PR DESCRIPTION
## Description
as there is a "new" public webdav API that we are about to start tests for, rename all the existing tests to be using the "old" API

## Related Issue
part of #36006

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
