### PR TITLE
Be flexible about HTTP status code for new chunking uploads

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2188,7 +2188,7 @@ trait WebDav {
 		}
 		$this->moveNewDavChunkToFinalFile($user, $chunkingId, $file, $headers);
 		if ($checkActions) {
-			$this->theHTTPStatusCodeShouldBeOr("201", "204");
+			$this->theHTTPStatusCodeShouldBeSuccess();
 		}
 		$this->lastUploadDeleteTime = \time();
 	}
@@ -2218,7 +2218,7 @@ trait WebDav {
 	 */
 	public function userHasCreatedANewChunkingUploadWithId($user, $id) {
 		$this->userCreatesANewChunkingUploadWithId($user, $id);
-		$this->theHTTPStatusCodeShouldBe("201");
+		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**
@@ -2251,7 +2251,7 @@ trait WebDav {
 	 */
 	public function userHasUploadedNewChunkFileOfWithToId($user, $num, $data, $id) {
 		$this->userUploadsNewChunkFileOfWithToId($user, $num, $data, $id);
-		$this->theHTTPStatusCodeShouldBeOr("201", "204");
+		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**


### PR DESCRIPTION
## Description
When doing new chunking uploads, just check that the HTTP  status a each stage of the upload process is a "success" `2xx` code. The purpose of these checks is just to gain some confidence that the upload is happening OK. In a `Given` step it is anyway not meant to be a definitive definition of the "requirement" for a particular HTTP  status code.

## Motivation and Context
When running activity app tests that did `Given` steps with async new chunking upload, the various upload status was being checked and required to bee `201` or `204`. But when doing async uploads, the server correctly returns `202` "Accepted" status for each chunk. We need to allow more "success" HTTP status codes.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
