### PR TITLE
Migration to delete entries in properties table with null value for fileid column and restrict null value in properties table

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20190823065724.php
+++ b/apps/dav/appinfo/Migrations/Version20190823065724.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\dav\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\IDBConnection;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Add NULL constraint to fileid column for properties table.
+ * The fileid column should not accept null values in the properties table.
+ */
+class Version20190823065724 implements ISchemaMigration {
+	/** @var IDBConnection  */
+	private $dbConnection;
+
+	public function __construct(IDBConnection $dbConnection) {
+		$this->dbConnection = $dbConnection;
+	}
+
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+
+		$table = $schema->getTable("${prefix}properties");
+		$column = $table->getColumn('fileid');
+		/**
+		 * If the fileid column's notnull is set to false then
+		 * make sure before altering the column, that no entry
+		 * in the table has fileid with null. Else the migration
+		 * would fail. The below check does the same.
+		 */
+		if ($column->getNotnull() !== true) {
+			$qb = $this->dbConnection->getQueryBuilder();
+			$qb->delete('properties')
+				->where($qb->expr()->isNull('fileid'));
+			$qb->execute();
+
+			$table->changeColumn('fileid', [
+				'notnull' => true,
+			]);
+		}
+	}
+}

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>ownCloud WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>0.4.0</version>
+	<version>0.5.0</version>
 	<default_enable/>
 	<use-migrations>true</use-migrations>
 	<types>

--- a/tests/Core/Command/Apps/AppsListTest.php
+++ b/tests/Core/Command/Apps/AppsListTest.php
@@ -58,9 +58,9 @@ class AppsListTest extends TestCase {
 	public function providesAppIds() {
 		return [
 			[[], '- files: 1.5'],
-			[['--shipped' => 'true'], '- dav: 0.4.0'],
+			[['--shipped' => 'true'], '- dav: 0.5.0'],
 			[['--shipped' => 'false'], '- comments:'],
-			[['search-pattern' => 'dav'], '- dav: 0.4.0']
+			[['search-pattern' => 'dav'], '- dav: 0.5.0']
 		];
 	}
 }


### PR DESCRIPTION
New migrations have been added to the dav app to
acheive the following:
1. Delete the existing entries in properties table
   which have null fileid entries
2. Restrict null value entry for fileid in properties table.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Restrict the usage of null value added to fileids in the properties table. When null value is allowed to enter, the background job like `CleanProperties` would end up in an infinite loop. Hence this PR addresses the problem by fixing it in the db, level. This introduces 2 migrations:
1. Cleanup the properties table entries which have fileid with null value
2. Alter the column fileid so that no null value is accepted.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/35292

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To fix the problem caused by entry of null value in the fileid, its better to attack the problem or fix the problem in the db.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Since this change invloves migration, I have used oc version `10.1.1` and `10.3.0 alpha`
- First install 10.1.1 oC instance. And then upload a file say `a.txt`
- Now apply proppatch to the file.
- Modify the properties entry in the table so that `fileid` is `NULL`
- Add another entry in the table with `fileid` is NULL.
- Now try to create another property where fileid is not NULL ( the idea here is after the migration this entry should be available to the user )
- The table entry will look like this:
```
mysql> select * from oc_properties;
+----+--------+-----------------------------------------------+---------------+
| id | fileid | propertyname                                  | propertyvalue |
+----+--------+-----------------------------------------------+---------------+
|  1 |   NULL | {http://example.com/neon/litmus/}valnspace    | Object        |
|  2 |   NULL | {http://example.com/neon/litmus/}valnspace123 | Object        |
|  3 |     16 | somethingfunny                                | Truth         |
+----+--------+-----------------------------------------------+---------------+
3 rows in set (0.00 sec)

mysql>
```
- Now follow the steps to upgrade. Remember that in this PR the dav version is upgraded to `0.5.0` hence the migration changes will be applied cleanly.
- After the migration the table would will have contents:
```
mysql> select * from oc_properties;
+----+--------+----------------+---------------+
| id | fileid | propertyname   | propertyvalue |
+----+--------+----------------+---------------+
|  3 |     16 | somethingfunny | Truth         |
+----+--------+----------------+---------------+
1 row in set (0.00 sec)

mysql> describe oc_properties;
+---------------+---------------------+------+-----+---------+----------------+
| Field         | Type                | Null | Key | Default | Extra          |
+---------------+---------------------+------+-----+---------+----------------+
| id            | bigint(20)          | NO   | PRI | NULL    | auto_increment |
| fileid        | bigint(20) unsigned | NO   | MUL | NULL    |                |
| propertyname  | varchar(255)        | NO   |     |         |                |
| propertyvalue | varchar(255)        | NO   |     | NULL    |                |
+---------------+---------------------+------+-----+---------+----------------+
4 rows in set (0.00 sec)

mysql>
```
- Try to insert null value to `fileid` as shown below, it wont allow:
```
mysql> insert into oc_properties (fileid, propertyname, propertyvalue) values (NULL, 'somethingfunny', 'Truth1');
ERROR 1048 (23000): Column 'fileid' cannot be null
mysql>
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
