### PR TITLE
New mount setting: read only mount

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -19,6 +19,10 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'		<label for="mountOptionsEncrypt">{{t "files_external" "Enable encryption"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
+	'		<input id="mountOptionsPreviews" name="read_only" type="checkbox" value="true"/>' +
+	'		<label for="mountOptionsPreviews">{{t "files_external" "Set read-only"}}</label>' +
+	'	</div>' +
+	'	<div class="optionRow">' +
 	'		<input id="mountOptionsPreviews" name="previews" type="checkbox" value="true" checked="checked"/>' +
 	'		<label for="mountOptionsPreviews">{{t "files_external" "Enable previews"}}</label>' +
 	'	</div>' +
@@ -960,6 +964,7 @@ MountConfigListView.prototype = _.extend({
 			// FIXME default backend mount options
 			$tr.find('input.mountOptions').val(JSON.stringify({
 				'encrypt': true,
+				'read_only': false,
 				'previews': true,
 				'enable_sharing': false,
 				'filesystem_check_changes': 1,
@@ -1342,6 +1347,7 @@ MountConfigListView.prototype = _.extend({
 		var $toggle = $tr.find('.mountOptionsToggle');
 		var dropDown = new MountOptionsDropdown();
 		var visibleOptions = [
+			'read_only',
 			'previews',
 			'filesystem_check_changes',
 			'encoding_compatibility'

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -19,8 +19,8 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'		<label for="mountOptionsEncrypt">{{t "files_external" "Enable encryption"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
-	'		<input id="mountOptionsPreviews" name="read_only" type="checkbox" value="true"/>' +
-	'		<label for="mountOptionsPreviews">{{t "files_external" "Set read-only"}}</label>' +
+	'		<input id="mountOptionsReadonly" name="read_only" type="checkbox" value="true"/>' +
+	'		<label for="mountOptionsReadonly">{{t "files_external" "Set read-only"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
 	'		<input id="mountOptionsPreviews" name="previews" type="checkbox" value="true" checked="checked"/>' +

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -184,6 +184,7 @@ class ListCommand extends Base {
 			'encrypt' => true,
 			'previews' => true,
 			'filesystem_check_changes' => 1,
+			'read_only' => false,
 			'enable_sharing' => false,
 			'encoding_compatibility' => false
 		];

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -5,6 +5,7 @@
 	use OCP\Files\External\IStoragesBackendService;
 
 	$l->t("Enable encryption");
+	$l->t("Set read-only");
 	$l->t("Enable previews");
 	$l->t("Enable sharing");
 	$l->t("Check for changes");

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -371,6 +371,7 @@ describe('OCA.External.Settings tests', function() {
 				expect(JSON.parse($tr.find('input.mountOptions').val())).toEqual({
 					encrypt: true,
 					previews: true,
+					read_only: false,
 					enable_sharing: false,
 					filesystem_check_changes: 0,
 					encoding_compatibility: false

--- a/changelog/unreleased/36397
+++ b/changelog/unreleased/36397
@@ -1,0 +1,7 @@
+Enhancement: Adding a option in the mount settings to provide a mount in read only mode
+
+Adds a new option in the mount settings to provide a mount in read only mode.
+This enables users or admins to provide a write protected mount independent of any backend settings.
+The sync client automatically respects this mount setting without any additional intervention. 
+
+https://github.com/owncloud/core/pull/36397

--- a/changelog/unreleased/36397
+++ b/changelog/unreleased/36397
@@ -1,4 +1,4 @@
-Enhancement: Adding a option in the mount settings to provide a mount in read only mode
+Enhancement: Add an option to provide a mount in read only mode
 
 Adds a new option in the mount settings to provide a mount in read only mode.
 This enables users or admins to provide a write protected mount independent of any backend settings.

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -175,6 +175,16 @@ class OC_Util {
 			return $storage;
 		});
 
+		\OC\Files\Filesystem::addStorageWrapper('read_only', function ($mountPoint, \OCP\Files\Storage $storage, \OCP\Files\Mount\IMountPoint $mount) {
+			if ($mount->getOption('read_only', false)) {
+				return new \OC\Files\Storage\Wrapper\PermissionsMask([
+					'storage' => $storage,
+					'mask' => \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE
+				]);
+			}
+			return $storage;
+		});
+
 		// install storage availability wrapper, before most other wrappers
 		\OC\Files\Filesystem::addStorageWrapper('oc_availability', function ($mountPoint, $storage) {
 			if (!$storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage') && !$storage->isLocal()) {

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -546,6 +546,39 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" should be able to rename (file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $entry
+	 * @param string $source
+	 * @param string $destination
+	 *
+	 * @return void
+	 */
+	public function theUserShouldBeAbleToRenameEntryTo($user, $entry, $source, $destination) {
+		$this->asFileOrFolderShouldExist($user, $entry, $source);
+		$this->userMovesFileUsingTheAPI($user, $source, "", $destination);
+		$this->asFileOrFolderShouldNotExist($user, $entry, $source);
+		$this->asFileOrFolderShouldExist($user, $entry, $destination);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" should not be able to rename (file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $entry
+	 * @param string $source
+	 * @param string $destination
+	 *
+	 * @return void
+	 */
+	public function theUserShouldNotBeAbleToRenameEntryTo($user, $entry, $source, $destination) {
+		$this->asFileOrFolderShouldExist($user, $entry, $source);
+		$this->userMovesFileUsingTheAPI($user, $source, "", $destination);
+		$this->asFileOrFolderShouldExist($user, $entry, $source);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" on "(LOCAL|REMOTE)" moves (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
@@ -1739,6 +1772,39 @@ trait WebDav {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $content
+	 * @param string $destination
+	 *
+	 * @return string
+	 */
+	public function uploadFileWithContent(
+		$user, $content, $destination
+	) {
+		$file = \GuzzleHttp\Stream\Stream::factory($content);
+		$this->pauseUploadDelete();
+		$this->response = $this->makeDavRequest(
+			$user, "PUT", $destination, [], $file
+		);
+		$this->lastUploadDeleteTime = \time();
+		return $this->response->getHeader('oc-fileid');
+	}
+
+	/**
+	 * @When the administrator uploads file with content :content to :destination using the WebDAV API
+	 *
+	 * @param string $content
+	 * @param string $destination
+	 *
+	 * @return string
+	 */
+	public function adminUploadsAFileWithContentTo(
+		$content, $destination
+	) {
+		return $this->uploadFileWithContent($this->getAdminUsername(), $content, $destination);
+	}
+
+	/**
 	 * @When user :user uploads file with content :content to :destination using the WebDAV API
 	 *
 	 * @param string $user
@@ -1750,13 +1816,7 @@ trait WebDav {
 	public function userUploadsAFileWithContentTo(
 		$user, $content, $destination
 	) {
-		$file = \GuzzleHttp\Stream\Stream::factory($content);
-		$this->pauseUploadDelete();
-		$this->response = $this->makeDavRequest(
-			$user, "PUT", $destination, [], $file
-		);
-		$this->lastUploadDeleteTime = \time();
-		return $this->response->getHeader('oc-fileid');
+		return $this->uploadFileWithContent($user, $content, $destination);
 	}
 
 	/**
@@ -1771,7 +1831,7 @@ trait WebDav {
 	public function userHasUploadedAFileWithContentTo(
 		$user, $content, $destination
 	) {
-		$fileId = $this->userUploadsAFileWithContentTo($user, $content, $destination);
+		$fileId = $this->uploadFileWithContent($user, $content, $destination);
 		$this->theHTTPStatusCodeShouldBeOr("201", "204");
 		return $fileId;
 	}

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -96,14 +96,12 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When the administrator creates the local storage mount :mount using the webUI
-	 * @Given the administrator has created the local storage mount :mount from the admin storage settings page
-	 *
 	 * @param string $mount
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	public function theAdministratorCreatesTheLocalStorageMountUsingTheWebui($mount) {
+	public function createLocalStorageMountUsingTheWebui($mount) {
 		$serverRoot = SetupHelper::getServerRoot(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
@@ -120,6 +118,31 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 		$storageIds = $this->featureContext->getStorageIds();
 		$lastMount = \end($storageIds);
 		$this->featureContext->addStorageId($mount, $lastMount + 1);
+	}
+
+	/**
+	 * @When the administrator creates the local storage mount :mount using the webUI
+	 *
+	 * @param string $mount
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorCreatesTheLocalStorageMountUsingTheWebui($mount) {
+		$this->createLocalStorageMountUsingTheWebui($mount);
+	}
+
+	/**
+	 * @Given the administrator has created the local storage mount :mount from the admin storage settings page
+	 *
+	 * @param string $mount
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasCreatedTheLocalStorageMountUsingTheWebui($mount) {
+		$this->createLocalStorageMountUsingTheWebui($mount);
+		$this->featureContext->asFileOrFolderShouldExist($this->featureContext->getAdminUsername(), "folder", $mount);
 	}
 
 	/**
@@ -159,6 +182,16 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	 */
 	public function theAdministratorDeletesTheLastCreatedLocalStorageMountUsingTheWebui() {
 		$this->adminStorageSettingsPage->deleteLastCreatedLocalMount($this->getSession());
+	}
+
+	/**
+	 * @When the administrator enables read-only for the last created local storage mount using the webUI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorEnablesReadonlyForTheLastCreatedLocalStorageMountUsingTheWebui() {
+		$this->adminStorageSettingsPage->openMountOptions($this->getSession());
+		$this->adminStorageSettingsPage->enableReadonlyMountOption($this->getSession());
 	}
 
 	/**

--- a/tests/acceptance/features/lib/AdminStorageSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminStorageSettingsPage.php
@@ -56,6 +56,8 @@ class AdminStorageSettingsPage extends OwncloudPage {
 	protected $applicableUserXpath = "//tr[@id='addMountPoint']/preceding-sibling::tr[1]//li[@class='select2-search-choice'][%s]//span";
 	protected $applicableUserDeleteXpath = "//tr[@id='addMountPoint']/preceding-sibling::tr[1]//li[@class='select2-search-choice'][%s]//a";
 	protected $lastCreatedMountDeleteButtonXpath = "//tr[@id='addMountPoint']/preceding-sibling::tr[1]/td[@class='remove']";
+	protected $lastCreatedMountOptionsButtonXpath = "//tr[@id='addMountPoint']/preceding-sibling::tr[1]/td[@class='mountOptionsToggle']";
+	protected $setReadonlyId = "mountOptionsReadonly";
 	protected $mountPointNameXpath = "//tr[@class='local'][%s]//input[@placeholder='Folder name']";
 
 	/**
@@ -279,6 +281,46 @@ class AdminStorageSettingsPage extends OwncloudPage {
 			if (($now - $start) * 1000 >= $timeout) {
 				break;
 			}
+		}
+	}
+
+	/**
+	 * open the mount options/advanced settings
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function openMountOptions($session) {
+		$lastCreatedMountOptionsButton = $this->find(
+			"xpath", $this->lastCreatedMountOptionsButtonXpath
+		);
+		$this->assertElementNotNull(
+			$lastCreatedMountOptionsButton,
+			__METHOD__ .
+			" xpath $this->lastCreatedMountOptionsButtonXpath " .
+			"could not find mount options advanced settings button for last created mount"
+		);
+		$lastCreatedMountOptionsButton->click();
+	}
+
+	/**
+	 * enable read-only mount option
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function enableReadonlyMountOption(Session $session) {
+		$checkCheckbox = $this->findById($this->setReadonlyId);
+		$this->assertElementNotNull(
+			$checkCheckbox,
+			__METHOD__ .
+			" id " . $this->setReadonlyId .
+			" could not find checkbox for read-only mount option"
+		);
+		if ((!($checkCheckbox->isChecked()))) {
+			$checkCheckbox->click();
 		}
 	}
 

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -19,8 +19,33 @@ Feature: admin storage settings
     And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
     When the administrator creates the local storage mount "local_storage1" using the webUI
+    And the administrator uploads file with content "this is a file in local storage" to "/local_storage1/file-in-local-storage.txt" using the WebDAV API
     And the user re-logs in as "user0" using the webUI
-    Then folder "local_storage1" should be listed on the webUI
+    And user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/local_storage1/textfile.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "201"
+    And as "user0" the files uploaded to "/local_storage1/textfile.txt" with all mechanisms should exist
+    And as "user0" file "local_storage1/file-in-local-storage.txt" should exist
+    And the content of file "/local_storage1/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And user "user0" should be able to rename file "/local_storage1/file-in-local-storage.txt" to "/local_storage1/another-name.txt"
+    And user "user0" should be able to delete file "/local_storage1/another-name.txt"
+    And folder "local_storage1" should be listed on the webUI
+
+  Scenario: administrator creates a read-only local storage mount
+    Given user "user0" has been created with default attributes and without skeleton files
+    And the administrator has browsed to the admin storage settings page
+    And the administrator has enabled the external storage
+    When the administrator creates the local storage mount "local_storage1" using the webUI
+    And the administrator uploads file with content "this is a file in local storage" to "/local_storage1/file-in-local-storage.txt" using the WebDAV API
+    And the administrator enables read-only for the last created local storage mount using the webUI
+    And the user re-logs in as "user0" using the webUI
+    And user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/local_storage1/textfile.txt" with all mechanisms using the WebDAV API
+    Then the HTTP status code of all upload responses should be "403"
+    And as "user0" the files uploaded to "/local_storage1/textfile.txt" with all mechanisms should not exist
+    And as "user0" file "local_storage1/file-in-local-storage.txt" should exist
+    And user "user0" should not be able to rename file "/local_storage1/file-in-local-storage.txt" to "/local_storage1/another-name.txt"
+    And user "user0" should not be able to delete file "/local_storage1/file-in-local-storage.txt"
+    And the content of file "/local_storage1/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And folder "local_storage1" should be listed on the webUI
 
   Scenario: administrator assigns an applicable user to a local storage mount
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/lib/Files/External/StorageConfigTest.php
+++ b/tests/lib/Files/External/StorageConfigTest.php
@@ -59,7 +59,7 @@ class StorageConfigTest extends \Test\TestCase {
 		$storageConfig->setPriority(128);
 		$storageConfig->setApplicableUsers(['user1', 'user2']);
 		$storageConfig->setApplicableGroups(['group1', 'group2']);
-		$storageConfig->setMountOptions(['preview' => false]);
+		$storageConfig->setMountOptions(['preview' => false, 'read_only' => true]);
 
 		$json = $storageConfig->jsonSerialize();
 
@@ -74,6 +74,6 @@ class StorageConfigTest extends \Test\TestCase {
 		$this->assertSame(128, $json['priority']);
 		$this->assertSame(['user1', 'user2'], $json['applicableUsers']);
 		$this->assertSame(['group1', 'group2'], $json['applicableGroups']);
-		$this->assertSame(['preview' => false], $json['mountOptions']);
+		$this->assertSame(['preview' => false, 'read_only' => true], $json['mountOptions']);
 	}
 }


### PR DESCRIPTION
This is an update to #33035 which was closed in favour of the ownCloud 10 codebase.
The original PR was filed by @TJHeeringa  

## Description
Provide an option in the mount settings for setting a mount to be read only

## Related Issue
- Fixes #29873

## Motivation and Context
Provide a mount in read only mode.

## How Has This Been Tested?
Local tests. Create a mount in master, switch to branch, read only is false. Set the option read only either on an existing mount or a new mount provides the mount in read only mode. Sync client syncs and tells on local changes that you do not have permission to write to.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3321281/68543736-81393880-03bb-11ea-9dbf-ef538d22cca2.png)
![image](https://user-images.githubusercontent.com/3321281/68543955-27863d80-03be-11ea-9a33-5c5c4be50fee.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: **will be added when approved**
- [x] Changelog item, see [TEMPLATE] (https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
