### PR TITLE
Fix file picker previews + error msg

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -782,11 +782,14 @@ var OCdialogs = {
 					date: OC.Util.relativeModifiedDate(entry.mtime)
 				});
 				if (entry.type === 'file') {
-					var urlSpec = {
-						file: dir + '/' + entry.name
-					};
-					var previewUrl = OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
-					$li.find('img').attr('src', previewUrl);
+					FileList.lazyLoadPreview({
+						path: dir + '/' + entry.name,
+						mime: entry.mimetype,
+						etag: entry.etag,
+						callback: function(url) {
+							$li.find('img').attr('src', url);
+						}
+					});
 				}
 				else {
 					$li.find('img').attr('src', OC.Util.replaceSVGIcon(entry.icon));
@@ -835,7 +838,7 @@ var OCdialogs = {
 		self._fillFilePicker(dir);
 		var getOcDialog = this.closest('.oc-dialog');
 		var buttonEnableDisable = $('.primary', getOcDialog);
-		if (this.$filePicker.data('mimetype') === "http/unix-directory") {
+		if (self.$filePicker.data('mimetype') === "http/unix-directory") {
 			buttonEnableDisable.prop("disabled", false);
 		} else {
 			buttonEnableDisable.prop("disabled", true);


### PR DESCRIPTION
## Description
File picker previews are now correctly loaded.
Fixed error in browser log when clicking breadcrumb by properly
accessing the $filePicker object.

## Related Issue
Fixes https://github.com/owncloud/core/issues/36201

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- manually: create folder "test", upload picture and upload "x.bin" file:
    - open file picker
    - folder icon looks ok
    - picture preview appears
    - bin file has generic cog icon

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)

@micbar FYI