### PR TITLE
Add migration to change the storage backend for amazons3

### DIFF
--- a/core/Migrations/Version20190905111710.php
+++ b/core/Migrations/Version20190905111710.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migrations;
+
+use OCP\IDBConnection;
+use OCP\Migration\ISqlMigration;
+
+/**
+ * Replace the storage backend amazons3 to files_external_s3.
+ * Reason for this is post 10.2.1 version of core the changes have been
+ * moved to files_external_s3 app. So kindly install and enable the app
+ * to get the data, after upgrade.
+ */
+class Version20190905111710 implements ISqlMigration {
+	public function sql(IDBConnection $connection) {
+		$qb = $connection->getQueryBuilder();
+		$qb->update('external_mounts')
+			->set(
+				'storage_backend',
+				$qb->expr()->literal('files_external_s3')
+			)
+			->where(
+				$qb->expr()->eq('storage_backend', $qb->expr()->literal('amazons3'))
+			);
+		$qb->execute();
+
+		return $qb->getSQL();
+	}
+}


### PR DESCRIPTION
Migration to change the storage backend of amazons3
to files_external_s3.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Post 10.2.1 release the storage backend of amazon s3 is moved to a separate app files_external_s3. Now as a result, after the upgrade the storage backend has to be updated in the db. So this migration step helps us to acheive the same. It would replace the column with `storage_backend` of external_mounts table from `amazons3` to `files_external_s3`. So that the files/folders of the root folder of the storage can be accessible again. And also it would help to get the connection with the s3.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Migration step to change `amazons3` to `files_external_s3` in the external_mounts table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Install oc 10.2.1. Enable external storage with amazon s3.
- Now add files and folder to the storage.
- Upgrade oC to 10.3.0.alpha2. Before upgrading kindly install `files_external_s3` app and enable it.
- Now try to access the files/folders inside the stoage.
- They should start working.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Depends on https://github.com/owncloud/files_external_s3/pull/237

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
