### PR TITLE
Avoid unnecessary "Avatar not found" logs by initializing ViewOnlyPlugin for only files

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -137,7 +137,6 @@ class Server {
 			$this->server->addPlugin(new PublicFilesPlugin());
 			$authPlugin->addBackend(new PublicSharingAuth($this->server, OC::$server->getShareManager()));
 			$this->server->addPlugin(new PublicLinkEventsPlugin(\OC::$server->getEventDispatcher()));
-			$this->server->addPlugin(new PublicFilesPlugin());
 		}
 		$authPlugin->addBackend(new PublicAuth());
 		$this->server->addPlugin($authPlugin);
@@ -218,10 +217,11 @@ class Server {
 			OC::$server->getLazyRootFolder()
 		));
 
-		// Allow view-only plugin for webdav requests
-		$this->server->addPlugin(new ViewOnlyPlugin(
-			OC::$server->getLogger()
-		));
+		if ($this->isRequestForSubtree(['files', 'trash-bin', 'public-files'])) {
+			$this->server->addPlugin(new ViewOnlyPlugin(
+				OC::$server->getLogger()
+			));
+		}
 
 		if (BrowserErrorPagePlugin::isBrowserRequest($request)) {
 			$this->server->addPlugin(new BrowserErrorPagePlugin());
@@ -245,7 +245,7 @@ class Server {
 					)
 				);
 
-				if ($this->isRequestForSubtree(['files', 'uploads', 'trash-bin'])) {
+				if ($this->isRequestForSubtree(['files', 'uploads', 'trash-bin', 'public-files'])) {
 					//For files only
 					$filePropertiesPlugin = new FileCustomPropertiesPlugin(
 						new FileCustomPropertiesBackend(

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -55,6 +55,7 @@ class ServerTest extends \Test\TestCase {
 			'principals' => ['principals/users/admin', ['caldav', 'oc-resource-sharing', 'carddav']],
 			'calendars' => ['calendars/admin', ['caldav', 'oc-resource-sharing']],
 			'addressbooks' => ['addressbooks/admin', ['carddav', 'oc-resource-sharing']],
+			'files' => ['files/admin', ['OCA\DAV\DAV\ViewOnlyPlugin']]
 		];
 	}
 }

--- a/changelog/unreleased/36281
+++ b/changelog/unreleased/36281
@@ -1,0 +1,5 @@
+Bugfix: Avoid unnecessary "Avatar not found" logs by initializing ViewOnlyPlugin for only files
+
+ViewOnlyPlugin was producing too many warning logs for users who have not an avatar. By registering ViewOnlyPlugin for only files problem resolved.
+
+https://github.com/owncloud/core/pull/36281


### PR DESCRIPTION
## Description
https://github.com/owncloud/core/blob/b9ff4c93e051c94adfb301545098ae627e52ef76/apps/dav/lib/DAV/ViewOnlyPlugin.php#L86
This line is throwing NotFound exception when a node not found and, this action is logged as a warning. By registering ViewOnlyPlugin for only files problem resolved. 

Also, minor bugs in `Server.php` that were previously overlooked were fixed.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3332

## Motivation and Context
The server clients are asking user avatars with DAV requests. When an avatar not found, the server producing lots of warning logs because of the ViewOnlyPlugin. By registering ViewOnlyPlugin for only files problem resolved. 

## How Has This Been Tested?
Manually with following scenario;
- Create a user but not upload any avatar.
- Login with the desktop client, no warning log should appear in owncloud.log.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
