### PR TITLE
Do not try to login via auth module if the user is disabled

### DIFF
--- a/changelog/unreleased/36257
+++ b/changelog/unreleased/36257
@@ -1,0 +1,8 @@
+Bugfix: Do not try to login via auth module if the user is disabled
+
+Trying to login via an auth module (such as OAuth2) created a new session
+token even if the user was disabled. This was causing errors to appear in the logs
+because the new session token created after enabling the user was in use.
+Now, a disabled user won't create that session token.
+
+https://github.com/owncloud/core/pull/36257

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -983,6 +983,11 @@ class Session implements IUserSession, Emitter {
 		foreach ($this->getAuthModules(false) as $authModule) {
 			$user = $authModule->auth($request);
 			if ($user !== null) {
+				if (!$user->isEnabled()) {
+					// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
+					$message = \OC::$server->getL10N('lib')->t('User disabled');
+					throw new LoginException($message);
+				}
 				$uid = $user->getUID();
 				$password = $authModule->getUserPassword($request);
 				$this->createSessionToken($request, $uid, $uid, $password);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1701,6 +1701,7 @@ class SessionTest extends TestCase {
 		$throwingModule = $this->createMock(IAuthModule::class);
 		$throwingModule->expects($this->any())->method('auth')->willThrowException(new \Exception('Invalid token'));
 		$user1 = $this->createMock(IUser::class);
+		$user1->expects($this->any())->method('isEnabled')->willReturn('true');
 		$user1->expects($this->any())->method('getUID')->willReturn('user1');
 		$user1Module = $this->createMock(IAuthModule::class);
 		$user1Module->expects($this->any())->method('auth')->willReturn($user1);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Do not try to login with a disabled user

## Related Issue
https://github.com/owncloud/enterprise/issues/2509

## Motivation and Context
Duplicated auth token error message was happening trying to refresh the token of a disabled user

## How Has This Been Tested?
Manually checked with desktop client 2.5.4
1. Using the desktop client and the oAuth2 app, login normally with a user via oAuth2 and let the desktop client sync
2. After the sync finishes, disable the user in ownCloud
3. Try to resync

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](../changelog/README.md)