### PR TITLE
Throw error message when a user with email address as uid exists

### DIFF
--- a/core/Migrations/Version20190909083926.php
+++ b/core/Migrations/Version20190909083926.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20190909083926 implements ISchemaMigration {
+	private $dbConnection;
+
+	public function __construct(IDBConnection $dbConnection) {
+		$this->dbConnection = $dbConnection;
+	}
+
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+
+		$table = $schema->getTable("${prefix}accounts");
+		$column = $table->getColumn('email');
+
+		/**
+		 * Remove email id's which are duplicated in the accounts table.
+		 */
+		$qb = $this->dbConnection->getQueryBuilder();
+		$subQuery = $this->dbConnection->getQueryBuilder();
+
+		$subQuery->select('email')
+			->from('accounts')
+			->groupBy('email')
+			->having($subQuery->createFunction('COUNT(email) > 1'));
+
+		$subQueryResult = $subQuery->execute()->fetchAll();
+
+		$emailArray = \array_map(function ($val) {
+			return $val['email'];
+		}, $subQueryResult);
+
+		$qb->update('accounts', 't1')
+			->set('t1.email', $qb->createParameter('email'))
+			->where($qb->expr()->in('t1.email', $qb->createNamedParameter($emailArray, IQueryBuilder::PARAM_STR_ARRAY)))
+			->setParameter('email', null);
+
+		$qb->execute();
+
+		/**
+		 * The email column of accounts is set to NULL where the duplicate email address
+		 * is found. Now we can safely alter the table.
+		 */
+
+		$table->addUniqueIndex(['email'], 'email_address_index');
+	}
+}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -44,6 +44,7 @@ use OCP\IUserBackend;
 use OCP\IUserSession;
 use OCP\PreConditionNotMetException;
 use OCP\User\IChangePasswordBackend;
+use OCP\UserEmailException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -202,13 +203,17 @@ class User implements IUser {
 	 * @since 9.0.0
 	 */
 	public function setEMailAddress($mailAddress) {
-		$mailAddress = \trim($mailAddress);
-		if ($mailAddress === $this->account->getEmail()) {
-			return;
+		try {
+			$mailAddress = \trim($mailAddress);
+			if ($mailAddress === $this->account->getEmail()) {
+				return;
+			}
+			$this->account->setEmail($mailAddress);
+			$this->mapper->update($this->account);
+			$this->triggerChange('eMailAddress', $mailAddress);
+		} catch (\Exception $exception) {
+			throw new UserEmailException("email: {$mailAddress} is already used. Kindly try different email address.");
 		}
-		$this->account->setEmail($mailAddress);
-		$this->mapper->update($this->account);
-		$this->triggerChange('eMailAddress', $mailAddress);
 	}
 
 	/**

--- a/lib/public/UserEmailException.php
+++ b/lib/public/UserEmailException.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+/**
+ * Class UserEmailException
+ * @package OCP
+ * @since 10.3.1
+ */
+class UserEmailException extends \Exception {
+	/**
+	 * UserEmailException constructor.
+	 * @param string $message
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 10.3.1
+	 */
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -52,6 +52,7 @@ use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\IAvatarManager;
 use OCP\Security\ISecureRandom;
+use OCP\UserEmailException;
 use OCP\UserTokenException;
 use OCP\UserTokenExpiredException;
 use OCP\UserTokenMismatchException;
@@ -1068,7 +1069,14 @@ class UsersController extends Controller {
 			($this->groupManager->getSubAdmin()->isSubAdmin($this->userSession->getUser()) &&
 				$this->groupManager->getSubAdmin()->isUserAccessible($this->userSession->getUser(), $user)) ||
 				($this->userSession->getUser()->getUID() === $id)) {
-			$user->setEMailAddress($mailAddress);
+			try {
+				$user->setEMailAddress($mailAddress);
+			} catch (UserEmailException $exception) {
+				return new JSONResponse([
+					'error' => 'cannotSetEmailAddress',
+					'message' => $this->l10n->t($exception->getMessage())
+				], HTTP::STATUS_CONFLICT);
+			}
 			if ($this->config->getUserValue($id, 'owncloud', 'changeMail') !== '') {
 				$this->config->deleteUserValue($id, 'owncloud', 'changeMail');
 			}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -853,7 +853,7 @@ $(document).ready(function () {
 						$input.removeAttr('disabled')
 							.triggerHandler('blur'); // needed instead of $input.blur() for Firefox
 					}).fail(function (result) {
-						OC.Notification.showTemporary(result.responseJSON.data.message);
+						OC.Notification.showTemporary(result.responseJSON.message);
 						$td.find('.loading-small').css('display', '');
 						$input.removeAttr('disabled')
 							.css('padding-right', '6px');

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -74,6 +74,21 @@ class UserTest extends TestCase {
 		$this->user = new User($this->account, $this->accountMapper, $this->emitter, $this->config, $this->urlGenerator, $this->eventDispatcher);
 	}
 
+	public function testEmailAddress() {
+		$this->user->setEMailAddress('foo@bar.com');
+		$this->assertEquals('foo@bar.com', $this->user->getEMailAddress());
+	}
+
+	/**
+	 * @expectedException \OCP\UserEmailException
+	 * @expectedExceptionMessage email: foo@bar.com is already used. Kindly try different email address.
+	 */
+	public function testEmailAddressWithDuplicateFail() {
+		$this->accountMapper->method('update')
+			->willThrowException(new \Exception());
+		$this->user->setEMailAddress('foo@bar.com');
+	}
+
 	public function testDisplayName() {
 		$this->account->setDisplayName('Foo');
 		$this->assertEquals('Foo', $this->user->getDisplayName());


### PR DESCRIPTION
When admin creates user we should check the users
with username as email address exists.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Lets consider a scenario where a user with username as email address exist ( for instance a guest user). And admin tries to create another user say `user1` with the email address of guest user. The user should not be created. And an error message should be displayed. This PR addresses the same. I have made the error message same as for:
a) when the user exists and admin tries to create the same user.
b) The user names differ, but one of the username is same as the email address of new user to be created.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A check to forbid the user creation when a user is created with same email address of a guest user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a guest user with a valid email address
- From the webUI create another user with different uid and with same email address of guest.
- Error is thrown in the webUI.
- Also this has been tested using occ command and provisioning api.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
