### PR TITLE
test download single file public links with new webdav API

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -162,23 +162,25 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1)
     Given using OCS API version "<ocs_api_version>"
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
-      | path | welcome.txt |
+      | path | randomfile.txt |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
-      | item_type              | file         |
-      | mimetype               | text/plain   |
-      | file_target            | /welcome.txt |
-      | path                   | /welcome.txt |
-      | permissions            | read         |
-      | share_type             | public_link  |
-      | displayname_file_owner | User Zero    |
-      | displayname_owner      | User Zero    |
-      | uid_file_owner         | user0        |
-      | uid_owner              | user0        |
-      | name                   |              |
-    And the last public shared file should be able to be downloaded without a password
+      | item_type              | file            |
+      | mimetype               | text/plain      |
+      | file_target            | /randomfile.txt |
+      | path                   | /randomfile.txt |
+      | permissions            | read            |
+      | share_type             | public_link     |
+      | displayname_file_owner | User Zero       |
+      | displayname_owner      | User Zero       |
+      | uid_file_owner         | user0           |
+      | uid_owner              | user0           |
+      | name                   |                 |
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -187,26 +189,30 @@ Feature: sharing
   @smokeTest @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file with password
     Given using OCS API version "<ocs_api_version>"
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
-      | path     | welcome.txt |
-      | password | %public%    |
+      | path     | randomfile.txt |
+      | password | %public%       |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
-      | item_type              | file         |
-      | mimetype               | text/plain   |
-      | file_target            | /welcome.txt |
-      | path                   | /welcome.txt |
-      | permissions            | read         |
-      | share_type             | public_link  |
-      | displayname_file_owner | User Zero    |
-      | displayname_owner      | User Zero    |
-      | uid_file_owner         | user0        |
-      | uid_owner              | user0        |
-      | name                   |              |
-    And the last public shared file should be able to be downloaded with password "%public%"
-    But the last public shared file should not be able to be downloaded with password "%regular%"
-    And the last public shared file should not be able to be downloaded without a password
+      | item_type              | file            |
+      | mimetype               | text/plain      |
+      | file_target            | /randomfile.txt |
+      | path                   | /randomfile.txt |
+      | permissions            | read            |
+      | share_type             | public_link     |
+      | displayname_file_owner | User Zero       |
+      | displayname_owner      | User Zero       |
+      | uid_file_owner         | user0           |
+      | uid_owner              | user0           |
+      | name                   |                 |
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "user0 file"
+    And the public download of the last publicly shared file using the old public WebDAV API with password "%regular%" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "%regular%" should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the old public WebDAV API without a password should fail with HTTP status code "401"
+    And the public download of the last publicly shared file using the new public WebDAV API without a password should fail with HTTP status code "401"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -215,24 +221,26 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
     Given using OCS API version "<ocs_api_version>"
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
-      | path        | welcome.txt |
-      | permissions | all         |
+      | path        | randomfile.txt |
+      | permissions | all            |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response should include
-      | item_type              | file         |
-      | mimetype               | text/plain   |
-      | file_target            | /welcome.txt |
-      | path                   | /welcome.txt |
-      | permissions            | read         |
-      | share_type             | public_link  |
-      | displayname_file_owner | User Zero    |
-      | displayname_owner      | User Zero    |
-      | uid_file_owner         | user0        |
-      | uid_owner              | user0        |
-      | name                   |              |
-    And the last public shared file should be able to be downloaded without a password
+      | item_type              | file            |
+      | mimetype               | text/plain      |
+      | file_target            | /randomfile.txt |
+      | path                   | /randomfile.txt |
+      | permissions            | read            |
+      | share_type             | public_link     |
+      | displayname_file_owner | User Zero       |
+      | displayname_owner      | User Zero       |
+      | uid_file_owner         | user0           |
+      | uid_owner              | user0           |
+      | name                   |                 |
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -827,12 +835,13 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: user creates a public link share of a file with file name longer than 64 chars
     Given using OCS API version "<ocs_api_version>"
