### PR TITLE
test downloading file from upload-only folder

### DIFF
--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -7,13 +7,15 @@ Feature: sharing
     And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest @public_link_share-feature-required
+  @issue-36076
   Scenario: Downloading from upload-only share is forbidden
     Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | create |
-    Then the public shared file "test.txt" should not be able to be downloaded
-    And the HTTP status code should be "404"
+    Then the public download of file "/test.txt" from inside the last public shared folder using the old public WebDAV API should fail with HTTP status code "404"
+    And the public should be able to download the range "bytes=0-7" of file "/test.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "ownCloud"
+    #And the public download of file "/test.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
 
   Scenario: Share a file by multiple channels and download from sub-folder and direct file share
     Given these users have been created with default attributes and skeleton files:

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -429,28 +429,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the public shared file "([^"]*)" should not be able to be downloaded$/
-	 *
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function publicSharedFileCannotBeDownloaded($path) {
-		$token = $this->getLastShareToken();
-		$fullUrl = $this->getBaseUrl()
-			. "/public.php/webdav/" . \rawurlencode(\ltrim($path, '/'));
-
-		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
-		$this->response = HttpRequestHelper::get($fullUrl, $token, "", $headers);
-		Assert::assertGreaterThanOrEqual(
-			400, $this->response->getStatusCode(), 'download must fail'
-		);
-		Assert::assertLessThanOrEqual(
-			499, $this->response->getStatusCode(), '4xx error expected'
-		);
-	}
-
-	/**
 	 * Give the mimetype of the last shared file
 	 *
 	 * @return string


### PR DESCRIPTION
## Description
additionally to the test itself deleted `publicSharedFileCannotBeDownloaded` and refactored `shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword` because both functions have been very similar

## Related Issue
part of #36006

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
