### PR TITLE
[OCM] Make webdav URL absolute according to spec

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/OcmController.php
+++ b/apps/federatedfilesharing/lib/Controller/OcmController.php
@@ -423,7 +423,7 @@ class OcmController extends Controller {
 	 */
 	protected function getProtocols() {
 		return [
-			'webdav' => '/public.php/webdav/'
+			'webdav' => $this->urlGenerator->getAbsoluteURL('/public.php/webdav/')
 		];
 	}
 

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -103,8 +103,25 @@ class Storage extends DAV implements ISharedStorage {
 			$this->memcacheFactory,
 			\OC::$server->getHTTPClientService()
 		);
+		$webDavEndpoint = $discoveryManager->getWebDavEndpoint($this->remote);
+		// OCM endpoint is absolute, OC legacy is relative
+		$isOcmWebDavEndpoint = \preg_match('#https?://#', $webDavEndpoint) === 1;
+		if ($isOcmWebDavEndpoint) {
+			// proto is anything before ://
+			// host starts just after a proto and ends before the first slash
+			// root starts from the first slash until the end and could be empty
+			\preg_match_all(
+				'#^(?<proto>https?)://(?<host>[^/]*)(?<root>.*)$#',
+				$webDavEndpoint,
+				$matches
+			);
+			$this->secure = $matches['proto'][0] === 'https';
+			$this->host = $matches['host'][0];
+			$this->root = isset($matches['root'][0]) ? $matches['root'][0] : '/';
+		} else {
+			$this->root = \rtrim($this->root, '/') . $webDavEndpoint;
+		}
 
-		$this->root = \rtrim($this->root, '/') . $discoveryManager->getWebDavEndpoint($this->remote);
 		if (!$this->root || $this->root[0] !== '/') {
 			$this->root = '/' . $this->root;
 		}


### PR DESCRIPTION
resubmit of https://github.com/owncloud/core/pull/34260
## Description
Return an absolute URL for OCM WebDav discovery endpoint and change the storage to work with absolute discovery URLs

Note: It makes OCM-based sharing in backward incompatible  without patching apps/files_sharing/lib/External/Storage.php

## Related Issue
- Fixes https://github.com/owncloud/core/issues/34631

## Motivation and Context
To comply with OCM 1.0.0-proposal1 spec

## How Has This Been Tested?
open URL owncloud.tld/ocm-provider/
#### expected 
```
{"enabled":true,"apiVersion":"1.0-proposal1",
"endPoint":"http:\/\/owncloud.tld\/index.php\/apps\/federatedfilesharing",
"shareTypes":[{"name":"file",
"protocols":{"webdav":"http:\/\/owncloud.tld\/public.php\/webdav\/"}}]}
```

#### actual
```
{"enabled":true,"apiVersion":"1.0-proposal1",
"endPoint":"http:\/\/owncloud.tld\/index.php\/apps\/federatedfilesharing",
"shareTypes":[{"name":"file",
"protocols":{"webdav":"\/public.php\/webdav\/"}}]}
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

