### PR TITLE
Avoid php_codesniffer 3.5.1 - it has a regression

### DIFF
--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "squizlabs/php_codesniffer": "3.*"
+    },
+    "conflict": {
+        "squizlabs/php_codesniffer": "3.5.1"
     }
 }


### PR DESCRIPTION
There was a regression in PHP_CodeSniffer 3.5.1 patch release which causes code style "fails" to be incorrectly reported. The "fix" for now is to avoid using 3.5.1. That was done in the `master` branch in PR #36286 

In the `release-10.3.0` branch, CI is failing because of this annoying issue - e.g. https://drone.owncloud.com/owncloud/core/20900/2/6

This PR to the `release-10.3.0` branch will avoid the code style regression. That will enable CI to pass on the  `release-10.3.0` branch in order to merge it back to `master`