### PR TITLE
Changelog for Symfony 3.4.32

### DIFF
--- a/changelog/unreleased/36244
+++ b/changelog/unreleased/36244
@@ -1,0 +1,15 @@
+Change: Update Symfony components to 3.4.32
+
+The following Symfony components have been updated to version 3.4.32:
+- console
+- event-dispatcher
+- process
+- translation
+- routing
+
+https://symfony.com/blog/symfony-3-4-32-released
+https://github.com/owncloud/core/pull/36244
+https://github.com/owncloud/core/pull/36245
+https://github.com/owncloud/core/pull/36246
+https://github.com/owncloud/core/pull/36247
+https://github.com/owncloud/core/pull/36248


### PR DESCRIPTION
## Description
Add a changelog entry for the Symfony 3.4.32 dependency bumps done by dependabot yesterday.

Symfony release notes: https://symfony.com/blog/symfony-3-4-32-released

Related PRs:
https://github.com/owncloud/core/pull/36244
https://github.com/owncloud/core/pull/36245
https://github.com/owncloud/core/pull/36246
https://github.com/owncloud/core/pull/36247
https://github.com/owncloud/core/pull/36248

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](changelog/TEMPLATE)
