### PR TITLE
Only show progressbar if option --progress is set

### DIFF
--- a/changelog/unreleased/issue-36298
+++ b/changelog/unreleased/issue-36298
@@ -1,0 +1,6 @@
+Bugfix: occ system:cron only shows progess bar if option is set
+
+occ system:cron will only output the progess bar if the newly introduced option --progress is set.
+When being executed from crontab occ system::cron shall only print out in case of error.
+
+https://github.com/owncloud/core/issues/36298

--- a/tests/Core/Command/System/CronTest.php
+++ b/tests/Core/Command/System/CronTest.php
@@ -111,7 +111,7 @@ class CronTest extends TestCase {
 		$this->jobList->method('getNext')->willReturnOnConsecutiveCalls($job, null);
 		$this->jobList->expects(self::once())->method('setLastJob')->with($job);
 
-		$this->commandTester->execute([]);
+		$this->commandTester->execute(['--progress' => true]);
 		$output = $this->commandTester->getDisplay();
 		$this->assertContains('1 [->--------------------------]', $output);
 	}


### PR DESCRIPTION
## Description


## Related Issue
- Fixes #36298

## How Has This Been Tested?
- occ system:cron -> no output
- occ system:cron -p -> see progress bar

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: https://github.com/owncloud/docs/issues/1955
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
