### PR TITLE
Skip 'Do not allow sharing of the entire share_folder' on LDAP and encryption

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1441,6 +1441,7 @@ Feature: sharing
     And the content of file "randomfile.txt" for user "user2" should be "user0 file"
     And the content of file "randomfile.txt" for user "user1" should be "user0 file"
 
+  @skipOnLDAP @user_ldap-issue-461 @skipOnEncryption @encryption-issue-157
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
Skip `Scenario Outline: Do not allow sharing of the entire share_folder` in the LDAP and encryption app test runs, because it is currently failing (see the issues mentioned below).

This will unblock CI in those apps, so that other unrelated PRs are able to pass CI and get merged.

The scenario should be unskipped when the issues are resolved.

## Related Issue
https://github.com/owncloud/user_ldap/issues/461
https://github.com/owncloud/encryption/issues/157

## Motivation and Context
Unblock CI in the `user_ldap`  and `encryption` apps.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
