### PR TITLE
Dont check the CSRF token on public link email API

### DIFF
--- a/apps/files_sharing/lib/Controller/NotificationController.php
+++ b/apps/files_sharing/lib/Controller/NotificationController.php
@@ -66,6 +66,7 @@ class NotificationController extends OCSController {
 	}
 
 	/**
+	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 *
 	 * @param string $link URL of the shared link


### PR DESCRIPTION
## Description
Dont check the CSRF token on public link email API

## Related Issue
- Fixes https://github.com/owncloud/core/issues/36157

## Motivation and Context
OCS API should allow third-party access. No need to CSRF check in here.

## How Has This Been Tested?
Manually with curl call.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
