### PR TITLE
Follow single-bucket initialization for multi-bucket setup

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -278,6 +278,7 @@ class OC_Util {
 
 		//check if we are using an object storage
 		$objectStore = \OC::$server->getSystemConfig()->getValue('objectstore', null);
+		$objectStore = \OC::$server->getSystemConfig()->getValue('objectstore_multibucket', $objectStore);
 		if (isset($objectStore)) {
 			self::initObjectStoreRootFS($objectStore);
 		} else {


### PR DESCRIPTION
Version information was being stored in the oc_filecache table when it
should be using the objectstore versioning.
In addition, a local storage was being created

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Before the change, version information was being stored in the oc_filecache for objectstore with multi-bucket setup. A local storage was also created.

```
MariaDB [owncloud]> select * from oc_storages;
+-------------------------+------------+-----------+--------------+
| id                      | numeric_id | available | last_checked |
+-------------------------+------------+-----------+--------------+
| object::user:admin      |          1 |         1 |         NULL |
| local::/mnt/data/files/ |          2 |         1 |         NULL |
| object::user:user1      |          3 |         1 |         NULL |
| object::user:user2      |          4 |         1 |         NULL |
+-------------------------+------------+-----------+--------------+
4 rows in set (0.00 sec)
```
```
|     28 |       1 | files_versions                         | 9692aae50022f45f1098646939b287b1 |      1 | files_versions          |        2 |        1 |   163 | 1571917092 |    1571917092 |         0 |                0 | 5db18d245982c |          31 | NULL                                                                                                |
|     29 |       1 | files_versions/welcome.txt.v1571917092 | 45f48ff521b17d5f43f9ac9af51a402f |     28 | welcome.txt.v1571917092 |        4 |        3 |   163 | 1571917092 |    1571917092 |         0 |                0 | 5db18d24450ba |          27 | NULL                                                                                                |
|     30 |       1 | thumbnails/4/2048-2048-max.png         | 1f5b8e9d4783513bb4690185e91b12c2 |      8 | 2048-2048-max.png       |        6 |        5 | 40062 | 1571917093 |    1571917093 |         0 |                0 | 5db18d2547a8f |          27 | SHA1:37f9ec83ef408d9dd9967f9bf1de5cc2fdb34018 MD5:609233b147c8c91960472fb3da2b4f41 ADLER32:e98822a8 |
|     31 |       1 | thumbnails/4/32-32.png                 | 556d041f5c3e8640e91ea5da02024a3c |      8 | 32-32.png               |        6 |        5 |  1605 | 1571917093 |    1571917093 |         0 |                0 | 5db18d2582ffb |          27 | SHA1:6019a62cdb0ff021c18fa69444de71de021f6e80 MD5:ec07d20b2d2e0fdaec8a1e601d602c16 ADLER32:2b510ef2 |
```
After the change, the versions are completely stored in the objectstore
```
MariaDB [owncloud]> select * from oc_storages;
+------------------------+------------+-----------+--------------+
| id                     | numeric_id | available | last_checked |
+------------------------+------------+-----------+--------------+
| object::user:admin     |          1 |         1 |         NULL |
| object::store:owncloud |          2 |         1 |         NULL |
| object::user:user1     |          3 |         1 |         NULL |
| object::user:user2     |          4 |         1 |         NULL |
+------------------------+------------+-----------+--------------+
4 rows in set (0.01 sec)
```
```
MariaDB [owncloud]> select * from oc_filecache where storage = 1;
+--------+---------+--------------------------------+----------------------------------+--------+-------------------+----------+----------+-------+------------+---------------+-----------+------------------+---------------+-------------+-----------------------------------------------------------------------------------------------------+
| fileid | storage | path                           | path_hash                        | parent | name              | mimetype | mimepart | size  | mtime      | storage_mtime | encrypted | unencrypted_size | etag          | permissions | checksum                                                                                            |
+--------+---------+--------------------------------+----------------------------------+--------+-------------------+----------+----------+-------+------------+---------------+-----------+------------------+---------------+-------------+-----------------------------------------------------------------------------------------------------+
|      3 |       1 | cache                          | 0fea6a13c52b4d4725368f24b045ca84 |      1 | cache             |        2 |        1 |     0 | 1571917716 |    1571917716 |         0 |                0 | 5db18f940d9c2 |          31 | NULL                                                                                                |
|     27 |       1 | thumbnails/5/2048-2048-max.png | 26520cc4dee2813be06c33c0ebdf9965 |      8 | 2048-2048-max.png |        6 |        5 | 40062 | 1571917884 |    1571917884 |         0 |                0 | 5db1903c5616b |          27 | SHA1:37f9ec83ef408d9dd9967f9bf1de5cc2fdb34018 MD5:609233b147c8c91960472fb3da2b4f41 ADLER32:e98822a8 |
|      7 |       1 | thumbnails                     | 3b8779ba05b8f0aed49650f3ff8beb4b |      1 | thumbnails        |        2 |        1 | 41667 | 1571917884 |    1571917719 |         0 |                0 | 5db1903caf077 |          31 | NULL                                                                                                |
|      2 |       1 | files                          | 45b963397aa40d4a0063e0d85e4fe7a1 |      1 | files             |        2 |        1 |   163 | 1571917716 |    1571917716 |         0 |                0 | 5db1903b916ac |          31 | NULL                                                                                                |
|      8 |       1 | thumbnails/5                   | 5a879f415920ad2c9f9ab5a8d20995d4 |      7 | 5                 |        2 |        1 | 41667 | 1571917884 |    1571917884 |         0 |                0 | 5db1903caf077 |          31 | NULL                                                                                                |
|     28 |       1 | thumbnails/5/32-32.png         | 755b8a586c4e8c3828ef7da2b6927128 |      8 | 32-32.png         |        6 |        5 |  1605 | 1571917884 |    1571917884 |         0 |                0 | 5db1903c93c93 |          27 | SHA1:6019a62cdb0ff021c18fa69444de71de021f6e80 MD5:ec07d20b2d2e0fdaec8a1e601d602c16 ADLER32:2b510ef2 |
|      5 |       1 | files/welcome.txt              | c49a144e772727f51b75705170e88a43 |      2 | welcome.txt       |        4 |        3 |   163 | 1571900185 |    1571917883 |         0 |                0 | 5db1903b8399c |          27 | SHA1:eeb2c08011374d8ad4e483a4938e1aa1007c089d MD5:368e3a6cb99f88c3543123931d786e21 ADLER32:c5ad3a63 |
|      1 |       1 |                                | d41d8cd98f00b204e9800998ecf8427e |     -1 |                   |        2 |        1 | 41830 | 1571917884 |    1571917716 |         0 |                0 | 5db1903caf077 |          31 | NULL                                                                                                |
+--------+---------+--------------------------------+----------------------------------+--------+-------------------+----------+----------+-------+------------+---------------+-----------+------------------+---------------+-------------+-----------------------------------------------------------------------------------------------------+
8 rows in set (0.00 sec)
```

## Related Issue
No issue opened

## Motivation and Context
There shouldn't be any version information handled by ownCloud because it's the objectstore responsibility.

## How Has This Been Tested?
Manually tested
1. Setup files_primary_s3 app as primary storage with multi-bucket support
2. Upload the same file multiple times to create multiple version
3. Check the oc_filecache table for information about versions (there shouldn't be any)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
