### PR TITLE
refactor remaining tests steps to be able to use also new public webdav API

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -153,18 +153,19 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" using the old public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
 	public function publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
-		$path, $password = ""
+		$path, $password = "", $publicWebDAVAPIVersion = "old"
 	) {
 		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
-			$path, $password, ""
+			$path, $password, "", $publicWebDAVAPIVersion
 		);
 	}
 
@@ -184,7 +185,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" with range "([^"]*)" using the old public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" with range "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -405,20 +405,21 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :content sending the locktoken of :itemToUseLockOf of the public using the old public WebDAV API
+	 * @When /^the public uploads file "([^"]*)" with content "([^"]*)" sending the locktoken of "([^"]*)" of the public using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $filename
 	 * @param string $content
 	 * @param string $itemToUseLockOf
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
 	public function publicUploadFileSendingLockTokenOfPublic(
-		$filename, $content, $itemToUseLockOf
+		$filename, $content, $itemToUseLockOf, $publicWebDAVAPIVersion
 	) {
 		$lockOwner = (string)$this->featureContext->getLastShareData()->data->token;
 		$this->publicUploadFileSendingLockTokenOfUser(
-			$filename, $content, $itemToUseLockOf, $lockOwner
+			$filename, $content, $itemToUseLockOf, $lockOwner, $publicWebDAVAPIVersion
 		);
 	}
 	/**


### PR DESCRIPTION
## Description
some last steps had to be refactored to be able to test also new webdav API
these steps are not used in core so no feature files needed change

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of #36006

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
