### PR TITLE
check Etag in header of file-operation responses

### DIFF
--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -13,7 +13,10 @@ Feature: sharing
       | permissions | create |
     When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     And the public uploads file "test.txt" with content "test2" with autorename mode using the old public WebDAV API
-    Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
+    And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
   @smokeTest @public_link_share-feature-required
@@ -26,6 +29,8 @@ Feature: sharing
     When the public uploads file "test.txt" with content "test" using the new public WebDAV API
     When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
@@ -102,8 +107,12 @@ Feature: sharing
       | permissions | create |
     When the public uploads file "test-old.txt" with content "test-old" using the old public WebDAV API
     Then the content of file "/FOLDER/test-old.txt" for user "user0" should be "test-old"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "user0" should be "test-new"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
 
   @public_link_share-feature-required
   Scenario: Uploading to a public upload-only share with password
@@ -127,6 +136,8 @@ Feature: sharing
       | shareWith   | user1  |
     When user "user1" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     Examples:
       | dav-path |
       | old      |
@@ -144,6 +155,8 @@ Feature: sharing
       | shareWith   | grp1   |
     When user "user1" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     Examples:
       | dav-path |
       | old      |
@@ -203,6 +216,8 @@ Feature: sharing
     And user "user0" has shared file "myfile.txt" with user "user1"
     When user "user1" uploads file "filesForUpload/textfile.txt" to "/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     Examples:
       | dav-path |
       | old      |
@@ -366,6 +381,8 @@ Feature: sharing
       | permissions | uploadwriteonly |
     When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     When the public uploads file "test.txt" with content "test2" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "<unsuccess-code>"
     And the content of file "/FOLDER/test.txt" for user "user0" should be "test"

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -21,6 +21,8 @@ Feature: Restore deleted files/folders
     And user "user1" has deleted file "/renamed_shared/shared_file.txt"
     When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
     And user "user1" should see the following elements
       | /renamed_shared/                |
@@ -38,6 +40,8 @@ Feature: Restore deleted files/folders
     And as "user0" file "/textfile0.txt" should exist in trash
     When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And as "user0" the folder with original path "/textfile0.txt" should not exist in trash
     And user "user0" should see the following elements
       | /FOLDER/           |
@@ -91,6 +95,8 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "<delete-path>"
     When user "user0" restores the file with original path "<delete-path>" to "<restore-path>" using the trashbin API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And as "user0" the file with original path "<delete-path>" should not exist in trash
     And as "user0" file "<restore-path>" should exist
     And as "user0" file "<delete-path>" should not exist
@@ -189,6 +195,8 @@ Feature: Restore deleted files/folders
     When user "user0" creates folder "/new-folder" using the WebDAV API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
     And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
@@ -209,6 +217,8 @@ Feature: Restore deleted files/folders
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And user "user0" should see the following elements
       | /local_storage/                  |

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -13,6 +13,8 @@ Feature: move (rename) file
     Given using <dav_version> DAV path
     When user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
     Examples:
       | dav_version |
@@ -24,6 +26,8 @@ Feature: move (rename) file
     Given using <dav_version> DAV path
     When user "user0" moves file "/welcome.txt" to "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
     And the downloaded content when downloading file "/textfile0.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
@@ -12,7 +12,9 @@ Feature: upload file
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path
     When user "user0" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
-    Then the content of file "<file_name>" for user "user0" should be "uploaded content"
+    Then the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
+    And the content of file "<file_name>" for user "user0" should be "uploaded content"
     Examples:
       | dav_version | file_name         |
       | old         | /upload.txt       |

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
@@ -16,7 +16,10 @@ Feature: upload file using new chunking
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
-    Then as "user0" file "/myChunkedFile.txt" should exist
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
+    And as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:
       | app |

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
@@ -11,11 +11,16 @@ Feature: upload file using old chunking
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
 
+  @issue-36115
   Scenario: Upload chunked file asc
     When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      #| ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^[a-f0-9]{1,32}$/ |
     Then as "user0" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 


### PR DESCRIPTION
## Description
Check the Etags in the headers of file-operations
I've only added the checks where I thought it makes sense other requests that are not soo much different don't get checked

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #36115
- #36080

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
