### PR TITLE
Bump sabre http 5.0.3

### DIFF
--- a/changelog/unreleased/36260
+++ b/changelog/unreleased/36260
@@ -1,0 +1,7 @@
+Change: Update sabre/http from version 5.0.2 to 5.0.3
+
+sabre/http 5.0.3 was released. It improved performance when downloading files
+that are larger than 4MB.
+
+https://github.com/owncloud/core/pull/36260
+https://github.com/sabre-io/http/releases/tag/5.0.3

--- a/composer.lock
+++ b/composer.lock
@@ -2109,16 +2109,16 @@
         },
         {
             "name": "sabre/http",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/http.git",
-                "reference": "c9833073175bf02c8550695860fe375e26b68709"
+                "reference": "59359212b84138ddb93167d67733fe5d06ba9b6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/http/zipball/c9833073175bf02c8550695860fe375e26b68709",
-                "reference": "c9833073175bf02c8550695860fe375e26b68709",
+                "url": "https://api.github.com/repos/sabre-io/http/zipball/59359212b84138ddb93167d67733fe5d06ba9b6b",
+                "reference": "59359212b84138ddb93167d67733fe5d06ba9b6b",
                 "shasum": ""
             },
             "require": {
@@ -2161,7 +2161,7 @@
             "keywords": [
                 "http"
             ],
-            "time": "2019-09-12T15:36:08+00:00"
+            "time": "2019-10-08T11:45:03+00:00"
         },
         {
             "name": "sabre/uri",

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -27,6 +27,17 @@ Feature: download file
       | old         |
       | new         |
 
+  Scenario Outline: download a file larger than 4MB (ref: https://github.com/sabre-io/http/pull/119 )
+    Given using <dav_version> DAV path
+    And user "user0" has uploaded file "/file9000000.txt" ending with "text at end of file" of size 9000000 bytes
+    When user "user0" downloads file "/file9000000.txt" using the WebDAV API
+    Then the size of the downloaded file should be 9000000 bytes
+    And the downloaded content should end with "text at end of file"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   @public_link_share-feature-required
   Scenario: download a public shared file with range
     Given the administrator has enabled DAV tech_preview

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -49,7 +49,7 @@ Feature: get quota
   Scenario Outline: Retrieving folder quota when quota is set and a file was uploaded
     Given using <dav_version> DAV path
     And the quota of user "user0" has been set to "1 KB"
-    And user "user0" has uploaded file "/prueba.txt" of 93 bytes
+    And user "user0" has uploaded file "/prueba.txt" of size 93 bytes
     When user "user0" gets the following properties of folder "/" using the WebDAV API
       | d:quota-available-bytes |
     Then the single response should contain a property "d:quota-available-bytes" with value "577"
@@ -62,7 +62,7 @@ Feature: get quota
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user1" has been set to "1 KB"
-    And user "user0" has uploaded file "/user0.txt" of 93 bytes
+    And user "user0" has uploaded file "/user0.txt" of size 93 bytes
     And user "user0" has shared file "user0.txt" with user "user1"
     When user "user1" gets the following properties of folder "/" using the WebDAV API
       | d:quota-available-bytes |

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1310,17 +1310,18 @@ trait BasicStructure {
 	 *
 	 * @param string $name
 	 * @param string $size
+	 * @param string $endData
 	 *
 	 * @return void
 	 */
-	public function createLocalFileOfSpecificSize($name, $size) {
+	public function createLocalFileOfSpecificSize($name, $size, $endData = 'a') {
 		$folder = $this->workStorageDirLocation();
 		if (!\is_dir($folder)) {
 			\mkDir($folder);
 		}
 		$file = \fopen($folder . $name, 'w');
-		\fseek($file, $size - 1, SEEK_CUR);
-		\fwrite($file, 'a'); // write a dummy char at SIZE position
+		\fseek($file, $size - \strlen($endData), SEEK_CUR);
+		\fwrite($file, $endData); // write the end data to force the file size
 		\fclose($file);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -656,6 +656,32 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then the size of the downloaded file should be :size bytes
+	 *
+	 * @param string $size
+	 *
+	 * @return void
+	 */
+	public function sizeOfDownloadedFileShouldBe($size) {
+		Assert::assertEquals(
+			$size, \strlen((string)$this->response->getBody())
+		);
+	}
+
+	/**
+	 * @Then /^the downloaded content should end with "([^"]*)"$/
+	 *
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function downloadedContentShouldEndWith($content) {
+		Assert::assertEquals(
+			$content, \substr((string)$this->response->getBody(), -\strlen($content))
+		);
+	}
+
+	/**
 	 * @Then /^the downloaded content should be "([^"]*)"$/
 	 *
 	 * @param string $content
@@ -1609,7 +1635,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :destination of :bytes bytes
+	 * @Given user :user has uploaded file :destination of size :bytes bytes
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -1617,14 +1643,14 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function userHasUploadedFileToOfBytes($user, $destination, $bytes) {
-		$this->userUploadsAFileToOfBytes($user, $destination, $bytes);
+	public function userHasUploadedFileToOfSizeBytes($user, $destination, $bytes) {
+		$this->userUploadsAFileToOfSizeBytes($user, $destination, $bytes);
 		$expectedElements = new TableNode([["$destination"]]);
 		$this->checkElementList($user, $expectedElements);
 	}
 
 	/**
-	 * @When user :user uploads file :destination of :bytes bytes
+	 * @When user :user uploads file :destination of size :bytes bytes
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -1632,9 +1658,39 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function userUploadsAFileToOfBytes($user, $destination, $bytes) {
+	public function userUploadsAFileToOfSizeBytes($user, $destination, $bytes) {
+		$this->userUploadsAFileToEndingWithOfSizeBytes($user, $destination, 'a', $bytes);
+	}
+
+	/**
+	 * @Given user :user has uploaded file :destination ending with :text of size :bytes bytes
+	 *
+	 * @param string $user
+	 * @param string $destination
+	 * @param string $text
+	 * @param string $bytes
+	 *
+	 * @return void
+	 */
+	public function userHasUploadedFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes) {
+		$this->userUploadsAFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes);
+		$expectedElements = new TableNode([["$destination"]]);
+		$this->checkElementList($user, $expectedElements);
+	}
+
+	/**
+	 * @When user :user uploads file :destination ending with :text of size :bytes bytes
+	 *
+	 * @param string $user
+	 * @param string $destination
+	 * @param string $text
+	 * @param string $bytes
+	 *
+	 * @return void
+	 */
+	public function userUploadsAFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes) {
 		$filename = "filespecificSize.txt";
-		$this->createLocalFileOfSpecificSize($filename, $bytes);
+		$this->createLocalFileOfSpecificSize($filename, $bytes, $text);
 		Assert::assertFileExists($this->workStorageDirLocation() . $filename);
 		$this->userUploadsAFileTo(
 			$user,


### PR DESCRIPTION
## Description
1) bump patch version of `sabre/http`
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating sabre/http (5.0.2 => 5.0.3): Loading from cache
```

https://github.com/sabre-io/http/releases/tag/5.0.3

Note: PR https://github.com/sabre-io/http/pull/119 "Significantly improve file download speed by enabling mmap based `stream_copy_to_stream` - optimizes behaviour for downloads of more than 4MB.

2) Acceptance test added to check a download of 9MB

Note: this PR is currently on top of #36253 which also touches `composer.lock`

## Motivation and Context
Be up-to-date with dependencies.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](../changelog/README.md)
