### PR TITLE
use empty control when trying to get existing home in user sync

### DIFF
--- a/changelog/unreleased/36365
+++ b/changelog/unreleased/36365
@@ -1,0 +1,8 @@
+Bugfix: Do not create error log about user home in user creation
+
+The server was producing an error log in every user creation and every first sync of a user account.
+This problem fixed with empty value control.
+
+https://github.com/owncloud/core/issues/30853
+https://github.com/owncloud/core/issues/32438
+https://github.com/owncloud/core/pull/36365

--- a/lib/private/User/Account.php
+++ b/lib/private/User/Account.php
@@ -40,7 +40,6 @@ use OCP\UserInterface;
  * @method void setState(integer $state)
  * @method string getQuota()
  * @method void setQuota(string $quota)
- * @method string getHome()
  * @method void setHome(string $home)
  *
  * @package OC\User
@@ -114,5 +113,12 @@ class Account extends Entity {
 	 */
 	public function getSearchTerms() {
 		return $this->terms;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getHome() {
+		return (string) $this->getter('home');
 	}
 }

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -254,7 +254,7 @@ class SyncService {
 		}
 		// Home is handled differently, it should only be set on account creation, when there is no home already set
 		// Otherwise it could change on a sync and result in a new user folder being created
-		if ($a->getHome() === null) {
+		if ($a->getHome() === '') {
 			$home = false;
 			if ($proividesHome) {
 				$home = $backend->getHome($uid);


### PR DESCRIPTION
## Description
The server is producing unintended error logs in every user creation.  This bug fixed with proper condition control. Also, since we are making lots of add/delete users in test scenarios, acceptance tests log files are full of this log, like https://drone.owncloud.com/owncloud/encryption/977/60/11 . This PR will make test log files more readable.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/30853
- Fixes https://github.com/owncloud/core/issues/32438
## Motivation and Context
More readable log file without false positives.

## How Has This Been Tested?
Use test steps given in the related issues. The error log will not be generated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
