### PR TITLE
all results that work in the old public link webDAV API should also work in the new one

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -330,8 +330,11 @@ class WebDavHelper {
 	public static function getDavPath(
 		$user, $davPathVersionToUse = 1, $type = "files"
 	) {
-		if ($type === "public-files") {
+		if ($type === "public-files" || $type === "public-files-old") {
 			return "public.php/webdav/";
+		}
+		if ($type === "public-files-new") {
+			return "remote.php/dav/public-files/$user/";
 		}
 		if ($type === "archive") {
 			return "remote.php/dav/archive/$user/files";

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -258,7 +258,9 @@ Feature: sharing
       | uid_owner              | user0                |
       | name                   |                      |
     And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "wnCloud"
     And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%" and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%" and the content should be "wnCloud"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -285,8 +287,11 @@ Feature: sharing
       | uid_owner              | user0                |
       | name                   |                      |
     And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"
     But the public should not be able to download file "/parent.txt" from inside the last public shared folder using the old public WebDAV API without a password
+    And the public should not be able to download file "/parent.txt" from inside the last public shared folder using the new public WebDAV API without a password
     And the public should not be able to download file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%"
+    And the public should not be able to download file "/parent.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -842,7 +847,8 @@ Feature: sharing
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    Then the public should be able to download the range "bytes=1-6" of file "/welcome.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "elcome"
+    And the public should be able to download the range "bytes=1-6" of file "/welcome.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "elcome"
+    And the public should be able to download the range "bytes=1-6" of file "/welcome.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "elcome"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -1279,6 +1285,7 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder, and checking it's content
     Given using OCS API version "<ocs_api_version>"
+    And user "user0" has uploaded file with content "ownCloud test text file parent" to "/PARENT/parent.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
     Then the OCS status code should be "<ocs_status_code>"
@@ -1292,8 +1299,8 @@ Feature: sharing
       | displayname_owner      | User Zero            |
       | uid_file_owner         | user0                |
       | uid_owner              | user0                |
-    When the public downloads file "/parent.txt" from inside the last public shared folder using the old public WebDAV API
-    Then the downloaded content should be "ownCloud test text file parent" plus end-of-line
+    And the public should be able to download file "parent.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "ownCloud test text file parent"
+    And the public should be able to download file "parent.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "ownCloud test text file parent"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -55,55 +55,88 @@ Feature: sharing
       | new              |
 
   @public_link_share-feature-required
+  @issue-36060
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions
     Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "user0" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "welcome.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "user0" file "PARENT/welcome.txt" <should-or-not> exist
     Examples:
-      | permissions               | http-status-code | should-or-not |
-      | read,update,create        | 403              | should        |
-      | read,update,create,delete | 204              | should not    |
+      | public-webdav-api-version | permissions               | http-status-code | should-or-not |
+      | old                       | read,update,create        | 403              | should        |
+      | new                       | read,update,create        | 204              | should not    |
+      #| new                       | read,update,create        | 403              | should        |
+      | old                       | read,update,create,delete | 204              | should not    |
+      | new                       | read,update,create,delete | 204              | should not    |
 
   @public_link_share-feature-required
+  @issue-36060
+  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create
+    Given user "user0" has created a public link share with settings
+      | path        | /PARENT            |
+      | permissions | read,update,create |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" file "/PARENT/parent.txt" should exist
+    And as "user0" file "/PARENT/newparent.txt" should not exist
+    Examples:
+      | public-webdav-api-version |
+      | old                       |
+      #| new                       |
+
+  @public_link_share-feature-required
+  @issue-36060
+  # After fixing the issue delete this scenario and use the one above to test both cases
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create
     Given user "user0" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "user0" file "/PARENT/parent.txt" should exist
-    And as "user0" file "/PARENT/newparent.txt" should not exist
-
-  @public_link_share-feature-required
-  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete
-    Given user "user0" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "user0" file "/PARENT/parent.txt" should not exist
     And as "user0" file "/PARENT/newparent.txt" should exist
 
   @public_link_share-feature-required
-  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create
+  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create,delete
+    Given user "user0" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "/PARENT/parent.txt" should not exist
+    And as "user0" file "/PARENT/newparent.txt" should exist
+    Examples:
+      | public-webdav-api-version |
+      | old                       |
+      | new                       |
+
+  @public_link_share-feature-required
+  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create
     Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "user0" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "lorem.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "user0" file "/PARENT/lorem.txt" should not exist
+    Examples:
+      | public-webdav-api-version |
+      | old                       |
+      | new                       |
 
   @public_link_share-feature-required
-  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete
+  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create,delete
     Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "user0" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "lorem.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "user0" should be "test"
+    Examples:
+      | public-webdav-api-version |
+      | old                       |
+      | new                       |

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -59,6 +59,7 @@ Feature: sharing
       | path     | PARENT   |
       | password | %public% |
     Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -87,6 +88,7 @@ Feature: sharing
       | password    | %public% |
       | permissions | change   |
     Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -115,3 +117,4 @@ Feature: sharing
       | password    | %public% |
       | permissions | read     |
     Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
+    And the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"

--- a/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
@@ -36,7 +36,9 @@ Feature: reshare as public link
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "some content"
     But uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -85,7 +87,9 @@ Feature: reshare as public link
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "some content"
     But uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -104,7 +108,9 @@ Feature: reshare as public link
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "some content"
     And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -142,6 +148,7 @@ Feature: reshare as public link
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -158,11 +165,13 @@ Feature: reshare as public link
       | permissions  | read      |
       | publicUpload | false     |
     And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     When user "user1" updates the last share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -291,6 +291,7 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -424,6 +425,7 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -444,6 +446,7 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -464,6 +467,7 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -506,6 +510,9 @@ Feature: sharing
       | permissions | read,update,create |
     When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
+    When the public deletes file "CHILD/child.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "404"
+    And as "user0" file "PARENT/CHILD/child.txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -526,6 +533,10 @@ Feature: sharing
       | permissions | read,update,create,delete |
     When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "204"
+    And as "user0" file "PARENT/CHILD/child.txt" should not exist
+    When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "204"
+    And as "user0" file "PARENT/parent.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -4,6 +4,7 @@ Feature: persistent-locking in case of a public link
   Background:
     Given user "user0" has been created with default attributes and skeleton files
 
+  @issue-36064
   Scenario Outline: Uploading a file into a locked public folder
     Given using <dav-path> DAV path
     And user "user0" has created a public link share of folder "FOLDER" with change permission
@@ -11,6 +12,9 @@ Feature: persistent-locking in case of a public link
       | lockscope | <lock-scope> |
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "423"
+    And uploading a file should work using the new public WebDAV API
+    #And uploading a file should not work using the new public WebDAV API
+    #And the HTTP status code should be "423"
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |
@@ -18,58 +22,110 @@ Feature: persistent-locking in case of a public link
       | new      | shared     |
       | new      | exclusive  |
 
+  @issue-36064
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
-    Given using <dav-path> DAV path
-    And user "user0" has created a public link share of folder "PARENT" with change permission
+    Given user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT/CHILD" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
-    And the public uploads file "CHILD/test.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    And the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
     And as "user0" file "/PARENT/CHILD/test.txt" should not exist
     But the content of file "/PARENT/test.txt" for user "user0" should be "test"
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | public-webdav-api-version | lock-scope |
+      | old                       | shared     |
+      | old                       | exclusive  |
+      #| new                       | shared     |
+      #| new                       | exclusive  |
 
+  @issue-36064
+  #after fixing the issue delete this Scenario and use the one above
+  Scenario Outline: Uploading a file into a locked subfolder of a public folder
+    Given user "user0" has created a public link share of folder "PARENT" with change permission
+    And user "user0" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    And the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "/PARENT/CHILD/test.txt" should exist
+    But the content of file "/PARENT/test.txt" for user "user0" should be "test"
+    Examples:
+      | public-webdav-api-version | lock-scope |
+      | new                       | shared     |
+      | new                       | exclusive  |
+
+  @issue-36064
   Scenario Outline: Overwrite a file inside a locked public folder
-    Given using <dav-path> DAV path
-    And user "user0" has created a public link share of folder "PARENT" with change permission
+    Given user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "parent.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "parent.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
     And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | public-webdav-api-version | lock-scope |
+      | old                       | shared     |
+      | old                       | exclusive  |
+      #| new                       | shared     |
+      #| new                       | exclusive  |
 
+  @issue-36064
+  #after fixing the issue delete this Scenario and use the one above
+  Scenario Outline: Overwrite a file inside a locked public folder
+    Given user "user0" has created a public link share of folder "PARENT" with change permission
+    And user "user0" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "parent.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/PARENT/parent.txt" for user "user0" should be "test"
+    Examples:
+      | public-webdav-api-version | lock-scope |
+      | new                       | shared     |
+      | new                       | exclusive  |
+
+  @issue-36064
   Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
-    Given using <dav-path> DAV path
-    And user "user0" has created a public link share of folder "PARENT" with change permission
+    Given user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT/CHILD" setting following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "parent.txt" with content "changed text" using the old public WebDAV API
-    And the public uploads file "CHILD/child.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "parent.txt" with content "changed text" using the <public-webdav-api-version> public WebDAV API
+    And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
     And the content of file "/PARENT/parent.txt" for user "user0" should be "changed text"
     But the content of file "/PARENT/CHILD/child.txt" for user "user0" should be "ownCloud test text file child" plus end-of-line
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | public-webdav-api-version | lock-scope |
+      | old                       | shared     |
+      | old                       | exclusive  |
+      #| new                       | shared     |
+      #| new                       | exclusive  |
 
-  Scenario: Public locking is forbidden
+  @issue-36064
+  #after fixing the issue delete this Scenario and use the one above
+  Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
     Given user "user0" has created a public link share of folder "PARENT" with change permission
-    When the public locks "/CHILD" in the last public shared folder using the WebDAV API setting following properties
-      | lockscope | exclusive |
+    And user "user0" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "parent.txt" with content "changed text" using the <public-webdav-api-version> public WebDAV API
+    And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/PARENT/parent.txt" for user "user0" should be "changed text"
+    But the content of file "/PARENT/CHILD/child.txt" for user "user0" should be "test"
+    Examples:
+      | public-webdav-api-version | lock-scope |
+      | new                       | shared     |
+      | new                       | exclusive  |
+
+  Scenario Outline: Public locking is forbidden
+    Given user "user0" has created a public link share of folder "PARENT" with change permission
+    When the public locks "/CHILD" in the last public shared folder using the <public-webdav-api-version> public WebDAV API setting following properties
+      | lockscope | <lock-scope> |
     Then the HTTP status code should be "403"
     And the value of the item "//s:message" in the response should be "Forbidden to lock from public endpoint"
+    Examples:
+      | public-webdav-api-version | lock-scope |
+      | old                       | shared     |
+      | old                       | exclusive  |
+      | new                       | shared     |
+      | new                       | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -79,6 +79,8 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "user0" using the old public WebDAV API
     Then the HTTP status code should be "423"
+    When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "user0" using the new public WebDAV API
+    Then the HTTP status code should be "412"
     And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | lock-scope |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -48,9 +48,9 @@ Feature: lock should propagate correctly if a share is reshared
       | new      | shared     |
       | new      | exclusive  |
 
+  @issue-36064
   Scenario Outline: public uploads to a reshared share that was locked by original owner
-    Given using <dav-path> DAV path
-    And user "user0" has shared folder "PARENT" with user "user1"
+    Given user "user0" has shared folder "PARENT" with user "user1"
     And user "user1" has shared folder "PARENT (2)" with user "user2"
     And user "user2" has created a public link share of folder "PARENT (2)" with change permission
     And user "user0" has locked folder "PARENT" setting following properties
@@ -58,12 +58,16 @@ Feature: lock should propagate correctly if a share is reshared
     When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "423"
     And as "user0" file "/PARENT/test.txt" should not exist
+    #When the public uploads file "test.txt" with content "test" using the new public WebDAV API
+    #Then the HTTP status code should be "423"
+    #And as "user0" file "/PARENT/test.txt" should not exist
+    When the public uploads file "test.txt" with content "test" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "/PARENT/test.txt" should exist
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | lock-scope |
+      | shared     |
+      | exclusive  |
 
   Scenario Outline: upload to a share that was locked by owner but renamed before
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -29,10 +29,12 @@ Feature: download file
 
   @public_link_share-feature-required
   Scenario: download a public shared file with range
-    When user "user0" creates a public link share using the sharing API with settings
+    Given user "user0" has created a public link share with settings
       | path | welcome.txt |
-    And the public downloads the last public shared file with range "bytes=51-77" using the old public WebDAV API
+    When the public downloads the last public shared file with range "bytes=51-77" using the old public WebDAV API
     Then the downloaded content should be "example file for developers"
+    When the public downloads the last public shared file with range "bytes=59-77" using the new public WebDAV API
+    Then the downloaded content should be "file for developers"
 
   @public_link_share-feature-required
   Scenario: download a public shared file inside a folder with range
@@ -40,6 +42,8 @@ Feature: download file
       | path | PARENT |
     And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API
     Then the downloaded content should be "wnCloud"
+    When the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=2-7" using the new public WebDAV API
+    Then the downloaded content should be "nCloud"
 
   @smokeTest
   Scenario Outline: Downloading a file should serve security headers

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
+use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';
 
@@ -38,85 +39,114 @@ class PublicWebDavContext implements Context {
 	private $featureContext;
 
 	/**
-	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the old public WebDAV API$/
+	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
-	 * @param string $range
+	 * @param string $range ignore if empty
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function downloadPublicFileWithRange($range) {
-		$token = $this->featureContext->getLastShareData()->data->token;
-		$fullUrl = $this->featureContext->getBaseUrl() . "/public.php/webdav";
-		$headers = [
-			'X-Requested-With' => 'XMLHttpRequest',
-			'Range' => $range
-		];
+	public function downloadPublicFileWithRange($range, $publicWebDAVAPIVersion) {
+		$lastShareData = $this->featureContext->getLastShareData()->data;
+		$token = $lastShareData->token;
+		$davPath = WebDavHelper::getDavPath(
+			$token, 0, "public-files-$publicWebDAVAPIVersion"
+		);
+		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath";
+		$user = $this->getUsernameForPublicWebdavApi(
+			$token, "", $publicWebDAVAPIVersion
+		);
+		if ($publicWebDAVAPIVersion === "new") {
+			$fullUrl = $fullUrl . $lastShareData->file_target;
+		}
+
+		$headers = [];
+		if ($range !== "") {
+			$headers = [
+				'X-Requested-With' => 'XMLHttpRequest',
+				'Range' => $range
+			];
+		}
 		$this->featureContext->setResponse(
-			HttpRequestHelper::get($fullUrl, $token, "", $headers)
+			HttpRequestHelper::get($fullUrl, $user, "", $headers)
 		);
 	}
 
 	/**
-	 * @When /^the public downloads the last public shared file using the old public WebDAV API$/
+	 * @When /^the public downloads the last public shared file using the (old|new) public WebDAV API$/
+	 *
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function downloadPublicFile() {
-		$token = $this->featureContext->getLastShareData()->data->token;
-		$fullUrl = $this->featureContext->getBaseUrl() . "/public.php/webdav";
-		$this->featureContext->setResponse(
-			HttpRequestHelper::get($fullUrl, $token)
-		);
+	public function downloadPublicFile($publicWebDAVAPIVersion) {
+		$this->downloadPublicFileWithRange("", $publicWebDAVAPIVersion);
 	}
 
 	/**
-	 * @When /^the public deletes file "([^"]*)" from the last public share using the old public WebDAV API$/
+	 * @When /^the public deletes file "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function deleteFileFromPublicShare($fileName) {
+	public function deleteFileFromPublicShare($fileName, $publicWebDAVAPIVersion) {
 		$token = $this->featureContext->getLastShareData()->data->token;
-		$fullUrl = $this->featureContext->getBaseUrl() . "/public.php/webdav/" . $fileName;
+		$davPath = WebDavHelper::getDavPath(
+			$token, 0, "public-files-$publicWebDAVAPIVersion"
+		);
+		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath$fileName";
+		$userName = $this->getUsernameForPublicWebdavApi(
+			$token, "", $publicWebDAVAPIVersion
+		);
 		$headers = [
 			'X-Requested-With' => 'XMLHttpRequest'
 		];
 		$this->featureContext->setResponse(
-			HttpRequestHelper::delete($fullUrl, $token, "", $headers)
+			HttpRequestHelper::delete($fullUrl, $userName, "", $headers)
 		);
 	}
 
 	/**
-	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public share using the old public WebDAV API$/
+	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $toFileName
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function renameFileFromPublicShare($fileName, $toFileName) {
+	public function renameFileFromPublicShare($fileName, $toFileName, $publicWebDAVAPIVersion) {
 		$token = $this->featureContext->getLastShareData()->data->token;
-		$fullUrl = $this->featureContext->getBaseUrl() . "/public.php/webdav/" . $fileName;
+		$davPath = WebDavHelper::getDavPath(
+			$token, 0, "public-files-$publicWebDAVAPIVersion"
+		);
+		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath$fileName";
+		$destination = $this->featureContext->getBaseUrl() . "/$davPath$toFileName";
+		$userName = $this->getUsernameForPublicWebdavApi(
+			$token, "", $publicWebDAVAPIVersion
+		);
 		$headers = [
 			'X-Requested-With' => 'XMLHttpRequest',
-			'Destination' => $this->featureContext->getBaseUrl() . "/public.php/webdav/" . $toFileName
+			'Destination' => $destination
 		];
 		$this->featureContext->setResponse(
-			HttpRequestHelper::sendRequest($fullUrl, "MOVE", $token, "", $headers)
+			HttpRequestHelper::sendRequest($fullUrl, "MOVE", $userName, "", $headers)
 		);
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the old public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function downloadPublicFileInsideAFolder($path) {
+	public function downloadPublicFileInsideAFolder($path, $publicWebDAVAPIVersion = "old") {
 		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
-			$path, "", ""
+			$path, "", "", $publicWebDAVAPIVersion
 		);
 	}
 
@@ -137,16 +167,17 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the old public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $range
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function downloadPublicFileInsideAFolderWithRange($path, $range) {
+	public function downloadPublicFileInsideAFolderWithRange($path, $range, $publicWebDAVAPIVersion) {
 		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
-			$path, "", $range
+			$path, "", $range, $publicWebDAVAPIVersion
 		);
 	}
 
@@ -155,16 +186,25 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @param string $path
 	 * @param string $password
-	 * @param string $range
+	 * @param string $range ignored when empty
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
 	public function publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
-		$path, $password, $range
+		$path, $password, $range, $publicWebDAVAPIVersion="old"
 	) {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
-		$fullUrl = $this->featureContext->getBaseUrl() . "/public.php/webdav/$path";
+		$token = $this->featureContext->getLastShareData()->data->token;
+		$davPath = WebDavHelper::getDavPath(
+			$token, 0, "public-files-$publicWebDAVAPIVersion"
+		);
+		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath$path";
+		$userName = $this->getUsernameForPublicWebdavApi(
+			$token, $password, $publicWebDAVAPIVersion
+		);
+
 		$headers = [
 			'X-Requested-With' => 'XMLHttpRequest'
 		];
@@ -172,8 +212,7 @@ class PublicWebDavContext implements Context {
 			$headers['Range'] = $range;
 		}
 		$response = HttpRequestHelper::get(
-			$fullUrl, $this->featureContext->getLastShareData()->data->token,
-			$password, $headers
+			$fullUrl, $userName, $password, $headers
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -192,6 +231,9 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * This only works with the old API, autorename is not suported in the new API
+	 * auto renaming is handled on files drop folders implicitly
+	 *
 	 * @When the public uploads file :filename with content :body with autorename mode using the old public WebDAV API
 	 * @Given the public has uploaded file :filename with content :body with autorename mode
 	 *
@@ -205,19 +247,22 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with password :password and content :body using the old public WebDAV API
+	 * @When /^the public uploads file "([^"]*)" with password "([^"]*)" and content "([^"]*)" using the (old|new) public WebDAV API$/
 	 * @Given the public has uploaded file :filename" with password :password and content :body
 	 *
 	 * @param string $filename target file name
 	 * @param string $password
 	 * @param string $body content to upload
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
 	public function publiclyUploadingContentWithPassword(
-		$filename, $password = '', $body = 'test'
+		$filename, $password = '', $body = 'test', $publicWebDAVAPIVersion="old"
 	) {
-		$this->publicUploadContent($filename, $password, $body);
+		$this->publicUploadContent(
+			$filename, $password, $body, false, [], $publicWebDAVAPIVersion
+		);
 	}
 
 	/**
@@ -234,159 +279,177 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :body using the old public WebDAV API
+	 * @When /^the public uploads file "([^"]*)" with content "([^"]*)" using the (old|new) public WebDAV API$/
 	 * @Given the public has uploaded file :filename with content :body
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function publiclyUploadingContent($filename, $body = 'test') {
-		$this->publicUploadContent($filename, '', $body);
+	public function publiclyUploadingContent(
+		$filename, $body = 'test', $publicWebDAVAPIVersion="old"
+	) {
+		$this->publicUploadContent(
+			$filename, '', $body, false, [], $publicWebDAVAPIVersion
+		);
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 * @param string $content
 	 *
 	 * @return void
 	 */
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolder(
-		$path, $content
+		$path, $publicWebDAVAPIVersion, $content
 	) {
 		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-			"", $path, "", $content
+			"", $path, $publicWebDAVAPIVersion, "", $content
 		);
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API without a password$/
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API without a password$/
 	 *
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
 	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolder(
-		$path
+		$path, $publicWebDAVAPIVersion
 	) {
 		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-			"", $path, ""
+			"", $path, $publicWebDAVAPIVersion, ""
 		);
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 * @param string $content
 	 *
 	 * @return void
 	 */
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
-		$path, $password, $content
+		$path, $publicWebDAVAPIVersion, $password, $content
 	) {
 		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-			"", $path, $password, $content
+			"", $path, $publicWebDAVAPIVersion, $password, $content
 		);
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 *
 	 * @return void
 	 */
 	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
-		$path, $password
+		$path, $publicWebDAVAPIVersion, $password
 	) {
 		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-			"", $path, $password
+			"", $path, $publicWebDAVAPIVersion, $password
 		);
 	}
 
 	/**
-	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 * @param string $content
 	 *
 	 * @return void
 	 */
 	public function shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-		$range, $path, $password, $content
+		$range, $path, $publicWebDAVAPIVersion, $password, $content
 	) {
 		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
-			$path, $password, $range
+			$path, $password, $range, $publicWebDAVAPIVersion
 		);
 		$this->featureContext->downloadedContentShouldBe($content);
 	}
 
 	/**
-	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 *
 	 * @return void
 	 */
 	public function shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-		$range, $path, $password
