### PR TITLE
Add password enforcement for Download/View/Edit option and add capability

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -80,10 +80,12 @@ class Capabilities implements ICapability {
 				$roPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no') === 'yes';
 				$rwPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
 				$woPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no') === 'yes';
+				$rwdPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 				$public['password']['enforced_for']['read_only'] = $roPasswordEnforced;
 				$public['password']['enforced_for']['read_write'] = $rwPasswordEnforced;
 				$public['password']['enforced_for']['upload_only'] = $woPasswordEnforced;
-				$public['password']['enforced'] = $roPasswordEnforced || $rwPasswordEnforced || $woPasswordEnforced;
+				$public['password']['enforced_for']['read_write_delete'] = $rwdPasswordEnforced;
+				$public['password']['enforced'] = $roPasswordEnforced || $rwPasswordEnforced || $woPasswordEnforced || $rwdPasswordEnforced;
 
 				$public['expire_date'] = [];
 				$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -132,25 +132,27 @@ class CapabilitiesTest extends \Test\TestCase {
 
 	public function linkPasswordProvider() {
 		return [
-			['no', 'no', 'yes'],
-			['no', 'yes', 'no'],
-			['no', 'yes', 'yes'],
-			['yes', 'no', 'no'],
-			['yes', 'no', 'yes'],
-			['yes', 'yes', 'no'],
-			['yes', 'yes', 'yes'],
+			['no', 'no', 'no', 'yes'],
+			['no', 'yes', 'no', 'no'],
+			['no', 'yes', 'no', 'yes'],
+			['no', 'no', 'yes', 'no'],
+			['yes', 'no', 'no', 'no'],
+			['yes', 'no', 'no', 'yes'],
+			['yes', 'yes', 'no', 'no'],
+			['yes', 'yes', 'yes', 'yes'],
 		];
 	}
 
 	/**
 	 * @dataProvider linkPasswordProvider
 	 */
-	public function testLinkPassword($readOnly, $readWrite, $writeOnly) {
+	public function testLinkPassword($readOnly, $readWrite, $readWriteDelete, $writeOnly) {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_only', 'no', $readOnly],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', $readWrite],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', $readWriteDelete],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', $writeOnly],
 		];
 		$result = $this->getResults($map);
@@ -162,6 +164,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertEquals($readOnly === 'yes', $result['public']['password']['enforced_for']['read_only']);
 		$this->assertEquals($readWrite === 'yes', $result['public']['password']['enforced_for']['read_write']);
 		$this->assertEquals($writeOnly === 'yes', $result['public']['password']['enforced_for']['upload_only']);
+		$this->assertEquals($readWriteDelete === 'yes', $result['public']['password']['enforced_for']['read_write_delete']);
 	}
 
 	public function testLinkNoPassword() {
@@ -170,6 +173,7 @@ class CapabilitiesTest extends \Test\TestCase {
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'no'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'no'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
@@ -179,6 +183,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['password']['enforced']);
 		$this->assertFalse($result['public']['password']['enforced_for']['read_only']);
 		$this->assertFalse($result['public']['password']['enforced_for']['read_write']);
+		$this->assertFalse($result['public']['password']['enforced_for']['read_write_delete']);
 		$this->assertFalse($result['public']['password']['enforced_for']['upload_only']);
 	}
 

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -69,6 +69,7 @@ if ($defaultExpireDateEnabled) {
 $enforceLinkPasswordReadOnly = $config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no') === 'yes';
 $enforceLinkPasswordReadWrite = $config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
 $enforceLinkPasswordWriteOnly = $config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no') === 'yes';
+$enforceLinkPasswordReadWriteDelete = $config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 $outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
 
 $countOfDataLocation = 0;
@@ -171,6 +172,7 @@ $array = [
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 				'enforceLinkPasswordReadOnly' => $enforceLinkPasswordReadOnly,
 				'enforceLinkPasswordReadWrite' => $enforceLinkPasswordReadWrite,
+				'enforceLinkPasswordReadWriteDelete' => $enforceLinkPasswordReadWriteDelete,
 				'enforceLinkPasswordWriteOnly' => $enforceLinkPasswordWriteOnly,
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -72,6 +72,10 @@ $enforceLinkPasswordWriteOnly = $config->getAppValue('core', 'shareapi_enforce_l
 $enforceLinkPasswordReadWriteDelete = $config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 $outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
 
+$container = \OC::$server->getAppContainer('files_sharing');
+$rolesController = $container->query('OC\Core\Controller\RolesController');
+$roles = $rolesController->getRoles();
+
 $countOfDataLocation = 0;
 
 $value = $config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no');
@@ -182,6 +186,9 @@ $array = [
 				'enabledPreviewProviders' => $previewManager->getSupportedMimes()
 			]
 		],
+	"oc_roles" => [
+			"roles" => $roles,
+	],
 	"oc_defaults" => [
 			'entity' => $defaults->getEntity(),
 			'name' => $defaults->getName(),
@@ -227,6 +234,7 @@ if (\OC::$server->getUserSession() !== null && \OC::$server->getUserSession()->i
 OC_Hook::emit('\OCP\Config', 'js', ['array' => &$array]);
 
 $array['oc_appconfig'] = \json_encode($array['oc_appconfig']);
+$array['oc_roles'] = \json_encode($array['oc_roles']['roles']);
 $array['oc_config'] = \json_encode($array['oc_config']);
 $array['oc_defaults'] = \json_encode($array['oc_defaults']);
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -14,6 +14,7 @@ var oc_webroot;
 var oc_requesttoken = document.getElementsByTagName('head')[0].getAttribute('data-requesttoken');
 
 window.oc_config = window.oc_config || {};
+window.oc_roles = window.oc_roles || {};
 
 if (typeof oc_webroot === "undefined") {
 	oc_webroot = location.pathname;

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -30,7 +30,8 @@
 			isRemoteShareAllowed: oc_appconfig.core.remoteShareAllowed,
 			defaultExpireDate: oc_appconfig.core.defaultExpireDate,
 			isResharingAllowed: oc_appconfig.core.resharingAllowed,
-			allowGroupSharing: oc_appconfig.core.allowGroupSharing
+			allowGroupSharing: oc_appconfig.core.allowGroupSharing,
+			roles: oc_roles.data,
 		},
 
 		/**

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -23,6 +23,7 @@
 			publicUploadEnabled: false,
 			enforceLinkPasswordReadOnly: oc_appconfig.core.enforceLinkPasswordReadOnly,
 			enforceLinkPasswordReadWrite: oc_appconfig.core.enforceLinkPasswordReadWrite,
+			enforceLinkPasswordReadWriteDelete: oc_appconfig.core.enforceLinkPasswordReadWriteDelete,
 			enforceLinkPasswordWriteOnly: oc_appconfig.core.enforceLinkPasswordWriteOnly,
 			isDefaultExpireDateEnforced: oc_appconfig.core.defaultExpireDateEnforced === true,
 			isDefaultExpireDateEnabled: oc_appconfig.core.defaultExpireDateEnabled === true,

--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -103,6 +103,7 @@
 			} else {
 				throw 'missing OC.Share.ShareItemModel';
 			}
+
 		},
 
 		onRemoveButtonClick: function (ev) {
@@ -150,7 +151,7 @@
 				expireDate: this.configModel.getDefaultExpirationDateString(),
 				shareType: OC.Share.SHARE_TYPE_LINK,
 				itemType: this.itemModel.get('itemType'),
-				itemSource: this.itemModel.get('itemSource')
+				itemSource: this.itemModel.get('itemSource'),
 			});
 			this._showPopupForShare(newShare);
 		},

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -28,15 +28,15 @@
 				'<p><em>{{publicReadDescription}}</em></p>' +
 			'</div>' +
 			'{{#if publicUploadPossible}}' +
-			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
-				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
-				'<p><em>{{publicReadWriteDescription}}</em></p>' +
-			'</div>' +
 			'<div id="allowpublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadWriteValue}}" name="publicPermissions" id="sharingDialogAllowpublicUploadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowpublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +
 				'<p><em>{{publicUploadWriteDescription}}</em></p>' +
+			'</div>' +
+			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
+				'<p><em>{{publicReadWriteDescription}}</em></p>' +
 			'</div>' +
 			'<div id="allowPublicUploadWrapper-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadValue}}" name="publicPermissions" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadSelected}}checked{{/if}} />' +
@@ -115,7 +115,8 @@
 			var roEnforcement = permissions === OC.PERMISSION_READ && this.configModel.get('enforceLinkPasswordReadOnly');
 			var woEnforcement = permissions === OC.PERMISSION_CREATE && this.configModel.get('enforceLinkPasswordWriteOnly');
 			var rwEnforcement = (permissions !== OC.PERMISSION_READ && permissions !== OC.PERMISSION_CREATE) && this.configModel.get('enforceLinkPasswordReadWrite');
-			if (roEnforcement || woEnforcement || rwEnforcement) {
+			var rwdEnforcement = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE) && this.configModel.get('enforceLinkPasswordReadWriteDelete'));
+			if (roEnforcement || woEnforcement || rwEnforcement || rwdEnforcement) {
 				return true;
 			} else {
 				return false;
@@ -269,7 +270,7 @@
 				publicUploadWriteSelected    : this.model.get('permissions') === (OC.PERMISSION_READ | OC.PERMISSION_CREATE),
 
 				publicReadWriteLabel       : t('core', 'Download / View / Edit'),
-				publicReadWriteDescription : t('core', 'Recipients can view, download and edit contents.'),
+				publicReadWriteDescription : t('core', 'Recipients can view, download, edit, delete and upload contents.'),
 				publicReadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE,
 				publicReadWriteSelected    : this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE),
 

--- a/core/js/tests/specs/sharedialoglinklistviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinklistviewSpec.js
@@ -29,9 +29,23 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 	var tooltipStub;
 	var showPopupStub;
 	var publicLinkStub;
+	var roles;
 
 	beforeEach(function() {
+		roles = {
+			"ocs":{
+				"data": {
+					"data":[
+						{"id":"core.viewer","displayName":"Download \/ View","context":{"publicLinks":{"displayDescription":"Recipients can view or download contents.","order":10,"resourceTypes":["*"],"permissions":{"ownCloud":{"read":true}}}}},
+						{"id":"core.editor","displayName":"Download \/ View \/ Edit","context":{"publicLinks":{"displayDescription":"Recipients can view, download and edit contents.","order":20,"resourceTypes":["httpd\/unix-directory"],"permissions":{"ownCloud":{"create":true,"read":true,"update":true,"delete":true}}}}},
+						{"id":"core.contributor","displayName":"Download \/ View \/ Upload","context":{"publicLinks":{"displayDescription":"Recipients can view, download and upload contents.","order":30,"resourceTypes":["httpd\/unix-directory"],"permissions":{"ownCloud":{"create":true,"read":true}}}}},
+						{"id":"core.uploader","displayName":"Upload only (File Drop)","context":{"publicLinks":{"displayDescription":"Receive files from multiple recipients without revealing the contents of the folder.","order":40,"resourceTypes":["httpd\/unix-directory"],"permissions":{"ownCloud":{"create":true}}}}}
+					]
+				}
+			}
+		};
 		configModel = new OC.Share.ShareConfigModel();
+		configModel.attributes.roles = roles.ocs.data;
 		fileInfoModel = new OCA.Files.FileInfoModel({
 			id: 123,
 			name: 'shared_file_name.txt',
@@ -39,7 +53,7 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 			size: 100,
 			mimetype: 'text/plain',
 			permissions: 31,
-			sharePermissions: 31
+			sharePermissions: 31,
 		});
 		itemModel = new OC.Share.ShareItemModel({
 			itemType: 'folder',
@@ -144,7 +158,7 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 		}
 
 		it('sets default values and shows popup', function() {
-			var defaultDateStub = sinon.stub(configModel, 'getDefaultExpirationDateString'); 
+			var defaultDateStub = sinon.stub(configModel, 'getDefaultExpirationDateString');
 			defaultDateStub.returns('2017-03-03');
 			var popup = showPopup();
 			expect(popup.model.toJSON()).toEqual({
@@ -154,7 +168,7 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 				expireDate: '2017-03-03',
 				shareType: OC.Share.SHARE_TYPE_LINK,
 				itemType: 'folder',
-				itemSource: 123
+				itemSource: 123,
 			});
 			expect(popup.configModel).toEqual(configModel);
 			expect(popup.itemModel).toEqual(itemModel);
@@ -212,10 +226,10 @@ describe('OC.Share.ShareDialogLinkListView', function() {
 		beforeEach(function() {
 			socialConfigStub = sinon.stub(configModel, 'isSocialShareEnabled');
 		});
-		afterEach(function() { 
-			socialConfigStub.restore(); 
+		afterEach(function() {
+			socialConfigStub.restore();
 		});
-		
+
 		it('does not show share button if social is disabled', function() {
 			socialConfigStub.returns(false);
 			view.render();

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -26,12 +26,22 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 	var tooltipStub;
 	var model;
 	var view;
+	var roles;
 
 	var PASSWORD_PLACEHOLDER_STARS = '**********';
 	var PASSWORD_PLACEHOLDER_MESSAGE = 'Choose a password';
 
 	beforeEach(function() {
+		roles = {
+					"data":[
+						{"id":"core.viewer","displayName":"Download \/ View","context":{"publicLinks":{"displayDescription":"Recipients can view or download contents.","order":10,"resourceTypes":["*"],"permissions":{"ownCloud":{"read":true}}}}},
+						{"id":"core.editor","displayName":"Download \/ View \/ Edit","context":{"publicLinks":{"displayDescription":"Recipients can view, download and edit contents.","order":20,"resourceTypes":["httpd\/unix-directory"],"permissions":{"ownCloud":{"create":true,"read":true,"update":true,"delete":true}}}}},
+						{"id":"core.contributor","displayName":"Download \/ View \/ Upload","context":{"publicLinks":{"displayDescription":"Recipients can view, download and upload contents.","order":30,"resourceTypes":["httpd\/unix-directory"],"permissions":{"ownCloud":{"create":true,"read":true}}}}},
+						{"id":"core.uploader","displayName":"Upload only (File Drop)","context":{"publicLinks":{"displayDescription":"Receive files from multiple recipients without revealing the contents of the folder.","order":40,"resourceTypes":["httpd\/unix-directory"],"permissions":{"ownCloud":{"create":true}}}}}
+					]
+		};
 		configModel = new OC.Share.ShareConfigModel();
+		configModel.attributes.roles = roles.data;
 		fileInfoModel = new OCA.Files.FileInfoModel({
 			id: 123,
 			name: 'shared_folder',
@@ -438,7 +448,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
 			configModel.set('enforceLinkPasswordReadWrite', true);
 			view.render();
-			view.$('#sharingDialogAllowpublicUploadWrite-' + view.cid).prop('checked', true)
+			view.$('#sharingDialogAllowpublicUploadWrite-' + view.cid).prop('checked', true);
 			var handler = sinon.stub();
 			view.on('saved', handler);
 			view._save();

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -282,6 +282,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 				configModel.set({
 					enforceLinkPasswordReadOnly : true,
 					enforceLinkPasswordWriteOnly : true,
+					enforceLinkPasswordReadWriteDelete: true,
 					enforceLinkPasswordReadWrite : true
 				});
 				view.render();
@@ -436,6 +437,18 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 		it('displays inline error when password enforced for read & write but missing', function() {
 			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
 			configModel.set('enforceLinkPasswordReadWrite', true);
+			view.render();
+			view.$('#sharingDialogAllowpublicUploadWrite-' + view.cid).prop('checked', true)
+			var handler = sinon.stub();
+			view.on('saved', handler);
+			view._save();
+			expect(handler.notCalled).toEqual(true);
+
+			expect(view.$('.linkPassText').next('.error-message').hasClass('hidden')).toEqual(false);
+		});
+		it('displays inline error when password enforced for read, write & delete but missing', function () {
+			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
+			configModel.set('enforceLinkPasswordReadWriteDelete', true);
 			view.render();
 			view.$('#sharingDialogAllowPublicReadWrite-' + view.cid).prop('checked', true)
 			var handler = sinon.stub();

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -192,9 +192,12 @@ class Manager implements IManager {
 	protected function passwordMustBeEnforced($permissions) {
 		$roEnforcement = $permissions === \OCP\Constants::PERMISSION_READ && $this->shareApiLinkEnforcePasswordReadOnly();
 		$woEnforcement = $permissions === \OCP\Constants::PERMISSION_CREATE && $this->shareApiLinkEnforcePasswordWriteOnly();
+		// use read, write & delete enforcement for the case
+		$rwdEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE)) &&
+			$this->shareApiLinkEnforcePasswordReadWriteDelete();
 		// use read & write enforcement for the rest of the cases
 		$rwEnforcement = ($permissions !== \OCP\Constants::PERMISSION_READ && $permissions !== \OCP\Constants::PERMISSION_CREATE) && $this->shareApiLinkEnforcePasswordReadWrite();
-		if ($roEnforcement || $woEnforcement || $rwEnforcement) {
+		if ($roEnforcement || $woEnforcement || $rwEnforcement || $rwdEnforcement) {
 			return true;
 		} else {
 			return false;
@@ -1520,6 +1523,15 @@ class Manager implements IManager {
 	 */
 	public function shareApiLinkEnforcePasswordReadWrite() {
 		return $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
+	}
+
+	/**
+	 * Is password enforced for read, write & delete shares?
+	 *
+	 * @return bool
+	 */
+	public function shareApiLinkEnforcePasswordReadWriteDelete() {
+		return $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 	}
 
 	/**

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -294,6 +294,14 @@ interface IManager {
 	public function shareApiLinkEnforcePasswordWriteOnly();
 
 	/**
+	 * Is password enforced for read,write & delete shares?
+	 *
+	 * @return bool true if password is enforced, false otherwise
+	 * @since 10.3.0
+	 */
+	public function shareApiLinkEnforcePasswordReadWriteDelete();
+
+	/**
 	 * Is default expire date enabled
 	 *
 	 * @return bool

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -92,6 +92,7 @@ class FileSharing implements ISettings {
 		$template->assign('allowPublicUpload', $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'));
 		$template->assign('enforceLinkPasswordReadOnly', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no'));
 		$template->assign('enforceLinkPasswordReadWrite', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no'));
+		$template->assign('enforceLinkPasswordReadWriteDelete', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no'));
 		$template->assign('enforceLinkPasswordWriteOnly', $this->config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no'));
 		$template->assign('shareDefaultExpireDateSet', $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'));
 		$template->assign('allowPublicMailNotification', $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no'));

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -43,7 +43,13 @@
 			value="1" <?php if ($_['enforceLinkPasswordReadWrite'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
-		<label for="enforceLinkPasswordReadWrite"><?php p($l->t('Enforce password protection for read & write links'));?></label><br/>
+		<label for="enforceLinkPasswordReadWrite"><?php p($l->t('Enforce password protection for read + write links'));?></label><br/>
+
+		<input type="checkbox" name="shareapi_enforce_links_password_read_write_delete" id="enforceLinkPasswordReadWriteDelete" class="checkbox"
+			   value="1" <?php if ($_['enforceLinkPasswordReadWriteDelete'] === 'yes') {
+	print_unescaped('checked="checked"');
+} ?> />
+		<label for="enforceLinkPasswordReadWriteDelete"><?php p($l->t('Enforce password protection for read + write + delete links'));?></label><br/>
 
 		<input type="checkbox" name="shareapi_enforce_links_password_write_only" id="enforceLinkPasswordWriteOnly" class="checkbox"
 			value="1" <?php if ($_['enforceLinkPasswordWriteOnly'] === 'yes') {

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -164,6 +164,19 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When /^the administrator (enables|disables) enforce password protection for read and write and delete links using the webUI$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 */
+	public function adminTogglesEnforcePasswordProtectionForReadWriteDeleteLinks($action) {
+		$this->adminSharingSettingsPage->toggleEnforcePasswordProtectionForReadWriteDeleteLinks(
+			$this->getSession(), $action
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) enforce password protection for upload only links using the webUI$/
 	 *
 	 * @param string $action

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -49,6 +49,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $enforceLinkPasswordReadOnlyCheckboxId = 'enforceLinkPasswordReadOnly';
 	protected $enforceLinkPasswordReadWriteCheckboxXpath = '//label[@for="enforceLinkPasswordReadWrite"]';
 	protected $enforceLinkPasswordReadWriteCheckboxId = 'enforceLinkPasswordReadWrite';
+	protected $enforceLinkPasswordReadWriteDeleteCheckboxXpath = '//label[@for="enforceLinkPasswordReadWriteDelete"]';
+	protected $enforceLinkPasswordReadWriteDeleteCheckboxId = 'enforceLinkPasswordReadWriteDelete';
 	protected $enforceLinkPasswordWriteOnlyCheckboxXpath = '//label[@for="enforceLinkPasswordWriteOnly"]';
 	protected $enforceLinkPasswordWriteOnlyCheckboxId = 'enforceLinkPasswordWriteOnly';
 	protected $allowResharingCheckboxXpath = '//label[@for="allowResharing"]';
@@ -227,6 +229,25 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			$action,
 			$this->enforceLinkPasswordReadWriteCheckboxXpath,
 			$this->enforceLinkPasswordReadWriteCheckboxId
+		);
+	}
+
+	/**
+	 * toggle enforce password protection for read, write and delete links
+	 *
+	 * @param Session $session
+	 * @param string $action "enables|disables"
+	 *
+	 * @return void
+	 */
+	public function toggleEnforcePasswordProtectionForReadWriteDeleteLinks(
+		Session $session, $action
+	) {
+		$this->toggleCheckbox(
+			$session,
+			$action,
+			$this->enforceLinkPasswordReadWriteDeleteCheckboxXpath,
+			$this->enforceLinkPasswordReadWriteDeleteCheckboxId
 		);
 	}
 

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -41,6 +41,11 @@ Feature: admin sharing settings
     When the administrator enables enforce password protection for read and write links using the webUI
     Then the "public@@@password@@@enforced_for@@@read_write" capability of files sharing app should be "1"
 
+  Scenario: enable enforce password protection for read and write and delete links
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables enforce password protection for read and write and delete links using the webUI
+    Then the "public@@@password@@@enforced_for@@@read_write_delete" capability of files sharing app should be "1"
+
   Scenario: enable enforce password protection for upload-only links
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables enforce password protection for upload only links using the webUI
@@ -105,6 +110,12 @@ Feature: admin sharing settings
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables enforce password protection for read and write links using the webUI
     Then the "public@@@password@@@enforced_for@@@read_write" capability of files sharing app should be "EMPTY"
+
+  Scenario: disable enforce password protection for read and write and delete links
+    Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables enforce password protection for read and write and delete links using the webUI
+    Then the "public@@@password@@@enforced_for@@@read_write_delete" capability of files sharing app should be "EMPTY"
 
   Scenario: disable enforce password protection for upload-only links
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "no"

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -612,6 +612,7 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_write_delete', 'no', 'yes'],
 		]));
 
 		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ]));
