### PR TITLE
regenerate .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3681,6 +3681,147 @@ steps:
   - bash tests/drone/install-server.sh
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: mariadb
+
+- name: testing-application
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - git clone https://github.com/owncloud/testing.git /drone/src/apps/testing
+  - cd /drone/src/apps/testing
+  - composer install
+  - cd /drone/src
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+
+- name: owncloud-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown www-data -R /drone/src
+
+- name: owncloud-logfile
+  pull: always
+  image: owncloudci/php:7.1
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: api-acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /drone/saved-settings.sh
+  - . /drone/saved-settings.sh
+  - make test-acceptance-api TESTING_REMOTE_SYSTEM=true
+  environment:
+    BEHAT_SUITE: apiFavorites
+    TEST_SERVER_URL: https://server
+
+services:
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_CONFIG_TEMPLATE: ssl
+    APACHE_SSL_CERT: /drone/server.crt
+    APACHE_SSL_CERT_CN: server
+    APACHE_SSL_KEY: /drone/server.key
+    APACHE_WEBROOT: /drone/src
+
+- name: mariadb
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/heads/master
+  - refs/tags/**
+  - refs/pull/**
+
+depends_on:
+- coding-standard
+- phan-php7.1
+- stan-php7.1
+
+---
+kind: pipeline
+name: behat-headless-master-qa-fed-apiFederation
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
   - php occ config:system:set trusted_domains 2 --value=federated
   - php occ log:manage --level 2
   - php occ config:list
@@ -3761,7 +3902,7 @@ steps:
   - . /drone/saved-settings.sh
   - make test-acceptance-api TESTING_REMOTE_SYSTEM=true
   environment:
-    BEHAT_SUITE: apiFavorites
+    BEHAT_SUITE: apiFederation
     TEST_SERVER_URL: https://server
 
 services:
@@ -3993,147 +4134,6 @@ services:
     APACHE_SSL_CERT_CN: federated
     APACHE_SSL_KEY: /drone/federated.key
     APACHE_WEBROOT: /drone/federated
-
-- name: mariadb
-  image: mariadb:10.2
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-trigger:
-  ref:
-  - refs/heads/master
-  - refs/tags/**
-  - refs/pull/**
-
-depends_on:
-- coding-standard
-- phan-php7.1
-- stan-php7.1
-
----
-kind: pipeline
-name: behat-headless-master-qa-fed-apiFederation
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /drone
-  path: src
-
-steps:
-- name: cache-restore
-  pull: always
-  image: plugins/s3-cache:1
-  settings:
-    access_key:
-      from_secret: cache_s3_access_key
-    endpoint:
-      from_secret: cache_s3_endpoint
-    restore: true
-    secret_key:
-      from_secret: cache_s3_secret_key
-  when:
-    instance:
-    - drone.owncloud.services
-    - drone.owncloud.com
-
-- name: composer-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make install-composer-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: vendorbin-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make vendor-bin-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: yarn-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make install-nodejs-deps
-  environment:
-    NPM_CONFIG_CACHE: /drone/src/.cache/npm
-    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
-    bower_storage__packages: /drone/src/.cache/bower
-
-- name: install-server
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - bash tests/drone/install-server.sh
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-  - php occ config:list
-  - php occ security:certificates:import /drone/server.crt
-  - php occ security:certificates
-  environment:
-    DB_TYPE: mariadb
-
-- name: testing-application
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - git clone https://github.com/owncloud/testing.git /drone/src/apps/testing
-  - cd /drone/src/apps/testing
-  - composer install
-  - cd /drone/src
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-
-- name: owncloud-permissions
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - chown www-data -R /drone/src
-
-- name: owncloud-logfile
-  pull: always
-  image: owncloudci/php:7.1
-  detach: true
-  commands:
-  - tail -f /drone/src/data/owncloud.log
-
-- name: api-acceptance-tests
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - touch /drone/saved-settings.sh
-  - . /drone/saved-settings.sh
-  - make test-acceptance-api TESTING_REMOTE_SYSTEM=true
-  environment:
-    BEHAT_SUITE: apiFederation
-    TEST_SERVER_URL: https://server
-
-services:
-- name: server
-  pull: always
-  image: owncloudci/php:7.1
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_CONFIG_TEMPLATE: ssl
-    APACHE_SSL_CERT: /drone/server.crt
-    APACHE_SSL_CERT_CN: server
-    APACHE_SSL_KEY: /drone/server.key
-    APACHE_WEBROOT: /drone/src
 
 - name: mariadb
   image: mariadb:10.2
@@ -9554,11 +9554,9 @@ steps:
   - bash tests/drone/install-server.sh
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
-  - php occ config:system:set trusted_domains 2 --value=federated
   - php occ log:manage --level 2
   - php occ config:list
   - php occ security:certificates:import /drone/server.crt
-  - php occ security:certificates:import /drone/federated.crt
   - php occ security:certificates
   environment:
     DB_TYPE: mariadb
@@ -9704,9 +9702,11 @@ steps:
   - bash tests/drone/install-server.sh
   - php occ a:l
   - php occ config:system:set trusted_domains 1 --value=server
+  - php occ config:system:set trusted_domains 2 --value=federated
   - php occ log:manage --level 2
   - php occ config:list
   - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates:import /drone/federated.crt
   - php occ security:certificates
   environment:
     DB_TYPE: mariadb


### PR DESCRIPTION
## Description
After PR #36047 when I type:
```
drone jsonnet --stream
```

It generates a different `.drone.yml` from `.drone.jsonnet` and `pipeline.libsonnnet`

Commit the newly-generated `.drone.yml`

I guess something happening in auto-merge of that PR.

## Related Issue
PR #36047 and issue #34500 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
