### PR TITLE
Disable trashbin and public webdav API by default

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -631,6 +631,12 @@ steps:
   environment:
     DB_TYPE: mariadb
 
+- name: tech-preview
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php occ config:system:set dav.enable.tech_preview --value=true --type boolean
+
 - name: setup-storage
   pull: always
   image: owncloudci/php:7.1

--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -41,7 +41,6 @@ class Capabilities implements ICapability {
 		$cap =  [
 			'dav' => [
 				'chunking' => '1.0',
-				'trashbin' => '1.0',
 				'reports' => [
 					'search-files',
 				]
@@ -50,6 +49,10 @@ class Capabilities implements ICapability {
 
 		if ($this->config->getSystemValue('dav.enable.async', false)) {
 			$cap['async'] = '1.0';
+		}
+
+		if ($this->config->getSystemValue('dav.enable.tech_preview', false) === true) {
+			$cap['dav']['trashbin'] = '1.0';
 		}
 
 		return $cap;

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -58,8 +58,12 @@ class RootCollection extends SimpleCollection {
 		$systemPrincipals->disableListing = $disableListing;
 		$filesCollection = new Files\RootCollection($userPrincipalBackend, 'principals/users');
 		$filesCollection->disableListing = $disableListing;
-		$trashBinCollection = new TrashBin\RootCollection($userPrincipalBackend, 'principals/users');
-		$trashBinCollection->disableListing = $disableListing;
+
+		if ($config->getSystemValue('dav.enable.tech_preview', false) === true) {
+			$trashBinCollection = new TrashBin\RootCollection($userPrincipalBackend, 'principals/users');
+			$trashBinCollection->disableListing = $disableListing;
+		}
+
 		$caldavBackend = new CalDavBackend($db, $userPrincipalBackend, $groupPrincipalBackend, $random);
 		$calendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users');
 		$calendarRoot->disableListing = $disableListing;
@@ -99,25 +103,28 @@ class RootCollection extends SimpleCollection {
 		$queueCollection->disableListing = $disableListing;
 
 		$children = [
-				new SimpleCollection('principals', [
-						$userPrincipals,
-						$groupPrincipals,
-						$systemPrincipals]),
-				$filesCollection,
-				$trashBinCollection,
-				$calendarRoot,
-				$publicCalendarRoot,
-				new SimpleCollection('addressbooks', [
-						$usersAddressBookRoot,
-						$systemAddressBookRoot]),
-				$systemTagCollection,
-				$systemTagRelationsCollection,
-				$uploadCollection,
-				$avatarCollection,
-				new Meta\RootCollection(\OC::$server->getLazyRootFolder()),
-				$queueCollection,
-				$publicFilesRoot
+			new SimpleCollection('principals', [
+				$userPrincipals,
+				$groupPrincipals,
+				$systemPrincipals]),
+			$filesCollection,
+			$calendarRoot,
+			$publicCalendarRoot,
+			new SimpleCollection('addressbooks', [
+				$usersAddressBookRoot,
+				$systemAddressBookRoot]),
+			$systemTagCollection,
+			$systemTagRelationsCollection,
+			$uploadCollection,
+			$avatarCollection,
+			new Meta\RootCollection(\OC::$server->getLazyRootFolder()),
+			$queueCollection,
+			$publicFilesRoot
 		];
+
+		if ($config->getSystemValue('dav.enable.tech_preview', false) === true) {
+			$children[] = $trashBinCollection;
+		}
 
 		parent::__construct('root', $children);
 	}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -131,7 +131,9 @@ class Server {
 		$this->server->addPlugin(new BlockLegacyClientPlugin($config));
 		$this->server->addPlugin(new CorsPlugin(OC::$server->getUserSession()));
 		$authPlugin = new Plugin();
-		if ($this->isRequestForSubtree(['public-files'])) {
+		if ($config->getSystemValue('dav.enable.tech_preview', false) === true
+			&& $this->isRequestForSubtree(['public-files'])
+		) {
 			$this->server->addPlugin(new PublicFilesPlugin());
 			$authPlugin->addBackend(new PublicSharingAuth($this->server, OC::$server->getShareManager()));
 			$this->server->addPlugin(new PublicLinkEventsPlugin(\OC::$server->getEventDispatcher()));
@@ -206,7 +208,11 @@ class Server {
 
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 		$this->server->addPlugin(new ChunkingPlugin());
-		$this->server->addPlugin(new TrashBinPlugin());
+
+		if ($config->getSystemValue('dav.enable.tech_preview', false) === true) {
+			$this->server->addPlugin(new TrashBinPlugin());
+		}
+
 		$this->server->addPlugin(new MetaPlugin(
 			OC::$server->getUserSession(),
 			OC::$server->getLazyRootFolder()

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1435,4 +1435,10 @@ $CONFIG = array(
  * Async dav extensions can be enabled or disabled.
  */
 'dav.enable.async' => false,
+
+
+/**
+ * Tech preview extensions are disabled by default.
+ */
+'dav.enable.tech_preview' => false,
 );

--- a/pipeline.libsonnet
+++ b/pipeline.libsonnet
@@ -453,6 +453,14 @@ local suites = {
         $.yarn(image='owncloudci/php:' + php),
       ] + $.server(image='owncloudci/php:' + php, db=database_name) + [
         {
+          name: 'tech-preview',
+          image: 'owncloudci/php:' + php,
+          pull: 'always',
+          commands: [
+            'php occ config:system:set dav.enable.tech_preview --value=true --type boolean',
+          ],
+        },
+        {
           name: 'setup-storage',
           image: 'owncloudci/php:' + php,
           pull: 'always',

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -108,6 +108,7 @@ default:
         - '%paths.base%/../features/apiShareManagement'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -117,6 +118,7 @@ default:
         - '%paths.base%/../features/apiShareManagementBasic'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -126,6 +128,7 @@ default:
         - '%paths.base%/../features/apiShareOperations'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -135,6 +138,7 @@ default:
         - '%paths.base%/../features/apiShareReshare'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -144,6 +148,7 @@ default:
         - '%paths.base%/../features/apiShareUpdate'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -183,6 +188,7 @@ default:
         - '%paths.base%/../features/apiWebdavLocks'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - WebDavLockingContext:
         - WebDavPropertiesContext:
@@ -192,6 +198,7 @@ default:
         - '%paths.base%/../features/apiWebdavLocks2'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - WebDavLockingContext:
         - WebDavPropertiesContext:
@@ -210,6 +217,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
+        - OccContext:
         - SearchContext:
         - PublicWebDavContext:
 
@@ -508,6 +516,7 @@ default:
         - '%paths.base%/../features/webUITrashbin'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - TrashbinContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -235,6 +235,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
+        - OccContext:
         - PublicWebDavContext:
 
     cliAppManagement:
@@ -363,6 +364,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUISharingContext:
+        - OccContext:
         - PublicWebDavContext:
 
     webUIPersonalSettings:
@@ -389,6 +391,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUISharingContext:
+        - OccContext:
         - PublicWebDavContext:
 
     webUIRenameFolders:
@@ -445,6 +448,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUISharingContext:
+        - OccContext:
         - PublicWebDavContext:
         - WebUIPersonalSharingSettingsContext:
         - WebUIAdminSharingSettingsContext:
@@ -493,6 +497,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
+        - OccContext:
         - PublicWebDavContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
@@ -531,6 +536,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUISharingContext:
+        - OccContext:
         - PublicWebDavContext:
 
     # This suite is part of the user_management app in later core versions
@@ -600,6 +606,7 @@ default:
         - WebUILoginContext:
         - WebUIWebDavLockingContext:
         - WebUISharingContext:
+        - OccContext:
         - PublicWebDavContext:
 
     webUIWebdavLockProtection:
@@ -613,6 +620,7 @@ default:
         - WebUILoginContext:
         - WebUIWebDavLockingContext:
         - WebUISharingContext:
+        - OccContext:
         - PublicWebDavContext:
 
   extensions:

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -161,8 +161,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1)
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path | randomfile.txt |
@@ -191,8 +190,7 @@ Feature: sharing
 
   @smokeTest @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file with password
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | randomfile.txt |
@@ -224,8 +222,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | randomfile.txt |
@@ -255,8 +252,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has uploaded file with content "user0 file" to "/PARENT/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
     Then the OCS status code should be "<ocs_status_code>"
@@ -273,10 +270,10 @@ Feature: sharing
       | uid_file_owner         | user0                |
       | uid_owner              | user0                |
       | name                   |                      |
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%" and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%" and the content should be "wnCloud"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "user0 file"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "user0 file"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%" and the content should be "user0 file"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%" and the content should be "user0 file"
     And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
     And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
@@ -286,8 +283,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder, with a password
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has uploaded file with content "user0 file" to "/PARENT/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
       | password | %public% |
@@ -305,12 +302,12 @@ Feature: sharing
       | uid_file_owner         | user0                |
       | uid_owner              | user0                |
       | name                   |                      |
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"
-    But the public should not be able to download file "/parent.txt" from inside the last public shared folder using the old public WebDAV API without a password
-    And the public should not be able to download file "/parent.txt" from inside the last public shared folder using the new public WebDAV API without a password
-    And the public should not be able to download file "/parent.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%"
-    And the public should not be able to download file "/parent.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "user0 file"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "user0 file"
+    But the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API without a password
+    And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API without a password
+    And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%"
+    And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -384,8 +381,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
@@ -421,8 +417,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with edit permissions keeps it
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /afolder                  |
@@ -442,8 +437,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with upload permissions keeps it
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /afolder    |
@@ -870,8 +864,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: user creates a public link share of a file with file name longer than 64 chars
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt |
@@ -886,16 +879,15 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
-    And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
+    And user "user0" has uploaded file with content "user0 file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the range "bytes=1-6" of file "/welcome.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "elcome"
-    And the public should be able to download the range "bytes=1-6" of file "/welcome.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "elcome"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "user0 file"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "user0 file"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -1151,8 +1143,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
@@ -1334,8 +1325,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder, and checking it's content
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "ownCloud test text file parent" to "/PARENT/parent.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -161,7 +161,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1)
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path | randomfile.txt |
@@ -190,7 +191,8 @@ Feature: sharing
 
   @smokeTest @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a file with password
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | randomfile.txt |
@@ -222,7 +224,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | randomfile.txt |
@@ -252,7 +255,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
     Then the OCS status code should be "<ocs_status_code>"
@@ -282,7 +286,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder, with a password
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
       | password | %public% |
@@ -379,7 +384,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
@@ -415,7 +421,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with edit permissions keeps it
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /afolder                  |
@@ -435,7 +442,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a link share with upload permissions keeps it
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/afolder"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | /afolder    |
@@ -862,7 +870,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: user creates a public link share of a file with file name longer than 64 chars
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt |
@@ -877,7 +886,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "welcome.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/welcome.txt"
     When user "user0" creates a public link share using the sharing API with settings
@@ -1141,7 +1151,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
@@ -1323,7 +1334,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share of a folder, and checking it's content
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "ownCloud test text file parent" to "/PARENT/parent.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -88,7 +88,8 @@ Feature: sharing
 
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
-    Given using OCS API version "1"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "1"
     And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
@@ -103,7 +104,8 @@ Feature: sharing
 
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
-    Given using OCS API version "1"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "1"
     And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -88,8 +88,7 @@ Feature: sharing
 
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "1"
+    Given using OCS API version "1"
     And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
@@ -104,8 +103,7 @@ Feature: sharing
 
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "1"
+    Given using OCS API version "1"
     And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -22,7 +22,8 @@ Feature: sharing
 
   @smokeTest @files_trashbin-app-required
   Scenario Outline: moving a file out of a share as recipient creates a backup for the owner
-    Given using <dav-path-version> DAV path
+    Given the administrator has enabled DAV tech_preview
+    And using <dav-path-version> DAV path
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared file "/shared" with user "user1"
@@ -38,7 +39,8 @@ Feature: sharing
 
   @files_trashbin-app-required
   Scenario Outline: moving a folder out of a share as recipient creates a backup for the owner
-    Given using <dav-path-version> DAV path
+    Given the administrator has enabled DAV tech_preview
+    And using <dav-path-version> DAV path
     And user "user0" has created folder "/shared"
     And user "user0" has created folder "/shared/sub"
     And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
@@ -56,7 +58,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions
-    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "user0" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
@@ -72,7 +75,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create
-    Given user "user0" has created a public link share with settings
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
@@ -86,7 +90,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create,delete
-    Given user "user0" has created a public link share with settings
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
@@ -100,7 +105,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create
-    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "user0" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
@@ -114,7 +120,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create,delete
-    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "user0" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -22,8 +22,7 @@ Feature: sharing
 
   @smokeTest @files_trashbin-app-required
   Scenario Outline: moving a file out of a share as recipient creates a backup for the owner
-    Given the administrator has enabled DAV tech_preview
-    And using <dav-path-version> DAV path
+    Given using <dav-path-version> DAV path
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared file "/shared" with user "user1"
@@ -39,8 +38,7 @@ Feature: sharing
 
   @files_trashbin-app-required
   Scenario Outline: moving a folder out of a share as recipient creates a backup for the owner
-    Given the administrator has enabled DAV tech_preview
-    And using <dav-path-version> DAV path
+    Given using <dav-path-version> DAV path
     And user "user0" has created folder "/shared"
     And user "user0" has created folder "/shared/sub"
     And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -9,8 +9,7 @@ Feature: sharing
   @smokeTest @public_link_share-feature-required
   @issue-36076
   Scenario: Downloading from upload-only share is forbidden
-    Given the administrator has enabled DAV tech_preview
-    And user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
+    Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | create |
@@ -19,8 +18,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Downloading from share after the share source was deleted
-    Given the administrator has enabled DAV tech_preview
-    And user "user0" has created a public link share with settings
+    Given user "user0" has created a public link share with settings
       | path        | PARENT |
       | permissions | read   |
     When user "user0" deletes folder "PARENT" using the WebDAV API
@@ -67,12 +65,12 @@ Feature: sharing
 
   @smokeTest @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
-    Given the administrator has enabled DAV tech_preview
+    Given user "user0" has uploaded file with content "user0 file" to "/PARENT/CHILD/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
       | password | %public% |
-    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"
+    Then the public should be able to download file "/CHILD/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "user0 file"
+    And the public should be able to download file "/CHILD/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "user0 file"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -96,13 +94,13 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission
-    Given the administrator has enabled DAV tech_preview
+    Given user "user0" has uploaded file with content "user0 file" to "/PARENT/CHILD/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |
       | password    | %public% |
       | permissions | change   |
-    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"
+    Then the public should be able to download file "/CHILD/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "user0 file"
+    And the public should be able to download file "/CHILD/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "user0 file"
 
   Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission
     Given user "user1" has been created with default attributes and skeleton files
@@ -126,10 +124,10 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission
-    Given the administrator has enabled DAV tech_preview
+    Given user "user0" has uploaded file with content "user0 file" to "/PARENT/CHILD/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |
       | password    | %public% |
       | permissions | read     |
-    Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "wnCloud"
-    And the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "wnCloud"
+    Then the public should be able to download file "/CHILD/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "user0 file"
+    And the public should be able to download file "/CHILD/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "user0 file"

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -9,7 +9,8 @@ Feature: sharing
   @smokeTest @public_link_share-feature-required
   @issue-36076
   Scenario: Downloading from upload-only share is forbidden
-    Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | create |
@@ -18,7 +19,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Downloading from share after the share source was deleted
-    Given user "user0" has created a public link share with settings
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share with settings
       | path        | PARENT |
       | permissions | read   |
     When user "user0" deletes folder "PARENT" using the WebDAV API
@@ -65,6 +67,7 @@ Feature: sharing
 
   @smokeTest @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
+    Given the administrator has enabled DAV tech_preview
     When user "user0" creates a public link share using the sharing API with settings
       | path     | PARENT   |
       | password | %public% |
@@ -93,6 +96,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission
+    Given the administrator has enabled DAV tech_preview
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |
       | password    | %public% |
@@ -122,6 +126,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission
+    Given the administrator has enabled DAV tech_preview
     When user "user0" creates a public link share using the sharing API with settings
       | path        | PARENT   |
       | password    | %public% |

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -22,7 +22,8 @@ Feature: sharing
   @smokeTest @public_link_share-feature-required
   Scenario: Uploading same file to a public upload-only share multiple times via new API
     # The new API does the autorename automatically in upload-only folders
-    Given as user "user0"
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
@@ -55,7 +56,8 @@ Feature: sharing
   @issue-36055
   #After fixing the issue delete this Scenario and use the commented-out step in the above scenario
   Scenario: Uploading file to a public upload-only share that was deleted does not work
-    Given user "user0" has created a public link share with settings
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     When user "user0" deletes file "/FOLDER" using the WebDAV API
@@ -64,6 +66,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading file to a public read-only share folder does not work
+    Given the administrator has enabled DAV tech_preview
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | read   |
@@ -101,7 +104,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading to a public upload-only share
-    Given as user "user0"
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
@@ -116,7 +120,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading to a public upload-only share with password
-    Given as user "user0"
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
@@ -164,7 +169,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading to a public read/write share with password
-    Given as user "user0"
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
@@ -259,6 +265,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder with read/write permission when the sharer has unsufficient quota does not work
+    Given the administrator has enabled DAV tech_preview
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | change |
@@ -304,6 +311,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has unsufficient quota does not work
+    Given the administrator has enabled DAV tech_preview
     When user "user0" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | create |
@@ -315,7 +323,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
-    Given user "user0" has created a public link share with settings
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
@@ -326,7 +335,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
-    Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    Given the administrator has enabled DAV tech_preview
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "user0" has created a public link share with settings
       | path        | FOLDER |
       | permissions | all    |
@@ -338,7 +348,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
-    Given user "user0" has created a public link share with settings
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -364,7 +375,8 @@ Feature: sharing
 
   @smokeTest @public_link_share-feature-required
   Scenario: Uploading to a public upload-read-write and no edit and no overwrite share
-    Given as user "user0"
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
@@ -375,7 +387,8 @@ Feature: sharing
 
   @smokeTest @public_link_share-feature-required
   Scenario Outline: Uploading same file to a public upload-read-write and no edit and no overwrite share multiple times
-    Given as user "user0"
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |

--- a/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
@@ -26,8 +26,7 @@ Feature: reshare as public link
 
   @public_link_share-feature-required
   Scenario Outline: creating a public link from a share with share+read only permissions is allowed
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "some content" to "/test/file.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions "share,read"
@@ -78,8 +77,7 @@ Feature: reshare as public link
 
   @public_link_share-feature-required
   Scenario Outline: creating a public link from a share with share+read+write permissions is allowed
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "some content" to "/test/file.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"
@@ -99,8 +97,7 @@ Feature: reshare as public link
 
   @public_link_share-feature-required
   Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "some content" to "/test/file.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"

--- a/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiShareReshare/reShareAsPublicLink.feature
@@ -26,7 +26,8 @@ Feature: reshare as public link
 
   @public_link_share-feature-required
   Scenario Outline: creating a public link from a share with share+read only permissions is allowed
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "some content" to "/test/file.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions "share,read"
@@ -77,7 +78,8 @@ Feature: reshare as public link
 
   @public_link_share-feature-required
   Scenario Outline: creating a public link from a share with share+read+write permissions is allowed
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "some content" to "/test/file.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"
@@ -97,7 +99,8 @@ Feature: reshare as public link
 
   @public_link_share-feature-required
   Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "some content" to "/test/file.txt"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -62,8 +62,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share with password and adding an expiration date
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | randomfile.txt |
@@ -414,8 +413,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"
@@ -457,8 +455,7 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -62,7 +62,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Creating a new public link share with password and adding an expiration date
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | randomfile.txt |
@@ -413,7 +414,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"
@@ -455,7 +457,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has shared folder "/test" with user "user1" with permissions "all"
@@ -498,7 +501,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Updating share permissions from change to read/update/create restricts public from deleting files
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
@@ -521,7 +525,8 @@ Feature: sharing
 
   @public_link_share-feature-required
   Scenario Outline: Updating share permissions from read/update/create to change allows public to delete files
-    Given using OCS API version "<ocs_api_version>"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
     And user "user0" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |

--- a/tests/acceptance/features/apiTrashbin/trashbinAPIDisabled.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinAPIDisabled.feature
@@ -1,0 +1,43 @@
+@api @TestAlsoOnExternalUserBackend @files_trashbin-app-required
+Feature: the trashbin API is not available when the tech preview setting is disabled
+  As an administrator
+  I want to be able to disable the tech preview of the trashbin API
+  So that I can control the availability of APIs that are tech previews
+
+  Background:
+    Given the administrator has disabled DAV tech_preview
+
+  @smokeTest
+  Scenario: Attempting to empty the whole trashbin fails
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    When user "user0" empties the trashbin using the trashbin API
+    Then the HTTP status code should be "404"
+    And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should exist in trash
+
+  Scenario: Attempting to delete a single file from the trashbin should fail
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    When user "user0" tries to delete the file with original path "textfile1.txt" from the trashbin using the trashbin API
+    Then as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should exist in trash
+
+  Scenario: Attempting to restore a deleted file from the trashbin should fail
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    And as "user0" file "/textfile0.txt" should exist in trash
+    When user "user0" tries to restore the file with original path "/textfile0.txt" using the trashbin API
+    Then as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    And user "user0" should see the following elements
+      | /FOLDER/           |
+      | /PARENT/           |
+      | /PARENT/parent.txt |
+      | /textfile1.txt     |
+      | /textfile2.txt     |
+      | /textfile3.txt     |
+      | /textfile4.txt     |
+    But user "user0" should not see the following elements
+      | /textfile0.txt     |

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -4,6 +4,9 @@ Feature: files and folders can be deleted from the trashbin
   I want to delete files and folders from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
+  Background:
+    Given the administrator has enabled DAV tech_preview
+
   @smokeTest
   Scenario Outline: Trashbin can be emptied
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -5,7 +5,8 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given using OCS API version "1"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "1"
     And as the administrator
 
   @smokeTest

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -5,7 +5,8 @@ Feature: Restore deleted files/folders
   So that I can recover accidentally deleted files/folders in ownCloud
 
   Background:
-    Given using OCS API version "1"
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "1"
     And as the administrator
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -2,7 +2,8 @@
 Feature: persistent-locking in case of a public link
 
   Background:
-    Given user "user0" has been created with default attributes and skeleton files
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has been created with default attributes and skeleton files
 
   @issue-36064
   Scenario Outline: Uploading a file into a locked public folder

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -74,7 +74,8 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | exclusive  |
 
   Scenario Outline: public cannot overwrite a file in a folder locked by the owner even when sending the locktoken
-    Given user "user0" has created a public link share of folder "PARENT" with change permission
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "user0" using the old public WebDAV API

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -50,7 +50,8 @@ Feature: lock should propagate correctly if a share is reshared
 
   @issue-36064
   Scenario Outline: public uploads to a reshared share that was locked by original owner
-    Given user "user0" has shared folder "PARENT" with user "user1"
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has shared folder "PARENT" with user "user1"
     And user "user1" has shared folder "PARENT (2)" with user "user2"
     And user "user2" has created a public link share of folder "PARENT (2)" with change permission
     And user "user0" has locked folder "PARENT" setting following properties

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -29,7 +29,8 @@ Feature: download file
 
   @public_link_share-feature-required
   Scenario: download a public shared file with range
-    Given user "user0" has created a public link share with settings
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has created a public link share with settings
       | path | welcome.txt |
     When the public downloads the last public shared file with range "bytes=51-77" using the old public WebDAV API
     Then the downloaded content should be "example file for developers"
@@ -38,6 +39,7 @@ Feature: download file
 
   @public_link_share-feature-required
   Scenario: download a public shared file inside a folder with range
+    Given the administrator has enabled DAV tech_preview
     When user "user0" creates a public link share using the sharing API with settings
       | path | PARENT |
     And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API

--- a/tests/acceptance/features/apiWebdavOperations/publicWebDAVAPIDisabled.feature
+++ b/tests/acceptance/features/apiWebdavOperations/publicWebDAVAPIDisabled.feature
@@ -1,0 +1,50 @@
+@api @TestAlsoOnExternalUserBackend
+Feature: the new public WebDAV API is not available when the tech preview setting is disabled
+  As an administrator
+  I want to be able to disable the tech preview of the public WebDAV API
+  So that I can control the availability of APIs that are tech previews
+
+  Background:
+    Given the administrator has disabled DAV tech_preview
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | user0    |
+
+  @public_link_share-feature-required
+  Scenario: Public cannot download file using the public WebDAV API when it is disabled
+    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "user0" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public downloads file "welcome.txt" from inside the last public shared folder using the new public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "user0" file "PARENT/welcome.txt" should exist
+
+  @public_link_share-feature-required
+  Scenario: Public cannot delete file using the public WebDAV API when it is disabled
+    Given user "user0" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "user0" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public deletes file "welcome.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "user0" file "PARENT/welcome.txt" should exist
+
+  @public_link_share-feature-required
+  Scenario: Public cannot rename file using the public WebDAV API when it is disabled
+    Given user "user0" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "user0" file "/PARENT/parent.txt" should exist
+    And as "user0" file "/PARENT/newparent.txt" should not exist
+
+  @public_link_share-feature-required
+  Scenario: Public cannot upload file using the public WebDAV API when it is disabled
+    Given user "user0" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "user0" file "/PARENT/lorem.txt" should not exist

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -57,6 +57,46 @@ class OccContext implements Context {
 	private $lastDeletedJobId;
 
 	/**
+	 * @var boolean techPreviewEnabled
+	 */
+	private $techPreviewEnabled = false;
+
+	/**
+	 * @return boolean
+	 */
+	public function isTechPreviewEnabled() {
+		return $this->techPreviewEnabled;
+	}
+
+	/**
+	 * @Given the administrator has enabled DAV tech_preview
+	 *
+	 * @return void
+	 */
+	public function enableDAVTechPreview() {
+		if (!$this->isTechPreviewEnabled()) {
+			$this->theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand(
+				"dav.enable.tech_preview", "true", "boolean"
+			);
+			$this->techPreviewEnabled = true;
+		}
+	}
+
+	/**
+	 * @Given the administrator has disabled DAV tech_preview
+	 *
+	 * @return void
+	 */
+	public function disableDAVTechPreview() {
+		if ($this->isTechPreviewEnabled()) {
+			$this->theAdministratorDeletesSystemConfigKeyUsingTheOccCommand(
+				"dav.enable.tech_preview"
+			);
+			$this->techPreviewEnabled = false;
+		}
+	}
+
+	/**
 	 * @When /^the administrator invokes occ command "([^"]*)"$/
 	 * @Given /^the administrator has invoked occ command "([^"]*)"$/
 	 *
@@ -927,6 +967,21 @@ class OccContext implements Context {
 			$this->theCommandShouldHaveBeenSuccessful();
 		}
 	}
+
+	/**
+	 * This will run after EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @AfterScenario
+	 *
+	 * @return void
+	 */
+	public function resetDAVTechPreview() {
+		if ($this->isTechPreviewEnabled()) {
+			$this->disableDAVTechPreview();
+		}
+	}
+
 	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -71,7 +71,7 @@ class OccContext implements Context {
 	/**
 	 * @Given the administrator has enabled DAV tech_preview
 	 *
-	 * @return void
+	 * @return bool true if DAV Tech Preview was disabled and had to be enabled
 	 */
 	public function enableDAVTechPreview() {
 		if (!$this->isTechPreviewEnabled()) {
@@ -79,7 +79,9 @@ class OccContext implements Context {
 				"dav.enable.tech_preview", "true", "boolean"
 			);
 			$this->techPreviewEnabled = true;
+			return true;
 		}
+		return false;
 	}
 
 	/**
@@ -88,12 +90,10 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function disableDAVTechPreview() {
-		if ($this->isTechPreviewEnabled()) {
-			$this->theAdministratorDeletesSystemConfigKeyUsingTheOccCommand(
-				"dav.enable.tech_preview"
-			);
-			$this->techPreviewEnabled = false;
-		}
+		$this->theAdministratorDeletesSystemConfigKeyUsingTheOccCommand(
+			"dav.enable.tech_preview"
+		);
+		$this->techPreviewEnabled = false;
 	}
 
 	/**

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -171,8 +171,7 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required
   Scenario: transferring ownership of folder shares which has public link
-    Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "user0 file" to "/test/somefile.txt"
@@ -180,10 +179,8 @@ Feature: transfer-ownership
       | path | /test/somefile.txt |
     When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
     Then the command should have been successful
-    When the public downloads the last public shared file using the old public WebDAV API
-    Then the downloaded content should be "user0 file"
-    When the public downloads the last public shared file using the new public WebDAV API
-    Then the downloaded content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "user0 file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "user0 file"
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of folder shared with third user

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -171,7 +171,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required
   Scenario: transferring ownership of folder shares which has public link
-    Given user "user0" has been created with default attributes and skeleton files
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/test"
     And user "user0" has uploaded file with content "user0 file" to "/test/somefile.txt"


### PR DESCRIPTION
## Description
A config switch to enable Trashbin and webdav API

- [x] system config switch `dav.enable.tech_preview` added
- [x] `pipeline.libsonnet` and `.drone.yml` adjusted to enable the switch when running litmus tests
- [x] acceptance test steps added to enable/disable the switch
- [x] enable the switch during acceptance test scenarios that are testing the new "tech preview" APIs
- [x] when `Then` steps using the new trashbin API are being done to check the results of previous `When` actions, then enable the switch (if not already enabled), do the check, disable the switch (if we enabled it). That allows `webUITrashbin` tests to run with the switch off for the webUI trashbin actions, and for the subsequent checks to work using the new trashbin API. Thus we know that the old webUI trashbin behavior is working with the switch off.
- [x] add acceptance tests to confirm that the tech preview trashbin WebDAV API is non-responsive when the switch is off.
- [x] add acceptance tests to confirm that the tech preview public link WebDAV API is non-responsive when the switch is off.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/36118

## Motivation and Context
We don't want to expose tech preview APIs in 10.3 by default

## How Has This Been Tested?
not tested yet

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
