### PR TITLE
Do not rely on include path

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -236,7 +236,7 @@ class OC_App {
 	private static function requireAppFile($app) {
 		try {
 			// encapsulated here to avoid variable scope conflicts
-			require_once $app . '/appinfo/app.php';
+			require_once self::getAppPath($app) . '/appinfo/app.php';
 		} catch (Exception $ex) {
 			\OC::$server->getLogger()->logException($ex);
 			$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();


### PR DESCRIPTION
## Description
Always use an absolute path to app.php

## Motivation and Context
outdated `appname/appinfo/app.php` could be loaded if there are two versions of the same app in app directories

## How Has This Been Tested?
1. install OC 10.2.1 with the default app directories:
 `apps` is non-writable, `apps-external` is writable
2. Copy any app from  `apps` into `apps-external`, increase version in `apps-external/appname/appinfo/app.php`
3. set breakpoints on `apps/appname/appinfo/app.php` and `apps-external/appname/appinfo/app.php` or add logging to both files

### Expected 
 breakpoint or logging is triggered in `apps-external/appname/appinfo/app.php` as it has more recent version

### Actual
 breakpoint or logging is triggered in `apps/appname/appinfo/app.php` 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

