### PR TITLE
check share type when identifying identical shares

### DIFF
--- a/changelog/unreleased/36359
+++ b/changelog/unreleased/36359
@@ -1,0 +1,7 @@
+Bugfix: Fix sharing behavior to distinguish user and group having the same name.
+
+Sharing a node with user and group having the same name was impossible.
+This bug resolved with adding share type check for share creation controls.
+
+https://github.com/owncloud/core/issues/35488
+https://github.com/owncloud/core/pull/36359

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -241,7 +241,7 @@ class Manager implements IManager {
 			}
 		} else {
 			// We can't handle other types yet
-			throw new \InvalidArgumentException('unkown share type');
+			throw new \InvalidArgumentException('Unknown share type');
 		}
 
 		// Verify the initiator of the share is set
@@ -481,8 +481,7 @@ class Manager implements IManager {
 		 *
 		 * Also this is not what we want in the future.. then we want to squash identical shares.
 		 */
-		$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_USER);
-		$existingShares = $provider->getSharesByPath($share->getNode());
+		$existingShares = $this->getSharesByPath($share->getNode());
 		foreach ($existingShares as $existingShare) {
 			// Ignore if it is the same share
 			try {
@@ -493,13 +492,12 @@ class Manager implements IManager {
 				//Shares are not identical
 			}
 
-			// Identical share already existst
-			if ($existingShare->getSharedWith() === $share->getSharedWith()) {
-				throw new \Exception('Path already shared with this user');
-			}
-
-			// The share is already shared with this user via a group share
-			if ($existingShare->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			// Identical share already exist
+			if ($existingShare->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
+				if ($existingShare->getSharedWith() === $share->getSharedWith()) {
+					throw new \Exception('Path already shared with this user');
+				}
+			} elseif ($existingShare->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
 				$group = $this->groupManager->get($existingShare->getSharedWith());
 				if ($group !== null) {
 					$user = $this->userManager->get($share->getSharedWith());
@@ -538,8 +536,7 @@ class Manager implements IManager {
 		 *
 		 * Also this is not what we want in the future.. then we want to squash identical shares.
 		 */
-		$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_GROUP);
-		$existingShares = $provider->getSharesByPath($share->getNode());
+		$existingShares = $this->getSharesByPath($share->getNode());
 		foreach ($existingShares as $existingShare) {
 			try {
 				if ($existingShare->getFullId() === $share->getFullId()) {
@@ -549,7 +546,7 @@ class Manager implements IManager {
 				//It is a new share so just continue
 			}
 
-			if ($existingShare->getSharedWith() === $share->getSharedWith()) {
+			if ($existingShare->getShareType() === \OCP\Share::SHARE_TYPE_GROUP && $existingShare->getSharedWith() === $share->getSharedWith()) {
 				throw new \Exception('Path already shared with this group');
 			}
 		}

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1347,7 +1347,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-35488 @skipOnLDAP
+  @skipOnLDAP
   Scenario: creating a new share with user and a group having same name
     Given these users have been created without skeleton files:
       | username |
@@ -1358,23 +1358,16 @@ Feature: sharing
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     And user "user0" has shared file "randomfile.txt" with group "user1"
     When user "user0" shares file "randomfile.txt" with user "user1" using the sharing API
-    # Replace these lines when issue is fixed
-    # Then the OCS status code should be "100"
-    # And the HTTP status code should be "200"
-    Then the OCS status message should be:
-      """
-      Path already shared with this user
-      """
-    Then the OCS status code should be "403"
+    Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    # And user "user1" should see the following elements
-    #  | /randomfile.txt |
+    And user "user1" should see the following elements
+      | /randomfile.txt |
     And user "user2" should see the following elements
       | /randomfile.txt |
-    # And the content of file "randomfile.txt" for user "user1" should be "user0 file"
+    And the content of file "randomfile.txt" for user "user1" should be "user0 file"
     And the content of file "randomfile.txt" for user "user2" should be "user0 file"
 
-  @issue-35488 @skipOnLDAP
+  @skipOnLDAP
   Scenario: creating a new share with group and a user having same name
     Given these users have been created without skeleton files:
       | username |
@@ -1385,21 +1378,14 @@ Feature: sharing
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     And user "user0" has shared file "randomfile.txt" with user "user1"
     When user "user0" shares file "randomfile.txt" with group "user1" using the sharing API
-    # Replace these lines when issue is fixed
-    # Then the OCS status code should be "100"
-    # And the HTTP status code should be "200"
-    Then the OCS status message should be:
-      """
-      Path already shared with this group
-      """
-    Then the OCS status code should be "403"
+    Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    # And user "user2" should see the following elements
-    #  | /randomfile.txt |
     And user "user1" should see the following elements
       | /randomfile.txt |
-    # And the content of file "randomfile.txt" for user "user2" should be "user0 file"
+    And user "user2" should see the following elements
+      | /randomfile.txt |
     And the content of file "randomfile.txt" for user "user1" should be "user0 file"
+    And the content of file "randomfile.txt" for user "user2" should be "user0 file"
 
   @skipOnLDAP
   Scenario: creating a new share with user and a group having same name but different case

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -33,45 +33,43 @@ Feature: Sharing files and folders with internal groups
       | ?\?@#%@,; |
       | नेपाली    |
 
-  @issue-35488
   Scenario: Share file with a user and a group with same name
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
+      | user2    |
     And user "user3" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | user1     |
     And user "user1" has been added to group "user1"
+    And user "user2" has been added to group "user1"
     And user "user3" has logged in using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user shares folder "simple-folder" with group "user1" using the webUI
-    # Remove this after issue is fixed
-    Then a notification should be displayed on the webUI with the text "Path already shared with this group"
     When the user re-logs in as "user1" using the webUI
     Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
-    # Uncomment this line after issue is fixed
-    # And folder "simple-folder" should be marked as shared with "user1" by "User Three" on the webUI
+    When the user re-logs in as "user2" using the webUI
+    Then folder "simple-folder" should be marked as shared with "user1" by "User Three" on the webUI
 
-  @issue-35488
   Scenario: Share file with a group and a user with same name
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
+      | user2    |
     And user "user3" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | user1     |
     And user "user1" has been added to group "user1"
+    And user "user2" has been added to group "user1"
     And user "user3" has logged in using the webUI
     When the user shares folder "simple-folder" with group "user1" using the webUI
     And the user shares folder "simple-folder" with user "User One" using the webUI
-    # Remove this after issue is fixed
-    Then a notification should be displayed on the webUI with the text "Path already shared with this user"
     When the user re-logs in as "user1" using the webUI
+    Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
+    When the user re-logs in as "user2" using the webUI
     Then folder "simple-folder" should be marked as shared with "user1" by "User Three" on the webUI
-	# Uncomment this line after issue is fixed
-	# And folder "simple-folder" should be marked as shared with "User One" by "User Three" on the webUI
 
   Scenario: Share file with a user and again with a group with same name but different case
     Given these users have been created with default attributes and without skeleton files:
@@ -89,7 +87,7 @@ Feature: Sharing files and folders with internal groups
     When the user re-logs in as "user1" using the webUI
     Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
     When the user re-logs in as "user2" using the webUI
-    And folder "simple-folder" should be marked as shared with "User1" by "User Three" on the webUI
+    Then folder "simple-folder" should be marked as shared with "User1" by "User Three" on the webUI
 
   Scenario: Share file with a group and again with a user with same name but different case
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -785,7 +785,7 @@ class ManagerTest extends \Test\TestCase {
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, $user1, $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, $group0, $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
-			[$this->createShare(null, -1, $file, null, $user0, $user0, 31, null, null), 'unkown share type', true],
+			[$this->createShare(null, -1, $file, null, $user0, $user0, 31, null, null), 'Unknown share type', true],
 
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $file, $user1, null, $user0, 31, null, null), 'SharedBy should be set', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, $group0, null, $user0, 31, null, null), 'SharedBy should be set', true],
@@ -1205,14 +1205,15 @@ class ManagerTest extends \Test\TestCase {
 		$share  = $this->manager->newShare();
 		$share2 = $this->manager->newShare();
 
-		$sharedWith = $this->createMock('\OCP\IUser');
 		$path = $this->createMock('\OCP\Files\Node');
 
 		$share->setSharedWith('sharedWith')->setNode($path)
-			->setProviderId('foo')->setId('bar');
+			->setProviderId('foo')->setId('bar')
+			->setShareType(\OCP\Share::SHARE_TYPE_USER);
 
 		$share2->setSharedWith('sharedWith')->setNode($path)
-			->setProviderId('foo')->setId('baz');
+			->setProviderId('foo')->setId('baz')
+			->setShareType(\OCP\Share::SHARE_TYPE_USER);
 
 		$this->defaultProvider
 			->method('getSharesByPath')
@@ -1439,12 +1440,14 @@ class ManagerTest extends \Test\TestCase {
 
 		$path = $this->createMock('\OCP\Files\Node');
 		$share->setSharedWith('sharedWith')
+			->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
 			->setNode($path)
 			->setProviderId('foo')
 			->setId('bar');
 
 		$share2 = $this->manager->newShare();
 		$share2->setSharedWith('sharedWith')
+			->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
 			->setProviderId('foo')
 			->setId('baz');
 


### PR DESCRIPTION
## Description
To allow share with user and group having the same name, share type check added to share validations.

## Related Issue
- Fixes #35488 

## Motivation and Context
Fighting with bugs.

## How Has This Been Tested?
There are unit tests and acceptance tests that cover the related bug. Also, tried steps described in related issue description.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
