### PR TITLE
Make sure to parse only if attributes are json string in reshare

### DIFF
--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -790,8 +790,9 @@
 				}
 			}
 			for (i = 0; i < SHARE_RESPONSE_JSON_PROPS.length; i++) {
+				// Parse JSON if not yet parsed
 				var propJson = SHARE_RESPONSE_JSON_PROPS[i];
-				if (!_.isUndefined(share[propJson])) {
+				if (!_.isUndefined(share[propJson]) && !_.isObject(share[propJson])) {
 					share[propJson] = JSON.parse(share[propJson]);
 				}
 			}


### PR DESCRIPTION
@PVince81 @micbar it would be good to have this as part of 10.3 too, to make sure in reshare scenario we only parse JSONwith attributes if it was not already parsed.

This issue affects only resharing scenario with attributes on reshare when creating another reshare.

As part of https://github.com/owncloud/core/pull/36186