### PR TITLE
ETag has to be surrounded by double quotes

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/SharedNodeTrait.php
+++ b/apps/dav/lib/Files/PublicFiles/SharedNodeTrait.php
@@ -53,7 +53,7 @@ trait SharedNodeTrait {
 	}
 
 	public function getETag() {
-		return $this->node->getETag();
+		return '"' . $this->node->getEtag() . '"';
 	}
 
 	public function delete() {

--- a/apps/dav/lib/Meta/MetaFile.php
+++ b/apps/dav/lib/Meta/MetaFile.php
@@ -87,7 +87,7 @@ class MetaFile extends File implements ICopySource, IFileNode, IProvidesAddition
 	 * @inheritdoc
 	 */
 	public function getETag() {
-		return $this->file->getEtag();
+		return '"' . $this->file->getEtag() . '"';
 	}
 
 	/**

--- a/apps/dav/lib/TrashBin/AbstractTrashBinNode.php
+++ b/apps/dav/lib/TrashBin/AbstractTrashBinNode.php
@@ -74,7 +74,7 @@ abstract class AbstractTrashBinNode implements ITrashBinNode {
 	}
 
 	public function getETag() {
-		return $this->fileInfo->getEtag();
+		return '"' . $this->fileInfo->getEtag() . '"';
 	}
 
 	public function getLastModified() {

--- a/apps/dav/tests/unit/Files/PublicFiles/PublicFileTest.php
+++ b/apps/dav/tests/unit/Files/PublicFiles/PublicFileTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\Files\PublicFiles;
+
+use OCA\DAV\Files\PublicFiles\SharedFile;
+use OCP\Files\File;
+use OCP\Share\IShare;
+use Test\TestCase;
+
+class PublicFileTest extends TestCase {
+	public function testETag() {
+		$file = $this->createMock(File::class);
+		$file->method('getETag')->willReturn('123456');
+		$share = $this->createMock(IShare::class);
+		$metaFile = new SharedFile($file, $share);
+		$this->assertEquals('"123456"', $metaFile->getETag());
+	}
+}

--- a/apps/dav/tests/unit/Meta/MetaFileTest.php
+++ b/apps/dav/tests/unit/Meta/MetaFileTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\Meta;
+
+use OCA\DAV\Meta\MetaFile;
+use OCP\Files\File;
+use Test\TestCase;
+
+class MetaFileTest extends TestCase {
+	public function testETag() {
+		$file = $this->createMock(File::class);
+		$file->method('getETag')->willReturn('123456');
+		$metaFile = new MetaFile($file);
+		$this->assertEquals('"123456"', $metaFile->getETag());
+	}
+}

--- a/apps/dav/tests/unit/TrashBin/TrashBinFileTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinFileTest.php
@@ -29,6 +29,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\ForbiddenException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\LockedException;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Test\TestCase;
 
@@ -38,7 +39,7 @@ class TrashBinFileTest extends TestCase {
 	 */
 	private $trashBinFile;
 	/**
-	 * @var TrashBinManager | \PHPUnit\Framework\MockObject\MockObject
+	 * @var TrashBinManager | MockObject
 	 */
 	private $trashBinManager;
 

--- a/apps/dav/tests/unit/TrashBin/TrashBinFolderTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinFolderTest.php
@@ -24,6 +24,7 @@ namespace OCA\DAV\Tests\Unit\TrashBin;
 use OCA\DAV\TrashBin\TrashBinFolder;
 use OCA\DAV\TrashBin\TrashBinManager;
 use OCP\Files\FileInfo;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\NotFound;
 use Test\TestCase;
 
@@ -33,11 +34,11 @@ class TrashBinFolderTest extends TestCase {
 	 */
 	private $trashBinFolder;
 	/**
-	 * @var TrashBinManager | \PHPUnit\Framework\MockObject\MockObject
+	 * @var TrashBinManager | MockObject
 	 */
 	private $trashBinManager;
 	/**
-	 * @var FileInfo | \PHPUnit\Framework\MockObject\MockObject
+	 * @var FileInfo | MockObject
 	 */
 	private $fileInfo;
 
@@ -122,7 +123,7 @@ class TrashBinFolderTest extends TestCase {
 		return [
 			['666', 'getName'],
 			['foo', 'getContentType'],
-			['abcdefgh', 'getEtag'],
+			['"abcdefgh"', 'getEtag'],
 			[789123456, 'getLastModified'],
 			[12345678, 'getSize'],
 			['foo', 'getOriginalFileName'],


### PR DESCRIPTION
## Description
As per spec ETag has to be surrounded by double quotes.
Changed all relevant implementations and added tests

## Related Issue
- fixes #36034
- fixes #36052

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
