### PR TITLE
Enhance acceptance test runOcc exceptions

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -662,6 +662,8 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			$body['env_variables'] = $envVariables;
 		}
 
+		$isTestingAppEnabledText = "Is the testing app installed and enabled?\n";
+
 		try {
 			$result = OcsApiHelper::sendRequest(
 				$baseUrl, $adminUsername, $adminPassword,
@@ -670,7 +672,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		} catch (ServerException $e) {
 			throw new Exception(
 				"Could not execute 'occ'. " .
-				"Is the testing app installed and enabled?\n" .
+				$isTestingAppEnabledText .
 				$e->getResponse()->getBody()
 			);
 		}
@@ -680,16 +682,54 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		$return['stdOut'] = $result->xml()->xpath("//ocs/data/stdOut");
 		$return['stdErr'] = $result->xml()->xpath("//ocs/data/stdErr");
 
-		if (!\is_a($return['code'][0], "SimpleXMLElement")
-			|| !\is_a($return['stdOut'][0], "SimpleXMLElement")
-			|| !\is_a($return['stdErr'][0], "SimpleXMLElement")
-		) {
+		if (!isset($return['code'][0])) {
 			throw new Exception(
-				"Could not execute 'occ'. " .
-				"Is the testing app installed and enabled?\n" .
+				"Return code not found after executing 'occ'. " .
+				$isTestingAppEnabledText .
 				$result->getBody()
 			);
 		}
+
+		if (!isset($return['stdOut'][0])) {
+			throw new Exception(
+				"Return stdOut not found after executing 'occ'. " .
+				$isTestingAppEnabledText .
+				$result->getBody()
+			);
+		}
+
+		if (!isset($return['stdErr'][0])) {
+			throw new Exception(
+				"Return stdOut not found after executing 'occ'. " .
+				$isTestingAppEnabledText .
+				$result->getBody()
+			);
+		}
+
+		if (!\is_a($return['code'][0], "SimpleXMLElement")) {
+			throw new Exception(
+				"Return code is not a SimpleXMLElement after executing 'occ'. " .
+				$isTestingAppEnabledText .
+				$result->getBody()
+			);
+		}
+
+		if (!\is_a($return['stdOut'][0], "SimpleXMLElement")) {
+			throw new Exception(
+				"Return stdOut is not a SimpleXMLElement after executing 'occ'. " .
+				$isTestingAppEnabledText .
+				$result->getBody()
+			);
+		}
+
+		if (!\is_a($return['stdErr'][0], "SimpleXMLElement")) {
+			throw new Exception(
+				"Return stdErr is not a SimpleXMLElement after executing 'occ'. " .
+				$isTestingAppEnabledText .
+				$result->getBody()
+			);
+		}
+
 		$return['code'] = $return['code'][0]->__toString();
 		$return['stdOut'] = $return['stdOut'][0]->__toString();
 		$return['stdErr'] = $return['stdErr'][0]->__toString();


### PR DESCRIPTION
## Description
When something goes wrong with an `occ` command via the acceptance tests there is sometimes a crash like https://drone.owncloud.com/owncloud/admin_audit/988/29/9
```
INFORMATION: could not delete user 'user0' 500 
  │
  ╳  Notice: Undefined offset: 0 in /var/www/owncloud/testrunner/tests/TestHelpers/SetupHelper.php line 683
  │
  └─ @AfterScenario # FeatureContext::restoreParametersAfterScenario()
  │
  ╳  Notice: Undefined offset: 0 in /var/www/owncloud/testrunner/tests/TestHelpers/SetupHelper.php line 683
```

Make this emit a "nicer" exception message.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
