### PR TITLE
only share owner and sharer update or delete share

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -302,7 +302,7 @@ class Share20OcsController extends OCSController {
 			return new Result(null, 404, 'could not delete share');
 		}
 
-		if (!$this->canAccessShare($share)) {
+		if (!$this->canChangeShare($share)) {
 			$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 			return new Result(null, 404, $this->l->t('Could not delete share'));
 		}
@@ -737,9 +737,9 @@ class Share20OcsController extends OCSController {
 
 		$share->getNode()->lock(ILockingProvider::LOCK_SHARED);
 
-		if (!$this->canAccessShare($share)) {
+		if (!$this->canChangeShare($share)) {
 			$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
-			return new Result(null, 404, $this->l->t('Wrong share ID, share doesn\'t exist'));
+			return new Result(null, 404, $this->l->t('Could not update share'));
 		}
 
 		$permissions = $this->getPermissionsFromRequest();
@@ -1010,6 +1010,22 @@ class Share20OcsController extends OCSController {
 		$share->setTarget($pathAttempt);
 
 		return $share;
+	}
+
+	/**
+	 * Check session user is owner or sharer of the share
+	 *
+	 * @param IShare $share
+	 * @return bool
+	 */
+	protected function canChangeShare(IShare $share) {
+		// Only owner or the sharer of the file can update or delete share
+		if ($share->getShareOwner() === $this->userSession->getUser()->getUID() ||
+			$share->getSharedBy() === $this->userSession->getUser()->getUID()
+		) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -1530,7 +1530,7 @@ class Share20OcsControllerTest extends TestCase {
 		$ocs->createShare();
 	}
 
-	public function testUpdateShareCantAccess() {
+	public function testUpdateShareCantChange() {
 		$node = $this->createMock('\OCP\Files\Folder');
 		$share = $this->newShare();
 		$share->setNode($node);
@@ -1541,7 +1541,7 @@ class Share20OcsControllerTest extends TestCase {
 
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 
-		$expected = new Result(null, 404, 'Wrong share ID, share doesn\'t exist');
+		$expected = new Result(null, 404, 'Could not update share');
 		$result = $this->ocs->updateShare(42);
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -120,8 +120,7 @@ Feature: sharing
     And as "user1" file "/sub/shared_file.txt" should exist in trash
 
   @smokeTest
-  Scenario Outline: unshare from self
-    Given using OCS API version "<ocs_api_version>"
+  Scenario: unshare from self
     And group "grp1" has been created
     And these users have been created with default attributes and without skeleton files:
       | username |
@@ -134,15 +133,10 @@ Feature: sharing
     And user "user2" has shared file "/PARENT/parent.txt" with group "grp1"
     And user "user2" has stored etag of element "/PARENT"
     And user "user1" has stored etag of element "/"
-    When user "user1" deletes the last share using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
+    When user "user1" unshares file "parent.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
     And the etag of element "/" of user "user1" should have changed
     And the etag of element "/PARENT" of user "user2" should not have changed
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
 
   Scenario: sharee of a read-only share folder tries to delete the shared folder
     Given using OCS API version "1"

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -176,17 +176,41 @@ Feature: sharing
   Scenario Outline: A Group share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "user0" has been created with default attributes and skeleton files
     And these users have been created with default attributes and without skeleton files:
       | username |
-      | user0    |
       | user1    |
-    # Note: in the user_ldap test environment user1 is in grp1
+      | user2    |
+    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
-    And user "user0" has shared file "/PARENT/parent.txt" with group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user0" has shared entry "<entry_to_share>" with group "grp1"
     When user "user1" deletes the last share using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "404"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user0" entry "<entry_to_share>" should exist
+    And as "user1" entry "<received_entry>" should exist
+    And as "user2" entry "<received_entry>" should exist
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 200             |
-      | 2               | 404             |
+      | entry_to_share     | ocs_api_version | http_status_code | received_entry |
+      | /PARENT/parent.txt | 1               | 200              | parent.txt     |
+      | /PARENT/parent.txt | 2               | 404              | parent.txt     |
+      | /PARENT            | 1               | 200              | PARENT         |
+      | /PARENT            | 2               | 404              | PARENT         |
+
+  Scenario Outline: An individual share recipient tries to delete the share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared entry "<entry_to_share>" with user "user1"
+    When user "user1" deletes the last share using the sharing API
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And as "user0" entry "<entry_to_share>" should exist
+    And as "user1" entry "<received_entry>" should exist
+    Examples:
+      | entry_to_share     | ocs_api_version | http_status_code | received_entry |
+      | /PARENT/parent.txt | 1               | 200              | parent.txt     |
+      | /PARENT/parent.txt | 2               | 404              | parent.txt     |
+      | /PARENT            | 1               | 200              | PARENT         |
+      | /PARENT            | 2               | 404              | PARENT         |

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -178,3 +178,21 @@ Feature: sharing
     And user "user1" deletes file "/shared/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "user0" file "/shared/textfile.txt" should exist
+
+  Scenario Outline: A Group share recipient tries to delete the share
+    Given using OCS API version "<ocs_api_version>"
+    And group "grp1" has been created
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    # Note: in the user_ldap test environment user1 is in grp1
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "/PARENT/parent.txt" with group "grp1"
+    When user "user1" deletes the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "404"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 200             |
+      | 2               | 404             |


### PR DESCRIPTION
## Description
Access permission, should not enough to update or delete a share. Only share-owner and sharer can update or delete the share.

## Related Issue
- Fixes owncloud/enterprise#3497

## Motivation and Context
Fighting with bugs.

## How Has This Been Tested?
Manually with the described scenario. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 