### PR TITLE
Fix scan for Guest users

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -188,6 +188,16 @@ class Scanner extends PublicEmitter {
 		if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 			(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 		) {
+			$isGuest = \OC::$server->getConfig()->getUserValue(
+					$this->user,
+				'owncloud',
+				'isGuest',
+				false
+				);
+			if ($isGuest) {
+				return true;
+			}
+
 			if ($storage->file_exists('') or $storage->getCache()->inCache('')) {
 				throw new ForbiddenException();
 			} else {// if the root exists in neither the cache nor the storage the user isn't setup yet


### PR DESCRIPTION
## Description

This PR fixes the files:scan (and the correspondent background job `OCA\Files\BackgroundJob\ScanFiles`) for Guest users.

## Related Issue

- Fixes https://github.com/owncloud/enterprise/issues/3561

## Motivation and Context

Currently, we are spamming the owncloud.log with `Forbidden` exceptions every time the background job or files:scan is processing Guest users.

## How Has This Been Tested?

Manually by running `files:scan` for Guest users and observing the scan correctly processing those users and by observing that the `OCA\Files\BackgroundJob\ScanFiles` background job does not trigger any `Forbideen` exception anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised 
- [ ] Changelog item