### PR TITLE
Updating sabre/http (5.0.2 => 5.0.4)

### DIFF
--- a/changelog/unreleased/36263
+++ b/changelog/unreleased/36263
@@ -1,0 +1,8 @@
+Change: Update sabre/http from version 5.0.2 to 5.0.4
+
+sabre/http 5.0.4 was released. It improved performance when downloading files
+that are larger than 4MB.
+
+https://github.com/owncloud/core/pull/36260
+https://github.com/sabre-io/http/releases/tag/5.0.3
+https://github.com/sabre-io/http/releases/tag/5.0.4

--- a/composer.lock
+++ b/composer.lock
@@ -162,28 +162,28 @@
             "authors": [
                 {
                     "name": "Nicolai Ehemann",
-                    "role": "Author/Maintainer",
-                    "email": "en@enlightened.de"
+                    "email": "en@enlightened.de",
+                    "role": "Author/Maintainer"
                 },
                 {
                     "name": "André Rothe",
-                    "role": "Contributor",
-                    "email": "arothe@zks.uni-leipzig.de"
+                    "email": "arothe@zks.uni-leipzig.de",
+                    "role": "Contributor"
                 },
                 {
                     "name": "Lukas Reschke",
-                    "role": "Contributor",
-                    "email": "lukas@owncloud.com"
+                    "email": "lukas@owncloud.com",
+                    "role": "Contributor"
                 },
                 {
                     "name": "Thomas Müller",
-                    "role": "Contributor",
-                    "email": "thomas.mueller@tmit.eu"
+                    "email": "thomas.mueller@tmit.eu",
+                    "role": "Contributor"
                 },
                 {
                     "name": "Roeland Jago Douma",
-                    "role": "Contributor",
-                    "email": "roeland@famdouma.nl"
+                    "email": "roeland@famdouma.nl",
+                    "role": "Contributor"
                 }
             ],
             "description": "Stream zip files without i/o overhead",
@@ -1046,14 +1046,14 @@
             "authors": [
                 {
                     "name": "Olivier Paroz",
-                    "role": "Developer",
                     "email": "dev-lognormalizer@interfasys.ch",
-                    "homepage": "http://www.interfasys.ch"
+                    "homepage": "http://www.interfasys.ch",
+                    "role": "Developer"
                 },
                 {
                     "name": "Jordi Boggiano",
-                    "role": "Developer",
-                    "email": "j.boggiano@seld.be"
+                    "email": "j.boggiano@seld.be",
+                    "role": "Developer"
                 }
             ],
             "description": "Parses variables and converts them to string so that they can be logged",
