### PR TITLE
Avoid PHP_CodeSniffer 3.5.1 due to regression

### DIFF
--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "squizlabs/php_codesniffer": "3.*"
+    },
+    "conflict": {
+        "squizlabs/php_codesniffer": "3.5.1"
     }
 }


### PR DESCRIPTION
## Description
https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.1 has a regression.
See issue https://github.com/squizlabs/PHP_CodeSniffer/issues/2654
So avoid patch release 3.5.1

## Related Issue
- Fixes #36287 

## Motivation and Context
Make CI great again.

## How Has This Been Tested?
Local `make test-php-style`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
