### PR TITLE
Block listing children of upload-only folder on GET request

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicSharedRootNode.php
@@ -69,7 +69,9 @@ class PublicSharedRootNode extends Collection implements IACL {
 	 */
 	public function getChildren() {
 		// Within a PROPFIND request we return no listing in case the share is a file drop folder
-		if ($this->isPropfind() && $this->isFileDropFolder()) {
+		if ($this->isFileDropFolder()
+			&& ($this->isPropfind() || $this->isGet())
+		) {
 			return [];
 		}
 
@@ -225,6 +227,13 @@ class PublicSharedRootNode extends Collection implements IACL {
 
 	private function isPropfind() {
 		return $this->request->getMethod() === 'PROPFIND';
+	}
+
+	/**
+	 * @return bool
+	 */
+	private function isGet() {
+		return $this->request->getMethod() === 'GET';
 	}
 
 	/**

--- a/apps/dav/tests/unit/Files/PublicFiles/PublicSharedRootNodeTest.php
+++ b/apps/dav/tests/unit/Files/PublicFiles/PublicSharedRootNodeTest.php
@@ -22,6 +22,7 @@
 namespace OCA\DAV\Tests\Unit\Files\PublicFiles;
 
 use OCA\DAV\Files\PublicFiles\PublicSharedRootNode;
+use OCP\Constants;
 use OCP\Files\NotFoundException;
 use OCP\IRequest;
 use OCP\Share\IShare;
@@ -38,5 +39,16 @@ class PublicSharedRootNodeTest extends TestCase {
 
 		$publicSharedRoot = new PublicSharedRootNode($share, $request);
 		$publicSharedRoot->getChildren();
+	}
+
+	public function testNoChildrenOnGetForPublicUpload() {
+		$share = $this->createMock(IShare::class);
+		$request = $this->createMock(IRequest::class);
+		$share->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+		$request->method('getMethod')->willReturn('GET');
+
+		$publicSharedRoot = new PublicSharedRootNode($share, $request);
+		$children = $publicSharedRoot->getChildren();
+		$this->assertEmpty($children);
 	}
 }

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -14,8 +14,7 @@ Feature: sharing
       | path        | FOLDER |
       | permissions | create |
     Then the public download of file "/test.txt" from inside the last public shared folder using the old public WebDAV API should fail with HTTP status code "404"
-    And the public should be able to download the range "bytes=0-7" of file "/test.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "ownCloud"
-    #And the public download of file "/test.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
+    And the public download of file "/test.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
 
   @public_link_share-feature-required
   Scenario: Downloading from share after the share source was deleted


### PR DESCRIPTION
## Description
Block listing children of upload-only folder on GET request

## Related Issue
- Fixes #36076 

## Motivation and Context
It should not be possible to read files in upload-only folder

## How Has This Been Tested?
Steps to reproduce
share a folder as "Upload Only" as public link
download a file from that folder using the new webdav public link api
```
curl --silent \
http://owncloud/remote.php/dav/public-files/Upload_Folder_Share_Token/Path_To_the_File \
-H 'X-Requested-With:XMLHttpRequest' \
-H "Range:bytes=0-150" \
-X GET
```

### Expected behaviour
download should not be possible (404)

### Actual behaviour
download is possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
