### PR TITLE
Adjust phpunit withConsecutive calls

### DIFF
--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -607,8 +607,8 @@ class ShareesTest extends TestCase {
 				$this->groupManager->expects($this->exactly(2))
 					->method('getUserGroupIds')
 					->withConsecutive(
-						$user,
-						$singleUser
+						[$user],
+						[$singleUser]
 					)
 					->willReturn($groupResponse);
 			} else {

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -3196,7 +3196,7 @@ class Share20OcsControllerTest extends TestCase {
 
 		$this->shareManager->expects($this->exactly(2))
 			->method('updateShareForRecipient')
-			->withConsecutive($userShare, $groupShare);
+			->withConsecutive([$userShare], [$groupShare]);
 
 		$userFolder = $this->createMock('OCP\Files\Folder');
 		if ($method === 'acceptShare') {

--- a/apps/files_sharing/tests/Service/NotificationPublisherTest.php
+++ b/apps/files_sharing/tests/Service/NotificationPublisherTest.php
@@ -335,7 +335,7 @@ class NotificationPublisherTest extends TestCase {
 
 		$this->notificationManager->expects($this->exactly(2))
 			->method('markProcessed')
-			->withConsecutive($notifications[0], $notifications[1]);
+			->withConsecutive([$notifications[0]], [$notifications[1]]);
 
 		$share = $this->createShare();
 		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_GROUP);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -431,7 +431,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->defaultProvider
 			->method('delete')
-			->withConsecutive($share3, $share2, $share1);
+			->withConsecutive([$share3], [$share2], [$share1]);
 
 		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['pre', 'post'])->getMock();
 		\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListner, 'pre');
@@ -562,7 +562,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider
 			->expects($this->exactly(3))
 			->method('delete')
-			->withConsecutive($child1, $child2, $child3);
+			->withConsecutive([$child1], [$child2], [$child3]);
 
 		$result = $this->invokePrivate($manager, 'deleteChildren', [$share]);
 		$this->assertSame($shares, $result);


### PR DESCRIPTION
## Description
`phpunit7` reports test fails like:
```
There was 1 error:

1) Test\Share20\ManagerTest::testDeleteChildren
PHPUnit\Framework\InvalidParameterGroupException: Parameter group #0 must be an array or Traversable, got object

/home/phil/git/owncloud/core/tests/lib/Share20/ManagerTest.php:565
```

Some unit test calls to `withConsecutive` are passing just a list of ordinary strings. But in the case where there is just a single parameter to send on each call, that single parameter should still be an array that has just 1 entry, the single parameter. `phpunit6` does not complain about this, but `phpunit7` will.

## Motivation and Context
May as well apply little unit test code fixes like this to the existing `phpunit6` test code.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
