### PR TITLE
allow to use  with new public webdav API

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -223,16 +223,20 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename using the old WebDAV API
+	 * @When the public uploads file :filename using the :publicWebDAVAPIVersion WebDAV API
 	 * @Given the public has uploaded file :filename
 	 *
 	 * @param string $source target file name
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function publiclyUploadingFile($source) {
+	public function publiclyUploadingFile($source, $publicWebDAVAPIVersion) {
 		$file = \GuzzleHttp\Stream\Stream::factory(\fopen($source, 'r'));
-		$this->publicUploadContent(\basename($source), '', $file->getContents());
+		$this->publicUploadContent(
+			\basename($source), '', $file->getContents(),
+			false, [], $publicWebDAVAPIVersion
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
allow this function to work with both versions of the public webdav API

## Related Issue
needed to test https://github.com/owncloud/files_classifier/issues/225

## Motivation and Context
make the function more flexible

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
