### PR TITLE
Fix #36114: Update documentation about uploadwriteonly permission

### DIFF
--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -63,13 +63,10 @@ class SharingHelper {
 	 *                                   share with.
 	 * @param string|int|string[]|int[]|null $permissions The permissions to set on the share.
 	 *                                                    1 = read; 2 = update; 4 = create;
-	 *                                                    8 = delete; 16 = share; 31 = all
-	 *                                                    15 = change
-	 *                                                    5 = uploadwriteonly
+	 *                                                    8 = delete; 16 = share
 	 *                                                    (default: 31, for public shares: 1)
-	 *                                                    Pass either the (total) number,
-	 *                                                    or the keyword,
-	 *                                                    or an array of keywords or numbers.
+	 *                                                    Pass either the (total) number or array of numbers,
+	 *                                                    or any of the above keywords or array of keywords.
 	 * @param string|null $linkName A (human-readable) name for the share,
 	 *                              which can be up to 64 characters in length.
 	 * @param string|null $expireDate **NOT IMPLEMENTED**
@@ -156,9 +153,7 @@ class SharingHelper {
 	 * 'update' => 2
 	 * 'create' => 4
 	 * 'delete' => 8
-	 * 'change' => 15
 	 * 'share' => 16
-	 * 'all' => 31
 	 *
 	 * @param string[]|string|int|int[] $permissions
 	 *

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -172,7 +172,7 @@ trait Sharing {
 	 *       |                 |     1 = read; 2 = update; 4 = create;               |
 	 *       |                 |     8 = delete; 16 = share; 31 = all                |
 	 *       |                 |     15 = change                                     |
-	 *       |                 |     7 = uploadwriteonly                             |
+	 *       |                 |     5 = uploadwriteonly                             |
 	 *       |                 |     (default: 31, for public shares: 1)             |
 	 *       |                 |     Pass either the (total) number,                 |
 	 *       |                 |     or the keyword,                                 |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
`uploadwriteonly` is something we created for only providing `read` and `create` but no `update` permissions. So, `read(1) + create(4) = uploadwriteonly(5)`.

The following scenario makes it clearer.
```feature
    Given as user "user0"
    And the user has created a public link share with settings
      | path        | FOLDER          |
      | permissions | uploadwriteonly |
    When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
    Then the HTTP status code should be "201"
    When the public uploads file "test.txt" with content "test2" using the <public-webdav-api-version> public WebDAV API
    Then the HTTP status code should be "403"
    And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
```
Notice the `403` when trying to update.

Also, `SharingHelper::getPermissionSum()` does not support derived permissions. So, the annotations/comments on `SharingHelper::createShare()` (which passes permissions to `getPermissionSum()`) is lying. This fixes it. Anything derived should be parsed first using `Sharing::splitPermissionsString([array])`.

#35825 changed `Sharing::getPermissionSum()` to not handle derived permissions.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #36114 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