@@ -1065,7 +1065,7 @@
             "time": "2015-08-01T16:27:37+00:00"
         },
         {
-            "name": "jeremeamia/superclosure",
+            "name": "jeremeamia/SuperClosure",
             "version": "2.4.0",
             "source": {
                 "type": "git",
@@ -1494,18 +1494,18 @@
             "authors": [
                 {
                     "name": "Greg Beaver",
-                    "role": "Helper",
-                    "email": "cellog@php.net"
+                    "email": "cellog@php.net",
+                    "role": "Helper"
                 },
                 {
                     "name": "Andrei Zmievski",
-                    "role": "Lead",
-                    "email": "andrei@php.net"
+                    "email": "andrei@php.net",
+                    "role": "Lead"
                 },
                 {
                     "name": "Stig Bakken",
-                    "role": "Developer",
-                    "email": "stig@php.net"
+                    "email": "stig@php.net",
+                    "role": "Developer"
                 }
             ],
             "description": "More info available on: http://pear.php.net/package/Console_Getopt",
@@ -1548,8 +1548,8 @@
             "authors": [
                 {
                     "name": "Christian Weiske",
-                    "role": "Lead",
-                    "email": "cweiske@php.net"
+                    "email": "cweiske@php.net",
+                    "role": "Lead"
                 }
             ],
             "description": "Minimal set of PEAR core files to be used as composer dependency",
@@ -1889,18 +1889,18 @@
             "authors": [
                 {
                     "name": "Michele Locati",
-                    "role": "Developer",
-                    "email": "mlocati@gmail.com"
+                    "email": "mlocati@gmail.com",
+                    "role": "Developer"
                 },
                 {
                     "name": "Remo Laubacher",
-                    "role": "Collaborator, motivator and perfectionist supporter",
-                    "email": "remo.laubacher@gmail.com"
+                    "email": "remo.laubacher@gmail.com",
+                    "role": "Collaborator, motivator and perfectionist supporter"
                 },
                 {
                     "name": "Christian Schmidt",
-                    "role": "Developer",
-                    "email": "github@chsc.dk"
+                    "email": "github@chsc.dk",
+                    "role": "Developer"
                 }
             ],
             "description": "PHP-Unicode CLDR",
@@ -2086,9 +2086,9 @@
             "authors": [
                 {
                     "name": "Evert Pot",
-                    "role": "Developer",
                     "email": "me@evertpot.com",
-                    "homepage": "http://evertpot.com/"
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
                 }
             ],
             "description": "sabre/event is a library for lightweight event-based programming",
@@ -2109,16 +2109,16 @@
         },
         {
             "name": "sabre/http",
-            "version": "5.0.2",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/http.git",
-                "reference": "c9833073175bf02c8550695860fe375e26b68709"
+                "reference": "73e2fa1ef894eddff145b698b6b0e2e2c5bf1d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/http/zipball/c9833073175bf02c8550695860fe375e26b68709",
-                "reference": "c9833073175bf02c8550695860fe375e26b68709",
+                "url": "https://api.github.com/repos/sabre-io/http/zipball/73e2fa1ef894eddff145b698b6b0e2e2c5bf1d72",
+                "reference": "73e2fa1ef894eddff145b698b6b0e2e2c5bf1d72",
                 "shasum": ""
             },
             "require": {
@@ -2161,7 +2161,7 @@
             "keywords": [
                 "http"
             ],
-            "time": "2019-09-12T15:36:08+00:00"
+            "time": "2019-10-09T20:27:43+00:00"
         },
         {
             "name": "sabre/uri",
@@ -2260,21 +2260,21 @@
             "authors": [
                 {
                     "name": "Evert Pot",
-                    "role": "Developer",
                     "email": "me@evertpot.com",
-                    "homepage": "http://evertpot.com/"
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
                 },
                 {
                     "name": "Dominik Tobschall",
-                    "role": "Developer",
                     "email": "dominik@fruux.com",
-                    "homepage": "http://tobschall.de/"
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
                 },
                 {
                     "name": "Ivan Enderlin",
-                    "role": "Developer",
                     "email": "ivan.enderlin@hoa-project.net",
-                    "homepage": "http://mnt.io/"
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
                 }
             ],
             "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
@@ -3783,18 +3783,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -4459,12 +4459,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "8a9c65d4dc3421877d806cb99b60d7f33689ca51"
+                "reference": "eb59d9f35a47f567ae15e7179d7c666489cd4b85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/8a9c65d4dc3421877d806cb99b60d7f33689ca51",
-                "reference": "8a9c65d4dc3421877d806cb99b60d7f33689ca51",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/eb59d9f35a47f567ae15e7179d7c666489cd4b85",
+                "reference": "eb59d9f35a47f567ae15e7179d7c666489cd4b85",
                 "shasum": ""
             },
             "conflict": {
@@ -4530,9 +4530,9 @@
                 "laravel/framework": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.42|>=5.6,<5.6.30",
                 "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
                 "league/commonmark": "<0.18.3",
-                "magento/magento1ce": "<1.9.4.1",
-                "magento/magento1ee": ">=1.9,<1.14.4.1",
-                "magento/product-community-edition": ">=2,<2.2.8|>=2.3,<2.3.1",
+                "magento/magento1ce": "<1.9.4.3",
+                "magento/magento1ee": ">=1,<1.14.4.3",
+                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
                 "monolog/monolog": ">=1.8,<1.12",
                 "namshi/jose": "<2.2",
                 "onelogin/php-saml": "<2.10.4",
@@ -4667,7 +4667,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-10-08T10:45:32+00:00"
+            "time": "2019-10-09T14:04:58+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5319,8 +5319,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -27,6 +27,17 @@ Feature: download file
       | old         |
       | new         |
 
+  Scenario Outline: download a file larger than 4MB (ref: https://github.com/sabre-io/http/pull/119 )
+    Given using <dav_version> DAV path
+    And user "user0" has uploaded file "/file9000000.txt" ending with "text at end of file" of size 9000000 bytes
+    When user "user0" downloads file "/file9000000.txt" using the WebDAV API
+    Then the size of the downloaded file should be 9000000 bytes
+    And the downloaded content should end with "text at end of file"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   @public_link_share-feature-required
   Scenario: download a public shared file with range
     Given the administrator has enabled DAV tech_preview

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -49,7 +49,7 @@ Feature: get quota
   Scenario Outline: Retrieving folder quota when quota is set and a file was uploaded
     Given using <dav_version> DAV path
     And the quota of user "user0" has been set to "1 KB"
-    And user "user0" has uploaded file "/prueba.txt" of 93 bytes
+    And user "user0" has uploaded file "/prueba.txt" of size 93 bytes
     When user "user0" gets the following properties of folder "/" using the WebDAV API
       | d:quota-available-bytes |
     Then the single response should contain a property "d:quota-available-bytes" with value "577"
@@ -62,7 +62,7 @@ Feature: get quota
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes and skeleton files
     And the quota of user "user1" has been set to "1 KB"
-    And user "user0" has uploaded file "/user0.txt" of 93 bytes
+    And user "user0" has uploaded file "/user0.txt" of size 93 bytes
     And user "user0" has shared file "user0.txt" with user "user1"
     When user "user1" gets the following properties of folder "/" using the WebDAV API
       | d:quota-available-bytes |

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1310,17 +1310,18 @@ trait BasicStructure {
 	 *
 	 * @param string $name
 	 * @param string $size
+	 * @param string $endData
 	 *
 	 * @return void
 	 */
-	public function createLocalFileOfSpecificSize($name, $size) {
+	public function createLocalFileOfSpecificSize($name, $size, $endData = 'a') {
 		$folder = $this->workStorageDirLocation();
 		if (!\is_dir($folder)) {
 			\mkDir($folder);
 		}
 		$file = \fopen($folder . $name, 'w');
-		\fseek($file, $size - 1, SEEK_CUR);
-		\fwrite($file, 'a'); // write a dummy char at SIZE position
+		\fseek($file, $size - \strlen($endData), SEEK_CUR);
+		\fwrite($file, $endData); // write the end data to force the file size
 		\fclose($file);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -656,6 +656,32 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then the size of the downloaded file should be :size bytes
+	 *
+	 * @param string $size
+	 *
+	 * @return void
+	 */
+	public function sizeOfDownloadedFileShouldBe($size) {
+		Assert::assertEquals(
+			$size, \strlen((string)$this->response->getBody())
+		);
+	}
+
+	/**
+	 * @Then /^the downloaded content should end with "([^"]*)"$/
+	 *
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function downloadedContentShouldEndWith($content) {
+		Assert::assertEquals(
+			$content, \substr((string)$this->response->getBody(), -\strlen($content))
+		);
+	}
+
+	/**
 	 * @Then /^the downloaded content should be "([^"]*)"$/
 	 *
 	 * @param string $content
@@ -1609,7 +1635,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :destination of :bytes bytes
+	 * @Given user :user has uploaded file :destination of size :bytes bytes
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -1617,14 +1643,14 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function userHasUploadedFileToOfBytes($user, $destination, $bytes) {
-		$this->userUploadsAFileToOfBytes($user, $destination, $bytes);
+	public function userHasUploadedFileToOfSizeBytes($user, $destination, $bytes) {
+		$this->userUploadsAFileToOfSizeBytes($user, $destination, $bytes);
 		$expectedElements = new TableNode([["$destination"]]);
 		$this->checkElementList($user, $expectedElements);
 	}
 
 	/**
-	 * @When user :user uploads file :destination of :bytes bytes
+	 * @When user :user uploads file :destination of size :bytes bytes
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -1632,9 +1658,39 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function userUploadsAFileToOfBytes($user, $destination, $bytes) {
+	public function userUploadsAFileToOfSizeBytes($user, $destination, $bytes) {
+		$this->userUploadsAFileToEndingWithOfSizeBytes($user, $destination, 'a', $bytes);
+	}
+
+	/**
+	 * @Given user :user has uploaded file :destination ending with :text of size :bytes bytes
+	 *
+	 * @param string $user
+	 * @param string $destination
+	 * @param string $text
+	 * @param string $bytes
+	 *
+	 * @return void
+	 */
+	public function userHasUploadedFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes) {
+		$this->userUploadsAFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes);
+		$expectedElements = new TableNode([["$destination"]]);
+		$this->checkElementList($user, $expectedElements);
+	}
+
+	/**
+	 * @When user :user uploads file :destination ending with :text of size :bytes bytes
+	 *
+	 * @param string $user
+	 * @param string $destination
+	 * @param string $text
+	 * @param string $bytes
+	 *
+	 * @return void
+	 */
+	public function userUploadsAFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes) {
 		$filename = "filespecificSize.txt";
-		$this->createLocalFileOfSpecificSize($filename, $bytes);
+		$this->createLocalFileOfSpecificSize($filename, $bytes, $text);
 		Assert::assertFileExists($this->workStorageDirLocation() . $filename);
 		$this->userUploadsAFileTo(
 			$user,


### PR DESCRIPTION
## Description
1) bump patch version of `sabre/http`
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating sabre/http (5.0.2 => 5.0.4): Loading from cache
```

https://github.com/sabre-io/http/releases/tag/5.0.3
https://github.com/sabre-io/http/releases/tag/5.0.4

Note: In 5.0.3 PR https://github.com/sabre-io/http/pull/119 "Significantly improve file download speed by enabling mmap based `stream_copy_to_stream` - optimizes behaviour for downloads of more than 4MB.

And I fixed a regression in that PR, which was released in 5.0.4 - PR https://github.com/sabre-io/http/pull/133

IMO the patch bump is working OK now.

2) Acceptance test added to check a download of 9MB

## Motivation and Context
Be up-to-date with dependencies.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](../changelog/README.md)
