### PR TITLE
Add acceptance tests for share_folder setting

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -315,6 +315,7 @@ default:
         - '%paths.base%/../features/webUICreateDelete'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - TagsContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
@@ -418,6 +419,7 @@ default:
         - '%paths.base%/../features/webUISharingAcceptShares'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - OccContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -418,6 +418,7 @@ default:
         - '%paths.base%/../features/webUISharingAcceptShares'
       contexts:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -42,3 +42,45 @@ Feature: delete folder
       | dav_version |
       | old         |
       | new         |
+
+  Scenario Outline: delete a folder when there is a default folder for received shares
+    Given using <dav_version> DAV path
+    And the administrator has set the default folder for received shares to "<share_folder>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/Received"
+    And user "user1" has created folder "/Top"
+    And user "user1" has created folder "/Top/ReceivedShares"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    When user "user1" deletes folder "<share_folder>" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user1" folder "<share_folder>/PARENT" should exist
+    And user "user1" should be able to delete folder "/Received"
+    And user "user1" should be able to delete folder "/Top/ReceivedShares"
+    And user "user1" should be able to delete folder "/Top"
+    Examples:
+      | dav_version | share_folder        |
+      | old         | /ReceivedShares     |
+      | new         | /ReceivedShares     |
+      | old         | ReceivedShares      |
+      | new         | ReceivedShares      |
+
+  Scenario Outline: delete a folder when there is a default folder for received shares that is a multi-level path
+    Given using <dav_version> DAV path
+    And the administrator has set the default folder for received shares to "/My/Received/Shares"
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/M"
+    And user "user1" has created folder "/Received"
+    And user "user1" has created folder "/Received/Shares"
+    And user "user0" has shared folder "/PARENT" with user "user1"
+    When user "user1" deletes folder "/My/Received/Shares" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And user "user1" should not be able to delete folder "/My/Received"
+    And user "user1" should not be able to delete folder "/My"
+    And as "user1" folder "/My/Received/Shares/PARENT" should exist
+    But user "user1" should be able to delete folder "/M"
+    And user "user1" should be able to delete folder "/Received/Shares"
+    And user "user1" should be able to delete folder "/Received"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -302,6 +302,19 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has set the default folder for received shares to :folder
+	 *
+	 * @param string $folder
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasSetTheDefaultFolderForReceivedSharesTo($folder) {
+		$this->theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand(
+			"share_folder", $folder
+		);
+	}
+
+	/**
 	 * @Given the administrator has set the mail smtpmode to :smtpmode
 	 *
 	 * @param string $smtpmode
@@ -309,8 +322,8 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorHasSetTheMailSmtpmodeTo($smtpmode) {
-		$this->invokingTheCommand(
-			"config:system:set  --value $smtpmode mail_smtpmode"
+		$this->theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand(
+			"mail_smtpmode", $smtpmode
 		);
 	}
 
@@ -657,7 +670,9 @@ class OccContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand($key, $value, $type="string") {
+	public function theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand(
+		$key, $value, $type="string"
+	) {
 		$this->invokingTheCommand(
 			"config:system:set --value ${value} --type ${type} ${key}"
 		);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1827,8 +1827,8 @@ trait Sharing {
 		foreach ($table as $row) {
 			$found = false;
 			//the API returns the path without trailing slash, but we want to
-			//be able to accept trailing slashes in the step definition
-			$row['path'] = \rtrim($row['path'], "/");
+			//be able to accept leading and/or trailing slashes in the step definition
+			$row['path'] = "/" . \trim($row['path'], "/");
 			foreach ($usersShares as $share) {
 				try {
 					Assert::assertArraySubset($row, $share);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1171,10 +1171,14 @@ trait WebDav {
 				'$expectedElements has to be an instance of TableNode'
 			);
 		}
-		$responseXmlObject = $this->listFolder($user, "/", 3);
+		$responseXmlObject = $this->listFolder($user, "/", 5);
 		$elementRows = $elements->getRows();
 		$elementsSimplified = $this->simplifyArray($elementRows);
 		foreach ($elementsSimplified as $expectedElement) {
+			// Allow the table of expected elements to have entries that do
+			// not have to specify the "implied" leading slash, or have multiple
+			// leading slashes, to make scenario outlines more flexible
+			$expectedElement = "/" . \ltrim($expectedElement, "/");
 			$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
 			$element = $responseXmlObject->xpath(
 				"//d:response/d:href[text() = \"$webdavPath\"]"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1727,31 +1727,34 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then user :user should be able to delete file :source
+	 * @Then /^user "([^"]*)" should be able to delete (file|folder|entry) "([^"]*)"$/
 	 *
 	 * @param string $user
+	 * @param string $entry
 	 * @param string $source
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	public function userShouldBeAbleToDeleteFile($user, $source) {
-		$this->asFileOrFolderShouldExist($user, "file", $source);
+	public function userShouldBeAbleToDeleteEntry($user, $entry, $source) {
+		$this->asFileOrFolderShouldExist($user, $entry, $source);
 		$this->userDeletesFile($user, $source);
-		$this->asFileOrFolderShouldNotExist($user, "file", $source);
+		$this->asFileOrFolderShouldNotExist($user, $entry, $source);
 	}
 
 	/**
-	 * @Then user :user should not be able to delete file :source
+	 * @Then /^user "([^"]*)" should not be able to delete (file|folder|entry) "([^"]*)"$/
 	 *
 	 * @param string $user
+	 * @param string $entry
 	 * @param string $source
 	 *
 	 * @return void
 	 */
