### PR TITLE
obey to config in share mail notifications APIs

### DIFF
--- a/apps/files_sharing/lib/Controller/NotificationController.php
+++ b/apps/files_sharing/lib/Controller/NotificationController.php
@@ -32,6 +32,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share;
+use OCP\Share\Exceptions\GenericShareException;
 
 class NotificationController extends OCSController {
 	/** @var MailNotifications */
@@ -80,12 +81,17 @@ class NotificationController extends OCSController {
 		$sender = $this->userSession->getUser();
 		$result = $recipients;
 		if ($sender) {
-			$result = $this->mailNotifications->sendLinkShareMail(
-				$sender,
-				$recipients,
-				$link,
-				$personalNote
-			);
+			try {
+				$result = $this->mailNotifications->sendLinkShareMail(
+					$sender,
+					$recipients,
+					$link,
+					$personalNote
+				);
+			} catch (GenericShareException $e) {
+				$code = $e->getCode() === 0 ? 403 : $e->getCode();
+				return new Result(null, $code, $e->getHint());
+			}
 		}
 		if (!empty($result)) {
 			$message = $this->l->t("Couldn't send mail to following recipient(s): %s ",
@@ -127,7 +133,12 @@ class NotificationController extends OCSController {
 		$userFolder = $this->rootFolder->getUserFolder($sender->getUID());
 		$nodes = $userFolder->getById($itemSource, true);
 		$node = $nodes[0] ?? null;
-		$result = $this->mailNotifications->sendInternalShareMail($sender, $node, $shareType, $recipientList);
+		try {
+			$result = $this->mailNotifications->sendInternalShareMail($sender, $node, $shareType, $recipientList);
+		} catch (GenericShareException $e) {
+			$code = $e->getCode() === 0 ? 403 : $e->getCode();
+			return new Result(null, $code, $e->getHint());
+		}
 
 		// if we were able to send to at least one recipient, mark as sent
 		// allowing the user to resend would spam users who already got a notification

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -38,6 +38,7 @@ use OCP\IUser;
 use OCP\Mail\IMailer;
 use OCP\ILogger;
 use OCP\Defaults;
+use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -111,10 +112,14 @@ class MailNotifications {
 	 * @param Node shared node
 	 * @param string $shareType share type
 	 * @param IUser[] $recipientList list of recipients
-	 *
+	 * @throws GenericShareException
 	 * @return array list of user to whom the mail send operation failed
 	 */
 	public function sendInternalShareMail($sender, $node, $shareType, $recipientList) {
+		if ($this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'no') !== 'yes') {
+			$message_t = $this->l->t("Internal mail notification for shared files is not allowed");
+			throw new GenericShareException($message_t, $message_t, 403);
+		}
 		$noMail = [];
 
 		foreach ($recipientList as $recipient) {
@@ -205,10 +210,14 @@ class MailNotifications {
 	 * @param string[] $recipients recipient email addresses
 	 * @param string $link the share link
 	 * @param string $personalNote sender note
-	 *
+	 * @throws GenericShareException
 	 * @return string[] $result of failed recipients
 	 */
 	public function sendLinkShareMail($sender, $recipients, $link, $personalNote = null) {
+		if ($this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') !== 'yes') {
+			$message_t = $this->l->t("Public link mail notification is not allowed");
+			throw new GenericShareException($message_t, $message_t, 403);
+		}
 		$recipientsAsString = \implode(', ', $recipients);
 		$currentUser = $sender->getUID();
 		$notificationLang = $this->config->getAppValue(


### PR DESCRIPTION
## Description
We have two different admin options (public link and internal mail) for enabling/disabling share mail notifications, but APIs don't obey to this config. This pr fixes this behavior.

## Related Issue
- Fixes #36156 

## Motivation and Context
Fighting with bugs.

## How Has This Been Tested?
Manually with Curl and unit test.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
