### PR TITLE
let resharer to send an e-mail for public link

### DIFF
--- a/changelog/unreleased/36393
+++ b/changelog/unreleased/36393
@@ -1,0 +1,6 @@
+Bugfix: allow re-sharer to send an e-mail for public link
+
+Sending an e-mail when creating public links from received shares was impossible. This problem fixed.
+
+https://github.com/owncloud/core/issues/36386
+https://github.com/owncloud/core/pull/36393

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -229,7 +229,7 @@ class MailNotifications {
 		$token = \array_pop($linkParts);
 		try {
 			$share = $this->shareManager->getShareByToken($token);
-			if ($share->getShareOwner() !== $currentUser) {
+			if ($share->getShareOwner() !== $currentUser && $share->getSharedBy() !== $currentUser) {
 				return $recipients;
 			}
 		} catch (ShareNotFound $e) {

--- a/tests/acceptance/features/webUISharingPublic/reShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/reShareByPublicLink.feature
@@ -18,20 +18,15 @@ Feature: Reshare by public link
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
-  @issue-36386
   Scenario: user shares a public link via email
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And user "user2" has logged in using the webUI
-    #When the user creates a new public link for folder "simple-folder" using the webUI with
-    When the user tries to create a new public link for folder "simple-folder" using the webUI with
+    When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co |
-    #Then the email address "foo@bar.co" should have received an email with the body containing
-	#		"""
-	#		User Two shared simple-folder with you
-	#		"""
-    #And the email address "foo@bar.co" should have received an email containing the last shared public link
-    Then dialog should be displayed on the webUI
-      | title                                | content                                                  |
-      | An error occured while sending email | Couldn't send mail to following recipient(s): foo@bar.co |
+    Then the email address "foo@bar.co" should have received an email with the body containing
+      """
+      User Two shared simple-folder with you
+      """
+    And the email address "foo@bar.co" should have received an email containing the last shared public link


### PR DESCRIPTION
## Description
let resharer to send an e-mail for public link.

## Related Issue
- Fixes #36386 

## Motivation and Context
Currently, sending an e-mail when creating public links from received shares is impossible. This PR will fix this issue.

## How Has This Been Tested?
Manually with issues scenario. Also, acceptance tests are ready.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
