### PR TITLE
Acceptance tests: Restore dav.tech_preview status after test run

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -62,6 +62,11 @@ class OccContext implements Context {
 	private $techPreviewEnabled = false;
 
 	/**
+	 * @var string initialTechPreviewStatus
+	 */
+	private $initialTechPreviewStatus;
+
+	/**
 	 * @return boolean
 	 */
 	public function isTechPreviewEnabled() {
@@ -992,7 +997,11 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function resetDAVTechPreview() {
-		if ($this->isTechPreviewEnabled()) {
+		if ($this->initialTechPreviewStatus === "") {
+			$this->featureContext->deleteSystemConfig('dav.enable.tech_preview');
+		} elseif ($this->initialTechPreviewStatus === 'true' && !$this->techPreviewEnabled) {
+			$this->enableDAVTechPreview();
+		} elseif ($this->initialTechPreviewStatus === 'false' && $this->techPreviewEnabled) {
 			$this->disableDAVTechPreview();
 		}
 	}
@@ -1012,5 +1021,8 @@ class OccContext implements Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
+		$techPreviewEnabled = \trim($this->featureContext->getSystemConfigValue('dav.enable.tech_preview'));
+		$this->initialTechPreviewStatus = $techPreviewEnabled;
+		$this->techPreviewEnabled = $techPreviewEnabled === 'true';
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Remember the initial dav.tech_preview status on each run and restore to that value after test run.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the tech_preview gets disabled after running tests and must be enabled again for any other manual tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