+		$range, $path, $publicWebDAVAPIVersion, $password
 	) {
 		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
-			$path, $password, $range
+			$path, $password, $range, $publicWebDAVAPIVersion
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(401);
 	}
 
 	/**
-	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API and the content should be "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 * @param string $content
 	 *
 	 * @return void
 	 */
 	public function shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolder(
-		$range, $path, $content
+		$range, $path, $publicWebDAVAPIVersion, $content
 	) {
 		$this->shouldBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-			$range, $path, "", $content
+			$range, $path, $publicWebDAVAPIVersion, "", $content
 		);
 	}
 
 	/**
-	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the old public WebDAV API without a password$/
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API without a password$/
 	 *
 	 * @param string $range
 	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
 	public function shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolder(
-		$range, $path
+		$range, $path, $publicWebDAVAPIVersion
 	) {
 		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-			$range, $path, ""
+			$range, $path, $publicWebDAVAPIVersion, ""
 		);
 	}
 
 	/**
-	 * @Then uploading a file should not work using the old public WebDAV API
+	 * @Then /^uploading a file should not work using the (old|new) public WebDAV API$/
+	 *
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function publiclyUploadingShouldNotWork() {
-		$this->publicUploadContent('whateverfilefortesting.txt', '', 'test');
+	public function publiclyUploadingShouldNotWork($publicWebDAVAPIVersion) {
+		$this->publicUploadContent(
+			'whateverfilefortesting.txt', '', 'test', false,
+			[], $publicWebDAVAPIVersion
+		);
 		$response = $this->featureContext->getResponse();
 		Assert::assertTrue(
 			($response->getStatusCode() == 507)
@@ -400,14 +463,18 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then uploading a file should work using the old public WebDAV API
+	 * @Then /^uploading a file should work using the (old|new) public WebDAV API$/
+	 *
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function publiclyUploadingShouldWork() {
-		$path = 'whateverfilefortesting.txt';
-		$content = 'test';
-		$this->publicUploadContent($path, '', $content);
+	public function publiclyUploadingShouldWork($publicWebDAVAPIVersion) {
+		$path = "whateverfilefortesting-$publicWebDAVAPIVersion-publicWebDAVAPI.txt";
+		$content = "test $publicWebDAVAPIVersion";
+		$this->publicUploadContent(
+			$path, '', $content, false, [], $publicWebDAVAPIVersion
+		);
 		$response = $this->featureContext->getResponse();
 		Assert::assertTrue(
 			($response->getStatusCode() == 201),
@@ -415,18 +482,19 @@ class PublicWebDavContext implements Context {
 			$response->getStatusCode()
 		);
 		$this->shouldBeAbleToDownloadFileInsidePublicSharedFolder(
-			$path, $content
+			$path, $publicWebDAVAPIVersion, $content
 		);
 	}
 
 	/**
-	 * Uploads a file through the old public WebDAV API and sets the response in FeatureContext
+	 * Uploads a file through the public WebDAV API and sets the response in FeatureContext
 	 *
 	 * @param string $filename
 	 * @param string $password
 	 * @param string $body
 	 * @param bool $autorename
 	 * @param array $additionalHeaders
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
@@ -435,15 +503,23 @@ class PublicWebDavContext implements Context {
 		$password = '',
 		$body = 'test',
 		$autorename = false,
-		$additionalHeaders = []
+		$additionalHeaders = [],
+		$publicWebDAVAPIVersion = "old"
 	) {
 		$password = $this->featureContext->getActualPassword($password);
-		$url = $this->featureContext->getBaseUrl() . "/public.php/webdav/";
+		$token =  $this->featureContext->getLastShareToken();
+		$davPath = WebDavHelper::getDavPath(
+			$token, 0, "public-files-$publicWebDAVAPIVersion"
+		);
+		$url = $this->featureContext->getBaseUrl() . "/$davPath";
+		$userName = $this->getUsernameForPublicWebdavApi(
+			$token, $password, $publicWebDAVAPIVersion
+		);
+
 		$filename = \implode(
 			'/', \array_map('rawurlencode', \explode('/', $filename))
 		);
 		$url .= \ltrim($filename, '/');
-		$token = $this->featureContext->getLastShareToken();
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 
 		if ($autorename) {
@@ -451,9 +527,31 @@ class PublicWebDavContext implements Context {
 		}
 		$headers = \array_merge($headers, $additionalHeaders);
 		$response = HttpRequestHelper::put(
-			$url, $token, $password, $headers, $body
+			$url, $userName, $password, $headers, $body
 		);
 		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @param string $token
+	 * @param string $password
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return string|null
+	 */
+	private function getUsernameForPublicWebdavApi(
+		$token, $password, $publicWebDAVAPIVersion
+	) {
+		if ($publicWebDAVAPIVersion === "old") {
+			$userName =  $token;
+		} else {
+			if ($password !== '') {
+				$userName =  'public';
+			} else {
+				$userName = null;
+			}
+		}
+		return $userName;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -179,14 +179,17 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public locks :file in the last public shared folder using the WebDAV API setting following properties
+	 * @When /^the public locks "([^"]*)" in the last public shared folder using the (old|new) public WebDAV API setting following properties$/
 	 *
 	 * @param string $file