@@ -627,10 +628,23 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_ALL]));
 	}
 
+	public function testPasswordMustBeEnforcedForReadWriteDelete() {
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+		]));
+
+		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced',
+			[\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE]));
+	}
+
 	public function testPasswordMustBeEnforcedForWriteOnly() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
@@ -641,6 +655,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'no'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
@@ -651,16 +666,30 @@ class ManagerTest extends \Test\TestCase {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
 		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_ALL]));
 	}
 
+	public function testPasswordMustBeEnforcedForReadWriteDeleteNotEnforced() {
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+		]));
+
+		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced',
+			[\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE]));
+	}
+
 	public function testPasswordMustBeEnforcedForWriteOnlyNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
 		]));
 


### PR DESCRIPTION
Add password enforcement for Download/View/Edit
option for the public share.
Also arranged the order of the permission, options
that come when user creates the public share.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR comprises of 2 commits. The first commit focuses on the change done in re-arranging the display of permissions displayed when user creates a new public link, that is the dialog window. Or say the user edits the dialog window ( both windows are same ).
Here is the detail about the first commit:
Updated the order of how permissions of public link appears when user creates a new share or edits the existing share. The current order according to this PR is:
1. `Download / View`
2. `Download / View / Upload`
3. `Download / View / Edit`
4. `Upload only ( File Drop )`

