### PR TITLE
fixed typos in 'phoenix.baseUrl' documentation

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -445,9 +445,9 @@ $CONFIG = array(
  * If phoenix.baseUrl is set, public and private links will be redirected to this
  * url. Phoenix will handle these links accordingly.
  *
- * As an example, in case 'phoenix.baseUrl' is set to 'http://phoenix,example.com',
+ * As an example, in case 'phoenix.baseUrl' is set to 'http://phoenix.example.com',
  * the shared link 'http://ocx.example.com/index.php/s/THoQjwYYMJvXMdW' will be redirected
- * by ownCloud to 'http://phoenix.example.com/index.html#//s/THoQjwYYMJvXMdW'.
+ * by ownCloud to 'http://phoenix.example.com/index.html#/s/THoQjwYYMJvXMdW'.
  */
 'phoenix.baseUrl' => '',
 /**


### PR DESCRIPTION
## Description
follow up of #36007 fixing typos