### PR TITLE
Add new regex config parameter version to blacklisted files and excluded directories

### DIFF
--- a/changelog/unreleased/36360
+++ b/changelog/unreleased/36360
@@ -1,0 +1,7 @@
+Enhancement: Regex version for blacklisted_files and excluded_directories
+
+Adds two config options blacklisted_files_regex and excluded_directories_regex to enable more flexible
+pattern matches. With this you can disable the upload of eg. exclude Microsoft Outlook .pst files or
+creation of directories containg eg. <yourdate>_backup.
+
+https://github.com/owncloud/core/pull/36360

--- a/changelog/unreleased/36360
+++ b/changelog/unreleased/36360
@@ -1,7 +1,8 @@
 Enhancement: Regex version for blacklisted_files and excluded_directories
 
-Adds two config options blacklisted_files_regex and excluded_directories_regex to enable more flexible
-pattern matches. With this you can disable the upload of eg. exclude Microsoft Outlook .pst files or
-creation of directories containg eg. <yourdate>_backup.
+Adds two config options blacklisted_files_regex and excluded_directories_regex
+to enable more flexible pattern matches. With this you can, for example, disable
+the upload of Microsoft Outlook .pst files or the creation of directories
+containing <yourdate>_backup.
 
 https://github.com/owncloud/core/pull/36360

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1276,9 +1276,21 @@ $CONFIG = [
   ],
 
 /**
+ * Define blacklisted files regular expression(s)
+ * Blacklist files that match any of the given regular expressions and disallow
+ * the upload of those files. The matching is case-insensitive.
+ *
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ */
+'blacklisted_files_regex' => [
+	'.*\.ext',
+	'^somefilename.*'
+  ],
+
+/**
  * Define excluded directories
  * Exclude specific directory names and disallow scanning, creating and renaming
- * using these names. Case insensitive.
+ * using these names. The matching is case insensitive.
  * Excluded directory names are queried at any path part like at the beginning,
  * in the middle or at the end and will not be further processed if found.
  * Please see the documentation for details and examples.
@@ -1289,6 +1301,23 @@ $CONFIG = [
 'excluded_directories' => [
 	'.snapshot',
 	'~snapshot',
+  ],
+
+/**
+ * Define excluded directories regular expression(s)
+ * Exclude directory names that match any of the given regular expressions and
+ * disallow scanning, creating and renaming using these names. The matching is
+ * case insensitive.
+ * Excluded directory names are queried at any path part like at the beginning,
+ * in the middle or at the end and will not be further processed if found.
+ * Please see the documentation for details and examples.
+ * Use when the storage backend supports, e.g. snapshot directories to be excluded.
+ *
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ */
+'excluded_directories_regex' => [
+	'^backup.*',
+	'.*backup$',
   ],
 
 /**

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -625,49 +625,165 @@ class Filesystem {
 	}
 
 	/**
-	* Check if the directory path / file name contains a Blacklisted or Excluded name
+	* Regex error explanation.
+	* Check last regex validation error origin. Return a string describing error cause.
+	* @return string
+	* @see https://www.php.net/manual/function.preg-last-error.php
+	*/
+	private static function is_preg_error() {
+		$errors = [
+			PREG_NO_ERROR               => 'Code 0 : No errors',
+			PREG_INTERNAL_ERROR         => 'Code 1 : Internal PCRE error, most likely a syntax error',
+			PREG_BACKTRACK_LIMIT_ERROR  => 'Code 2 : Backtrack limit was exhausted',
+			PREG_RECURSION_LIMIT_ERROR  => 'Code 3 : Recursion limit was exhausted',
+			PREG_BAD_UTF8_ERROR         => 'Code 4 : The offset did not correspond to the begin of a valid UTF-8 code point',
+			PREG_BAD_UTF8_OFFSET_ERROR  => 'Code 5 : Malformed UTF-8 data',
+			PREG_JIT_STACKLIMIT_ERROR   => 'Code 6 : Just-in-time compiler stack limit reached',
+		];
+		return $errors[\preg_last_error()];
+	}
+
+	/**
+	 * Regex validity check.
+	 * @param string $regexToBeChecked regex to be checked
+	 * @param string $callerMessage message from the calling function to identify where is coming from
+	 * @return boolean
+	 */
+	private static function regexValidityCheck($regexToBeChecked, $callerMessage='') {
+		if (\preg_last_error() !== PREG_NO_ERROR) {
+			\OC::$server->getLogger()->error('Regex error: '.$regexToBeChecked
+					.' - '.$callerMessage.': '.self::is_preg_error(),
+					['app' => __CLASS__]);
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Manage regex against Folder or File.
+	 * @param array $regexList Regex array as defined in Config file
+	 * @param array $path Folder path or File contained in an array
+	 * @param string $callerMessage Message from the calling function to identify where a possible error it is coming from
+	 * @param string $msgRegexMatchError message given in log in case of invalid regex
+	 * @return boolean folder or file regex status
+	 */
+	private static function checkRegexAgainstFolderOrFile($regexList, $path, $callerMessage='') {
+		foreach ($regexList as $item) {                           // foreach given regex
+			// check if the first and last charachter is a '/' and add one if not
+			// terminate with i == case insensitive
+			$newItem=$item;
+			if (\substr($item, 0, 1) !== '/') {
+				$newItem = '/' . $item;
+			}
+			if (\substr($item, -1) !== '/') {
+				$newItem = $newItem . '/i';
+			} else {
+				$newItem = $newItem . 'i';
+			}
+			@\preg_match($newItem, null);                         // regex validity check
+			if (self::regexValidityCheck($item, $callerMessage)) {  // check if regex error occurred
+				foreach ($path as $path_part) {                   // foreach folder or file in given path
+					if (@\preg_match($newItem, $path_part)        // regex match item
+						&& self::regexValidityCheck($item,
+								'Checked string: '.$path_part)) { // check if regex error occurred
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	*
+	* Check if the directory path / file name contains a Blacklisted or Excluded name as defined in config.
 	* config.php parameter arrays can contain file names to be blacklisted or directory names to be excluded
-	* Blacklist ... files that may harm the owncloud environment like a foreign .htaccess file
+	* Blacklist ... files that may harm the owncloud environment like a foreign `.htaccess` file or other unwanted files
 	* Excluded  ... directories that are excluded from beeing further processed, like snapshot directories
-	* The parameter $ed is only used in conjunction with unit tests as we handover here the excluded
-	* directory name to be tested against. $ed and the query with can be redesigned if filesystem.php will get
+	* $ed and the query with can be redesigned if filesystem.php will get
 	* a constructor where it is then possible to define the excluded directory names for unit tests.
-	* @param string $FileOrDir
-	* @param array $ed
+	* @param string $FileOrDir is an array describing full folder path or full filename
+	* @param array $ed is only used in conjunction with unit tests as we handover here the blacklisted / excluded
+	* directory name to be tested against
 	* @return boolean
 	*/
 	public static function isForbiddenFileOrDir($FileOrDir, $ed = []) {
-		$excluded = [];
-		$blacklist = [];
+		$exclude_folders = [];
+		$exclude_folders_regex = [];
+		$blacklist_files = [];
+		$blacklist_files_regex = [];
+		$blacklist_array = [];
 		$path_parts = [];
 		$ppx = [];
-		$blacklist = \OC::$server->getSystemConfig()->getValue('blacklisted_files', ['.htaccess']);
+
+		// force blacklist/exclude arraylist/arrayRegex for unit tests
 		if ($ed) {
-			$excluded = $ed;
+			$exclude_folders = $ed;
+			$exclude_folders_regex = $ed;
+			$blacklist_files = $ed;
+			$blacklist_files_regex = $ed;
 		} else {
-			$excluded = \OC::$server->getSystemConfig()->getValue('excluded_directories', $ed);
+			$exclude_folders       = \OC::$server->getSystemConfig()->getValue('excluded_directories', []);
+			$exclude_folders_regex = \OC::$server->getSystemConfig()->getValue('excluded_directories_regex', []);
+			$blacklist_files       = \OC::$server->getSystemConfig()->getValue('blacklisted_files', ['.htaccess']);
+			$blacklist_files_regex = \OC::$server->getSystemConfig()->getValue('blacklisted_files_regex', []);
 		}
+
+		// empty array elements ('') will cause to run the code forever
+		// removes double or empty array elements and adds exact one '.htaccess' if not present.
+		// important, because if you define an empty config value, '.htaccess' will not be added...
+		// prevents misuse with a fake config value
+		$blacklist_files[] = '.htaccess';
+		$blacklist_files = \array_unique($blacklist_files);
+		$blacklist_files = \array_values(\array_filter($blacklist_files));
+		// removes double or empty array elements
+		$exclude_folders = \array_unique($exclude_folders);
+		$exclude_folders = \array_values(\array_filter($exclude_folders));
+		$exclude_folders_regex = \array_unique($exclude_folders_regex);
+		$exclude_folders_regex = \array_values(\array_filter($exclude_folders_regex));
+		$blacklist_files_regex = \array_unique($blacklist_files_regex);
+		$blacklist_files_regex = \array_values(\array_filter($blacklist_files_regex));
+
 		// explode '/'
 		$ppx = \array_filter(\explode('/', $FileOrDir), 'strlen');
 		$ppx = \array_map('strtolower', $ppx);
+
 		// further explode each array element with '\' and add to result array if found
 		foreach ($ppx as $pp) {
 			// only add an array element if strlen != 0
 			$path_parts = \array_merge($path_parts, \array_filter(\explode('\\', $pp), 'strlen'));
 		}
-		if ($excluded) {
-			$excluded = \array_map('trim', $excluded);
-			$excluded = \array_map('strtolower', $excluded);
-			$match = \array_intersect($path_parts, $excluded);
-			if ($match) {
+
+		// force that the last element (possible the filename) is an array
+		// this is necessary for the called function which expects an array
+		$blacklist_array[] = \end($path_parts);
+
+		// first, check if the folder is excluded
+		if (isset($exclude_folders)) {
+			$exclude_folders= \array_map('trim', $exclude_folders);
+			$exclude_folders= \array_map('strtolower', $exclude_folders);
+			if (\array_intersect($exclude_folders, $path_parts)) {
 				return true;
 			}
 		}
-		$blacklist = \array_map('trim', $blacklist);
-		$blacklist = \array_map('strtolower', $blacklist);
-		$match = \array_intersect($path_parts, $blacklist);
-		if ($match) {
-			return true;
+		if (isset($exclude_folders_regex)) {
+			if (self::checkRegexAgainstFolderOrFile($exclude_folders_regex, $path_parts,
+					"Check excluded_directories_regex variable in config file")) {
+				return true;
+			}
+		}
+
+		// second, check if the file is blacklisted
+		if (isset($blacklist_files)) {
+			if (\array_intersect($blacklist_files, $blacklist_array)) {
+				return true;
+			}
+		}
+		if (isset($blacklist_files_regex)) {
+			if (self::checkRegexAgainstFolderOrFile($blacklist_files_regex, $blacklist_array,
+					"Check blacklisted_files_regex variable in config file")) {
+				return true;
+			}
 		}
 		return false;
 	}

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -248,12 +248,12 @@ Feature: move (rename) file
       | filename.ext                           | 403       | no     |
       | bannedfilename.txt                     | 403       | no     |
       | containsbannedstring                   | 403       | no     |
-      | this-containsbannedstring.txt          | 403       | no     |
+      | this-ContainsBannedString.txt          | 403       | no     |
       | /FOLDER/.ext                           | 403       | no     |
       | /FOLDER/filename.ext                   | 403       | no     |
       | /FOLDER/bannedfilename.txt             | 403       | no     |
       | /FOLDER/containsbannedstring           | 403       | no     |
-      | /FOLDER/this-containsbannedstring.txt  | 403       | no     |
+      | /FOLDER/this-ContainsBannedString.txt  | 403       | no     |
       | .extension                             | 201       | yes    |
       | filename.txt                           | 201       | yes    |
       | bannedfilename                         | 201       | yes    |

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -237,6 +237,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+  @skipOnOcV10.3
   Scenario Outline: rename a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
@@ -289,6 +290,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+  @skipOnOcV10.3
   Scenario Outline: rename a file to a filename that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -237,6 +237,38 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+  Scenario Outline: rename a file to a filename that matches (or not) blacklisted_files_regex
+    Given using <dav_version> DAV path
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" moves file "/welcome.txt" to these filenames using the webDAV API then the results should be as listed
+      | filename                               | http-code | exists |
+      | .ext                                   | 403       | no     |
+      | filename.ext                           | 403       | no     |
+      | bannedfilename.txt                     | 403       | no     |
+      | containsbannedstring                   | 403       | no     |
+      | this-containsbannedstring.txt          | 403       | no     |
+      | /FOLDER/.ext                           | 403       | no     |
+      | /FOLDER/filename.ext                   | 403       | no     |
+      | /FOLDER/bannedfilename.txt             | 403       | no     |
+      | /FOLDER/containsbannedstring           | 403       | no     |
+      | /FOLDER/this-containsbannedstring.txt  | 403       | no     |
+      | .extension                             | 201       | yes    |
+      | filename.txt                           | 201       | yes    |
+      | bannedfilename                         | 201       | yes    |
+      | bannedfilenamewithoutdot               | 201       | yes    |
+      | not-contains-banned-string.txt         | 201       | yes    |
+      | /FOLDER/.extension                     | 201       | yes    |
+      | /FOLDER/filename.txt                   | 201       | yes    |
+      | /FOLDER/bannedfilename                 | 201       | yes    |
+      | /FOLDER/bannedfilenamewithoutdot       | 201       | yes    |
+      | /FOLDER/not-contains-banned-string.txt | 201       | yes    |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   Scenario Outline: rename a file to an excluded directory name
     Given using <dav_version> DAV path
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
@@ -252,6 +284,40 @@ Feature: move (rename) file
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "user0" moves file "/welcome.txt" to "/FOLDER/.github" using the WebDAV API
     Then the HTTP status code should be "403"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: rename a file to a filename that matches (or not) excluded_directories_regex
+    Given using <dav_version> DAV path
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" moves file "/welcome.txt" to these filenames using the webDAV API then the results should be as listed
+      | filename                                   | http-code | exists |
+      | endswith.bad                               | 403       | no     |
+      | thisendswith.bad                           | 403       | no     |
+      | .git                                       | 403       | no     |
+      | .github                                    | 403       | no     |
+      | containsvirusinthename                     | 403       | no     |
+      | this-containsvirusinthename.txt            | 403       | no     |
+      | /FOLDER/endswith.bad                       | 403       | no     |
+      | /FOLDER/thisendswith.bad                   | 403       | no     |
+      | /FOLDER/.git                               | 403       | no     |
+      | /FOLDER/.github                            | 403       | no     |
+      | /FOLDER/containsvirusinthename             | 403       | no     |
+      | /FOLDER/this-containsvirusinthename.txt    | 403       | no     |
+      | endswith.badandotherstuff                  | 201       | yes    |
+      | thisendswith.badandotherstuff              | 201       | yes    |
+      | name.git                                   | 201       | yes    |
+      | name.github                                | 201       | yes    |
+      | not-contains-virus-in-the-name.txt         | 201       | yes    |
+      | /FOLDER/endswith.badandotherstuff          | 201       | yes    |
+      | /FOLDER/thisendswith.badandotherstuff      | 201       | yes    |
+      | /FOLDER/name.git                           | 201       | yes    |
+      | /FOLDER/name.github                        | 201       | yes    |
+      | /FOLDER/not-contains-virus-in-the-name.txt | 201       | yes    |
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
@@ -160,12 +160,12 @@ Feature: move (rename) file
       | filename.ext                           | 403       | no     |
       | bannedfilename.txt                     | 403       | no     |
       | containsbannedstring                   | 403       | no     |
-      | this-containsbannedstring.txt          | 403       | no     |
+      | this-ContainsBannedString.txt          | 403       | no     |
       | /FOLDER/.ext                           | 403       | no     |
       | /FOLDER/filename.ext                   | 403       | no     |
       | /FOLDER/bannedfilename.txt             | 403       | no     |
       | /FOLDER/containsbannedstring           | 403       | no     |
-      | /FOLDER/this-containsbannedstring.txt  | 403       | no     |
+      | /FOLDER/this-ContainsBannedString.txt  | 403       | no     |
       | .extension                             | 202       | yes    |
       | filename.txt                           | 202       | yes    |
       | bannedfilename                         | 202       | yes    |

--- a/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
@@ -150,6 +150,7 @@ Feature: move (rename) file
     And user "user0" should see the following elements
       | /welcome.txt |
 
+  @skipOnOcV10.3
   Scenario: rename a file to a filename that matches (or not) blacklisted_files_regex
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -191,6 +192,7 @@ Feature: move (rename) file
     And user "user0" should see the following elements
       | /welcome.txt |
 
+  @skipOnOcV10.3
   Scenario: rename a file to a filename that matches (or not) excluded_directories_regex
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavMove/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFolder.feature
@@ -81,12 +81,12 @@ Feature: move (rename) folder
       | filename.ext                           | 403       | no     |
       | bannedfilename.txt                     | 403       | no     |
       | containsbannedstring                   | 403       | no     |
-      | this-containsbannedstring.txt          | 403       | no     |
+      | this-ContainsBannedString.txt          | 403       | no     |
       | /FOLDER/.ext                           | 403       | no     |
       | /FOLDER/filename.ext                   | 403       | no     |
       | /FOLDER/bannedfilename.txt             | 403       | no     |
       | /FOLDER/containsbannedstring           | 403       | no     |
-      | /FOLDER/this-containsbannedstring.txt  | 403       | no     |
+      | /FOLDER/this-ContainsBannedString.txt  | 403       | no     |
       | .extension                             | 201       | yes    |
       | filename.txt                           | 201       | yes    |
       | bannedfilename                         | 201       | yes    |

--- a/tests/acceptance/features/apiWebdavMove/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFolder.feature
@@ -69,6 +69,7 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
+  @skipOnOcV10.3
   Scenario Outline: rename a folder to a folder name that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     And user "user0" has created folder "/testshare"
@@ -128,6 +129,7 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
+  @skipOnOcV10.3
   Scenario Outline: rename a folder to a folder name that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     And user "user0" has created folder "/testshare"

--- a/tests/acceptance/features/apiWebdavMove/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFolder.feature
@@ -69,6 +69,39 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
+  Scenario Outline: rename a folder to a folder name that matches (or not) blacklisted_files_regex
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "/testshare"
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" moves folder "/testshare" to these foldernames using the webDAV API then the results should be as listed
+      | foldername                             | http-code | exists |
+      | .ext                                   | 403       | no     |
+      | filename.ext                           | 403       | no     |
+      | bannedfilename.txt                     | 403       | no     |
+      | containsbannedstring                   | 403       | no     |
+      | this-containsbannedstring.txt          | 403       | no     |
+      | /FOLDER/.ext                           | 403       | no     |
+      | /FOLDER/filename.ext                   | 403       | no     |
+      | /FOLDER/bannedfilename.txt             | 403       | no     |
+      | /FOLDER/containsbannedstring           | 403       | no     |
+      | /FOLDER/this-containsbannedstring.txt  | 403       | no     |
+      | .extension                             | 201       | yes    |
+      | filename.txt                           | 201       | yes    |
+      | bannedfilename                         | 201       | yes    |
+      | bannedfilenamewithoutdot               | 201       | yes    |
+      | not-contains-banned-string.txt         | 201       | yes    |
+      | /FOLDER/.extension                     | 201       | yes    |
+      | /FOLDER/filename.txt                   | 201       | yes    |
+      | /FOLDER/bannedfilename                 | 201       | yes    |
+      | /FOLDER/bannedfilenamewithoutdot       | 201       | yes    |
+      | /FOLDER/not-contains-banned-string.txt | 201       | yes    |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   Scenario Outline: Rename a folder to an excluded directory name
     Given using <dav_version> DAV path
     And user "user0" has created folder "/testshare"
@@ -90,6 +123,41 @@ Feature: move (rename) folder
     Then the HTTP status code should be "403"
     And user "user0" should see the following elements
       | /testshare/ |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: rename a folder to a folder name that matches (or not) excluded_directories_regex
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "/testshare"
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" moves folder "/testshare" to these foldernames using the webDAV API then the results should be as listed
+      | foldername                                 | http-code | exists |
+      | endswith.bad                               | 403       | no     |
+      | thisendswith.bad                           | 403       | no     |
+      | .git                                       | 403       | no     |
+      | .github                                    | 403       | no     |
+      | containsvirusinthename                     | 403       | no     |
+      | this-containsvirusinthename.txt            | 403       | no     |
+      | /FOLDER/endswith.bad                       | 403       | no     |
+      | /FOLDER/thisendswith.bad                   | 403       | no     |
+      | /FOLDER/.git                               | 403       | no     |
+      | /FOLDER/.github                            | 403       | no     |
+      | /FOLDER/containsvirusinthename             | 403       | no     |
+      | /FOLDER/this-containsvirusinthename.txt    | 403       | no     |
+      | endswith.badandotherstuff                  | 201       | yes    |
+      | thisendswith.badandotherstuff              | 201       | yes    |
+      | name.git                                   | 201       | yes    |
+      | name.github                                | 201       | yes    |
+      | not-contains-virus-in-the-name.txt         | 201       | yes    |
+      | /FOLDER/endswith.badandotherstuff          | 201       | yes    |
+      | /FOLDER/thisendswith.badandotherstuff      | 201       | yes    |
+      | /FOLDER/name.git                           | 201       | yes    |
+      | /FOLDER/name.github                        | 201       | yes    |
+      | /FOLDER/not-contains-virus-in-the-name.txt | 201       | yes    |
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
@@ -98,6 +98,38 @@ Feature: upload file
       | old         |
       | new         |
 
+  Scenario Outline: upload a file to a filename that matches (or not) blacklisted_files_regex
+    Given using <dav_version> DAV path
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" uploads to these filenames with content "uploaded content" using the webDAV API then the results should be as listed
+      | filename                               | http-code | exists |
+      | .ext                                   | 403       | no     |
+      | filename.ext                           | 403       | no     |
+      | bannedfilename.txt                     | 403       | no     |
+      | containsbannedstring                   | 403       | no     |
+      | this-containsbannedstring.txt          | 403       | no     |
+      | /FOLDER/.ext                           | 403       | no     |
+      | /FOLDER/filename.ext                   | 403       | no     |
+      | /FOLDER/bannedfilename.txt             | 403       | no     |
+      | /FOLDER/containsbannedstring           | 403       | no     |
+      | /FOLDER/this-containsbannedstring.txt  | 403       | no     |
+      | .extension                             | 201       | yes    |
+      | filename.txt                           | 201       | yes    |
+      | bannedfilename                         | 201       | yes    |
+      | bannedfilenamewithoutdot               | 201       | yes    |
+      | not-contains-banned-string.txt         | 201       | yes    |
+      | /FOLDER/.extension                     | 201       | yes    |
+      | /FOLDER/filename.txt                   | 201       | yes    |
+      | /FOLDER/bannedfilename                 | 201       | yes    |
+      | /FOLDER/bannedfilenamewithoutdot       | 201       | yes    |
+      | /FOLDER/not-contains-banned-string.txt | 201       | yes    |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   Scenario Outline: upload a file to an excluded directory name
     Given using <dav_version> DAV path
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
@@ -116,6 +148,40 @@ Feature: upload file
     Then the HTTP status code should be "403"
     And as "user0" folder "/FOLDER" should exist
     But as "user0" file "/FOLDER/.github" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: upload a file to a filename that matches (or not) excluded_directories_regex
+    Given using <dav_version> DAV path
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" uploads to these filenames with content "uploaded content" using the webDAV API then the results should be as listed
+      | filename                                   | http-code | exists |
+      | endswith.bad                               | 403       | no     |
+      | thisendswith.bad                           | 403       | no     |
+      | .git                                       | 403       | no     |
+      | .github                                    | 403       | no     |
+      | containsvirusinthename                     | 403       | no     |
+      | this-containsvirusinthename.txt            | 403       | no     |
+      | /FOLDER/endswith.bad                       | 403       | no     |
+      | /FOLDER/thisendswith.bad                   | 403       | no     |
+      | /FOLDER/.git                               | 403       | no     |
+      | /FOLDER/.github                            | 403       | no     |
+      | /FOLDER/containsvirusinthename             | 403       | no     |
+      | /FOLDER/this-containsvirusinthename.txt    | 403       | no     |
+      | endswith.badandotherstuff                  | 201       | yes    |
+      | thisendswith.badandotherstuff              | 201       | yes    |
+      | name.git                                   | 201       | yes    |
+      | name.github                                | 201       | yes    |
+      | not-contains-virus-in-the-name.txt         | 201       | yes    |
+      | /FOLDER/endswith.badandotherstuff          | 201       | yes    |
+      | /FOLDER/thisendswith.badandotherstuff      | 201       | yes    |
+      | /FOLDER/name.git                           | 201       | yes    |
+      | /FOLDER/name.github                        | 201       | yes    |
+      | /FOLDER/not-contains-virus-in-the-name.txt | 201       | yes    |
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
@@ -109,12 +109,12 @@ Feature: upload file
       | filename.ext                           | 403       | no     |
       | bannedfilename.txt                     | 403       | no     |
       | containsbannedstring                   | 403       | no     |
-      | this-containsbannedstring.txt          | 403       | no     |
+      | this-ContainsBannedString.txt          | 403       | no     |
       | /FOLDER/.ext                           | 403       | no     |
       | /FOLDER/filename.ext                   | 403       | no     |
       | /FOLDER/bannedfilename.txt             | 403       | no     |
       | /FOLDER/containsbannedstring           | 403       | no     |
-      | /FOLDER/this-containsbannedstring.txt  | 403       | no     |
+      | /FOLDER/this-ContainsBannedString.txt  | 403       | no     |
       | .extension                             | 201       | yes    |
       | filename.txt                           | 201       | yes    |
       | bannedfilename                         | 201       | yes    |

--- a/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFile.feature
@@ -98,6 +98,7 @@ Feature: upload file
       | old         |
       | new         |
 
+  @skipOnOcV10.3
   Scenario Outline: upload a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
@@ -153,6 +154,7 @@ Feature: upload file
       | old         |
       | new         |
 
+  @skipOnOcV10.3
   Scenario Outline: upload a file to a filename that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
@@ -162,6 +162,7 @@ Feature: upload file using new chunking
     Then the HTTP status code should be "403"
     And as "user0" file "/blacklisted-file.txt" should not exist
 
+  @skipOnOcV10.3
   Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -179,6 +180,7 @@ Feature: upload file using new chunking
       | bannedfilename.txt            |
       | this-ContainsBannedString.txt |
 
+  @skipOnOcV10.3
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -212,6 +214,7 @@ Feature: upload file using new chunking
     And as "user0" folder "/FOLDER" should exist
     But as "user0" file "/FOLDER/.github" should not exist
 
+  @skipOnOcV10.3
   Scenario Outline: upload a file to a filename that matches excluded_directories_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
@@ -229,6 +232,7 @@ Feature: upload file using new chunking
       | .github                         |
       | this-containsvirusinthename.txt |
 
+  @skipOnOcV10.3
   Scenario: upload a file to a filename that does not match excluded_directories_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
@@ -162,6 +162,35 @@ Feature: upload file using new chunking
     Then the HTTP status code should be "403"
     And as "user0" file "/blacklisted-file.txt" should not exist
 
+  Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using new chunking and async MOVE
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    Given the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" asynchronously to "<filename>" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" file "<filename>" should not exist
+    Examples:
+      | filename                      |
+      | filename.ext                  |
+      | bannedfilename.txt            |
+      | this-containsbannedstring.txt |
+
+  Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking and async MOVE
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    Given the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" asynchronously to "not-contains-banned-string.txt" using the WebDAV API
+    Then the HTTP status code should be "202"
+    And as "user0" file "not-contains-banned-string.txt" should exist
+
   Scenario: Upload to an excluded directory name using new chunking and async MOVE
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -182,6 +211,35 @@ Feature: upload file using new chunking
     Then the HTTP status code should be "403"
     And as "user0" folder "/FOLDER" should exist
     But as "user0" file "/FOLDER/.github" should not exist
+
+  Scenario Outline: upload a file to a filename that matches excluded_directories_regex using new chunking and async MOVE
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    Given the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" asynchronously to "<filename>" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" file "<filename>" should not exist
+    Examples:
+      | filename                        |
+      | thisendswith.bad                |
+      | .github                         |
+      | this-containsvirusinthename.txt |
+
+  Scenario: upload a file to a filename that does not match excluded_directories_regex using new chunking and async MOVE
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    Given the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" asynchronously to "not-contains-virus-in-the-name.txt" using the WebDAV API
+    Then the HTTP status code should be "202"
+    And as "user0" file "not-contains-virus-in-the-name.txt" should exist
 
   Scenario: disabled async operations leads to original behavior
     Given the administrator has disabled async operations

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileAsyncUsingNewChunking.feature
@@ -177,7 +177,7 @@ Feature: upload file using new chunking
       | filename                      |
       | filename.ext                  |
       | bannedfilename.txt            |
-      | this-containsbannedstring.txt |
+      | this-ContainsBannedString.txt |
 
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
@@ -177,6 +177,7 @@ Feature: upload file using new chunking
     Then the HTTP status code should be "403"
     And as "user0" file "blacklisted-file.txt" should not exist
 
+  @skipOnOcV10.3
   Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -194,6 +195,7 @@ Feature: upload file using new chunking
       | bannedfilename.txt            |
       | this-ContainsBannedString.txt |
 
+  @skipOnOcV10.3
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -227,6 +229,7 @@ Feature: upload file using new chunking
     And as "user0" folder "/FOLDER" should exist
     But as "user0" file "/FOLDER/.github" should not exist
 
+  @skipOnOcV10.3
   Scenario Outline: upload a file to a filename that matches excluded_directories_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
@@ -244,6 +247,7 @@ Feature: upload file using new chunking
       | .github                         |
       | this-containsvirusinthename.txt |
 
+  @skipOnOcV10.3
   Scenario: upload a file to a filename that does not match excluded_directories_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
@@ -192,7 +192,7 @@ Feature: upload file using new chunking
       | filename                      |
       | filename.ext                  |
       | bannedfilename.txt            |
-      | this-containsbannedstring.txt |
+      | this-ContainsBannedString.txt |
 
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingNewChunking.feature
@@ -177,6 +177,35 @@ Feature: upload file using new chunking
     Then the HTTP status code should be "403"
     And as "user0" file "blacklisted-file.txt" should not exist
 
+  Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using new chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    Given the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "<filename>" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" file "<filename>" should not exist
+    Examples:
+      | filename                      |
+      | filename.ext                  |
+      | bannedfilename.txt            |
+      | this-containsbannedstring.txt |
+
+  Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    Given the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "not-contains-banned-string.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "not-contains-banned-string.txt" should exist
+
   Scenario: Upload a file to an excluded directory name using new chunking
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -197,3 +226,32 @@ Feature: upload file using new chunking
     Then the HTTP status code should be "403"
     And as "user0" folder "/FOLDER" should exist
     But as "user0" file "/FOLDER/.github" should not exist
+
+  Scenario Outline: upload a file to a filename that matches excluded_directories_regex using new chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    Given the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "<filename>" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" file "<filename>" should not exist
+    Examples:
+      | filename                        |
+      | thisendswith.bad                |
+      | .github                         |
+      | this-containsvirusinthename.txt |
+
+  Scenario: upload a file to a filename that does not match excluded_directories_regex using new chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    Given the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "not-contains-virus-in-the-name.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "not-contains-virus-in-the-name.txt" should exist

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
@@ -94,7 +94,7 @@ Feature: upload file using old chunking
     #Then the HTTP status code should be "403"
     And as "user0" file "blacklisted-file.txt" should not exist
 
-  @issue-36645
+  @skipOnOcV10.3 @issue-36645
   Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -108,6 +108,7 @@ Feature: upload file using old chunking
       | bannedfilename.txt            | 403         | ok          |
       | this-ContainsBannedString.txt | 403         | ok          |
 
+  @skipOnOcV10.3
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -133,7 +134,7 @@ Feature: upload file using old chunking
     And as "user0" folder "/FOLDER" should exist
     But as "user0" file "/FOLDER/.github" should not exist
 
-  @issue-36645
+  @skipOnOcV10.3 @issue-36645
   Scenario Outline: upload a file to a filename that matches excluded_directories_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
@@ -147,6 +148,7 @@ Feature: upload file using old chunking
       | .github                         | 403         | ok          |
       | this-containsvirusinthename.txt | 403         | ok          |
 
+  @skipOnOcV10.3
   Scenario: upload a file to a filename that does not match excluded_directories_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
@@ -95,6 +95,28 @@ Feature: upload file using old chunking
     And as "user0" file "blacklisted-file.txt" should not exist
 
   @issue-36645
+  Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using old chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    Given the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "<filename>" in 3 chunks using the WebDAV API
+    Then the HTTP status code should be "<http-status>"
+    And as "user0" file "<filename>" should not exist
+    Examples:
+      | filename                      | http-status | comment     |
+      | filename.ext                  | 507         | issue-36645 |
+      | bannedfilename.txt            | 403         | ok          |
+      | this-containsbannedstring.txt | 403         | ok          |
+
+  Scenario: upload a file to a filename that does not match blacklisted_files_regex using old chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    Given the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "not-contains-banned-string.txt" in 3 chunks using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "not-contains-banned-string.txt" should exist
+
+  @issue-36645
   Scenario: Upload a file to an excluded directory name using old chunking
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "user0" uploads file "filesForUpload/textfile.txt" to "/.github" in 3 chunks using the WebDAV API
@@ -110,3 +132,25 @@ Feature: upload file using old chunking
     #Then the HTTP status code should be "403"
     And as "user0" folder "/FOLDER" should exist
     But as "user0" file "/FOLDER/.github" should not exist
+
+  @issue-36645
+  Scenario Outline: upload a file to a filename that matches excluded_directories_regex using old chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    Given the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "<filename>" in 3 chunks using the WebDAV API
+    Then the HTTP status code should be "<http-status>"
+    And as "user0" file "<filename>" should not exist
+    Examples:
+      | filename                        | http-status | comment     |
+      | thisendswith.bad                | 507         | issue-36645 |
+      | .github                         | 403         | ok          |
+      | this-containsvirusinthename.txt | 403         | ok          |
+
+  Scenario: upload a file to a filename that does not match excluded_directories_regex using old chunking
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    Given the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    When user "user0" uploads file "filesForUpload/textfile.txt" to "not-contains-virus-in-the-name.txt" in 3 chunks using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" file "not-contains-virus-in-the-name.txt" should exist

--- a/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload/uploadFileUsingOldChunking.feature
@@ -106,7 +106,7 @@ Feature: upload file using old chunking
       | filename                      | http-status | comment     |
       | filename.ext                  | 507         | issue-36645 |
       | bannedfilename.txt            | 403         | ok          |
-      | this-containsbannedstring.txt | 403         | ok          |
+      | this-ContainsBannedString.txt | 403         | ok          |
 
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -123,7 +123,7 @@ Feature: rename files
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | filename.ext                  |
       | bannedfilename.txt            |
-      | this-containsbannedstring.txt |
+      | this-ContainsBannedString.txt |
     Then notifications should be displayed on the webUI with the text
       | Could not rename "randomfile.txt" |
       | Could not rename "randomfile.txt" |

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -114,6 +114,22 @@ Feature: rename files
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 
+  Scenario: Rename a file to a filename that matches (or not) blacklisted_files_regex
+    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    And user "user1" has logged in using the webUI
+    When the user renames file "randomfile.txt" to one of these names using the webUI
+      | filename.ext                  |
+      | bannedfilename.txt            |
+      | this-containsbannedstring.txt |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "randomfile.txt" |
+      | Could not rename "randomfile.txt" |
+      | Could not rename "randomfile.txt" |
+    And file "randomfile.txt" should be listed on the webUI
+
   Scenario: Rename a file to an excluded folder name
     Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
@@ -133,6 +149,22 @@ Feature: rename files
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | .github |
     Then notifications should be displayed on the webUI with the text
+      | Could not rename "randomfile.txt" |
+    And file "randomfile.txt" should be listed on the webUI
+
+  Scenario: Rename a file to a filename that matches (or not) excluded_directories_regex
+    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    And user "user1" has logged in using the webUI
+    When the user renames file "randomfile.txt" to one of these names using the webUI
+      | thisendswith.bad                |
+      | .github                         |
+      | this-containsvirusinthename.txt |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "randomfile.txt" |
+      | Could not rename "randomfile.txt" |
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -114,6 +114,7 @@ Feature: rename files
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: Rename a file to a filename that matches (or not) blacklisted_files_regex
     Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
@@ -152,6 +153,7 @@ Feature: rename files
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: Rename a file to a filename that matches (or not) excluded_directories_regex
     Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -96,6 +96,7 @@ Feature: rename folders
       | Could not rename "a-folder" |
     And folder "a-folder" should be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: Rename a folder to a foldername that matches (or not) blacklisted_files_regex
     Given user "user1" has created folder "a-folder"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
@@ -134,6 +135,7 @@ Feature: rename folders
       | Could not rename "a-folder" |
     And folder "a-folder" should be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: Rename a folder to a foldername that matches (or not) excluded_directories_regex
     Given user "user1" has created folder "a-folder"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -105,7 +105,7 @@ Feature: rename folders
     When the user renames folder "a-folder" to one of these names using the webUI
       | filename.ext                  |
       | bannedfilename.txt            |
-      | this-containsbannedstring.txt |
+      | this-ContainsBannedString.txt |
     Then notifications should be displayed on the webUI with the text
       | Could not rename "a-folder" |
       | Could not rename "a-folder" |

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -96,6 +96,22 @@ Feature: rename folders
       | Could not rename "a-folder" |
     And folder "a-folder" should be listed on the webUI
 
+  Scenario: Rename a folder to a foldername that matches (or not) blacklisted_files_regex
+    Given user "user1" has created folder "a-folder"
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
+    And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    And user "user1" has logged in using the webUI
+    When the user renames folder "a-folder" to one of these names using the webUI
+      | filename.ext                  |
+      | bannedfilename.txt            |
+      | this-containsbannedstring.txt |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "a-folder" |
+      | Could not rename "a-folder" |
+      | Could not rename "a-folder" |
+    And folder "a-folder" should be listed on the webUI
+
   Scenario: Rename a folder to an excluded folder name
     Given user "user1" has created folder "a-folder"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
@@ -115,6 +131,22 @@ Feature: rename folders
     When the user renames folder "a-folder" to one of these names using the webUI
       | .github            |
     Then notifications should be displayed on the webUI with the text
+      | Could not rename "a-folder" |
+    And folder "a-folder" should be listed on the webUI
+
+  Scenario: Rename a folder to a foldername that matches (or not) excluded_directories_regex
+    Given user "user1" has created folder "a-folder"
+    # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
+    # The actual regular expressions end up being endswith\.bad$ and ^\.git
+    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    And user "user1" has logged in using the webUI
+    When the user renames folder "a-folder" to one of these names using the webUI
+      | thisendswith.bad                |
+      | .github                         |
+      | this-containsvirusinthename.txt |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "a-folder" |
+      | Could not rename "a-folder" |
       | Could not rename "a-folder" |
     And folder "a-folder" should be listed on the webUI
 

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -273,7 +273,30 @@ class FilesystemTest extends TestCase {
 	 * @dataProvider isFileBlacklistedData
 	 */
 	public function testIsFileBlacklisted($path, $expected) {
-		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path));
+		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path, ['.htaccess']));
+	}
+
+	public function isFileBlacklistedDataRegex() {
+		return [
+			['/etc/foo/outlook.ptt',      [ '.*\.pst$', '.*dummy.*', '^sample.*', ], false],
+			['/etc/foo/outlook.pst',      [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
+			['/etc/foo/outlook.PST',      [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
+			['/toto.txt',                 [ '.*\.pst$', '.*dummy.*', '^sample.*', ], false],
+			['/etc/toto.txt',             [ '.*\.pst$', '.*dummy.*', '^sample.*', ], false],
+			['/etc/foo/machin.txt',       [ '.*\.pst$', '.*dummy.*', '^sample.*', ], false],
+			['/etc/dummy/machin.chose',   [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
+			['/etc/foo/dummy_machin.txt', [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
+			['/etc/foo/dUMMy_machin.txt', [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
+			['/etc/foo/sample.txt',       [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
+			['/sample.pst',               [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
+		];
+	}
+
+	/**
+	 * @dataProvider isFileBlacklistedDataRegex
+	 */
+	public function testIsFileBlacklistedRegex($path, $regex, $expected) {
+		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path, $regex));
 	}
 
 	public function isExcludedData() {
@@ -297,6 +320,31 @@ class FilesystemTest extends TestCase {
 	 */
 	public function testIsExcluded($path, $expected) {
 		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path, ['.snapshot']));
+	}
+
+	public function isExcludedDataRegex() {
+		return [
+			['/backup',               [ '.*backup.*', 'Thomas.*', ], true],
+			['/_backup',              [ '.*backup.*', 'Thomas.*', ], true],
+			['/backup_',              [ '.*backup.*', 'Thomas.*', ], true],
+			['/foo/backup/bar',       [ '.*backup.*', 'Thomas.*', ], true],
+			['/foo/baCKup/bar',       [ '.*backup.*', 'Thomas.*', ], true],
+			['/foo/bac.kup/bar',      [ '.*backup.*', 'Thomas.*', ], false],
+			['/ThomasFolder',         [ '.*backup.*', 'Thomas.*', ], true],
+			['/thomasFolder',         [ '.*backup.*', 'Thomas.*', ], true],
+			['/foo/_Thomas/Files',    [ '.*backup.*', 'Thomas.*', ], true],
+			['/foo/ThomasFoo/Files',  [ '.*backup.*', 'Thomas.*', ], true],
+			['/foo/_ThomasFoo/Files', [ '.*backup.*', 'Thomas.*', ], true],
+		];
+	}
+
+	/**
+	 * The parameter array can be redesigned if filesystem.php will get a constructor where it is possible to
+	 * define the excluded directories for unit tests
+	 * @dataProvider isExcludedDataRegex
+	 */
+	public function testIsExcludedRegex($path, $regex, $expected) {
+		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path, $regex));
 	}
 
 	public function testNormalizePathUTF8() {

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -276,7 +276,7 @@ class FilesystemTest extends TestCase {
 		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path, ['.htaccess']));
 	}
 
-	public function isFileBlacklistedDataRegex() {
+	public function isFileBlacklistedRegexData() {
 		return [
 			['/etc/foo/outlook.ptt',      [ '.*\.pst$', '.*dummy.*', '^sample.*', ], false],
 			['/etc/foo/outlook.pst',      [ '.*\.pst$', '.*dummy.*', '^sample.*', ], true],
@@ -293,7 +293,7 @@ class FilesystemTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider isFileBlacklistedDataRegex
+	 * @dataProvider isFileBlacklistedRegexData
 	 */
 	public function testIsFileBlacklistedRegex($path, $regex, $expected) {
 		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path, $regex));


### PR DESCRIPTION
This PR is based on the work of @tdaget at PR https://github.com/owncloud/core/pull/36331 (closed)
The referenced PR is now closed because of rebasing issues and CI will never get green there.
I improved the original work a bit.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR enhances the existing config parameters `blacklisted_files` and `excluded_directories` by a new regex parameter version `blacklisted_files_regex` and `excluded_directories_regex`. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- No issue related

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes it is necessary to exclude/blacklist files or directories to be written/renamed/scanned on a more complex parameter than a static version as we have right now. This PR allows eg. to prevent uploading Microsoft Outlook .pst files or creating / renaming / scanning directories based on a pattern defined by a regex. The existing parameters are not touched.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running local with various scenarios successfully.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: Not necessary as doc is part of config.sample.php 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
