### PR TITLE
Fix access denied error while listing the contents of the folder

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -218,6 +218,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 					}
 				} catch (NotFoundException $e) {
 					$this->swallow(__FUNCTION__, $e);
+				} catch (ForbiddenException $e) {
+					$this->swallow(__FUNCTION__, $e);
 				}
 			}
 		} catch (ConnectException $e) {


### PR DESCRIPTION
This can happen inside a DFSR folder. The "DfsrPrivate" always appear
but trying to access to it will throw an access denied error for most of
the users (only a few priveleged users can access to the folder).

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
An access denied is thrown while trying to access to the "DfsrFolder" inside a dfs replicated folder which is accessible via smb share. This folder is always visible even though the "access based enumeration" setting is enable in the windows share.
The error happens when we try to check if that file is hidden or not. As said, it throws an access denied.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/enterprise/issues/3471

## Motivation and Context
Without this fix, accessing to the mention share will show an empty folder, caused by the access denied error.
This patch skips the problematic folder, so the rest of the content is checked and it's properly listed in the web UI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with a windows server 2016 share replicated with DFSR
1. Setup a replication folder with DFSR
2. Share the replicated folder
3. Make sure your user has enough permissions to access to the folder.
4. Try to access to the share

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](../changelog/README.md)