### PR TITLE
Acceptance tests for top-level share owner editing sub-share permissions

### DIFF
--- a/tests/acceptance/features/apiShareReshare/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare/reShare.feature
@@ -224,6 +224,7 @@ Feature: sharing
       | permissions | share,read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -239,6 +240,7 @@ Feature: sharing
       | permissions | share,create,update,read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -248,16 +250,97 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
-    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,read"
-    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,create,read"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
     When user "user1" updates the last share using the sharing API with
       | permissions | all |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
+
+  Scenario Outline: Update of user reshare by the original share owner can increase permissions up to the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,update,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @issue-36107
+  Scenario Outline: Update of user reshare by the original share owner can increase permissions to more than the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,update,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    #And the HTTP status code should be "200"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    #And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 404             | 200              |
+      | 2               | 404             | 404              |
+      #| ocs_api_version | ocs_status_code |
+      #| 1               | 100             |
+      #| 2               | 200             |
+
+  Scenario Outline: Update of group reshare by the original share owner can increase permissions up to permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,update,read"
+    And user "user1" has shared folder "/TMP" with group "grp1" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @issue-36107
+  Scenario Outline: Update of group reshare by the original share owner can increase permissions to more than the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,update,read"
+    And user "user1" has shared folder "/TMP" with group "grp1" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    #And the HTTP status code should be "200"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    #And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 404             | 200              |
+      | 2               | 404             | 404              |
+      #| ocs_api_version | ocs_status_code |
+      #| 1               | 100             |
+      #| 2               | 200             |
 
   Scenario Outline: User is allowed to reshare a sub-folder with the same permissions
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
## Description
Add acceptance test scenarios for when:
1) The original sharer edits the permissions of a reshare, up to the permissions that they gave in the original share - that works fine.
2) The original sharer edits the permissions of a reshare, to more than the permissions that they gave in the original share - that does not work, but it should be allowed. The scenarios demonstrate the current behaviour.

## Related Issue
#36107 

## How Has This Been Tested?
Local runs of new acceptance tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
