### PR TITLE
upload to public links tests with different permissions

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -273,6 +273,8 @@ Feature: sharing
     And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "wnCloud"
     And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%" and the content should be "wnCloud"
     And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%" and the content should be "wnCloud"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -388,10 +390,28 @@ Feature: sharing
       | id          | A_NUMBER    |
       | share_type  | public_link |
       | permissions | read        |
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario Outline: Creating a link share with update permissions defaults to read permissions when public upload disabled globally
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And user "user0" has created folder "/afolder"
+    When user "user0" creates a public link share using the sharing API with settings
+      | path        | /afolder                  |
+      | permissions | read,update,create,delete |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And the last response should be empty
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 403             | 200              |
+      | 2               | 403             | 403              |
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with edit permissions keeps it
@@ -406,6 +426,8 @@ Feature: sharing
       | id          | A_NUMBER                  |
       | share_type  | public_link               |
       | permissions | read,update,create,delete |
+    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -424,6 +446,8 @@ Feature: sharing
       | id          | A_NUMBER    |
       | share_type  | public_link |
       | permissions | read,create |
+    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -550,23 +550,26 @@ class PublicWebDavContext implements Context {
 
 	/**
 	 * @Then /^uploading a file should not work using the (old|new) public WebDAV API$/
+	 * @Then /^the public upload to the last publicly shared folder using the (old|new) public WebDAV API should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $publicWebDAVAPIVersion
+	 * @param string $expectedHttpCode
 	 *
 	 * @return void
 	 */
-	public function publiclyUploadingShouldNotWork($publicWebDAVAPIVersion) {
+	public function publiclyUploadingShouldNotWork(
+		$publicWebDAVAPIVersion, $expectedHttpCode = null
+	) {
 		$this->publicUploadContent(
 			'whateverfilefortesting.txt', '', 'test', false,
 			[], $publicWebDAVAPIVersion
 		);
 		$response = $this->featureContext->getResponse();
-		Assert::assertTrue(
-			($response->getStatusCode() == 507)
-			|| (
-				($response->getStatusCode() >= 400)
-				&& ($response->getStatusCode() <= 499)
-				),
+		if ($expectedHttpCode === null) {
+			$expectedHttpCode = [507, 400, 401, 403, 404, 423];
+		}
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			$expectedHttpCode,
 			"upload should have failed but passed with code " .
 			$response->getStatusCode()
 		);


### PR DESCRIPTION
## Description
some more tests to check upload for public shares in different conditions

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #36006

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
