### PR TITLE
Validate reshare permissions and attributes based on supershare

### DIFF
--- a/changelog/unreleased/36265
+++ b/changelog/unreleased/36265
@@ -1,0 +1,6 @@
+Change: Validate reshare permissions and attributes based on supershare
+
+This PR uniformed a way reshare permissions and attributes are enforced in a
+reshare scenario - strict subset checking has been used in both cases.
+
+https://github.com/owncloud/core/pull/36265

--- a/changelog/unreleased/36265
+++ b/changelog/unreleased/36265
@@ -1,6 +1,6 @@
 Change: Validate reshare permissions and attributes based on supershare
 
-This PR uniformed a way reshare permissions and attributes are enforced in a
-reshare scenario - strict subset checking has been used in both cases.
+This change provides a uniform way that reshare permissions and attributes are
+internally checked and enforced. There is no change to external behaviour.
 
 https://github.com/owncloud/core/pull/36265

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -3524,24 +3524,24 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider strictSubsetOfDataProvider
+	 * @dataProvider strictSubsetOfPermissionsDataProvider
 	 *
 	 * @param int $allowedPermissions
 	 * @param int $newPermissions
 	 * @param boolean $expected
 	 */
-	public function testStrictSubsetOf($allowedPermissions, $newPermissions, $expected) {
+	public function testStrictSubsetOfPermissions($allowedPermissions, $newPermissions, $expected) {
 		$this->assertEquals(
 			$expected,
 			$this->invokePrivate(
 				$this->manager,
-				'strictSubsetOf',
+				'strictSubsetOfPermissions',
 				[$allowedPermissions, $newPermissions]
 			)
 		);
 	}
 
-	public function strictSubsetOfDataProvider() {
+	public function strictSubsetOfPermissionsDataProvider() {
 		return [
 			[\bindec('11111'), \bindec('0111'), true],
 			[\bindec('01101'), \bindec('01001'), true],


### PR DESCRIPTION
Goal: do not allow privilege escalations with share attributes e.g. in Secure View resharing scenario.

There is no need to calculate reshare permission and attributes, these are already calculated by ShareProviders e.g. https://github.com/owncloud/core/blob/master/apps/files_sharing/lib/MountProvider.php#L71-L105

- Obsoletes https://github.com/owncloud/core/pull/36208
- This improves security in the scope of e.g. Secure View (as reshare check for attributes is done)

Attributes in this logic, in reshare scenario **can only be disabled** (1->0 in bitmap), it is **not possible however to add or remove additional attributes** (add/remove bits in bitmap) **nor enabling the disabled attribute** (0->1 in bitmap).

- [x] add more unit tests coverage in ManagerTest