### PR TITLE
Add webUI tests for making public link shares of a received share

### DIFF
--- a/tests/acceptance/features/lib/OwncloudPageElement/OCDialog.php
+++ b/tests/acceptance/features/lib/OwncloudPageElement/OCDialog.php
@@ -95,12 +95,14 @@ class OCDialog extends OwncloudPage {
 		$contentElement = $this->dialogElement->find(
 			"xpath", $this->contentClassXpath
 		);
-		$this->assertElementNotNull(
-			$contentElement,
-			__METHOD__ .
-			" xpath $this->contentClassXpath " .
-			"could not find content element"
-		);
+		// Some dialogs (e.g. create link share) are not "ordinary" dialogs that
+		// just display a message. Those may not have any element matching
+		// contentClassXpath. We want to be able to iterate past those when
+		// looking for an "ordinary" message/error dialog. So in that case just
+		// return an empty string as the message.
+		if ($contentElement === null) {
+			return '';
+		}
 		return $this->getTrimmedText($contentElement);
 	}
 

--- a/tests/acceptance/features/webUISharingPublic/reShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/reShareByPublicLink.feature
@@ -1,0 +1,37 @@
+@webUI @insulated @disablePreviews @mailhog @public_link_share-feature-required
+Feature: Reshare by public link
+  As a user
+  I want to create public link shares from files/folders shared with me
+  So that users who do not have an account on my ownCloud server can access them
+
+  Background:
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
+
+  @smokeTest
+  Scenario: resharing by public link of a received share
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And user "user2" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI
+    And the public accesses the last created public link using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+
+  @issue-36386
+  Scenario: user shares a public link via email
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user2" has logged in using the webUI
+    #When the user creates a new public link for folder "simple-folder" using the webUI with
+    When the user tries to create a new public link for folder "simple-folder" using the webUI with
+      | email | foo@bar.co |
+    #Then the email address "foo@bar.co" should have received an email with the body containing
+	#		"""
+	#		User Two shared simple-folder with you
+	#		"""
+    #And the email address "foo@bar.co" should have received an email containing the last shared public link
+    Then dialog should be displayed on the webUI
+      | title                                | content                                                  |
+      | An error occured while sending email | Couldn't send mail to following recipient(s): foo@bar.co |


### PR DESCRIPTION
## Description
Users can create a public link share from a share that they have received from another user.
When creating the public link share, they can specify an email address(es) to notify about the new public link share.

We have test scenarios for doing this when making a public link share of your own folder, but not when you make a public link share of a folder you have received from another user.

- add initial test scenarios
- adjust the 2nd test scenario so it passes, demonstrating the error dialog that pops up.

## Related Issue
- Tests for #36386 

## Motivation and Context
Have a test scenario that demonstrates the issue.

## How Has This Been Tested?
Local run of the test scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
