### PR TITLE
IE doesn't redirect to login page when user is not logged in

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -195,7 +195,9 @@ class SecurityMiddleware extends Middleware {
 		}
 
 		if ($exception instanceof SecurityException) {
-			if (\stripos($this->request->getHeader('Accept'), 'html') === false) {
+			if ($this->request->getHeader('Accept') !== '*/*'
+				&& \stripos($this->request->getHeader('Accept'), 'html') === false
+			) {
 				$response = new JSONResponse(
 					['message' => $exception->getMessage()],
 					$exception->getCode()


### PR DESCRIPTION
## Description
send html response when the client says any content-type  is acceptable

## Motivation and Context
0. IE 11 is set as a default browser
1. ownCloud User on Windows clicks on ownCloud private permalink (included in e.g. email) 

# Expected behavior
 IE opens and login page is presented

# Actual behavior
IE opens and user receives download dialog to download a file of 43 bytes (which is the uid of the user)
User needs to change URL to point to ../login.php and authenticate there

## How Has This Been Tested?
Not tested yet

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

