### PR TITLE
fix file creation with content in public webdav api

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
@@ -97,7 +97,7 @@ class PublicSharedRootNode extends Collection {
 		}
 		try {
 			$file = $this->share->getNode()->newFile($name);
-			$file->putContent(data);
+			$file->putContent($data);
 			return $file->getEtag();
 		} catch (NotPermittedException $ex) {
 			throw new Forbidden('Permission denied to create file');


### PR DESCRIPTION
## Description
write the correct content to the file

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #36048

## Motivation and Context
we want to write the data that was received into the file

## How Has This Been Tested?
`PUT` to the webdav endpoint and check the content

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
