### PR TITLE
Add downloadPublicFileWithPassword step

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -48,29 +48,13 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function downloadPublicFileWithRange($range, $publicWebDAVAPIVersion, $password ="") {
-		$lastShareData = $this->featureContext->getLastShareData()->data;
-		$password = $this->featureContext->getActualPassword($password);
-		$token = $lastShareData->token;
-		$davPath = WebDavHelper::getDavPath(
-			$token, 0, "public-files-$publicWebDAVAPIVersion"
-		);
-		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath";
-		$user = $this->getUsernameForPublicWebdavApi(
-			$token, $password, $publicWebDAVAPIVersion
-		);
 		if ($publicWebDAVAPIVersion === "new") {
-			$fullUrl = $fullUrl . $lastShareData->file_target;
+			$path = $this->featureContext->getLastShareData()->data->file_target;
+		} else {
+			$path = "";
 		}
-
-		$headers = [];
-		if ($range !== "") {
-			$headers = [
-				'X-Requested-With' => 'XMLHttpRequest',
-				'Range' => $range
-			];
-		}
-		$this->featureContext->setResponse(
-			HttpRequestHelper::get($fullUrl, $user, $password, $headers)
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
+			$path, $password, $range, $publicWebDAVAPIVersion
 		);
 	}
 
@@ -83,6 +67,18 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFile($publicWebDAVAPIVersion) {
 		$this->downloadPublicFileWithRange("", $publicWebDAVAPIVersion);
+	}
+
+	/**
+	 * @When /^the public downloads the last public shared file with password "([^"]*)" using the (old|new) public WebDAV API$/
+	 *
+	 * @param string $password
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function downloadPublicFileWithPassword($password, $publicWebDAVAPIVersion) {
+		$this->downloadPublicFileWithRange("", $publicWebDAVAPIVersion, $password);
 	}
 
 	/**


### PR DESCRIPTION
## Description
- refactor `downloadPublicFileWithRange` so it calls `publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange` to reduce code dupication.
- add step `downloadPublicFileWithPassword` which is needed in `admin_audit` for testing when we have made a public link share with password.

## Related Issue
related to #36006

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
