### PR TITLE
Allow to display version numbers also for disabled apps

### DIFF
--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -103,7 +103,7 @@ class ListApps extends Base {
 
 		\sort($disabledApps);
 		foreach ($disabledApps as $app) {
-			$apps['disabled'][$app] = null;
+			$apps['disabled'][$app] = (isset($versions[$app])) ? $versions[$app] : null;
 		}
 
 		$this->writeAppList($input, $output, $apps);


### PR DESCRIPTION
## Description
This PR allows to display version numbers also for disabled apps. Means apps that have been once enabled and afterwards disabled. Apps that have never been enabled will not have a version number displayed since the configkey `installed_version` in the `oc_appconfig` table is not present for them.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/33555

## How Has This Been Tested?
- Manually by first enabling the app, disabling it and then running `app:list` occ command

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised