### PR TITLE
Fix bug with attribute disabled being saved as null

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -1196,7 +1196,7 @@ class Share20OcsController extends OCSController {
 				if (isset($formattedAttr['enabled'])) {
 					$value = (bool) \json_decode($formattedAttr['enabled']);
 				}
-				if ($value) {
+				if ($value !== null) {
 					$newShareAttributes->setAttribute(
 						$formattedAttr['scope'],
 						$formattedAttr['key'],


### PR DESCRIPTION
This commit (https://github.com/owncloud/core/commit/2ef190a4fce0d0ab6173da1304ffaa35e95ede95) broke the logic of share attributes in case where share attribute "enabled" was set to false. 

This fixes it by checking for null instead.