### PR TITLE
Sharing tests scenario fixes

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -254,6 +254,7 @@ default:
         - FederationContext:
         - WebDavPropertiesContext:
         - FilesVersionsContext:
+        - PublicWebDavContext:
 
     cliProvisioning:
       paths:

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -42,78 +42,55 @@ Feature: sharing
     And as "user0" file "/sub/shared_file.txt" should exist in trash
 
   @public_link_share-feature-required
-  Scenario Outline: Public can delete file through publicly shared link having delete permissions
-    Given using OCS API version "<ocs_api_version>"
-    And user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
-    When user "user0" creates a public link share using the sharing API with settings
+  Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions
+    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "user0" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    And the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "user0" file "PARENT/welcome.txt" <should-or-not> exist
     Examples:
-      | ocs_api_version | permissions               | http-status-code | should-or-not |
-      | 1               | read,update,create        | 403              | should        |
-      | 2               | read,update,create        | 403              | should        |
-      | 1               | read,update,create,delete | 204              | should not    |
-      | 2               | read,update,create,delete | 204              | should not    |
+      | permissions               | http-status-code | should-or-not |
+      | read,update,create        | 403              | should        |
+      | read,update,create,delete | 204              | should not    |
 
   @public_link_share-feature-required
-  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create
-    Given using OCS API version "<ocs_api_version>"
-    When user "user0" creates a public link share using the sharing API with settings
+  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create
+    Given user "user0" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    And the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
     And as "user0" file "/PARENT/parent.txt" should exist
     And as "user0" file "/PARENT/newparent.txt" should not exist
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
 
   @public_link_share-feature-required
-  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create,delete
-    Given using OCS API version "<ocs_api_version>"
-    When user "user0" creates a public link share using the sharing API with settings
+  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete
+    Given user "user0" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    And the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "201"
     And as "user0" file "/PARENT/parent.txt" should not exist
     And as "user0" file "/PARENT/newparent.txt" should exist
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
 
   @public_link_share-feature-required
-  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create
-    Given using OCS API version "<ocs_api_version>"
-    And user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
-    When user "user0" creates a public link share using the sharing API with settings
+  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create
+    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "user0" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    And the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "403"
     And as "user0" file "/PARENT/lorem.txt" should not exist
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
 
   @public_link_share-feature-required
-  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create,delete
-    Given using OCS API version "<ocs_api_version>"
-    And user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
-    When user "user0" creates a public link share using the sharing API with settings
+  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete
+    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "user0" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    And the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "user0" should be "test"
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -2,24 +2,28 @@
 Feature: sharing
 
   Background:
-    Given using OCS API version "1"
-    And using old DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
 
   @smokeTest
-  Scenario: moving a file into a share as recipient
-    Given user "user0" has created folder "/shared"
+  Scenario Outline: moving a file into a share as recipient
+    Given using <dav-path-version> DAV path
+    And user "user0" has created folder "/shared"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the WebDAV API
     Then as "user1" file "/shared/shared_file.txt" should exist
     And as "user0" file "/shared/shared_file.txt" should exist
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @smokeTest @files_trashbin-app-required
-  Scenario: moving a file out of a share as recipient creates a backup for the owner
-    Given user "user0" has created folder "/shared"
+  Scenario Outline: moving a file out of a share as recipient creates a backup for the owner
+    Given using <dav-path-version> DAV path
+    And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared file "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/shared_renamed"
@@ -27,10 +31,15 @@ Feature: sharing
     Then as "user1" file "/taken_out.txt" should exist
     And as "user0" file "/shared/shared_file.txt" should not exist
     And as "user0" file "/shared_file.txt" should exist in trash
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @files_trashbin-app-required
-  Scenario: moving a folder out of a share as recipient creates a backup for the owner
-    Given user "user0" has created folder "/shared"
+  Scenario Outline: moving a folder out of a share as recipient creates a backup for the owner
+    Given using <dav-path-version> DAV path
+    And user "user0" has created folder "/shared"
     And user "user0" has created folder "/shared/sub"
     And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
     And user "user0" has shared file "/shared" with user "user1"
@@ -40,6 +49,10 @@ Feature: sharing
     And as "user0" folder "/shared/sub" should not exist
     And as "user0" folder "/sub" should exist in trash
     And as "user0" file "/sub/shared_file.txt" should exist in trash
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @public_link_share-feature-required
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -239,7 +239,6 @@ trait Sharing {
 
 	/**
 	 * @When /^user "([^"]*)" creates a public link share using the sharing API with settings$/
-	 * @Given /^user "([^"]*)" has created a public link share with settings$/
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
@@ -252,6 +251,20 @@ trait Sharing {
 		$rows[] = ['shareType', 'public_link'];
 		$newBody = new TableNode($rows);
 		$this->userCreatesAShareWithSettings($user, $newBody);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has created a public link share with settings$/
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function userHasCreatedAPublicLinkShareWithSettings($user, $body) {
+		$this->userCreatesAPublicLinkShareWithSettings($user, $body);
+		$this->ocsContext->theOCSStatusCodeShouldBe([100, 200]);
+		$this->theHTTPStatusCodeShouldBe(200);
 	}
 
 	/**

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -173,15 +173,14 @@ Feature: transfer-ownership
   Scenario: transferring ownership of folder shares which has public link
     Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
-    And user "user0" has shared folder "/test" with user "user2" with permissions "all"
-    And user "user1" has created a public link share with settings
+    And user "user0" has uploaded file with content "user0 file" to "/test/somefile.txt"
+    And user "user0" has created a public link share with settings
       | path | /test/somefile.txt |
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
     Then the command should have been successful
-    And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
+    When the public downloads the last public shared file using the old public WebDAV API
+    Then the downloaded content should be "user0 file"
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder shared with third user


### PR DESCRIPTION
## Description
1. the public share tests do not need to be run with different OCS API versions, we do not want to test the sharing (tested in other tests) but the webdav access
2. where it makes sense run tests with different WebDAV API versions. Where we test WebDAV, we want to test with both versions
3. fix a random transfer-ownership test that was discovered to be wrong by splitting Given & When step in 1. 

## How Has This Been Tested?
:robot:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
