### PR TITLE
Bump core version to 10.3.2 alpha

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 3, 1, 1];
+$OC_Version = [10, 3, 2, 0];
 
 // The human readable string
-$OC_VersionString = '10.3.1';
+$OC_VersionString = '10.3.2 alpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
Bump the core version to `10.3.2 alpha`

## Related Issue
- https://github.com/owncloud/encryption/issues/158
- PR #36390 

## Motivation and Context
There are bugfixes merged to master that have test scenarios that will fail against core version 10.2.* 10.3.0 and 10.3.1. We want to be able to skip those new/changed scenarios when the acceptance tests are run against one of those core release tarballs. But we want the tests to run when using core master, and on upcoming releases.

So we need the core version on master to now be later/higher than the previous releases.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
