### PR TITLE
Improve logging when a remote host went down suddenly

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -279,7 +279,14 @@ class DAV extends Common {
 					$this->convertException($e, $path);
 				}
 			} catch (\Exception $e) {
-				$this->convertException($e, $path);
+				if ($e->getCode() === \CURLE_COULDNT_CONNECT || $e->getCode() === \CURLE_OPERATION_TIMEDOUT) {
+					\OC::$server->getLogger()->warning(
+						'Storage is not available due to the connection timeout to {hostName}',
+						['hostName' => $this->host]
+					);
+				} else {
+					$this->convertException($e, $path);
+				}
 			}
 		} else {
 			$response = $cachedResponse;

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -254,6 +254,7 @@ class DAV extends Common {
 		// we either don't know it, or we know it exists but need more details
 		if ($cachedResponse === null || $cachedResponse === true) {
 			$this->init();
+			$response = false;
 			try {
 				// client propfind is in \OC\HTTP\Client
 				/* @phan-suppress-next-line PhanUndeclaredMethod */
@@ -274,9 +275,9 @@ class DAV extends Common {
 				if ($e->getHttpStatus() === Http::STATUS_NOT_FOUND) {
 					$this->statCache->clear($path . '/');
 					$this->statCache->set($path, false);
-					return false;
+				} else {
+					$this->convertException($e, $path);
 				}
-				$this->convertException($e, $path);
 			} catch (\Exception $e) {
 				$this->convertException($e, $path);
 			}


### PR DESCRIPTION
## Description
- Always init `$response` variable
- Check the exception code against curl connection timeout and  log a short warning instead of the exception in this case.

## Related Issue
- https://github.com/owncloud/enterprise/issues/3494

## Motivation and Context
Cleaner log file

## How Has This Been Tested?
If the host went down the following notice appears:
```
{
"reqId":"3EdDVjLQAdFPB3WKwPWW",
"level":3,
"user":"--",
"app":"PHP",
"method":"--",
"url":"--",
"message":"Undefined variable: response at owncloud_10.2.1\/lib\/private\/Files\/Storage\/DAV.php#282"
}
```
followed by the exception:
```
{
"reqId":"pBFrHaZTKmwAgQuPYn5C",
"level":3,
"time":"2019-08-23T14:15:07+02:00",
"remoteAddr":",
"user":"--",
"app":"no app in context",
"method":"--",
"url":"--",
"message":"Exception:
{
"Exception":"SabreHTTPClientException",
"Message":"Failed connect to hostname; Connection timed out",
"Code":7,
"Trace":"A_LONG_TRACE_HERE"
```

this PR removes the notice and replaces the exception entry with 
```
{
"reqId":"AqiNEOi2818nZryQoqRw",
"level":2,
"time":"2019-09-11T15:29:43+00:00",
"remoteAddr":"127.0.0.1",
"user":"admin",
"app":"no app in context",
"method":"GET","url":"\/oc\/remote.php\/webdav\/testor%20(2)","message":"Storage is not available due to the connection timeout to  host.down"}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
