### PR TITLE
if a log-entry does not contain an attribute mark it at not-matching

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -360,9 +360,12 @@ trait Logging {
 						} else {
 							$match = (\strpos($logEntry[$attribute], $logEntryExpectedNotToExist[$attribute]) !== false);
 						}
-						if (!$match) {
-							break;
-						}
+					}
+					if (!isset($logEntry[$attribute])) {
+						$match = false;
+					}
+					if (!$match) {
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
## Description
if the log-entry would not have that searched attribute at all it would not be marked as not-matching because of the `isset`

## Motivation and Context
found while writing tests for admin_audit

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
