### PR TITLE
Add acceptance tests for checking trashbin api access by invalid user

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -53,3 +53,45 @@ Feature: files and folders can be deleted from the trashbin
       And as "user0" the file with original path "/PARENT/CHILD/child.txt" should not exist in trash
       But as "user0" the file with original path "/textfile0.txt" should exist in trash
       And as "user0" the file with original path "/PARENT/child.txt" should exist in trash
+
+    Scenario: User tries to delete another user's trashbin
+      Given user "user0" has been created with default attributes and skeleton files
+      Given user "user1" has been created with default attributes and skeleton files
+      And user "user0" has deleted file "/textfile0.txt"
+      And user "user0" has deleted file "/textfile1.txt"
+      And user "user0" has deleted file "/PARENT/parent.txt"
+      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+      When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the trashbin API
+      Then the HTTP status code should be "404"
+      And as "user0" the file with original path "/textfile1.txt" should exist in trash
+      And as "user0" the file with original path "/textfile0.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+
+    Scenario: User tries to delete trashbin file using invalid password
+      Given user "user0" has been created with default attributes and skeleton files
+      Given user "user1" has been created with default attributes and skeleton files
+      And user "user0" has deleted file "/textfile0.txt"
+      And user "user0" has deleted file "/textfile1.txt"
+      And user "user0" has deleted file "/PARENT/parent.txt"
+      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+      When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "invalid" and the trashbin API
+      Then the HTTP status code should be "401"
+      And as "user0" the file with original path "/textfile1.txt" should exist in trash
+      And as "user0" the file with original path "/textfile0.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+
+    Scenario: User tries to delete trashbin file using no password
+      Given user "user0" has been created with default attributes and skeleton files
+      Given user "user1" has been created with default attributes and skeleton files
+      And user "user0" has deleted file "/textfile0.txt"
+      And user "user0" has deleted file "/textfile1.txt"
+      And user "user0" has deleted file "/PARENT/parent.txt"
+      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+      When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "" and the trashbin API
+      Then the HTTP status code should be "401"
+      And as "user0" the file with original path "/textfile1.txt" should exist in trash
+      And as "user0" the file with original path "/textfile0.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -181,3 +181,103 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path |
       | old      |
       | new      |
