### PR TITLE
Fix public download step text

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -38,7 +38,7 @@ Feature: download file
   Scenario: download a public shared file inside a folder with range
     When user "user0" creates a public link share using the sharing API with settings
       | path | PARENT |
-    And the public downloads file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with range "bytes=1-7" using the old public WebDAV API
+    And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API
     Then the downloaded content should be "wnCloud"
 
   @smokeTest

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -121,7 +121,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" using the old public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" using the old public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -137,7 +137,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with range "([^"]*)" using the old public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the old public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $range
@@ -151,7 +151,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" with range "([^"]*)" using the old public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" with range "([^"]*)" using the old public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password


### PR DESCRIPTION
## Description
Some `using the old public WebDAV API` was accidentally duplicated in PR #36041 
Remove the duplication.

## Related Issue
#36006

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
