### PR TITLE
Add password enforcement for Download/View/Edit option

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -80,10 +80,12 @@ class Capabilities implements ICapability {
 				$roPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no') === 'yes';
 				$rwPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
 				$woPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no') === 'yes';
+				$rwdPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 				$public['password']['enforced_for']['read_only'] = $roPasswordEnforced;
 				$public['password']['enforced_for']['read_write'] = $rwPasswordEnforced;
 				$public['password']['enforced_for']['upload_only'] = $woPasswordEnforced;
-				$public['password']['enforced'] = $roPasswordEnforced || $rwPasswordEnforced || $woPasswordEnforced;
+				$public['password']['enforced_for']['read_write_delete'] = $rwdPasswordEnforced;
+				$public['password']['enforced'] = $roPasswordEnforced || $rwPasswordEnforced || $woPasswordEnforced || $rwdPasswordEnforced;
 
 				$public['roles_api'] = true;
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -155,25 +155,27 @@ class CapabilitiesTest extends \Test\TestCase {
 
 	public function linkPasswordProvider() {
 		return [
-			['no', 'no', 'yes'],
-			['no', 'yes', 'no'],
-			['no', 'yes', 'yes'],
-			['yes', 'no', 'no'],
-			['yes', 'no', 'yes'],
-			['yes', 'yes', 'no'],
-			['yes', 'yes', 'yes'],
+			['no', 'no', 'no', 'yes'],
+			['no', 'yes', 'no', 'no'],
+			['no', 'yes', 'no', 'yes'],
+			['no', 'no', 'yes', 'no'],
+			['yes', 'no', 'no', 'no'],
+			['yes', 'no', 'no', 'yes'],
+			['yes', 'yes', 'no', 'no'],
+			['yes', 'yes', 'yes', 'yes'],
 		];
 	}
 
 	/**
 	 * @dataProvider linkPasswordProvider
 	 */
-	public function testLinkPassword($readOnly, $readWrite, $writeOnly) {
+	public function testLinkPassword($readOnly, $readWrite, $readWriteDelete, $writeOnly) {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_only', 'no', $readOnly],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', $readWrite],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', $readWriteDelete],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', $writeOnly],
 		];
 		$result = $this->getResults($map);
@@ -185,6 +187,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertEquals($readOnly === 'yes', $result['public']['password']['enforced_for']['read_only']);
 		$this->assertEquals($readWrite === 'yes', $result['public']['password']['enforced_for']['read_write']);
 		$this->assertEquals($writeOnly === 'yes', $result['public']['password']['enforced_for']['upload_only']);
+		$this->assertEquals($readWriteDelete === 'yes', $result['public']['password']['enforced_for']['read_write_delete']);
 	}
 
 	public function testLinkNoPassword() {
@@ -193,6 +196,7 @@ class CapabilitiesTest extends \Test\TestCase {
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'no'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'no'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
@@ -202,6 +206,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['password']['enforced']);
 		$this->assertFalse($result['public']['password']['enforced_for']['read_only']);
 		$this->assertFalse($result['public']['password']['enforced_for']['read_write']);
+		$this->assertFalse($result['public']['password']['enforced_for']['read_write_delete']);
 		$this->assertFalse($result['public']['password']['enforced_for']['upload_only']);
 	}
 

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -69,6 +69,7 @@ if ($defaultExpireDateEnabled) {
 $enforceLinkPasswordReadOnly = $config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no') === 'yes';
 $enforceLinkPasswordReadWrite = $config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
 $enforceLinkPasswordWriteOnly = $config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no') === 'yes';
+$enforceLinkPasswordReadWriteDelete = $config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 $outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
 
 $countOfDataLocation = 0;
@@ -171,6 +172,7 @@ $array = [
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 				'enforceLinkPasswordReadOnly' => $enforceLinkPasswordReadOnly,
 				'enforceLinkPasswordReadWrite' => $enforceLinkPasswordReadWrite,
+				'enforceLinkPasswordReadWriteDelete' => $enforceLinkPasswordReadWriteDelete,
 				'enforceLinkPasswordWriteOnly' => $enforceLinkPasswordWriteOnly,
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -23,6 +23,7 @@
 			publicUploadEnabled: false,
 			enforceLinkPasswordReadOnly: oc_appconfig.core.enforceLinkPasswordReadOnly,
 			enforceLinkPasswordReadWrite: oc_appconfig.core.enforceLinkPasswordReadWrite,
+			enforceLinkPasswordReadWriteDelete: oc_appconfig.core.enforceLinkPasswordReadWriteDelete,
 			enforceLinkPasswordWriteOnly: oc_appconfig.core.enforceLinkPasswordWriteOnly,
 			isDefaultExpireDateEnforced: oc_appconfig.core.defaultExpireDateEnforced === true,
 			isDefaultExpireDateEnabled: oc_appconfig.core.defaultExpireDateEnabled === true,

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -114,8 +114,9 @@
 			var permissions = this._getPermissions();
 			var roEnforcement = permissions === OC.PERMISSION_READ && this.configModel.get('enforceLinkPasswordReadOnly');
 			var woEnforcement = permissions === OC.PERMISSION_CREATE && this.configModel.get('enforceLinkPasswordWriteOnly');
-			var rwEnforcement = (permissions !== OC.PERMISSION_READ && permissions !== OC.PERMISSION_CREATE) && this.configModel.get('enforceLinkPasswordReadWrite');
-			if (roEnforcement || woEnforcement || rwEnforcement) {
+			var rwEnforcement = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_CREATE) && this.configModel.get('enforceLinkPasswordReadWrite'));
+			var rwdEnforcement = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE) && this.configModel.get('enforceLinkPasswordReadWriteDelete'));
+			if (roEnforcement || woEnforcement || rwEnforcement || rwdEnforcement) {
 				return true;
 			} else {
 				return false;

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -282,6 +282,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 				configModel.set({
 					enforceLinkPasswordReadOnly : true,
 					enforceLinkPasswordWriteOnly : true,
+					enforceLinkPasswordReadWriteDelete: true,
 					enforceLinkPasswordReadWrite : true
 				});
 				view.render();
@@ -436,6 +437,18 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 		it('displays inline error when password enforced for read & write but missing', function() {
 			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
 			configModel.set('enforceLinkPasswordReadWrite', true);
+			view.render();
+			view.$('#sharingDialogAllowpublicUploadWrite-' + view.cid).prop('checked', true)
+			var handler = sinon.stub();
+			view.on('saved', handler);
+			view._save();
+			expect(handler.notCalled).toEqual(true);
+
+			expect(view.$('.linkPassText').next('.error-message').hasClass('hidden')).toEqual(false);
+		});
+		it('displays inline error when password enforced for read, write & delete but missing', function () {
+			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
+			configModel.set('enforceLinkPasswordReadWriteDelete', true);
 			view.render();
 			view.$('#sharingDialogAllowPublicReadWrite-' + view.cid).prop('checked', true)
 			var handler = sinon.stub();

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -192,9 +192,12 @@ class Manager implements IManager {
 	protected function passwordMustBeEnforced($permissions) {
 		$roEnforcement = $permissions === \OCP\Constants::PERMISSION_READ && $this->shareApiLinkEnforcePasswordReadOnly();
 		$woEnforcement = $permissions === \OCP\Constants::PERMISSION_CREATE && $this->shareApiLinkEnforcePasswordWriteOnly();
+		// use read, write & delete enforcement for the case
+		$rwdEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE)) &&
+			$this->shareApiLinkEnforcePasswordReadWriteDelete();
 		// use read & write enforcement for the rest of the cases
-		$rwEnforcement = ($permissions !== \OCP\Constants::PERMISSION_READ && $permissions !== \OCP\Constants::PERMISSION_CREATE) && $this->shareApiLinkEnforcePasswordReadWrite();
-		if ($roEnforcement || $woEnforcement || $rwEnforcement) {
+		$rwEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE)) && $this->shareApiLinkEnforcePasswordReadWrite();
+		if ($roEnforcement || $woEnforcement || $rwEnforcement || $rwdEnforcement) {
 			return true;
 		} else {
 			return false;
@@ -1520,6 +1523,15 @@ class Manager implements IManager {
 	 */
 	public function shareApiLinkEnforcePasswordReadWrite() {
 		return $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
+	}
+
+	/**
+	 * Is password enforced for read, write & delete shares?
+	 *
+	 * @return bool
+	 */
+	public function shareApiLinkEnforcePasswordReadWriteDelete() {
+		return $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 	}
 
 	/**

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -294,6 +294,14 @@ interface IManager {
 	public function shareApiLinkEnforcePasswordWriteOnly();
 
 	/**
+	 * Is password enforced for read,write & delete shares?
+	 *
+	 * @return bool true if password is enforced, false otherwise
+	 * @since 10.3.0
+	 */
+	public function shareApiLinkEnforcePasswordReadWriteDelete();
+
+	/**
 	 * Is default expire date enabled
 	 *
 	 * @return bool

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -92,6 +92,7 @@ class FileSharing implements ISettings {
 		$template->assign('allowPublicUpload', $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'));
 		$template->assign('enforceLinkPasswordReadOnly', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no'));
 		$template->assign('enforceLinkPasswordReadWrite', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no'));
+		$template->assign('enforceLinkPasswordReadWriteDelete', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no'));
 		$template->assign('enforceLinkPasswordWriteOnly', $this->config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no'));
 		$template->assign('shareDefaultExpireDateSet', $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'));
 		$template->assign('allowPublicMailNotification', $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no'));

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -43,7 +43,13 @@
 			value="1" <?php if ($_['enforceLinkPasswordReadWrite'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
-		<label for="enforceLinkPasswordReadWrite"><?php p($l->t('Enforce password protection for read & write links'));?></label><br/>
+		<label for="enforceLinkPasswordReadWrite"><?php p($l->t('Enforce password protection for read + write links'));?></label><br/>
+
+		<input type="checkbox" name="shareapi_enforce_links_password_read_write_delete" id="enforceLinkPasswordReadWriteDelete" class="checkbox"
+			   value="1" <?php if ($_['enforceLinkPasswordReadWriteDelete'] === 'yes') {
+	print_unescaped('checked="checked"');
+} ?> />
+		<label for="enforceLinkPasswordReadWriteDelete"><?php p($l->t('Enforce password protection for read + write + delete links'));?></label><br/>
 
 		<input type="checkbox" name="shareapi_enforce_links_password_write_only" id="enforceLinkPasswordWriteOnly" class="checkbox"
 			value="1" <?php if ($_['enforceLinkPasswordWriteOnly'] === 'yes') {

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -164,6 +164,19 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When /^the administrator (enables|disables) enforce password protection for read and write and delete links using the webUI$/
+	 *
+	 * @param string $action
+	 *
+	 * @return void
+	 */
+	public function adminTogglesEnforcePasswordProtectionForReadWriteDeleteLinks($action) {
+		$this->adminSharingSettingsPage->toggleEnforcePasswordProtectionForReadWriteDeleteLinks(
+			$this->getSession(), $action
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) enforce password protection for upload only links using the webUI$/
 	 *
 	 * @param string $action

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -49,6 +49,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $enforceLinkPasswordReadOnlyCheckboxId = 'enforceLinkPasswordReadOnly';
 	protected $enforceLinkPasswordReadWriteCheckboxXpath = '//label[@for="enforceLinkPasswordReadWrite"]';
 	protected $enforceLinkPasswordReadWriteCheckboxId = 'enforceLinkPasswordReadWrite';
+	protected $enforceLinkPasswordReadWriteDeleteCheckboxXpath = '//label[@for="enforceLinkPasswordReadWriteDelete"]';
+	protected $enforceLinkPasswordReadWriteDeleteCheckboxId = 'enforceLinkPasswordReadWriteDelete';
 	protected $enforceLinkPasswordWriteOnlyCheckboxXpath = '//label[@for="enforceLinkPasswordWriteOnly"]';
 	protected $enforceLinkPasswordWriteOnlyCheckboxId = 'enforceLinkPasswordWriteOnly';
 	protected $allowResharingCheckboxXpath = '//label[@for="allowResharing"]';
@@ -227,6 +229,25 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			$action,
 			$this->enforceLinkPasswordReadWriteCheckboxXpath,
 			$this->enforceLinkPasswordReadWriteCheckboxId
+		);
+	}
+
+	/**
+	 * toggle enforce password protection for read, write and delete links
+	 *
+	 * @param Session $session
+	 * @param string $action "enables|disables"
+	 *
+	 * @return void
+	 */
+	public function toggleEnforcePasswordProtectionForReadWriteDeleteLinks(
+		Session $session, $action
+	) {
+		$this->toggleCheckbox(
+			$session,
+			$action,
+			$this->enforceLinkPasswordReadWriteDeleteCheckboxXpath,
+			$this->enforceLinkPasswordReadWriteDeleteCheckboxId
 		);
 	}
 

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -41,6 +41,11 @@ Feature: admin sharing settings
     When the administrator enables enforce password protection for read and write links using the webUI
     Then the "public@@@password@@@enforced_for@@@read_write" capability of files sharing app should be "1"
 
+  Scenario: enable enforce password protection for read and write and delete links
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables enforce password protection for read and write and delete links using the webUI
+    Then the "public@@@password@@@enforced_for@@@read_write_delete" capability of files sharing app should be "1"
+
   Scenario: enable enforce password protection for upload-only links
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables enforce password protection for upload only links using the webUI
@@ -105,6 +110,12 @@ Feature: admin sharing settings
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables enforce password protection for read and write links using the webUI
     Then the "public@@@password@@@enforced_for@@@read_write" capability of files sharing app should be "EMPTY"
+
+  Scenario: disable enforce password protection for read and write and delete links
+    Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "no"
+    And the administrator has browsed to the admin sharing settings page
+    When the administrator disables enforce password protection for read and write and delete links using the webUI
+    Then the "public@@@password@@@enforced_for@@@read_write_delete" capability of files sharing app should be "EMPTY"
 
   Scenario: disable enforce password protection for upload-only links
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "no"

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -125,7 +125,7 @@ Feature: Share by public link
   Scenario: user tries to create a public link with read-write permission without entering share password while enforce password on read-write public share is enforced
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has logged in using the webUI
-    And parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_links_password_read_write_delete" of app "core" has been set to "yes"
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -612,6 +612,7 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_write_delete', 'no', 'yes'],
 		]));
 
 		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ]));