-    And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
+    And user "user0" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded without a password
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "long file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "long file"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -1107,30 +1116,32 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
-      | path | textfile0.txt |
+      | path | randomfile.txt |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     And the fields of the last response should include
-      | file_target | /textfile0.txt |
-      | path        | /textfile0.txt |
-      | item_type   | file           |
-      | share_type  | public_link    |
-      | permissions | read           |
-      | uid_owner   | user0          |
-      | expiration  | +7 days        |
+      | file_target | /randomfile.txt |
+      | path        | /randomfile.txt |
+      | item_type   | file            |
+      | share_type  | public_link     |
+      | permissions | read            |
+      | uid_owner   | user0           |
+      | expiration  | +7 days         |
     When user "user0" gets the info of the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     And the fields of the last response should include
-      | file_target | /textfile0.txt |
-      | path        | /textfile0.txt |
-      | item_type   | file           |
-      | share_type  | public_link    |
-      | permissions | read           |
-      | uid_owner   | user0          |
-      | expiration  | +7 days        |
-    And the last public shared file should be able to be downloaded without a password
+      | file_target | /randomfile.txt |
+      | path        | /randomfile.txt |
+      | item_type   | file            |
+      | share_type  | public_link     |
+      | permissions | read            |
+      | uid_owner   | user0           |
+      | expiration  | +7 days         |
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -63,15 +63,16 @@ Feature: sharing
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share with password and adding an expiration date
     Given using OCS API version "<ocs_api_version>"
-    And as user "user0"
-    When the user creates a public link share using the sharing API with settings
-      | path     | welcome.txt |
+    And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path     | randomfile.txt |
       | password | %public%    |
-    And the user updates the last share using the sharing API with
+    And user "user0" updates the last share using the sharing API with
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the last public shared file should be able to be downloaded with password "%public%"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "user0 file"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -438,62 +438,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the last public shared file should be able to be downloaded without a password$/
-	 *
-	 * @return void
-	 */
-	public function checkLastPublicSharedFileDownload() {
-		if (\count($this->lastShareData->data->element) > 0) {
-			$url = $this->lastShareData->data[0]->url;
-		} else {
-			$url = $this->lastShareData->data->url;
-		}
-		$fullUrl = "$url/download";
-		$this->checkDownload($fullUrl, null, null, $this->getMimeTypeOfLastSharedFile());
-	}
-
-	/**
-	 * @Then the last public shared file should not be able to be downloaded without a password
-	 *
-	 * @return void
-	 */
-	public function theLastPublicSharedFileShouldNotBeAbleToBeDownloadedWithoutAPassword() {
-		$this->theLastPublicSharedFileShouldNotBeAbleToBeDownloadedWithPassword(null);
-	}
-
-	/**
-	 * @Then /^the last public shared file should be able to be downloaded with password "([^"]*)"$/
-	 *
-	 * @param string $password
-	 *
-	 * @return void
-	 */
-	public function checkLastPublicSharedFileWithPasswordDownload($password) {
-		$token = $this->getLastShareToken();
-		$fullUrl = $this->getBaseUrl() . "/public.php/webdav";
-		$this->checkDownload($fullUrl, $token, $password, $this->getMimeTypeOfLastSharedFile());
-	}
-
-	/**
-	 * @Then the last public shared file should not be able to be downloaded with password :password
-	 *
-	 * @param string $password
-	 *
-	 * @return void
-	 */
-	public function theLastPublicSharedFileShouldNotBeAbleToBeDownloadedWithPassword($password) {
-		$token = $this->getLastShareToken();
-		$fullUrl = $this->getBaseUrl() . "/public.php/webdav";
-		$this->response = HttpRequestHelper::get(
-			$fullUrl, $token, $password
-		);
-		Assert::assertEquals(
-			401,
-			$this->response->getStatusCode()
-		);
-	}
-
-	/**
 	 * @Then user :user should be able to download the range :range of file :path using the sharing API and the content should be :content
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
Test downloading single files from the new public webdav API
used also the chance to refactor/reword the steps and move them to the correct context

## Related Issue
part of https://github.com/owncloud/core/issues/36006

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
