### PR TITLE
shareowner can now edit re-share permissions without any restriction

### DIFF
--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -179,6 +179,7 @@ class EtagPropagationTest extends PropagationTestCase {
 				$this->fileEtags[$id] = $this->rootView->getFileInfo($path)->getEtag();
 			}
 		}
+		$this->logout();
 	}
 
 	public function testOwnerWritesToShare() {
@@ -442,6 +443,7 @@ class EtagPropagationTest extends PropagationTestCase {
 	}
 
 	public function testEtagChangeOnPermissionsChange() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$userFolder = $this->rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
 		$node = $userFolder->get('/sub1/sub2/folder');
 

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -303,6 +303,7 @@ class SharedMountTest extends TestCase {
 		\OC\Files\Filesystem::rename($path, "newPath");
 		$this->assertTrue(\OC\Files\Filesystem::file_exists('newPath'));
 		$this->assertFalse(\OC\Files\Filesystem::file_exists($path));
+		$this->logout();
 
 		// change permissions
 		$share->setPermissions($afterPerm);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -886,7 +886,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$c->getLazyRootFolder(),
 				$c->getEventDispatcher(),
 				new View('/'),
-				$c->getDatabaseConnection()
+				$c->getDatabaseConnection(),
+				$c->getUserSession()
 			);
 
 			return $manager;

--- a/tests/acceptance/features/apiShareReshare/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare/reShare.feature
@@ -224,6 +224,7 @@ Feature: sharing
       | permissions | share,read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -239,6 +240,7 @@ Feature: sharing
       | permissions | share,create,update,read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -248,16 +250,85 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/TMP"
-    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,read"
-    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,create,read"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
     When user "user1" updates the last share using the sharing API with
       | permissions | all |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
+    And user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
+
+  Scenario Outline: Update of user reshare by the original share owner can increase permissions up to the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,update,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Update of user reshare by the original share owner can increase permissions to more than the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,update,read"
+    And user "user1" has shared folder "/TMP" with user "user2" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Update of group reshare by the original share owner can increase permissions up to permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,create,update,read"
+    And user "user1" has shared folder "/TMP" with group "grp1" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Update of group reshare by the original share owner can increase permissions to more than the permissions of the top-level share
+    Given using OCS API version "<ocs_api_version>"
+    And user "user2" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "user2" has been added to group "grp1"
+    And user "user0" has created folder "/TMP"
+    And user "user0" has shared folder "/TMP" with user "user1" with permissions "share,update,read"
+    And user "user1" has shared folder "/TMP" with group "grp1" with permissions "share,read"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | share,create,update,read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "/TMP/textfile.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   Scenario Outline: User is allowed to reshare a sub-folder with the same permissions
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
This is the first PR of related issue. The other PRs do not feel right to me and I returned back to this one. Sorry for all the confusion.

I just made the UserSession nullable in the Manager constructor and adjusted tests. @PVince81 like you said in here https://github.com/owncloud/core/pull/36166#discussion_r323642423, whenever the session user is null, mentioned `if` condition will be disabled in this pr.

## Description
Shareowner should have full permission on re-shares. For detecting re-share, this PR compares the session user UID with the shareowner UID as described in this comment: https://github.com/owncloud/core/issues/36107#issuecomment-525170914. 

## Related Issue
- Fixes #36107 

## Motivation and Context
Fighting with bugs.

## How Has This Been Tested?
Manually with steps in #36107, acceptance tests added and unit tests adjusted.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
