### PR TITLE
Remove null fileid from the properties

### DIFF
--- a/apps/dav/lib/BackgroundJob/CleanProperties.php
+++ b/apps/dav/lib/BackgroundJob/CleanProperties.php
@@ -63,7 +63,8 @@ class CleanProperties extends TimedJob {
 		$qb = $this->connection->getQueryBuilder();
 
 		$qb->delete('properties')
-			->where($qb->expr()->in('fileid', $qb->createParameter('fileids')));
+			->where($qb->expr()->in('fileid', $qb->createParameter('fileids')))
+			->orWhere($qb->expr()->isNull('fileid'));
 		$qb->setParameter('fileids', $fileids, IQueryBuilder::PARAM_INT_ARRAY);
 		$qb->execute();
 	}


### PR DESCRIPTION
Remove null fileid from the properties.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Delete null fileid from the properties table. The fileid points to the ids in the filecache. If the fileid points to `NULL`, then something has gone wrong. This PR removes the row(s) which have fileid with `NULL` value.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35292

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove entries with fileid as `NULL` in the properties table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created entry in the table with fileId null. Created another entry with proper fileid ( fileid was taken from the filecache table)
- Now execute the CleanProperties job.
- The null entry will be removed.
- Also there won't be infinite loop caused due to null value of fileid.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
