### PR TITLE
use bit operators when checking file permission, resolves #36025

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1486,7 +1486,7 @@ class View {
 
 			$data = $this->getCacheEntry($storage, $internalPath, $directory);
 
-			if (!$data instanceof ICacheEntry || !isset($data['fileid']) || !($data->getPermissions() && Constants::PERMISSION_READ)) {
+			if (!$data instanceof ICacheEntry || !isset($data['fileid']) || !($data->getPermissions() & Constants::PERMISSION_READ)) {
 				return [];
 			}
 
@@ -1539,7 +1539,7 @@ class View {
 						$rootEntry = $subCache->get('');
 					}
 
-					if ($rootEntry && ($rootEntry->getPermissions() && Constants::PERMISSION_READ)) {
+					if ($rootEntry && ($rootEntry->getPermissions() & Constants::PERMISSION_READ)) {
 						$relativePath = \trim(\substr($mountPoint, $dirLength), '/');
 						if ($pos = \strpos($relativePath, '/')) {
 							//mountpoint inside subfolder add size to the correct folder


### PR DESCRIPTION
## Description
This PR corrects readability control in View. You can not use `&&` operator when checking share permissions, use `&` (bitwise AND) instead.

## Related Issue
- Fixes #36025 

## Motivation and Context
Fixing bugs.

## How Has This Been Tested?
- share a file with `permission=2` to a user.  `curl --user admin:admin "http://localhost/owncloud-core/ocs/v1.php/apps/files_sharing/api/v1/shares"  --data 'path=/data.zip&shareType=0&shareWith=uu1&permissions=2'`
- as receiver open the webUI
- webUI should work OK and the file should not be visible in file list.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
