### PR TITLE
Take accounts.enable_medial_search into account while searching for remote users in share autocomplete

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -91,7 +91,7 @@ class AddressBookImpl implements IAddressBook {
 	 * @since 5.0.0
 	 */
 	public function search($pattern, $searchProperties, $options, $limit = null, $offset = null) {
-		$results = $this->backend->search($this->getKey(), $pattern, $searchProperties, $limit, $offset);
+		$results = $this->backend->searchEx($this->getKey(), $pattern, $searchProperties, $options, $limit, $offset);
 
 		$vCards = [];
 		foreach ($results as $result) {

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -102,8 +102,8 @@ class AddressBookImplTest extends TestCase {
 		$pattern = 'pattern';
 		$searchProperties = ['properties'];
 
-		$this->backend->expects($this->once())->method('search')
-			->with($this->addressBookInfo['id'], $pattern, $searchProperties, 10, 0)
+		$this->backend->expects($this->once())->method('searchEx')
+			->with($this->addressBookInfo['id'], $pattern, $searchProperties, [], 10, 0)
 			->willReturn(
 				[
 					['uri' => 'foo.vcf', 'carddata' => 'cardData1'],

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -360,7 +360,16 @@ class ShareesController extends OCSController {
 		// Fetch remote search properties from app config
 		$searchProperties = \explode(',', $this->config->getAppValue('dav', 'remote_search_properties', 'CLOUD,FN'));
 		// Search in contacts
-		$addressBookContacts = $this->contactsManager->search($search, $searchProperties, [], $this->limit, $this->offset);
+		$matchMode = $this->config->getSystemValue('accounts.enable_medial_search', true) === true
+			? 'ANY'
+			: 'START';
+		$addressBookContacts = $this->contactsManager->search(
+			$search,
+			$searchProperties,
+			[ 'matchMode' => $matchMode ],
+			$this->limit,
+			$this->offset
+		);
 		$foundRemoteById = false;
 		foreach ($addressBookContacts as $contact) {
 			if (isset($contact['isLocalSystemBook'])) {

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1426,10 +1426,14 @@ class ShareesTest extends TestCase {
 		$this->invokePrivate($this->sharees, 'limit', [2]);
 		$this->invokePrivate($this->sharees, 'offset', [0]);
 
+		$configMap = [
+			['trusted_domains', [], ['trusted.domain.tld', 'trusted2.domain.tld']],
+			['accounts.enable_medial_search', true, true]
+		];
+
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->with('trusted_domains')
-			->willReturn(['trusted.domain.tld', 'trusted2.domain.tld']);
+			->will($this->returnValueMap($configMap));
 		$this->userSearch->expects($this->any())
 			->method('isSearchable')
 			->willReturn($isSearchable);
@@ -1448,7 +1452,7 @@ class ShareesTest extends TestCase {
 		$this->invokePrivate($this->sharees, 'shareeEnumeration', [$shareeEnumeration]);
 		$this->contactsManager->expects($this->any())
 			->method('search')
-			->with($searchTerm, ['EMAIL', 'CLOUD', 'FN'], [], 2, 0)
+			->with($searchTerm, ['EMAIL', 'CLOUD', 'FN'], ['matchMode' => 'ANY'], 2, 0)
 			->willReturn($contacts);
 
 		$this->invokePrivate($this->sharees, 'getRemote', [$searchTerm]);
@@ -1961,7 +1965,7 @@ class ShareesTest extends TestCase {
 
 		$exactExpected = [['label' => 'Bob', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'testBob']]];
 		$expected = [];
-		
+
 		$this->invokePrivate($this->sharees, 'getUsers', [$searchTerm]);
 		$result = $this->invokePrivate($this->sharees, 'result');
 		$this->assertEquals($exactExpected, $result['exact']['users']);

--- a/changelog/unreleased/36225
+++ b/changelog/unreleased/36225
@@ -1,0 +1,7 @@
+Bugfix: Respect accounts.enable_medial_search while searching for remote users in share autocomplete
+
+Users taken from a federated instance were always searched with medial search
+in the share autocomplete box. Config option accounts.enable_medial_search
+was not taken into account.
+
+https://github.com/owncloud/core/pull/36225


### PR DESCRIPTION
## Description
Add `matchMode` search option for carddav backend. Make it `any` by default and switch to `start` when accounts medial search is off
 
## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3495

## Motivation and Context
Use medial search only if it is enabled when searching for users synced via federation app

## How Has This Been Tested?
1. Setup 2 ownclouds and add them as trusted to each other at Settings -> Admin -> Sharing -> Federation
2. Execute cron on both servers e.g. with `occ system:cron`
3. Execute `occ federation:sync-addressbooks`
4. Disable account medial search on both
5 Try share autocomplete using  the middle chars of remote users usernames 

#### Expected 
No remote users in autocomplete as medial search is off
 
#### Actual 
Remote users with the search patterns in the middle of username are still proposed 


## Screenshots (if appropriate):
![medial](https://user-images.githubusercontent.com/991300/65876741-a6856080-e392-11e9-98b0-39929db4ab17.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
