### PR TITLE
Acceptance tests: fix create share function to use correct permission on uploadwriteonly

### DIFF
--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -440,7 +440,7 @@ Feature: sharing
     Then the HTTP status code should be "403"
 
   @smokeTest @public_link_share-feature-required
-  Scenario: Uploading to a public upload-read-write and no edit and no overwrite share
+  Scenario: Uploading to a public upload-write and no edit and no overwrite share
     Given as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER          |
@@ -449,7 +449,7 @@ Feature: sharing
     Then the content of file "/FOLDER/test-old.txt" for user "user0" should be "test-old"
 
   @smokeTest @public_link_share-feature-required
-  Scenario: Uploading to a public upload-read-write and no edit and no overwrite share
+  Scenario: Uploading to a public upload-write and no edit and no overwrite share
     Given the administrator has enabled DAV tech_preview
     And as user "user0"
     And the user has created a public link share with settings
@@ -458,21 +458,37 @@ Feature: sharing
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "user0" should be "test-new"
 
-  @smokeTest @public_link_share-feature-required
-  Scenario Outline: Uploading same file to a public upload-read-write and no edit and no overwrite share multiple times
+  @smokeTest @public_link_share-feature-required @issue-36356
+  Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times
     Given the administrator has enabled DAV tech_preview
     And as user "user0"
     And the user has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
-    When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9]{1,32}"$/ |
-    When the public uploads file "test.txt" with content "test2" using the <public-webdav-api-version> public WebDAV API
+    When the public uploads file "test.txt" with content "test2" using the old public WebDAV API
+    # Uncomment these once the issue is fixed
+    # Then the HTTP status code should be "201"
+    # And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+    # And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
     Then the HTTP status code should be "403"
     And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
+
+  @smokeTest @public_link_share-feature-required
+  Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
+    And the user has created a public link share with settings
+      | path        | FOLDER          |
+      | permissions | uploadwriteonly |
+    When the public uploads file "test.txt" with content "test" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions
+      | ETag | /^"[a-f0-9]{1,32}"$/ |
+    When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+    And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -111,7 +111,7 @@ trait Sharing {
 		if (\in_array('uploadwriteonly', $permissions, true)) {
 			// remove 'uploadwriteonly' from $permissions
 			$permissions = \array_diff($permissions, ['uploadwriteonly']);
-			$permissions = \array_merge($permissions, ['create', 'read']);
+			$permissions = \array_merge($permissions, ['create']);
 		}
 		if (\in_array('change', $permissions, true)) {
 			// remove 'change' from $permissions
@@ -172,7 +172,7 @@ trait Sharing {
 	 *       |                 |     1 = read; 2 = update; 4 = create;               |
 	 *       |                 |     8 = delete; 16 = share; 31 = all                |
 	 *       |                 |     15 = change                                     |
-	 *       |                 |     5 = uploadwriteonly                             |
+	 *       |                 |     4 = uploadwriteonly                             |
 	 *       |                 |     (default: 31, for public shares: 1)             |
 	 *       |                 |     Pass either the (total) number,                 |
 	 *       |                 |     or the keyword,                                 |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
In acceptance tests the create share function added read permission in addition to create when we specify `uploadwriteonly` as permission string. this PR removes the read option and only keeps read as it acts as upload only public links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
