### PR TITLE
Guests' home storage will be read-only so check for isReadable instead

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -184,9 +184,10 @@ class Scanner extends PublicEmitter {
 			return false;
 		}
 
-		// if the home storage isn't writable then the scanner is run as the wrong user
+		// if the home storage isn't readable then the scanner is run as the wrong user
+		// (guests will have a read-only home storage)
 		if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
-			(!$storage->isCreatable('') or !$storage->isCreatable('files'))
+			(!$storage->isReadable('') or !$storage->isReadable('files'))
 		) {
 			if ($storage->file_exists('') or $storage->getCache()->inCache('')) {
 				throw new ForbiddenException();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Prevent Forbidden errors to pop up in the logs while scanning the home storages of guest users (via background jobs)
Alternative approach to https://github.com/owncloud/core/pull/36256

Note that scanning the home storage of guest users might be possible now. This means that if files are placed manually into the guest home folder, those files will be visible (note that this flow isn't common)

## Related Issue
https://github.com/owncloud/enterprise/issues/3561

## Motivation and Context
Previous "isCreatable" check doesn't make sense when you're checking in order to scan. Writing in the storage isn't planned during a scan process.
In addition, guest users will have a read-only storage.

## How Has This Been Tested?
1. Install guests app and create a new guest
2. With any local user, share a folder with a guest user
3. Follow standard guest flow and login with the guest. Verify you can access to the shared folder
4. Force the "scan files" background job to be executed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
