### PR TITLE
Handle no longer existing resource of a link share

### DIFF
--- a/apps/dav/tests/unit/Files/PublicFiles/PublicSharedRootNodeTest.php
+++ b/apps/dav/tests/unit/Files/PublicFiles/PublicSharedRootNodeTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\Files\PublicFiles;
+
+use OCA\DAV\Files\PublicFiles\PublicSharedRootNode;
+use OCP\Files\NotFoundException;
+use OCP\IRequest;
+use OCP\Share\IShare;
+use Test\TestCase;
+
+class PublicSharedRootNodeTest extends TestCase {
+	/**
+	 * @expectedException \Sabre\DAV\Exception\NotFound
+	 */
+	public function testNoLongerExistingResource() {
+		$share = $this->createMock(IShare::class);
+		$request = $this->createMock(IRequest::class);
+		$share->method('getNode')->willThrowException(new NotFoundException());
+
+		$publicSharedRoot = new PublicSharedRootNode($share, $request);
+		$publicSharedRoot->getChildren();
+	}
+}

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -17,6 +17,15 @@ Feature: sharing
     And the public should be able to download the range "bytes=0-7" of file "/test.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "ownCloud"
     #And the public download of file "/test.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
 
+  @public_link_share-feature-required
+  Scenario: Downloading from share after the share source was deleted
+    Given user "user0" has created a public link share with settings
+      | path        | PARENT |
+      | permissions | read   |
+    When user "user0" deletes folder "PARENT" using the WebDAV API
+    Then the public download of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API should fail with HTTP status code "404"
+    And the public download of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
+
   Scenario: Share a file by multiple channels and download from sub-folder and direct file share
     Given these users have been created with default attributes and skeleton files:
       | username |


### PR DESCRIPTION
## Description
Handle NotFound exception properly

## Related Issue
- Fixes #36055

## How Has This Been Tested?
- follow steps as per #36055

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
