### PR TITLE
Add restic/calens for changelog management

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -76,7 +76,7 @@
   RewriteRule ^\.well-known/carddav /remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
-  RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
+  RewriteRule ^(?:build|tests|config|lib|3rdparty|templates|changelog)/.* - [R=404,L]
   RewriteCond %{REQUEST_URI} !^/.well-known/(acme-challenge|pki-validation)/.*
   RewriteRule ^(?:\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>

--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -1,0 +1,32 @@
+{{- range $changes := . }}{{ with $changes -}}
+Changelog for ownCloud Core {{ .Version }} ({{ .Date }})
+=======================================
+
+The following sections list the changes in ownCloud core {{ .Version }} relevant to
+ownCloud admins and users. The changes are ordered by importance.
+
+Summary
+-------
+{{ range $entry := .Entries }}{{ with $entry }}
+* {{ .TypeShort }} [#{{ .PrimaryID }}]({{ .PrimaryURL }}): {{ .Title }}
+{{- end }}{{ end }}
+
+Details
+-------
+{{ range $entry := .Entries }}{{ with $entry }}
+* {{ .Type }} [#{{ .PrimaryID }}]({{ .PrimaryURL }}): {{ .Title }}
+{{ range $par := .Paragraphs }}
+{{ wrap $par 80 3 }}
+{{ end -}}
+{{ range $url := .IssueURLs }}
+{{ $url -}}
+{{ end -}}
+{{ range $url := .PRURLs }}
+{{ $url -}}
+{{ end -}}
+{{ range $url := .OtherURLs }}
+{{ $url -}}
+{{ end }}
+{{ end }}{{ end }}
+
+{{ end }}{{ end -}}

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,14 @@
+# Changelog
+
+We are using [calens](https://github.com/restic/calens) to properly generate a
+changelog before we are tagging a new release. 
+
+## Create Changelog items
+Create a file according to the [template](TEMPLATE) for each 
+changelog in the [unreleased](./unreleased) folder. The following change types are possible: `Bugfix, Change, Enhancement, Security`.
+
+## Generate the Changelog 
+- copy the files from the [unreleased](./unreleased) folder into a folder matching the
+schema `10.0.0_2019-09-01` to tag and 
+- execute `docker run -ti --rm -v $(pwd):$(pwd) -w $(pwd) toolhippie/calens:latest` 
+in the root folder of the project.

--- a/changelog/TEMPLATE
+++ b/changelog/TEMPLATE
@@ -1,0 +1,12 @@
+Bugfix: Fix behavior for foobar (in present tense)
+
+We've fixed the behavior for foobar, a long-standing annoyance for ownCloud
+users.
+
+The text in the paragraphs is written in past tense. The last section is a list
+of issue URLs, PR URLs and other URLs. The first issue ID (or the first PR ID,
+in case there aren't any issue links) is used as the primary ID.
+
+https://github.com/owncloud/core/issues/1234
+https://github.com/owncloud/core/pull/55555
+https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html


### PR DESCRIPTION
## Description
Calens is a changelog management tool. It allows us to create and manage changelog entries more easily.

We are using [calens](https://github.com/restic/calens) to properly generate a
changelog before we are tagging a new release. 

## Create Changelog items
Create a file according to the [template](TEMPLATE) for each 
changelog in the [unreleased](./unreleased) folder. The following change types are possible: `Bugfix, Change, Enhancement, Security`.

## Generate the Changelog 
- copy the files from the [unreleased](./unreleased) folder into a folder matching the
schema `10.0.0_2019-09-01` to tag and 
- execute `docker run -ti --rm -v $(pwd):$(pwd) -w $(pwd) toolhippie/calens:latest` in the root folder of the project.

## Example Output:
Changelog for ownCloud Core unreleased (UNRELEASED)
=======================================

The following sections list the changes in ownCloud core unreleased relevant to
ownCloud admins and users. The changes are ordered by importance.

Summary
-------

* Fix [#1234](https://github.com/owncloud/core/issues/1234): Fix behavior for foobar (in present tense)

Details
-------

* Bugfix [#1234](https://github.com/owncloud/core/issues/1234): Fix behavior for foobar (in present tense)

We've fixed the behavior for foobar, a long-standing annoyance for ownCloud users.

The text in the paragraphs is written in past tense. The last section is a list of issue URLs, PR
   URLs and other URLs. These urls need to be plain urls of public resource. The first issue ID (or
   the first PR ID, in case there aren't any issue links) is used as the primary ID.

https://github.com/owncloud/core/issues/1234
https://github.com/owncloud/core/pull/55555
https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
