### PR TITLE
Objectstore transfer

### DIFF
--- a/apps/files/tests/Command/TransferOwnershipTest.php
+++ b/apps/files/tests/Command/TransferOwnershipTest.php
@@ -163,6 +163,15 @@ class TransferOwnershipTest extends TestCase {
 			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$this->shareManager->createShare($share);
+
+		$subFolder = $userFolder->get('transfer/sub_folder');
+		$share = $this->shareManager->newShare();
+		$share->setNode($subFolder)
+			->setSharedBy('source-user')
+			->setSharedWith('share-receiver')
+			->setShareType(Share::SHARE_TYPE_USER)
+			->setPermissions(19);
+		$this->shareManager->createShare($share);
 	}
 
 	public function testTransferAllFiles() {
@@ -178,13 +187,13 @@ class TransferOwnershipTest extends TestCase {
 		$sourceShares = $this->shareManager->getSharesBy($this->sourceUser->getUID(), Share::SHARE_TYPE_USER);
 		$targetShares = $this->shareManager->getSharesBy($this->targetUser->getUID(), Share::SHARE_TYPE_USER);
 		$this->assertCount(0, $sourceShares);
-		$this->assertCount(3, $targetShares);
+		$this->assertCount(4, $targetShares);
 	}
 
 	public function folderPathProvider() {
 		return [
-			['transfer', 1, 2],
-			['transfer/sub_folder', 2, 1]
+			['transfer', 1, 3],
+			['transfer/sub_folder', 2, 2]
 		];
 	}
 

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -29,7 +29,6 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Cache\Updater;
 use OC\Files\ObjectStore\NoopScanner;
 use OC\Files\ObjectStore\ObjectStoreStorage;
-use OCP\Files\Cache\ICache;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IVersionedObjectStorage;
@@ -139,36 +138,14 @@ class ObjectStoreTest extends TestCase {
 	}
 
 	public function testMoveFromStorageWithObjectStore() {
-		$sourceStorage = $this->getMockBuilder(ObjectStoreStorage::class)
-			->setMethods(['getCache'])
-			->setConstructorArgs(['objectstore' => $this->impl])
-			->getMock();
-		$sourceObjectStoreCache = $this->createMock(ICache::class);
-		$sourceObjectStoreCache->expects($this->never())->method('put');
-		$sourceObjectStoreCache->expects($this->never())->method('remove');
-		$sourceObjectStoreCache->expects($this->never())->method('move');
-		$sourceObjectStoreCache->expects($this->never())->method('update');
-		$sourceStorage->method('getCache')->willReturn($sourceObjectStoreCache);
+		$sourceStorage = new ObjectStoreStorage([
+			'objectstore' => $this->impl
+		]);
 
 		$this->objectStore = $this->getMockBuilder(ObjectStoreStorage::class)
-			->setMethods(['getUpdater', 'getCache'])
+			->setMethods(['getUpdater'])
 			->setConstructorArgs([['objectstore' => $this->impl]])
 			->getMock();
-
-		// only one "moveFromCache" operation is expected to hit the cache
-		$objectStoreCache = $this->createMock(ICache::class);
-		$objectStoreCache->expects($this->never())->method('put');
-		$objectStoreCache->expects($this->never())->method('remove');
-		$objectStoreCache->expects($this->never())->method('move');
-		$objectStoreCache->expects($this->never())->method('update');
-		$objectStoreCache->expects($this->once())
-			->method('moveFromCache')
-			->with(
-				$this->equalTo($sourceStorage),
-				$this->equalTo('text.txt'),
-				$this->equalTo('foo/bar.txt')
-			);
-		$this->objectstore->method('getCache')->willReturn($objectStoreCache);
 
 		$updater = $this->createMock(Updater::class);
 		$this->objectStore->expects($this->once())->method('getUpdater')->willReturn($updater);

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -29,6 +29,7 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Cache\Updater;
 use OC\Files\ObjectStore\NoopScanner;
 use OC\Files\ObjectStore\ObjectStoreStorage;
+use OCP\Files\Cache\ICache;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IVersionedObjectStorage;
@@ -138,14 +139,36 @@ class ObjectStoreTest extends TestCase {
 	}
 
 	public function testMoveFromStorageWithObjectStore() {
-		$sourceStorage = new ObjectStoreStorage([
-			'objectstore' => $this->impl
-		]);
+		$sourceStorage = $this->getMockBuilder(ObjectStoreStorage::class)
+			->setMethods(['getCache'])
+			->setConstructorArgs(['objectstore' => $this->impl])
+			->getMock();
+		$sourceObjectStoreCache = $this->createMock(ICache::class);
+		$sourceObjectStoreCache->expects($this->never())->method('put');
+		$sourceObjectStoreCache->expects($this->never())->method('remove');
+		$sourceObjectStoreCache->expects($this->never())->method('move');
+		$sourceObjectStoreCache->expects($this->never())->method('update');
+		$sourceStorage->method('getCache')->willReturn($sourceObjectStoreCache);
 
 		$this->objectStore = $this->getMockBuilder(ObjectStoreStorage::class)
-			->setMethods(['getUpdater'])
+			->setMethods(['getUpdater', 'getCache'])
 			->setConstructorArgs([['objectstore' => $this->impl]])
 			->getMock();
+
+		// only one "moveFromCache" operation is expected to hit the cache
+		$objectStoreCache = $this->createMock(ICache::class);
+		$objectStoreCache->expects($this->never())->method('put');
+		$objectStoreCache->expects($this->never())->method('remove');
+		$objectStoreCache->expects($this->never())->method('move');
+		$objectStoreCache->expects($this->never())->method('update');
+		$objectStoreCache->expects($this->once())
+			->method('moveFromCache')
+			->with(
+				$this->equalTo($sourceStorage),
+				$this->equalTo('text.txt'),
+				$this->equalTo('foo/bar.txt')
+			);
+		$this->objectstore->method('getCache')->willReturn($objectStoreCache);
 
 		$updater = $this->createMock(Updater::class);
 		$this->objectStore->expects($this->once())->method('getUpdater')->willReturn($updater);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fix `files:transfer-ownership` command for multibucket objectstores (checked with files_primary_s3 app against a scality server, with multibucket configuration)

**NOTE** Only files are moved between buckets if needed. Thumbnails and versions remain in the old bucket. The owncloud's filecache also keeps the thumbnails and versions in the same storages (to be investigated further)

## Related Issue
https://github.com/owncloud/enterprise/issues/3520

## Motivation and Context
transfer-ownership was causing problems with the shares because the fileid of the transferred files was changing. This PR aims to prevent the fileid change so the shares are still bound to valid ids (the files are transferred anyway)

## How Has This Been Tested?
1. With user1, create "file1.txt", "f1/file2.txt" and "f1/f2/file3.txt" (with the required folders)
2. user1 shares "f1/f2" and "f1/file2.txt" with the admin user
3. run `occ files:transfer-ownership user1 user2` (user2 must exists and be valid)

The transfer happens. The admin can still access to the previously shared files. Shares are visible for user2 (user2 owns the shares)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
