### PR TITLE
Handle error scenario in File::putContent

### DIFF
--- a/lib/private/Files/Node/File.php
+++ b/lib/private/Files/Node/File.php
@@ -63,12 +63,15 @@ class File extends Node implements \OCP\Files\File, IPreviewNode {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function putContent($data) {
-		if ($this->checkPermissions(\OCP\Constants::PERMISSION_UPDATE)) {
-			$this->sendHooks(['preWrite']);
-			$this->view->file_put_contents($this->path, $data);
-			$this->fileInfo = null;
-			$this->sendHooks(['postWrite']);
-		} else {
+		if (!$this->checkPermissions(\OCP\Constants::PERMISSION_UPDATE)) {
+			throw new NotPermittedException();
+		}
+
+		$this->sendHooks(['preWrite']);
+		$result = $this->view->file_put_contents($this->path, $data);
+		$this->fileInfo = null;
+		$this->sendHooks(['postWrite']);
+		if ($result === false) {
 			throw new NotPermittedException();
 		}
 	}


### PR DESCRIPTION
## Description
In case file_put_content is failing an execption is thrown. Before this was silently ignored

## Related Issue
- refs #36056 

## How Has This Been Tested?
- follow steps in #36056 
- this will return with 403/forbidden and no empty file will be created
- the proper quota check will be added in a followup pr

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
