### PR TITLE
Disallow sharing of share_folder and it's parents

### DIFF
--- a/changelog/unreleased/36297
+++ b/changelog/unreleased/36297
@@ -1,0 +1,7 @@
+Bugfix: Disallow sharing share_folder or it's parents
+
+share_folder had share permission so it was possible for the user to share it along with some received shares.
+It caused aweird behavior. So sharing share_folder (or any of it's parent folders) was prohibited.
+
+https://github.com/owncloud/core/issues/36241
+https://github.com/owncloud/core/pull/36297

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1440,3 +1440,17 @@ Feature: sharing
       | /randomfile.txt |
     And the content of file "randomfile.txt" for user "user2" should be "user0 file"
     And the content of file "randomfile.txt" for user "user1" should be "user0 file"
+
+  Scenario Outline: Do not allow sharing of the entire share_folder
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "<share_folder>"
+    When user "user0" shares folder "/FOLDER" with user "user1" using the sharing API
+    And user "user1" unshares folder "ReceivedShares/FOLDER" using the WebDAV API
+    And user "user1" shares folder "/ReceivedShares" with user "user0" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code | share_folder    |
+      | 1               | 403             | 200              | /ReceivedShares |
+      | 2               | 403             | 403              | /ReceivedShares |


### PR DESCRIPTION
## Description
Remove share permission for `share_folder`

## Related Issue
- Fixes #36241

## Motivation and Context
It doesn't allow sharing the entire `share_folder` to other users/groups

## How Has This Been Tested?
1. Add share_folder into config.php
2. User1 shares a file with User2
3. User2 deletes the file from their account
4. User2 shares share_folder

### Actual result
share_folder can be shared. Any new files which are added to that folder as newly received shares are not shared to the collaborators. But new files can be added via public links.

### Expected result
Sharing of share_folder is not allowed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