This change updates the description of permission `Download / View / Edit` to `Recipients can view, download, edit, delete and upload contents.`.

This change also includes password enforcement for all the permission. Because of the introduction of new permission to public link, the password enforcement change was not done. This change brings that too.

Detail about second commit:
The second commit uses the roles api introduced in the server. So in this commit, I used core/js/config.php to fetch the details about roles provided by core. And this value is passed across the configmodel which is used by the respective frontend. I gave a thought about using ajax request to get the roles details. But then this data has to be saved and we should not do query again and again as the data wouldn't change in the server that frequently. So I thought the good place to have the roles details in core/js/config.php. 
And then I have introduced functions like `populateData` in the sharedialoglinkshareview.js. The idea is to populate the role data received from the server and pass it to the handlebar template.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Re-arrange the order in which the permission has to be displayed in the public link.
Adjust the description text for `Download / View / Edit`.
And make sure password enforcement is available for all the permissions of public link share.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested the password enforcement by enabling the checkbox in the sharing page ( of admins settings page )
     - Verified that public links created for `Download / View` with password set ( because its checked in the Sharing page for testing), can be opened with the same password provided.
     - Verified that public links created for `Download / View / Upload` with password set ( because its checked in the Sharing page for testing), can be opened with the same password provided.
     - Verified that public links created for `Download / View / Edit` with password set ( because its checked in the Sharing page for testing), can be opened with the same password provided.
     - Verified that public links created for `Upload only` with password set ( because its checked in the Sharing page for testing), can be opened with the same password provided.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
