### PR TITLE
compare shareowner and session user when detecting re-share

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -886,7 +886,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$c->getLazyRootFolder(),
 				$c->getEventDispatcher(),
 				new View('/'),
-				$c->getDatabaseConnection()
+				$c->getDatabaseConnection(),
+				$c->getUserSession()
 			);
 
 			return $manager;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -40,6 +40,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use OCP\Share\Exceptions\GenericShareException;
@@ -85,6 +86,8 @@ class Manager implements IManager {
 	private $view;
 	/** @var IDBConnection  */
 	private $connection;
+	/** @var IUserSession  */
+	private $userSession;
 
 	/**
 	 * Manager constructor.
@@ -99,6 +102,10 @@ class Manager implements IManager {
 	 * @param IProviderFactory $factory
 	 * @param IUserManager $userManager
 	 * @param IRootFolder $rootFolder
+	 * @param EventDispatcher $eventDispatcher
+	 * @param View $view
+	 * @param IDBConnection $connection
+	 * @param IUserSession $userSession
 	 */
 	public function __construct(
 			ILogger $logger,
@@ -113,7 +120,8 @@ class Manager implements IManager {
 			IRootFolder $rootFolder,
 			EventDispatcher $eventDispatcher,
 			View $view,
-			IDBConnection $connection
+			IDBConnection $connection,
+			$userSession
 	) {
 		$this->logger = $logger;
 		$this->config = $config;
@@ -129,6 +137,7 @@ class Manager implements IManager {
 		$this->eventDispatcher = $eventDispatcher;
 		$this->view = $view;
 		$this->connection = $connection;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -319,7 +328,7 @@ class Manager implements IManager {
 		}
 
 		/** If it is re-share, calculate $maxPermissions based on all incoming share permissions */
-		if ($shareNode->getOwner()->getUID() !== $share->getSharedBy()) {
+		if ($share->getShareOwner() !== $this->userSession->getUser()->getUID()) {
 			$maxPermissions = $this->calculateReshareNodePermissions($share);
 		}
 
@@ -639,8 +648,6 @@ class Manager implements IManager {
 	public function createShare(\OCP\Share\IShare $share) {
 		$this->canShare($share);
 
-		$this->generalChecks($share);
-
 		// Verify if there are any issues with the path
 		$this->pathCreateChecks($share->getNode());
 
@@ -658,6 +665,8 @@ class Manager implements IManager {
 		} else {
 			$share->setShareOwner($share->getNode()->getOwner()->getUID());
 		}
+
+		$this->generalChecks($share);
 
 		//Verify share type
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
@@ -1277,13 +1286,13 @@ class Manager implements IManager {
 	 */
 	public function getAllSharedWith($userId, $shareTypes, $node = null) {
 		$shares = [];
-		
+
 		// Aggregate all required $shareTypes by mapping provider to supported shareTypes
 		$providerIdMap = $this->shareTypeToProviderMap($shareTypes);
 		foreach ($providerIdMap as $providerId => $shareTypeArray) {
 			// Get provider from cache
 			$provider = $this->factory->getProvider($providerId);
-			
+
 			// Obtain all shares for all the supported provider types
 			$queriedShares = $provider->getAllSharedWith($userId, $node);
 			$shares = \array_merge($shares, $queriedShares);
@@ -1291,7 +1300,7 @@ class Manager implements IManager {
 
 		return $shares;
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */


### PR DESCRIPTION
## Description
Shareowner should have full permission on re-shares. For detecting re-share, this PR compares the session user UID with the shareowner UID as described in this comment: https://github.com/owncloud/core/issues/36107#issuecomment-525170914. 

## Related Issue
- Fixes #36107 

## Motivation and Context
Fighting with bugs.

## How Has This Been Tested?
Manually with steps in #36107. Also, unit tests are adjusted.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
