### PR TITLE
Add proper ACLs on PublicSharedRootNode

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -182,7 +182,7 @@ Feature: sharing
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
     And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
-    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "404"
+    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -244,7 +244,7 @@ Feature: sharing
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
     And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
-    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "404"
+    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -55,7 +55,6 @@ Feature: sharing
       | new              |
 
   @public_link_share-feature-required
-  @issue-36060
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions
     Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "user0" has created a public link share with settings
@@ -67,13 +66,11 @@ Feature: sharing
     Examples:
       | public-webdav-api-version | permissions               | http-status-code | should-or-not |
       | old                       | read,update,create        | 403              | should        |
-      | new                       | read,update,create        | 204              | should not    |
-      #| new                       | read,update,create        | 403              | should        |
+      | new                       | read,update,create        | 403              | should        |
       | old                       | read,update,create,delete | 204              | should not    |
       | new                       | read,update,create,delete | 204              | should not    |
 
   @public_link_share-feature-required
-  @issue-36060
   Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create
     Given user "user0" has created a public link share with settings
       | path        | /PARENT            |
@@ -85,19 +82,7 @@ Feature: sharing
     Examples:
       | public-webdav-api-version |
       | old                       |
-      #| new                       |
-
-  @public_link_share-feature-required
-  @issue-36060
-  # After fixing the issue delete this scenario and use the one above to test both cases
-  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create
-    Given user "user0" has created a public link share with settings
-      | path        | /PARENT            |
-      | permissions | read,update,create |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "201"
-    And as "user0" file "/PARENT/parent.txt" should not exist
-    And as "user0" file "/PARENT/newparent.txt" should exist
+      | new                       |
 
   @public_link_share-feature-required
   Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create,delete

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -367,9 +367,9 @@ Feature: sharing
     When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "201"
     When the public uploads file "test.txt" with content "test2" using the <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "<unsuccess-code>"
+    Then the HTTP status code should be "403"
     And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
     Examples:
-      | public-webdav-api-version | unsuccess-code |
-      | old                       | 403            |
-      | new                       | 404            |
+      | public-webdav-api-version |
+      | old                       |
+      | new                       |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -512,7 +512,7 @@ Feature: sharing
     When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
     When the public deletes file "CHILD/child.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "403"
     And as "user0" file "PARENT/CHILD/child.txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code |


### PR DESCRIPTION
## Description
ACLs have been missing on the root node of a public share

## Related Issue
- Fixes #36060

## How Has This Been Tested?
- follow steps in #36060

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
