### PR TITLE
Fixes #36067 - start rename index with 2

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicFilesPlugin.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicFilesPlugin.php
@@ -86,7 +86,7 @@ class PublicFilesPlugin extends ServerPlugin {
 		$fileName = $pathInfo['filename'];
 		$ext = $pathInfo['extension'];
 
-		$i = 1;
+		$i = 2;
 		while ($this->server->tree->nodeExists("$dirName/$fileName ($i).$ext")) {
 			$i++;
 		}

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -17,7 +17,6 @@ Feature: sharing
     And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
   @smokeTest @public_link_share-feature-required
-  @issue-36067
   Scenario: Uploading same file to a public upload-only share multiple times via new API
     # The new API does the autorename automatically in upload-only folders
     Given as user "user0"
@@ -28,8 +27,7 @@ Feature: sharing
     When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
-    And the content of file "/FOLDER/test (1).txt" for user "user0" should be "test2"
-    #And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
+    And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
   @public_link_share-feature-required
   @issue-36055


### PR DESCRIPTION

## Description
 start rename index with 2

## Related Issue
- Fixes #36067

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
