### PR TITLE
Allow sharing with guest users when sharing is limited by user groups

### DIFF
--- a/changelog/unreleased/36384
+++ b/changelog/unreleased/36384
@@ -1,0 +1,6 @@
+Bugfix: Allow sharing with guests when group restriction is active
+
+It was not possible to share with guest users when
+'Restrict users to only share with users in their groups' is enabled.
+
+https://github.com/owncloud/core/pull/36384

--- a/lib/private/Helper/UserTypeHelper.php
+++ b/lib/private/Helper/UserTypeHelper.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Helper;
+
+use OCP\App\IAppManager;
+use OCP\IConfig;
+
+class UserTypeHelper {
+	/** @var IAppManager */
+	private $appManager;
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IAppManager $appManager = null, IConfig $config = null) {
+		$this->appManager = $appManager;
+		if ($appManager === null) {
+			$this->appManager = \OC::$server->getAppManager();
+		}
+		$this->config = $config;
+		if ($config === null) {
+			$this->config = \OC::$server->getConfig();
+		}
+	}
+
+	/**
+	 * Checks whether given uid belongs to the user created by the guests app
+	 *
+	 * @param string $uid
+	 * @return bool
+	 */
+	public function isGuestUser($uid) {
+		$guestsAppEnabled = $this->appManager->isEnabledForUser('guests');
+		if ($guestsAppEnabled) {
+			return (bool) $this->config->getUserValue(
+				$uid, 'owncloud', 'isGuest', false
+			);
+		}
+		return false;
+	}
+}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -29,6 +29,7 @@ namespace OC\Share20;
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\View;
+use OC\Helper\UserTypeHelper;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -462,8 +463,11 @@ class Manager implements IManager {
 	 * @throws \Exception
 	 */
 	protected function userCreateChecks(\OCP\Share\IShare $share) {
+		$userTypeHelper = new UserTypeHelper();
+		$isGuestUser = $userTypeHelper->isGuestUser($share->getSharedWith());
 		// Check if we can share with group members only
-		if ($this->shareWithGroupMembersOnly()) {
+		// We still should be able to share with guest user even when it's not a group member
+		if (!$isGuestUser && $this->shareWithGroupMembersOnly()) {
 			$sharedBy = $this->userManager->get($share->getSharedBy());
 			$sharedWith = $this->userManager->get($share->getSharedWith());
 			// Verify we can share with this user
@@ -471,6 +475,7 @@ class Manager implements IManager {
 					$this->groupManager->getUserGroupIds($sharedBy),
 					$this->groupManager->getUserGroupIds($sharedWith)
 			);
+
 			if (empty($groups)) {
 				throw new \Exception('Only sharing with group members is allowed');
 			}

--- a/tests/lib/Helper/UserTypeHelperTest.php
+++ b/tests/lib/Helper/UserTypeHelperTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Helper;
+
+use OC\Helper\UserTypeHelper;
+use OCP\App\IAppManager;
+use OCP\IConfig;
+use Test\TestCase;
+
+class UserTypeHelperTest extends TestCase {
+
+	/** @var IAppManager | \PHPUnit\Framework\MockObject\MockObject */
+	protected $appManager;
+
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
+	protected $config;
+
+	/** @var UserTypeHelper | \PHPUnit\Framework\MockObject\MockObject */
+	protected $userTypeHelper;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->userTypeHelper = new UserTypeHelper($this->appManager, $this->config);
+	}
+
+	/**
+	 * @dataProvider isGuestUserDataProvider
+	 *
+	 * @param bool $isGuestsAppEnabled
+	 * @param bool $isUserGuest
+	 * @param bool $expected
+	 */
+	public function testIsGuestUser($isGuestsAppEnabled, $isUserGuest, $expected) {
+		$this->appManager->method('isEnabledForUser')->willReturn($isGuestsAppEnabled);
+		$this->config->method('getUserValue')->willReturn($isUserGuest);
+		$this->assertEquals($expected, $this->userTypeHelper->isGuestUser('foobar'));
+	}
+
+	public function isGuestUserDataProvider() {
+		return [
+			[false, false, false],
+			[false, true, false],
+			[true, false, false],
+			[true, true, true],
+		];
+	}
+}


### PR DESCRIPTION
## Description
Allow sharing with guest users when `Restrict users to only share with users in their groups` option is enabled

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3578

## Motivation and Context
Guests app should not be affected by the ordinary sharing group restriction

## How Has This Been Tested?
1. Enable the guests app
2.  Check `Restrict users to only share with users in their groups` on the settings page
3. Share any item with `someuser@example.org` (guest)

### Expected 
User is created, a share is added for this user. No errors

### Actual
User is created, but the share is NOT added for this user. Sharing error popup in the web UI


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
