### PR TITLE
Remove hardcoded protocol.

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -34,7 +34,7 @@ $dir = \OC\Files\Filesystem::normalizePath($dir);
 try {
 	$dirInfo = \OC\Files\Filesystem::getFileInfo($dir);
 	if (!$dirInfo || !$dirInfo->getType() === 'dir') {
-		\header("HTTP/1.0 404 Not Found");
+		\http_response_code(404);
 		exit();
 	}
 

--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -32,7 +32,7 @@ OCP\User::checkLoggedIn();
 $filename = $_GET["file"];
 
 if (!\OC\Files\Filesystem::file_exists($filename)) {
-	\header("HTTP/1.0 404 Not Found");
+	\http_response_code(404);
 	$tmpl = new OCP\Template('', '404', 'guest');
 	$tmpl->assign('file', $filename);
 	$tmpl->printPage();
@@ -43,7 +43,7 @@ if (!\OC\Files\Filesystem::file_exists($filename)) {
 $event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['path' => $filename]);
 OC::$server->getEventDispatcher()->dispatch('file.beforeGetDirect', $event);
 if ($event->hasArgument('errorMessage')) {
-	\header("HTTP/1.0 403 Forbidden");
+	\http_response_code(403);
 	$tmpl = new OCP\Template('', '403', 'guest');
 	$tmpl->assign('file', $filename);
 	$tmpl->printPage();

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -30,7 +30,7 @@ $route = isset($_GET['download']) ? 'files_sharing.sharecontroller.downloadShare
 if ($token !== '') {
 	OC_Response::redirect($urlGenerator->linkToRoute($route, ['token' => $token]));
 } else {
-	\header('HTTP/1.0 404 Not Found');
+	\http_response_code(404);
 	$tmpl = new OCP\Template('', '404', 'guest');
 	print_unescaped($tmpl->fetchPage());
 }

--- a/apps/files_trashbin/ajax/list.php
+++ b/apps/files_trashbin/ajax/list.php
@@ -34,7 +34,7 @@ $data = [];
 try {
 	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser(), $sortAttribute, $sortDirection);
 } catch (Exception $e) {
-	\header("HTTP/1.0 404 Not Found");
+	\http_response_code(404);
 	exit();
 }
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -294,7 +294,7 @@ class OC {
 			&& !$isOccControllerRequested
 		) {
 			// send http status 503
-			\header('HTTP/1.1 503 Service Temporarily Unavailable');
+			\http_response_code(503);
 			\header('Status: 503 Service Temporarily Unavailable');
 			\header('Retry-After: 120');
 
@@ -322,7 +322,7 @@ class OC {
 			}
 		}
 		// send http status 503
-		\header('HTTP/1.1 503 Service Temporarily Unavailable');
+		\http_response_code(503);
 		\header('Status: 503 Service Temporarily Unavailable');
 		\header('Retry-After: 120');
 
@@ -369,7 +369,7 @@ class OC {
 		}
 		if ($disableWebUpdater || $tooBig) {
 			// send http status 503
-			\header('HTTP/1.1 503 Service Temporarily Unavailable');
+			\http_response_code(503);
 			\header('Status: 503 Service Temporarily Unavailable');
 			\header('Retry-After: 120');
 
@@ -684,7 +684,7 @@ class OC {
 		// Check whether the sample configuration has been copied
 		if ($systemConfig->getValue('copied_sample_config', false)) {
 			$l = \OC::$server->getL10N('lib');
-			\header('HTTP/1.1 503 Service Temporarily Unavailable');
+			\http_response_code(503);
 			\header('Status: 503 Service Temporarily Unavailable');
 			OC_Template::printErrorPage(
 				$l->t('Sample configuration detected'),
@@ -706,7 +706,7 @@ class OC {
 			&& !\OC::$server->getTrustedDomainHelper()->isTrustedDomain($host)
 			&& self::$server->getConfig()->getSystemValue('installed', false)
 		) {
-			\header('HTTP/1.1 400 Bad Request');
+			\http_response_code(400);
 			\header('Status: 400 Bad Request');
 
 			\OC::$server->getLogger()->warning(
@@ -923,7 +923,7 @@ class OC {
 				}
 				throw $e;
 			} catch (Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {
-				//header('HTTP/1.0 404 Not Found');
+				//http_response_code(404);
 			} catch (Symfony\Component\Routing\Exception\MethodNotAllowedException $e) {
 				OC_Response::setStatus(405);
 				return;
@@ -935,7 +935,7 @@ class OC {
 			// not allowed any more to prevent people
 			// mounting this root directly.
 			// Users need to mount remote.php/webdav instead.
-			\header('HTTP/1.1 405 Method Not Allowed');
+			\http_response_code(405);
 			\header('Status: 405 Method Not Allowed');
 			return;
 		}

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -433,7 +433,7 @@ class OC_API {
 			} else {
 				\header('WWW-Authenticate: Basic realm="Authorisation Required"');
 			}
-			\header('HTTP/1.0 401 Unauthorized');
+			\http_response_code(401);
 		}
 
 		foreach ($result->getHeaders() as $name => $value) {

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -76,7 +76,7 @@ class OC_Files {
 		$type = \OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
 		if ($fileSize > -1) {
 			if (!empty($rangeArray)) {
-				\header('HTTP/1.1 206 Partial Content', true);
+				\http_response_code(206);
 				\header('Accept-Ranges: bytes', true);
 				if (\count($rangeArray) > 1) {
 					$type = 'multipart/byteranges; boundary='.self::getBoundary();
@@ -274,7 +274,7 @@ class OC_Files {
 		if (\OC\Files\Filesystem::isReadable($filename) && !$event->hasArgument('errorMessage')) {
 			self::sendHeaders($filename, $name, $rangeArray);
 		} elseif (!\OC\Files\Filesystem::file_exists($filename)) {
-			\header("HTTP/1.1 404 Not Found");
+			\http_response_code(404);
 			$tmpl = new OC_Template('', '404', 'guest');
 			$tmpl->printPage();
 			exit();
@@ -312,7 +312,7 @@ class OC_Files {
 				// file is unseekable
 				\header_remove('Accept-Ranges');
 				\header_remove('Content-Range');
-				\header("HTTP/1.1 200 OK");
+				\http_response_code(200);
 				self::sendHeaders($filename, $name, []);
 				$view->readfile($filename);
 			}

--- a/public.php
+++ b/public.php
@@ -42,7 +42,7 @@ try {
 	$pathInfo = $request->getPathInfo();
 
 	if (!$pathInfo && $request->getParam('service', '') === '') {
-		\header('HTTP/1.0 404 Not Found');
+		\http_response_code(404);
 		exit;
 	} elseif ($request->getParam('service', '')) {
 		$service = $request->getParam('service', '');
@@ -52,7 +52,7 @@ try {
 	}
 	$file = \OC::$server->getConfig()->getAppValue('core', 'public_' . \strip_tags($service));
 	if ($file === null) {
-		\header('HTTP/1.0 404 Not Found');
+		\http_response_code(404);
 		exit;
 	}
 


### PR DESCRIPTION
## Description
Seen by https://github.com/Rello/audioplayer/pull/421:

> I'm betting browsers think it's weird, when they get HTTP 1.1 response over HTTP/2 connection. Or over HTTP 1.0 if they feel a bit retro.

and https://github.com/nextcloud/server/pull/10009 and found by:

```
egrep -lR "header\s*\(.+HTTP" . --include=*.php
```

https://github.com/owncloud/core/blob/34558869c3dc83dd27c3d945b158aa3e12a2e7d0/lib/private/legacy/files.php#L79

Seen "true" default:

>  replace
>
>    The optional replace parameter indicates whether the header should replace a previous similar header, or add a second header of the same type. By default it will replace, but if you pass in FALSE as the second argument you can force multiple headers of the same type. For example: 

by https://www.php.net/manual/en/function.header.php so replace possible.

## Related Issue
- Fixes #36128

## Motivation and Context
Cleaning

## How Has This Been Tested?
Not know how testing done

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
