### PR TITLE
Improve share_folder checks in rmdir

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -352,10 +352,13 @@ class View {
 	 */
 	public function rmdir($path) {
 		return $this->emittingCall(function () use (&$path) {
-			if (($path !== '') &&
-				(\strpos($this->config->getSystemValue('share_folder', '/'), $path) !== false)) {
-				Util::writeLog("core", "The folder $path could not be deleted as it is configured as share_folder in config.", Util::WARN);
-				return false;
+			if ($path !== '') {
+				$shareFolder = \trim($this->config->getSystemValue('share_folder', '/'), '/');
+				$trimmedPath = \trim($path, '/');
+				if ((\strpos("$shareFolder/", "$trimmedPath/") === 0)) {
+					Util::writeLog("core", "The folder $path could not be deleted as it is configured as share_folder in config.", Util::WARN);
+					return false;
+				}
 			}
 			$absolutePath = $this->getAbsolutePath($path);
 			$mount = Filesystem::getMountManager()->find($absolutePath);


### PR DESCRIPTION
## Description
The folder being deleted is only part of the path to `share_folder` if its path matches at the start of `share_folder` and has the complete matching folder name (i.e. when `share_folder` is `/abc/def` then it is OK to `rmdir` `/abc/de`)

Make it so with trim and putting slashes and strpos.

The code here also fixes what is in PR #36168 

## Related Issue
- Fixes #36167 
- Fixes #36169 

## How Has This Been Tested?
Local unit test runs, and trying combinations of folder deletes in the webUI.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
