### PR TITLE
Fix single trashbin item deletion via DAV endpoint

### DIFF
--- a/apps/dav/lib/TrashBin/TrashBinManager.php
+++ b/apps/dav/lib/TrashBin/TrashBinManager.php
@@ -105,7 +105,7 @@ class TrashBinManager {
 	public function delete(string $user, AbstractTrashBinNode $trashItem) {
 		$path = $trashItem->getPathInTrash();
 		$path = \implode('/', $path);
-		Trashbin::delete($path, $user, $trashItem->getDeleteTimestamp());
+		Trashbin::delete($path, $user);
 	}
 
 	public function deleteAll() {

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -4,10 +4,6 @@ Feature: files and folders can be deleted from the trashbin
   I want to delete files and folders from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
-  Background:
-    Given using OCS API version "1"
-    And as the administrator
-
   @smokeTest
   Scenario Outline: Trashbin can be emptied
     Given using <dav-path> DAV path
@@ -24,3 +20,33 @@ Feature: files and folders can be deleted from the trashbin
       | dav-path |
       | old      |
       | new      |
+
+    Scenario: delete a single file from the trashbin
+      Given user "user0" has been created with default attributes and skeleton files
+      And user "user0" has deleted file "/textfile0.txt"
+      And user "user0" has deleted file "/textfile1.txt"
+      And user "user0" has deleted file "/PARENT/parent.txt"
+      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+      When user "user0" deletes the file with original path "textfile1.txt" from the trashbin using the trashbin API
+      Then the HTTP status code should be "204"
+      And as "user0" the file with original path "/textfile1.txt" should not exist in trash
+      But as "user0" the file with original path "/textfile0.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+
+    Scenario: delete multiple files from the trashbin and make sure the correct ones are gone
+      Given user "user0" has been created with default attributes and skeleton files
+      And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
+      And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/child.txt"
+      And user "user0" has deleted file "/textfile0.txt"
+      And user "user0" has deleted file "/textfile1.txt"
+      And user "user0" has deleted file "/PARENT/parent.txt"
+      And user "user0" has deleted file "/PARENT/child.txt"
+      And user "user0" has deleted file "/PARENT/textfile0.txt"
+      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+      When user "user0" deletes the file with original path "/PARENT/textfile0.txt" from the trashbin using the trashbin API
+      And user "user0" deletes the file with original path "/PARENT/CHILD/child.txt" from the trashbin using the trashbin API
+      Then as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in trash
+      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should not exist in trash
+      But as "user0" the file with original path "/textfile0.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/child.txt" should exist in trash


### PR DESCRIPTION
## Description
Remove excessive timestamp

## Related Issue
- Fixes #35997

## Motivation and Context


## How Has This Been Tested?
1. create a file
2. delete this file
3. find the trashbin webdav URL of this file: `curl -u admin:admin http://localhost/owncloud-core/remote.php/dav/trash-bin/admin -X PROPFIND | xmllint --format -`
4. delete the file from trashbin `curl -u admin:admin http://localhost/owncloud-core/remote.php/dav/trash-bin/admin/2147624736 -X DELETE -v`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
