### PR TITLE
Update jQuery-File-Upload from 9.18 to 9.34

### DIFF
--- a/changelog/unreleased/36343
+++ b/changelog/unreleased/36343
@@ -1,0 +1,6 @@
+Update: Update jQuery-File-Upload from 9.18 to 9.34
+
+Updated jQuery-File-Upload component to the v9.34 with fixed Edge garbage collection for huge files
+
+https://github.com/blueimp/jQuery-File-Upload/pull/3508
+https://github.com/owncloud/core/pull/36343


### PR DESCRIPTION
## Description
jQuery-File-Upload component update


## Motivation and Context
Better GC in Edge.
 See https://github.com/blueimp/jQuery-File-Upload/pull/3508

## How Has This Been Tested?
https://github.com/blueimp/jQuery-File-Upload/pull/3508#issue-195549318

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
