### PR TITLE
Acceptance tests: remember fed trusted servers only if it exists

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -653,6 +653,16 @@ trait AppConfiguration {
 		}
 		$this->usingServer($previousServer);
 		$this->currentUser = $user;
+	}
+
+	/**
+	 * Before Scenario to Save trusted Servers
+	 *
+	 * @BeforeScenario @federation-app-required
+	 *
+	 * @return void
+	 */
+	public function setInitialTrustedServersBeforeScenario() {
 		$this->initialTrustedServer = [
 			'LOCAL' => $this->getTrustedServers(),
 			'REMOTE' => $this->getTrustedServers('REMOTE')
@@ -662,12 +672,14 @@ trait AppConfiguration {
 	/**
 	 * After Scenario. restore trusted servers
 	 *
-	 * @AfterScenario
+	 * @AfterScenario @federation-app-required
 	 *
 	 * @return void
 	 */
 	public function restoreTrustedServersAfterScenario() {
-		$this->runFunctionOnEveryServer([$this, 'restoreTrustedServers']);
+		if ($this->federatedServerExists()) {
+			$this->runFunctionOnEveryServer([$this, 'restoreTrustedServers']);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingExternal/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUISharingExternal/adminSharingSettings.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend
+@webUI @insulated @federation-app-required @disablePreviews @TestAlsoOnExternalUserBackend
 Feature: Manage Trusted servers from the webUI
   As an administrator
   I want to add, view, delete and edit trusted servers from the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend
+@webUI @federation-app-required @insulated @disablePreviews @TestAlsoOnExternalUserBackend
 Feature: Federation Sharing - sharing with users on other cloud storages
   As a user
   I want to share files with any users on other cloud storages


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
In acceptance tests set initial trusted servers for remote servers while only running tests with federation server.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To reduce network calls while running acceptance tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
