### PR TITLE
Allow share_folder to be specified without leading slash

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -352,10 +352,14 @@ class View {
 	 */
 	public function rmdir($path) {
 		return $this->emittingCall(function () use (&$path) {
-			if (($path !== '') &&
-				(\strpos($this->config->getSystemValue('share_folder', '/'), $path) !== false)) {
-				Util::writeLog("core", "The folder $path could not be deleted as it is configured as share_folder in config.", Util::WARN);
-				return false;
+			if ($path !== '') {
+				$shareFolder = Filesystem::normalizePath(
+					$this->config->getSystemValue('share_folder', '/')
+				);
+				if (\strpos($shareFolder, $path) !== false) {
+					Util::writeLog("core", "The folder $path could not be deleted as it is configured as share_folder in config.", Util::WARN);
+					return false;
+				}
 			}
 			$absolutePath = $this->getAbsolutePath($path);
 			$mount = Filesystem::getMountManager()->find($absolutePath);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2681,7 +2681,10 @@ class ViewTest extends TestCase {
 	public function providesShareFolder() {
 		return [
 			['/MyTestShareFolder', '/MyTestShareFolder'],
+			['MyTestShareFolder', '/MyTestShareFolder'],
 			['/MyTestShareFolder/Share/Foo', '/MyTestShareFolder'],
+			['MyTestShareFolder/Share/Foo', '/MyTestShareFolder'],
+			['/MyTestShareFolder/Share/Foo', '/MyTestShareFolder/Share'],
 		];
 	}
 


### PR DESCRIPTION
## Description
`normalizePath` of `share_folder` value. That ensures that it has a leading slash (and other good stuff). 

Note: other uses of `share_folder` already pass it through `normalizePath` - that is why they work when `share_folder` does not have a leading slash.

## Related Issue
- Fixes #36167 


## How Has This Been Tested?
Unit tests and manual verification by setting `share_folder` to just `SharedFolder` and then receiving a share and trying to delete that folder.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