@@ -624,13 +625,26 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
-		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_ALL]));
+		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE]));
+	}
+
+	public function testPasswordMustBeEnforcedForReadWriteDelete() {
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+		]));
+
+		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced',
+			[\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE]));
 	}
 
 	public function testPasswordMustBeEnforcedForWriteOnly() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
@@ -641,6 +655,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'no'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
@@ -651,16 +666,30 @@ class ManagerTest extends \Test\TestCase {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
 		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_ALL]));
 	}
 
+	public function testPasswordMustBeEnforcedForReadWriteDeleteNotEnforced() {
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+		]));
+
+		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced',
+			[\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE]));
+	}
+
 	public function testPasswordMustBeEnforcedForWriteOnlyNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
 		]));
 


### PR DESCRIPTION
Add password enforcement for Download/View/Edit
option for the public share.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This change includes password enforcement for all the permission. Because of the introduction of new permission to public link, the password enforcement change was not done. This change brings that. To be precise, in admin->settings->sharing page, a new checkbox is introduced for password enforcement for `Download/View/Edit`. So user can have password enforcement for all the public link creation permissions available. Meaning password enforcement is now available for:
- `Download/View`
- `Download/View/Upload`
- `Download/View/Edit`
- and `Upload only (File Drop)`

After making the change by ticking the checkbox, it is advisable to refresh the page. Because the data stored in oc_appconfig is passed to frontend or the UI.

Another change that I have done from the logical point in this PR is: the permission check is not made loose for readwrite (or `Download/View/Upload` ). Meaning the permission has to be 5, i.e, READ + CREATE = 5. And the similar logic for readwritedelete (or `Download/View/Edit`) ,i.e, READ + UPDATE + CREATE + DELETE = 15. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Password enforcement for `Download/View/Edit` is introduced with this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested manually by checking the box for read, write and delete option `Enforce password protection for read + write + delete links`. And verified that after ticking the checkbox, without entering password the share is not created.
- This test was also conducted by ticking other options inorder to verify the other changes are not messed up because of this change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
