### PR TITLE
[For 10.4] Fix doc links in the admin settings

### DIFF
--- a/changelog/unreleased/36315
+++ b/changelog/unreleased/36315
@@ -1,0 +1,6 @@
+Bugfix: Fix links in setupchecks.js
+
+Security tips at Settings -> Admin -> General had two broken links to the owncloud docs in the messages performing HTTPS and HSTS checks
+
+https://github.com/owncloud/core/pull/36315
+https://github.com/owncloud/core/issues/36238

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -272,6 +272,9 @@
 			var messages = [];
 
 			if (xhr.status === 200) {
+				var oc_defaults = oc_defaults || {};
+				var docPlaceholderUrl = oc_defaults.docPlaceholderUrl || '';
+
 				if(OC.getProtocol() === 'https') {
 					// Extract the value of 'Strict-Transport-Security'
 					var transportSecurityValidity = xhr.getResponseHeader('Strict-Transport-Security');
@@ -283,17 +286,20 @@
 							transportSecurityValidity = transportSecurityValidity.substring(8);
 						}
 					}
-
 					var minimumSeconds = 15552000;
 					if(isNaN(transportSecurityValidity) || transportSecurityValidity <= (minimumSeconds - 1)) {
 						messages.push({
-							msg: t('core', 'The "Strict-Transport-Security" HTTP header is not configured to at least "{seconds}" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="{docUrl}" rel="noreferrer">security tips</a>.', {'seconds': minimumSeconds, docUrl: '#admin-tips'}),
+							msg: t('core',
+								'The "Strict-Transport-Security" HTTP header is not configured to at least "{seconds}" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="{docUrl}" rel="noreferrer">security tips</a>.',
+								{'seconds': minimumSeconds, docUrl: docPlaceholderUrl.replace('PLACEHOLDER', 'enable-http-strict-transport-security')}),
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 						});
 					}
 				} else {
 					messages.push({
-						msg: t('core', 'You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="{docUrl}">security tips</a>.', {docUrl: '#admin-tips'}),
+						msg: t('core',
+							'You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="{docUrl}">security tips</a>.',
+							{docUrl: docPlaceholderUrl.replace('PLACEHOLDER', 'use-https')}),
 						type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 					});
 				}

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -114,7 +114,7 @@ describe('OC.SetupChecks tests', function() {
 				done();
 			});
 		});
-		
+
 		it('should not return an error if data directory is protected', function(done) {
 			var async = OC.SetupChecks.checkDataProtected();
 
@@ -391,7 +391,7 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
-					msg: 'Error occurred while checking server setup', 
+					msg: 'Error occurred while checking server setup',
 					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
 				},{
 					msg: 'Error occurred while checking server setup',
@@ -457,7 +457,7 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
-					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.', 
+					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING,
 				}, {
 					msg: 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.',
@@ -508,7 +508,7 @@ describe('OC.SetupChecks tests', function() {
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([{
-				msg: 'You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="#admin-tips">security tips</a>.',
+				msg: 'You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="">security tips</a>.',
 				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 			}]);
 			done();
@@ -527,7 +527,7 @@ describe('OC.SetupChecks tests', function() {
 		);
 		async.done(function( data, s, x ){
 			expect(data).toEqual([{
-				msg: 'Error occurred while checking server setup', 
+				msg: 'Error occurred while checking server setup',
 				type: OC.SetupChecks.MESSAGE_TYPE_ERROR
 			}, {
 				msg: 'Error occurred while checking server setup',
@@ -554,7 +554,7 @@ describe('OC.SetupChecks tests', function() {
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([{
-				msg: 'The "Strict-Transport-Security" HTTP header is not configured to at least "15552000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips" rel="noreferrer">security tips</a>.',
+				msg: 'The "Strict-Transport-Security" HTTP header is not configured to at least "15552000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="" rel="noreferrer">security tips</a>.',
 				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 			}]);
 			done();
@@ -579,7 +579,7 @@ describe('OC.SetupChecks tests', function() {
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([{
-				msg: 'The "Strict-Transport-Security" HTTP header is not configured to at least "15552000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips" rel="noreferrer">security tips</a>.',
+				msg: 'The "Strict-Transport-Security" HTTP header is not configured to at least "15552000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="" rel="noreferrer">security tips</a>.',
 				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 			}]);
 			done();
@@ -604,7 +604,7 @@ describe('OC.SetupChecks tests', function() {
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([{
-				msg: 'The "Strict-Transport-Security" HTTP header is not configured to at least "15552000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips" rel="noreferrer">security tips</a>.',
+				msg: 'The "Strict-Transport-Security" HTTP header is not configured to at least "15552000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="" rel="noreferrer">security tips</a>.',
 				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 			}]);
 			done();


### PR DESCRIPTION
## TODO
DOC should have the following rewrites:
- [ ] https://doc.owncloud.org/server/10.3/go.php?to=use-https 
to 
https://doc.owncloud.org/server/10.3/admin_manual/configuration/server/harden_server.html#use-https

- [ ] https://doc.owncloud.org/server/10.3/go.php?to=enable-http-strict-transport-security
to
https://doc.owncloud.org/server/10.3/admin_manual/configuration/server/harden_server.html#enable-http-strict-transport-security


## Description
Fix links in setupchecks.js

## Related Issue
- Fixes #36238 

## Motivation and Context
Proper documentation links

## How Has This Been Tested?
Browse to Settings -> Admin -> General via HTTP
Check where link `You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our security tips.` points


### Expected 
to ownCloud docs

### Actual
to not-existing `#admin-tips` anchor on the same page

The same is valid for HSTS message

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
