### PR TITLE
test uploading to a single-file public link

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -181,6 +181,8 @@ Feature: sharing
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
+    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "404"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -241,6 +243,8 @@ Feature: sharing
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
+    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "404"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -529,6 +529,29 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @Then /^the public upload to the last publicly shared file using the (old|new) public WebDAV API should fail with HTTP status code "([^"]*)"$/
+	 *
+	 * @param string $publicWebDAVAPIVersion
+	 * @param string $expectedHttpCode
+	 *
+	 * @return void
+	 */
+	public function publiclyUploadingShouldToSharedFileShouldFail(
+		$publicWebDAVAPIVersion, $expectedHttpCode
+	) {
+		$filename = "";
+		if ($publicWebDAVAPIVersion === "new") {
+			$filename = $this->featureContext->getLastShareData()->data[0]->file_target;
+		}
+
+		$this->publicUploadContent(
+			$filename, '', 'test', false,
+			[], $publicWebDAVAPIVersion
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBe($expectedHttpCode);
+	}
+
+	/**
 	 * @Then /^uploading a file should not work using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $publicWebDAVAPIVersion


### PR DESCRIPTION
## Description
test that upload to a publicly linked file is not possible

## Related Issue
part of #36006

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