+
+  # This issue makes this scenario behave differently based on previously created users.
+  # So we use user that has not been created in any other scenarios.
+  @issue-36378 @skipOnLDAP
+  Scenario Outline: Listing other user's trashbin is prohibited
+    Given using <dav-path> DAV path
+    And user "user40" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user40" has deleted file "/textfile1.txt"
+    When user "user1" tries to list the trashbin content for user "user40"
+    Then the HTTP status code should be "207"
+    And the last webdav response should contain the following elements
+    # Then the HTTP status code should be "401"
+    # And the last webdav response should not contain following elements
+      | path           | user  |
+      | textfile1.txt | user40 |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  # This issue makes this scenario behave differently based on previously created users.
+  # So we use user that has not been created in any other scenarios.
+  @issue-36378 @skipOnLDAP
+  Scenario Outline: Listing other user's trashbin is prohibited
+    Given using <dav-path> DAV path
+    And user "user60" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user60" has deleted file "/textfile0.txt"
+    And user "user60" has deleted file "/textfile2.txt"
+    When user "user1" tries to list the trashbin content for user "user60"
+    Then the HTTP status code should be "207"
+    And the last webdav response should contain the following elements
+    # Then the HTTP status code should be "401"
+    # And the last webdav response should not contain the following elements
+      | path           | user   |
+      | textfile0.txt  | user60 |
+      | textfile2.txt  | user60 |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  # This issue makes this scenario behave differently based on previously created users.
+  # So we use user that has not been created in any other scenarios.
+  @issue-36378 @skipOnLDAP
+  Scenario Outline: Listing other user's trashbin is prohibited
+    Given using <dav-path> DAV path
+    And user "user504" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user504" has deleted file "/textfile0.txt"
+    And user "user504" has deleted file "/textfile2.txt"
+    And the administrator deletes user "user504" using the provisioning API
+    Given these users have been created with default attributes and skeleton files but not initialized:
+    | username    |
+    | user504     |
+    And user "user504" has deleted file "/textfile3.txt"
+    When user "user1" tries to list the trashbin content for user "user504"
+    Then the HTTP status code should be "207"
+    # Then the HTTP status code should be "401"
+    And the last webdav response should contain the following elements
+      | path           | user    |
+      | textfile3.txt  | user504 |
+    And the last webdav response should not contain the following elements
+      | path           | user    |
+      | textfile0.txt  | user504 |
+      | textfile2.txt  | user504 |
+      # | textfile3.txt  | user504 |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  Scenario Outline: Get trashbin content with wrong password
+    Given using <dav-path> DAV path
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user0" tries to list the trashbin content for user "user0" using password "invalid"
+    Then the HTTP status code should be "401"
+    And the last webdav response should not contain the following elements
+      | path           | user  |
+      | /textfile0.txt | user0 |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  Scenario Outline: Get trashbin content without password
+    Given using <dav-path> DAV path
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user0" tries to list the trashbin content for user "user0" using password ""
+    Then the HTTP status code should be "401"
+    And the last webdav response should not contain the following elements
+      | path           | user  |
+      | /textfile0.txt | user0 |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -264,3 +264,51 @@ Feature: Restore deleted files/folders
     Then the HTTP status code should be "201"
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
+
+  @smokeTest
+  Scenario Outline: A deleted file cannot be restored by a different user
+    Given using <dav-path> DAV path
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user1" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the trashbin API
+    Then the HTTP status code should be "404"
+    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    And user "user0" should not see the following elements
+      | /textfile0.txt     |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @smokeTest
+  Scenario Outline: A deleted file cannot be restored with invalid password
+    Given using <dav-path> DAV path
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user0" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the password "invalid" and the trashbin API
+    Then the HTTP status code should be "401"
+    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    And user "user0" should not see the following elements
+      | /textfile0.txt     |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @smokeTest
+  Scenario Outline: A deleted file cannot be restored without using a password
+    Given using <dav-path> DAV path
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    When user "user0" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the password "" and the trashbin API
+    Then the HTTP status code should be "401"
+    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    And user "user0" should not see the following elements
+      | /textfile0.txt     |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -190,7 +190,7 @@ trait BasicStructure {
 	 * @var string|null
 	 */
 	private $sourceIpAddress = null;
-	
+
 	private $guzzleClientHeaders = [];
 
 	/**
@@ -635,7 +635,7 @@ trait BasicStructure {
 	public function getGuzzleClientHeaders() {
 		return $this->guzzleClientHeaders;
 	}
-	
+
 	/**
 	 * @param array $guzzleClientHeaders ['X-Foo' => 'Bar']
 	 *
@@ -941,7 +941,7 @@ trait BasicStructure {
 		if ($password === null) {
 			$password = $this->getPasswordForUser($user);
 		}
-		
+
 		$headers = $this->guzzleClientHeaders;
 
 		$config = null;
@@ -952,7 +952,7 @@ trait BasicStructure {
 				]
 			];
 		}
-		
+
 		$cookies = null;
 		if (!empty($this->cookieJar->toArray())) {
 			$cookies = $this->cookieJar;
@@ -1183,7 +1183,7 @@ trait BasicStructure {
 	public function userHasLoggedInToAWebStyleSessionUsingTheAPI($user) {
 		$loginUrl = $this->getBaseUrl() . '/login';
 		// Request a new session and extract CSRF token
-		
+
 		$config = null;
 		if ($this->sourceIpAddress !== null) {
 			$config = [
@@ -1223,7 +1223,7 @@ trait BasicStructure {
 	 */
 	public function sendingAToWithRequesttoken($method, $url) {
 		$headers = $this->guzzleClientHeaders;
-		
+
 		$config = null;
 		if ($this->sourceIpAddress !== null) {
 			$config = [


### PR DESCRIPTION
## Description
Add more tests for Trashbin API. This PR aims to check more security features on the trashbin API.

## Related Issue
- Related #36302 and #36378 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
