### PR TITLE
[API] user-sync OCS API

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -39,6 +39,9 @@ use OC\Core\Controller\RolesController;
 use OC\Core\Controller\TokenController;
 use OC\Core\Controller\TwoFactorChallengeController;
 use OC\Core\Controller\UserController;
+use OC\Core\Controller\UserSyncController;
+use OC\User\AccountMapper;
+use OC\User\SyncService;
 use OC_Defaults;
 use OCP\AppFramework\App;
 use OCP\BackgroundJob\IJobList;
@@ -151,6 +154,19 @@ class Application extends App {
 				$c->query('Request'),
 				$c->query('L10N'),
 				$serverContainer->getEventDispatcher()
+			);
+		});
+		$container->registerService('UserSyncController', static function (SimpleContainer $c) {
+			$syncService = new SyncService(
+				$c->query(IConfig::class),
+				$c->query(ILogger::class),
+				$c->query(AccountMapper::class)
+			);
+			return new UserSyncController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$syncService,
+				$c->query('UserManager')
 			);
 		});
 		$container->registerService('CronController', static function (SimpleContainer $c) {

--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -260,8 +260,7 @@ class SyncBackend extends Command {
 		$dummy = new Account(); // to prevent null pointer when writing messages
 		if (\count($users) === 1) {
 			// Run the sync using the internal username if mapped
-			$syncService->run($backend, new \ArrayIterator([$users[0]]), function () {
-			});
+			$syncService->run($backend, new \ArrayIterator([$users[0]]));
 		} else {
 			// Not found
 			$this->handleRemovedUsers([$uid => $dummy], $input, $output, $missingAccountsAction);

--- a/core/Controller/UserSyncController.php
+++ b/core/Controller/UserSyncController.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace OC\Core\Controller;
+
+use ArrayIterator;
+use OC\OCS\Result;
+use OC\User\SyncService;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\IUserManager;
+
+/**
+ * Class UserSyncController
+ *
+ * External systems for user provisioning can use this API to trigger a single-user
+ * sync to update user settings from an external user management (e.g. LDAP) or even
+ * to create the account in ownCloud if necessary.
+ *
+ * In contrary to the occ user:sync command this API will not disable or delete the
+ * user if the user no longer exists. The external user provisioning system can use
+ * existing APIs to disable or delete a user.
+ *
+ * @package OC\Core\Controller
+ */
+class UserSyncController extends OCSController {
+
+	/**
+	 * @var SyncService
+	 */
+	private $syncService;
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
+
+	/**
+	 * UserSyncController constructor.
+	 *
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param SyncService $syncService
+	 * @param IUserManager $userManager
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								SyncService $syncService,
+								IUserManager $userManager) {
+		parent::__construct($appName, $request);
+		$this->syncService = $syncService;
+		$this->userManager = $userManager;
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 *
+	 * @param string $userId
+	 * @return Result
+	 */
+	public function syncUser($userId): Result {
+		foreach ($this->userManager->getBackends() as $backEnd) {
+			$users = $backEnd->getUsers($userId, 2);
+			if (\count($users) > 1) {
+				$backEndName = \get_class($backEnd);
+				return new Result([], 409, "Multiple users returned from backend($backEndName) for: $userId. Cancelling sync.");
+			}
+
+			if (\count($users) === 1) {
+				// Run the sync using the internal username if mapped
+				$this->syncService->run($backEnd, new ArrayIterator([$users[0]]));
+				return new Result();
+			}
+		}
+
+		return new Result([], 404, "User is not known in any user backend: $userId");
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -57,6 +57,7 @@ $application->registerRoutes($this, [
 		['root' => '/cloud', 'name' => 'Cloud#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Cloud#getCurrentUser', 'url' => '/user', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Roles#getRoles', 'url' => '/roles', 'verb' => 'GET'],
+		['root' => '/cloud', 'name' => 'UserSync#syncUser', 'url' => '/user-sync/{userId}', 'verb' => 'POST'],
 	]
 ]);
 

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -122,7 +122,7 @@ class SyncService {
 	 * @param \Traversable $userIds of users
 	 * @param \Closure $callback is called for every user to progress display
 	 */
-	public function run(UserInterface $backend, \Traversable $userIds, \Closure $callback) {
+	public function run(UserInterface $backend, \Traversable $userIds, \Closure $callback = null) {
 		// update existing and insert new users
 		foreach ($userIds as $uid) {
 			try {
@@ -138,7 +138,9 @@ class SyncService {
 			}
 
 			// call the callback
-			$callback($uid);
+			if ($callback) {
+				$callback($uid);
+			}
 		}
 	}
 

--- a/tests/Core/Controller/UserSyncControllerTest.php
+++ b/tests/Core/Controller/UserSyncControllerTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+declare(strict_types = 1);
+
+namespace Tests\Core\Controller;
+
+use OC\Core\Controller\UserSyncController;
+use OC\OCS\Result;
+use OC\User\SyncService;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\UserInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+/**
+ * Class RolesControllerTest
+ *
+ * @package OC\Core\Controller
+ */
+class UserSyncControllerTest extends TestCase {
+	/**
+	 * @var UserSyncController
+	 */
+	private $controller;
+	/**
+	 * @var MockObject | IUserManager
+	 */
+	private $userManager;
+	/**
+	 * @var MockObject | SyncService
+	 */
+	private $syncService;
+
+	protected function setUp() {
+		/** @var IRequest $request */
+		$request = $this->createMock(IRequest::class);
+		$this->syncService = $this->createMock(SyncService::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->controller = new UserSyncController('core', $request, $this->syncService, $this->userManager);
+
+		return parent::setUp();
+	}
+
+	public function testSimpleSync() {
+		$user = $this->createMock(IUser::class);
+		$userBackend = $this->createMock(UserInterface::class);
+		$userBackend->method('getUsers')->willReturn([$user]);
+		$this->userManager->method('getBackends')->willReturn([$userBackend]);
+		$this->syncService->expects(self::once())->method('run')->with($userBackend, new \ArrayIterator([$user]));
+
+		$result = $this->controller->syncUser('alice');
+
+		$this->assertEquals([], $result->getData());
+		$this->assertEquals(['status' => 'ok',
+			'statuscode' => 100,
+			'message' => null
+		], $result->getMeta());
+	}
+
+	public function testUnknownUser() {
+		$userBackend = $this->createMock(UserInterface::class);
+		$userBackend->method('getUsers')->willReturn([]);
+		$this->userManager->method('getBackends')->willReturn([$userBackend]);
+		$this->syncService->expects(self::never())->method('run');
+
+		$result = $this->controller->syncUser('alice');
+
+		$this->assertEquals([], $result->getData());
+		$this->assertEquals(['status' => 'failure',
+			'statuscode' => 404,
+			'message' => 'User is not known in any user backend: alice'
+		], $result->getMeta());
+	}
+
+	public function testConflict() {
+		$user = $this->createMock(IUser::class);
+		$userBackend = $this->createMock(UserInterface::class);
+		$userBackend->method('getUsers')->willReturn([$user, $user]);
+		$this->userManager->method('getBackends')->willReturn([$userBackend]);
+		$this->syncService->expects(self::never())->method('run');
+
+		$result = $this->controller->syncUser('alice');
+
+		$this->assertEquals([], $result->getData());
+		$backEndClass = \get_class($userBackend);
+		$this->assertEquals(['status' => 'failure',
+			'statuscode' => 409,
+			'message' => "Multiple users returned from backend($backEndClass) for: alice. Cancelling sync."
+		], $result->getMeta());
+	}
+}

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -111,8 +111,7 @@ class SyncServiceTest extends TestCase {
 		// Ignore state flag
 
 		$s = new SyncService($this->config, $this->logger, $this->mapper);
-		$s->run($backend, new AllUsersIterator($backend), function ($uid) {
-		});
+		$s->run($backend, new AllUsersIterator($backend));
 
 		static::invokePrivate($s, 'syncHome', [$account, $backend]);
 	}
@@ -135,8 +134,7 @@ class SyncServiceTest extends TestCase {
 		$this->logger->expects($this->at(1))->method('logException');
 
 		$s = new SyncService($this->config, $this->logger, $this->mapper);
-		$s->run($backend, new AllUsersIterator($backend), function ($uid) {
-		});
+		$s->run($backend, new AllUsersIterator($backend));
 	}
 
 	public function testSyncHomeLogsWhenBackendDiffersFromExisting() {
@@ -294,7 +292,7 @@ class SyncServiceTest extends TestCase {
 			->method('getUserValue')
 			->with('user1', 'core', 'username', null)
 			->willReturn(null);
-		
+
 		$this->config->expects($this->once())
 			->method('setUserValue')
 			->with('user1', 'core', 'username', 'userName1');


### PR DESCRIPTION
## Description
External user provisioning system need an http api to trigger user-sync for a specific user.

### Authorization
The http API can only be executed by a user with admin priviledges. Suggestion is to create a technical user who is in the admin group

### Route
```sh
 curl -X POST http://localhost:8080/ocs/v2.php/cloud/user-sync/admin -v -u admin

```

### Response
- 200 - if sync was executed
- 404 - given userId is unknown
- 409 - mutliple users have been found for the given user id - not unique user criteria

## Related Issue
- refs https://github.com/owncloud/enterprise/issues/3521

## How Has This Been Tested?
- user curl command as above with an admin user

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