+	 * @param string $publicWebDAVAPIVersion
 	 * @param TableNode $properties
 	 *
 	 * @return void
 	 */
-	public function publicLocksFileLastSharedFolder($file, TableNode $properties) {
+	public function publicLocksFileLastSharedFolder(
+		$file, $publicWebDAVAPIVersion, TableNode $properties
+	) {
 		$this->lockFile(
 			(string)$this->featureContext->getLastShareData()->data->token,
 			$file, $properties, true, false
@@ -379,24 +382,25 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :content sending the locktoken of file :itemToUseLockOf of user :lockOwner using the old public WebDAV API
+	 * @When /^the public uploads file "([^"]*)" with content "([^"]*)" sending the locktoken of file "([^"]*)" of user "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $filename
 	 * @param string $content
 	 * @param string $itemToUseLockOf
 	 * @param string $lockOwner
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 *
 	 */
 	public function publicUploadFileSendingLockTokenOfUser(
-		$filename, $content, $itemToUseLockOf, $lockOwner
+		$filename, $content, $itemToUseLockOf, $lockOwner, $publicWebDAVAPIVersion
 	) {
 		$headers = [
 			"If" => "(<" . $this->tokenOfLastLock[$lockOwner][$itemToUseLockOf] . ">)"
 		];
 		$this->publicWebDavContext->publicUploadContent(
-			$filename, '', $content, false, $headers
+			$filename, '', $content, false, $headers, $publicWebDAVAPIVersion
 		);
 	}
 

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -181,6 +181,8 @@ Feature: transfer-ownership
     Then the command should have been successful
     When the public downloads the last public shared file using the old public WebDAV API
     Then the downloaded content should be "user0 file"
+    When the public downloads the last public shared file using the new public WebDAV API
+    Then the downloaded content should be "user0 file"
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder shared with third user


### PR DESCRIPTION
## Description
tests for the new public webdav API
most things should work the same a in the old one

## Related Issue
- Fixes #36006

## Motivation and Context
test what was merged in #35932

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
