### PR TITLE
PublicFiles: Quote ETag in headers as well

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
@@ -120,7 +120,7 @@ class PublicSharedRootNode extends Collection {
 			$etag =  $pendingFile->getEtag();
 			// all operations have been successful - no need to cleanup the pending file in finally block
 			$pendingFile = null;
-			return $etag;
+			return '"' . $etag . '"';
 		} catch (NotPermittedException $ex) {
 			throw new Forbidden('Permission denied to create file');
 		} catch (InvalidPathException $ex) {

--- a/apps/dav/lib/Files/PublicFiles/SharedFolder.php
+++ b/apps/dav/lib/Files/PublicFiles/SharedFolder.php
@@ -23,6 +23,8 @@ namespace OCA\DAV\Files\PublicFiles;
 
 use OCP\Constants;
 use OCP\Files\Folder;
+use OCP\Files\InvalidPathException;
+use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Share\IShare;
 use Sabre\DAV\Collection;
@@ -71,8 +73,17 @@ class SharedFolder extends Collection implements IACL, IPublicSharedNode {
 	}
 
 	public function createFile($name, $data = null) {
-		$file = $this->folder->newFile($name);
-		$file->putContent($data);
+		try {
+			$file = $this->folder->newFile($name);
+			$file->putContent($data);
+			return '"' . $file->getEtag() . '"';
+		} catch (NotPermittedException $ex) {
+			throw new Forbidden('Permission denied to create file');
+		} catch (InvalidPathException $ex) {
+			throw new Forbidden('Permission denied to create file');
+		} catch (NotFoundException $ex) {
+			throw new Forbidden('Permission denied to create file');
+		}
 	}
 
 	public function getACL() {


### PR DESCRIPTION
## Description
Missing piece as of #36053

## Related Issue
- many failing sdk prs - e.g. https://drone.owncloud.com/owncloud/owncloud-sdk/383

## How Has This Been Tested?
- :hand: with owncloud-sdk test suite

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
