### PR TITLE
Add capability for roles api in files_sharing

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -85,6 +85,8 @@ class Capabilities implements ICapability {
 				$public['password']['enforced_for']['upload_only'] = $woPasswordEnforced;
 				$public['password']['enforced'] = $roPasswordEnforced || $rwPasswordEnforced || $woPasswordEnforced;
 
+				$public['roles_api'] = true;
+
 				$public['expire_date'] = [];
 				$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';
 				if ($public['expire_date']['enabled']) {

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -120,6 +120,29 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['enabled']);
 	}
 
+	public function providesRolesCapability() {
+		return [
+			[['core', 'shareapi_enabled', 'yes', 'no'],['core', 'shareapi_allow_links', 'yes', 'no']],
+			[['core', 'shareapi_enabled', 'yes', 'yes'],['core', 'shareapi_allow_links', 'yes', 'no']],
+			[['core', 'shareapi_enabled', 'yes', 'yes'],['core', 'shareapi_allow_links', 'yes', 'yes']]
+		];
+	}
+
+	/**
+	 * @dataProvider providesRolesCapability
+	 */
+	public function testRolesCapability($shareApiEnabled, $shareApiAllowLinks) {
+		$map = [$shareApiEnabled, $shareApiAllowLinks];
+		$results = $this->getResults($map);
+
+		if (($shareApiEnabled[3] === 'no') || ($shareApiAllowLinks[3] === 'no')) {
+			$this->assertArrayNotHasKey('roles_api', $results);
+		} else {
+			$this->assertArrayHasKey('roles_api', $results['public']);
+			$this->assertTrue($results['public']['roles_api']);
+		}
+	}
+
 	public function testOnlyLinkSharing() {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],

--- a/core/Controller/RolesController.php
+++ b/core/Controller/RolesController.php
@@ -83,12 +83,33 @@ class RolesController extends OCSController {
 			]);
 		$event->addRole(
 			[
+				'id' => 'core.contributor',
+				'displayName' => $this->l10n->t('Download / View / Upload'),
+				'context' => [
+					'publicLinks' => [
+						'displayDescription' => $this->l10n->t('Recipients can view, download and upload contents.'),
+						'order' => 20,
+						'resourceTypes' => [
+							'httpd/unix-directory'
+						],
+						'permissions' => [
+							'ownCloud' => [
+								'create' => true,
+								'read' => true,
+							]
+						]
+					]
+				]
+
+			]);
+		$event->addRole(
+			[
 				'id' => 'core.editor',
 				'displayName' => $this->l10n->t('Download / View / Edit'),
 				'context' => [
 					'publicLinks' => [
-						'displayDescription' => $this->l10n->t('Recipients can view, download and edit contents.'),
-						'order' => 20,
+						'displayDescription' => $this->l10n->t('Recipients can view, download, edit, delete and upload contents.'),
+						'order' => 30,
 						'resourceTypes' => [
 							'httpd/unix-directory'
 						],
@@ -102,27 +123,6 @@ class RolesController extends OCSController {
 						]
 					]
 				]
-			]);
-		$event->addRole(
-			[
-				'id' => 'core.contributor',
-				'displayName' => $this->l10n->t('Download / View / Upload'),
-				'context' => [
-					'publicLinks' => [
-						'displayDescription' => $this->l10n->t('Recipients can view, download and upload contents.'),
-						'order' => 30,
-						'resourceTypes' => [
-							'httpd/unix-directory'
-						],
-						'permissions' => [
-							'ownCloud' => [
-								'create' => true,
-								'read' => true,
-							]
-						]
-					]
-				]
-
 			]);
 		$event->addRole(
 			[

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -28,15 +28,15 @@
 				'<p><em>{{publicReadDescription}}</em></p>' +
 			'</div>' +
 			'{{#if publicUploadPossible}}' +
-			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
-				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
-				'<p><em>{{publicReadWriteDescription}}</em></p>' +
-			'</div>' +
 			'<div id="allowpublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadWriteValue}}" name="publicPermissions" id="sharingDialogAllowpublicUploadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowpublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +
 				'<p><em>{{publicUploadWriteDescription}}</em></p>' +
+			'</div>' +
+			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
+				'<p><em>{{publicReadWriteDescription}}</em></p>' +
 			'</div>' +
 			'<div id="allowPublicUploadWrapper-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadValue}}" name="publicPermissions" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadSelected}}checked{{/if}} />' +
@@ -269,7 +269,7 @@
 				publicUploadWriteSelected    : this.model.get('permissions') === (OC.PERMISSION_READ | OC.PERMISSION_CREATE),
 
 				publicReadWriteLabel       : t('core', 'Download / View / Edit'),
-				publicReadWriteDescription : t('core', 'Recipients can view, download and edit contents.'),
+				publicReadWriteDescription : t('core', 'Recipients can view, download, edit, delete and upload contents.'),
 				publicReadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE,
 				publicReadWriteSelected    : this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE),
 


### PR DESCRIPTION
Add capability for roles api in files_sharing

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add capabilty for roles api added in the server. `roles_api` is added to the public array to true, if `shareapi_enabled` is `yes` and `shareapi_allow_links` is `yes` set in the appconfig table.
Updated the change to arrange alignment of roles delivered from the RolesController and adjusted the description of View/Download/Edit in the roles. Updated the alignmnent and description change in the fontend (core/js/sharedialoglinkshareview.js).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Roles api can now be obtained from the capabilities. The key `roles_api` is added to true, if:
- `shareapi_enabled` is set to `yes`, in appconfig
- `shareapi_allow_links` is set to `yes`, in appconfig.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- php unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
