### PR TITLE
Tests for second attempt 36107

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -321,8 +321,9 @@ class Manager implements IManager {
 			$maxPermissions |= \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_UPDATE;
 		}
 
+		$nodeOwner = $shareNode->getOwner()->getUID();
 		/** If it is re-share, calculate $maxPermissions based on all incoming share permissions */
-		if ($shareNode->getOwner()->getUID() !== $share->getSharedBy()) {
+		if ($nodeOwner !== $share->getSharedBy() && $nodeOwner !== $this->rootFolder->getOwner()->getUID()) {
 			$maxPermissions = $this->calculateReshareNodePermissions($share);
 		}
 
@@ -1280,13 +1281,13 @@ class Manager implements IManager {
 	 */
 	public function getAllSharedWith($userId, $shareTypes, $node = null) {
 		$shares = [];
-		
+
 		// Aggregate all required $shareTypes by mapping provider to supported shareTypes
 		$providerIdMap = $this->shareTypeToProviderMap($shareTypes);
 		foreach ($providerIdMap as $providerId => $shareTypeArray) {
 			// Get provider from cache
 			$provider = $this->factory->getProvider($providerId);
-			
+
 			// Obtain all shares for all the supported provider types
 			$queriedShares = $provider->getAllSharedWith($userId, $node);
 			$shares = \array_merge($shares, $queriedShares);
@@ -1294,7 +1295,7 @@ class Manager implements IManager {
 
 		return $shares;
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */

--- a/tests/acceptance/features/apiShareReshare/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare/reShare.feature
@@ -224,6 +224,7 @@ Feature: sharing
       | permissions | share,read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -239,6 +240,7 @@ Feature: sharing
       | permissions | share,create,update,read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -248,16 +250,97 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
-    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,read"
-    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,create,read"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
     When user "user1" updates the last share using the sharing API with
       | permissions | all |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
+
+  Scenario Outline: Update of user reshare by the original share owner can increase permissions up to the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,update,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @issue-36107
+  Scenario Outline: Update of user reshare by the original share owner can increase permissions to more than the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,update,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    #And the HTTP status code should be "200"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    #And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 404             | 200              |
+      | 2               | 404             | 404              |
+      #| ocs_api_version | ocs_status_code |
+      #| 1               | 100             |
+      #| 2               | 200             |
+
+  Scenario Outline: Update of group reshare by the original share owner can increase permissions up to permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,update,read"
+    And user "user1" has shared folder "/TMP" with group "grp1" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @issue-36107
+  Scenario Outline: Update of group reshare by the original share owner can increase permissions to more than the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,update,read"
+    And user "user1" has shared folder "/TMP" with group "grp1" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    #And the HTTP status code should be "200"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    #And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 404             | 200              |
+      | 2               | 404             | 404              |
+      #| ocs_api_version | ocs_status_code |
+      #| 1               | 100             |
+      #| 2               | 200             |
 
   Scenario Outline: User is allowed to reshare a sub-folder with the same permissions
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareReshare/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare/reShare.feature
@@ -278,7 +278,6 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-36107
   Scenario Outline: Update of user reshare by the original share owner can increase permissions to more than the permissions of the top-level share
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
@@ -288,17 +287,12 @@ Feature: sharing
     When user "user0" updates the last share using the sharing API with
       | permissions | share,create,update,read |
     Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    #And the HTTP status code should be "200"
-    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
-    #And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 404             | 200              |
-      | 2               | 404             | 404              |
-      #| ocs_api_version | ocs_status_code |
-      #| 1               | 100             |
-      #| 2               | 200             |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   Scenario Outline: Update of group reshare by the original share owner can increase permissions up to permissions of the top-level share
     Given using OCS API version "<ocs_api_version>"
@@ -318,7 +312,6 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-36107
   Scenario Outline: Update of group reshare by the original share owner can increase permissions to more than the permissions of the top-level share
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
@@ -330,17 +323,12 @@ Feature: sharing
     When user "user0" updates the last share using the sharing API with
       | permissions | share,create,update,read |
     Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    #And the HTTP status code should be "200"
-    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
-    #And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 404             | 200              |
-      | 2               | 404             | 404              |
-      #| ocs_api_version | ocs_status_code |
-      #| 1               | 100             |
-      #| 2               | 200             |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   Scenario Outline: User is allowed to reshare a sub-folder with the same permissions
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
## Description
I made some scenarios where the original sharer modifies the permissions of the reshare.

My first commit has scenarios that demonstrate the existing behaviour in master.

My 2nd commit adjusts those to demonstrate the corrected behaviour with PR #36159 

## Related Issue
#36107 

## How Has This Been Tested?
Local runs of added acceptance tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