-	public function theUserShouldNotBeAbleToDeleteFile($user, $source) {
-		$this->asFileOrFolderShouldExist($user, "file", $source);
+	public function theUserShouldNotBeAbleToDeleteEntry($user, $entry, $source) {
+		$this->asFileOrFolderShouldExist($user, $entry, $source);
 		$this->userDeletesFile($user, $source);
-		$this->asFileOrFolderShouldExist($user, "file", $source);
+		$this->asFileOrFolderShouldExist($user, $entry, $source);
 	}
 
 	/**

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -216,3 +216,29 @@ Feature: deleting files and folders
     And as "user1" folder "simple-folder/simple-empty-folder" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
+
+  Scenario Outline: delete a folder when there is a default folder for received shares
+    Given the administrator has set the default folder for received shares to "<share_folder>"
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/ShareThis"
+    And user "user1" has created folder "<other_folder1>"
+    And user "user1" has created folder "<top_folder2>"
+    And user "user1" has created folder "<top_folder2>/<other_folder2>"
+    And user "user0" has shared folder "/ShareThis" with user "user1"
+    And the user reloads the current page of the webUI
+    When the user deletes folder "<other_folder1>" using the webUI
+    Then as "user1" folder "<other_folder1>" should not exist
+    When the user opens folder "<top_folder2>" using the webUI
+    And the user deletes folder "<other_folder2>" using the webUI
+    Then as "user1" folder "<top_folder2>/<other_folder2>" should not exist
+    When the user browses to the files page
+    And the user deletes folder "<top_folder2>" using the webUI
+    Then as "user1" folder "<top_folder2>" should not exist
+    When the user deletes folder "<top_share_folder_on_ui>" using the webUI
+    Then a notification should be displayed on the webUI with the text 'Error deleting file "<top_share_folder_on_ui>".'
+    And as "user1" folder "<share_folder>/ShareThis" should exist
+    Examples:
+      | share_folder        | top_share_folder_on_ui |other_folder1 | top_folder2 | other_folder2  |
+      | /ReceivedShares     | ReceivedShares         | Received     | Top         | ReceivedShares |
+      | ReceivedShares      | ReceivedShares         | Received     | Top         | ReceivedShares |
+      | /My/Received/Shares | My                     | M            | Received    | Shares         |

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -66,6 +66,21 @@ Feature: accept/decline shares coming from internal users
     And folder "simple-folder" should be listed in the files page on the webUI
     And file "testimage.jpg" should not be listed in the files page on the webUI
 
+  Scenario Outline: accept an offered share when there is a default folder for received shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And the administrator has set the default folder for received shares to "<share_folder>"
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And user "user1" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
+    And the user accepts share "testimage.jpg" offered by user "User Two" using the webUI
+    Then folder "simple-folder" should be listed in the files page folder "<share_folder>" on the webUI
+    And file "testimage.jpg" should be listed in the files page folder "<share_folder>" on the webUI
+    Examples:
+      | share_folder        |
+      | /ReceivedShares     |
+      | /My/Received/Shares |
+
   @smokeTest
   Scenario: decline an offered (pending) share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -175,6 +190,19 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
     And folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "" in the shared-with-you page on the webUI
+
+  Scenario Outline: auto-accept a share when there is a default folder for received shares
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And the administrator has set the default folder for received shares to "<share_folder>"
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    When user "user1" logs in using the webUI
+    Then folder "simple-folder" should be listed in the files page folder "<share_folder>" on the webUI
+    And file "testimage.jpg" should be listed in the files page folder "<share_folder>" on the webUI
+    Examples:
+      | share_folder        |
+      | /ReceivedShares     |
+      | /My/Received/Shares |
 
   Scenario: decline auto-accepted shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled


### PR DESCRIPTION
## Description
The first commit adds API and webUI test scenarios for receiving shares when `share_folder` is set to various values.

The second commit will add test scenarios to check that `share_folder` cannot be deleted, and that other similarly-named folders can be deleted.

## Related Issue
- Fixes #36184 

## How Has This Been Tested?
Local acceptance test runs plus CI
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
