### PR TITLE
Disallow sharing and deleting of share_folder and it's parents

### DIFF
--- a/changelog/unreleased/36337
+++ b/changelog/unreleased/36337
@@ -1,0 +1,11 @@
+Bugfix: Disallow sharing share_folder or it's parents, show share folder permission correctly.
+
+share_folder had share permission so it was possible for the user to share it along with some received shares.
+It caused weird behavior. So sharing share_folder (or any of it's parent folders) was prohibited.
+Deleting shared_folder was already prohibited, but, the server did not return the correct node permissions.
+This situation led to dysfunctionality in client sides. This problem fixed.
+
+https://github.com/owncloud/core/issues/36241
+https://github.com/owncloud/core/issues/36252
+https://github.com/owncloud/core/pull/36337
+https://github.com/owncloud/core/pull/36297

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -63,7 +63,7 @@ class Manager implements IMountManager {
 	 * Find the mount for $path
 	 *
 	 * @param string $path
-	 * @return MountPoint
+	 * @return MountPoint | null
 	 */
 	public function find($path) {
 		\OC_Util::setupFS();

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -8,7 +8,7 @@
  * @author Jesús Macias <jmacias@solidgear.es>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
- * @author karakayasemi <karakayasemi@itu.edu.tr>
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  * @author Klaas Freitag <freitag@owncloud.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Luke Policinski <lpolicinski@gmail.com>
@@ -353,9 +353,7 @@ class View {
 	public function rmdir($path) {
 		return $this->emittingCall(function () use (&$path) {
 			if ($path !== '') {
-				$shareFolder = \trim($this->config->getSystemValue('share_folder', '/'), '/');
-				$trimmedPath = \trim($path, '/');
-				if ((\strpos("$shareFolder/", "$trimmedPath/") === 0)) {
+				if ($this->isShareFolderOrShareFolderParent($path)) {
 					Util::writeLog("core", "The folder $path could not be deleted as it is configured as share_folder in config.", Util::WARN);
 					return false;
 				}
@@ -378,6 +376,24 @@ class View {
 			}
 			return $result;
 		}, ['before' => ['path' => $this->getAbsolutePath($path)], 'after' => ['path' => $this->getAbsolutePath($path)]], 'file', 'delete');
+	}
+
+	/**
+	 * Checks whether given path is a share folder or one of share folder parents
+	 *
+	 * @param $path - path relative to the files folder
+	 *
+	 * @return bool
+	 */
+	protected function isShareFolderOrShareFolderParent($path) {
+		$shareFolder = \trim($this->config->getSystemValue('share_folder', '/'), '/');
+		if ($shareFolder === '') {
+			return false;
+		}
+		$user = \OC_User::getUser();
+		$shareFolderAbsolutePath = "/$user/files/$shareFolder";
+		$trimmedAbsolutePath = $this->getAbsolutePath(\trim($path, '/'));
+		return $shareFolderAbsolutePath === $trimmedAbsolutePath || \strpos($shareFolderAbsolutePath, "$trimmedAbsolutePath/") === 0;
 	}
 
 	/**
@@ -1436,6 +1452,16 @@ class View {
 			if ($mount instanceof MoveableMount && $internalPath === '') {
 				$data['permissions'] |= \OCP\Constants::PERMISSION_DELETE;
 			}
+			try {
+				$itemPath = $this->getPath($data['fileid'], false);
+				$hasShareFolderInPath = $this->isShareFolderOrShareFolderParent($itemPath);
+			} catch (NotFoundException $e) {
+				$hasShareFolderInPath = false;
+			}
+			if ($hasShareFolderInPath) {
+				$data['permissions'] = $data['permissions'] & ~\OCP\Constants::PERMISSION_DELETE;
+				$data['permissions'] = $data['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
+			}
 
 			$owner = $this->getUserObjectForOwner($storage->getOwner($internalPath));
 			$info = new FileInfo($path, $storage, $internalPath, $data, $mount, $owner);
@@ -1504,8 +1530,18 @@ class View {
 				return (!\OC\Files\Filesystem::isForbiddenFileOrDir($content['path']));
 			});
 			$files = \array_map(function (ICacheEntry $content) use ($path, $storage, $mount, $sharingDisabled) {
-				if ($sharingDisabled) {
+				try {
+					$itemPath = $this->getPath($content['fileid'], false);
+					$hasShareFolderInPath = $this->isShareFolderOrShareFolderParent($itemPath);
+				} catch (NotFoundException $e) {
+					$hasShareFolderInPath = false;
+				}
+
+				if ($sharingDisabled || $hasShareFolderInPath) {
 					$content['permissions'] = $content['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
+				}
+				if ($hasShareFolderInPath) {
+					$content['permissions'] = $content['permissions'] & ~\OCP\Constants::PERMISSION_DELETE;
 				}
 				$owner = $this->getUserObjectForOwner($storage->getOwner($content['path']));
 				return new FileInfo($path . '/' . $content['name'], $storage, $content['path'], $content, $mount, $owner);
@@ -1774,7 +1810,10 @@ class View {
 		$id = (int)$id;
 		$manager = Filesystem::getMountManager();
 		$mounts = $manager->findIn($this->fakeRoot);
-		$mounts[] = $manager->find($this->fakeRoot);
+		$findResult = $manager->find($this->fakeRoot);
+		if ($findResult) {
+			$mounts[] = $findResult;
+		}
 		// reverse the array so we start with the storage this view is in
 		// which is the most likely to contain the file we're looking for
 		$mounts = \array_reverse($mounts);

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1440,3 +1440,17 @@ Feature: sharing
       | /randomfile.txt |
     And the content of file "randomfile.txt" for user "user2" should be "user0 file"
     And the content of file "randomfile.txt" for user "user1" should be "user0 file"
+
+  Scenario Outline: Do not allow sharing of the entire share_folder
+    Given using OCS API version "<ocs_api_version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "<share_folder>"
+    When user "user0" shares folder "/FOLDER" with user "user1" using the sharing API
+    And user "user1" unshares folder "ReceivedShares/FOLDER" using the WebDAV API
+    And user "user1" shares folder "/ReceivedShares" with user "user0" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code | share_folder    |
+      | 1               | 404             | 200              | /ReceivedShares |
+      | 2               | 404             | 404              | /ReceivedShares |

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -234,8 +234,7 @@ Feature: deleting files and folders
     When the user browses to the files page
     And the user deletes folder "<top_folder2>" using the webUI
     Then as "user1" folder "<top_folder2>" should not exist
-    When the user deletes folder "<top_share_folder_on_ui>" using the webUI
-    Then a notification should be displayed on the webUI with the text 'Error deleting file "<top_share_folder_on_ui>".'
+    And it should not be possible to delete folder "<top_share_folder_on_ui>" using the webUI
     And as "user1" folder "<share_folder>/ShareThis" should exist
     Examples:
       | share_folder        | top_share_folder_on_ui |other_folder1 | top_folder2 | other_folder2  |


### PR DESCRIPTION
## Description
Remove share and delete permission for `share_folder` . Since View's root is not persistent, we can not rely on the relative path of share folder when restricting share_folder actions. Because of this, the share folder is deletable via desktop client.
I changed the path comparison to absolute path, and remove  "share and delete" permission of share_folder.

## Related Issue
- Fixes #36241
- Fixes #36252

## Motivation and Context
The server shouldn't allow sharing and deleting the entire `share_folder`

## How Has This Been Tested?
Scenario 1:
1. Add share_folder into config.php
2. User1 shares a file with User2
3. User2 deletes the file from their account
4. User2 shares share_folder
5. User2 tries to delete share_folder via desktop client

### Actual result
- share_folder can be shared. Any new files which are added to that folder as newly received shares are not shared with the collaborators. But new files can be added via public links.
- share_folder deletable via desktop client

### Expected result
Sharing and deleting of share_folder should not be allowed in anyway.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)