### PR TITLE
Do not change the parentId if it's null

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -171,7 +171,7 @@ class Scanner extends BasicEmitter implements IScanner {
 						$parentData = $this->scanFile($parent);
 						$parentId = $parentData['fileid'];
 					}
-					if ($parent) {
+					if ($parent && $parentId !== null) {
 						$data['parent'] = $parentId;
 					}
 					if ($cacheData === null) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The parentId can't be null due to DB constraints. We won't try to set a null parentId, so it will remain unchained (the rest of the info will be updated if needed)

## Related Issue
https://github.com/owncloud/core/issues/36305

## Motivation and Context
example of initial DB data:
```
--------+
| fileid | storage | path                                   | path_hash                        | parent | name      | mimetype | mimepart | size   | mtime      | storage_mtime | encrypted | unencrypted_size | etag          | permissions | checksum |
+--------+---------+----------------------------------------+----------------------------------+--------+-----------+----------+----------+--------+------------+---------------+-----------+------------------+---------------+-------------+----------+
|     52 |       6 | 3580/aclf230/folder1/folder2           | a1afc58c1e4520ff205ad997dd39c70a |     -1 | folder2   |        2 |        1 | 495134 | 1571825485 |    1571825485 |         0 |                0 | 5db02b71a4e62 |          17 |          |
|     53 |       6 | 3580/aclf230/folder1/folder2/7zkiG.gif | dbefded9ae94a11c1f2a7994eb8b75fa |     52 | 7zkiG.gif |        7 |        5 | 495134 | 1571825485 |    1571825485 |         0 |                0 | 5db02b71b1cc0 |          17 |          |
+--------+---------+----------------------------------------+----------------------------------+--------+-----------+----------+----------+--------+------------+---------------+-----------+------------------+---------------+-------------+----------+

```
Note that "folder2" has a parentId = -1. This was there before breaking, and seemed to work fine. Uploading a file inside the folder was causing problems because the code was trying to insert a null as parentId of the "folder2". (Note that "folder1" isn't accessible).
Taking this into account, I've decided to ignore the parentId change and update only the rest of the information.

## How Has This Been Tested?
Tested following the steps of https://github.com/owncloud/enterprise/issues/3580

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
