### PR TITLE
delete duplication in acceptance test-code

### DIFF
--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -46,14 +46,14 @@ Feature: sharing
       | path      | PARENT |
       | shareType | user   |
       | shareWith | user1  |
-    Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
+    Then the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "user1" with range "bytes=1-7" should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
     Given user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     When user "user0" has shared folder "PARENT" with group "grp1"
-    Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
+    Then the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "user1" with range "bytes=1-7" should be "wnCloud"
 
   @smokeTest @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
@@ -70,7 +70,7 @@ Feature: sharing
       | shareType   | user   |
       | shareWith   | user1  |
       | permissions | change |
-    Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
+    Then the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "user1" with range "bytes=1-7" should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -81,7 +81,7 @@ Feature: sharing
       | shareType   | group  |
       | shareWith   | grp1   |
       | permissions | change |
-    Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
+    Then the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "user1" with range "bytes=1-7" should be "wnCloud"
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission
@@ -99,7 +99,7 @@ Feature: sharing
       | shareType   | user   |
       | shareWith   | user1  |
       | permissions | read   |
-    Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
+    Then the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "user1" with range "bytes=1-7" should be "wnCloud"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -110,7 +110,7 @@ Feature: sharing
       | shareType   | group  |
       | shareWith   | grp1   |
       | permissions | read   |
-    Then user "user1" should be able to download the range "bytes=1-7" of file "/PARENT (2)/CHILD/child.txt" using the sharing API and the content should be "wnCloud"
+    Then the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "user1" with range "bytes=1-7" should be "wnCloud"
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -438,38 +438,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then user :user should be able to download the range :range of file :path using the sharing API and the content should be :content
-	 *
-	 * @param string $user
-	 * @param string $range
-	 * @param string $path
-	 * @param string $content
-	 *
-	 * @return void
-	 */
-	public function userShouldBeAbleToDownloadTheRangeOfFileAndTheContentShouldBe($user, $range, $path, $content) {
-		$path = \ltrim($path, "/");
-		$url = $this->getBaseUrl() . "/remote.php/webdav/$path";
-		$headers = [
-			'Range' => $range
-		];
-		$this->response = HttpRequestHelper::get(
-			$url, $user, $this->getPasswordForUser($user), $headers
-		);
-		Assert::assertEquals(
-			206,
-			$this->response->getStatusCode()
-		);
-		$buf = '';
-		$body = $this->response->getBody();
-		while (!$body->eof()) {
-			// read everything
-			$buf .= $body->read(8192);
-		}
-		Assert::assertSame($content, $buf);
-	}
-
-	/**
 	 * @param string $url
 	 * @param string $user
 	 * @param string $password


### PR DESCRIPTION
## Description
both test steps are very  similar. The only difference I could spot is that `userShouldBeAbleToDownloadTheRangeOfFileAndTheContentShouldBe()` would not obey  `Given using old|new DAV path`

## Motivation and Context
deleted code is debugged code

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
