### PR TITLE
Fix for app:enable in case of not valid/not existing enterprise key

### DIFF
--- a/changelog/unreleased/36399
+++ b/changelog/unreleased/36399
@@ -1,0 +1,10 @@
+Bugfix: Inform the admin if they enable an enterprise app without valid key
+
+Previously no message was displayed but the app was not enabled.
+
+Now, when the admin tries to enable an enterprise app when the enterprise key
+is invalid, the message "cannot be enabled because of invalid enterprise key"
+is displayed.
+
+https://github.com/owncloud/core/issues/36351
+https://github.com/owncloud/core/pull/36399

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -24,6 +24,7 @@
 
 namespace OC\Core\Command\App;
 
+use OCP\IConfig;
 use OCP\App\IAppManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -36,12 +37,17 @@ class Enable extends Command {
 	/** @var IAppManager */
 	protected $manager;
 
+	/** @var IConfig */
+	protected $config;
+
 	/**
 	 * @param IAppManager $manager
+	 * @param IConfig $config
 	 */
-	public function __construct(IAppManager $manager) {
+	public function __construct(IAppManager $manager, IConfig $config) {
 		parent::__construct();
 		$this->manager = $manager;
+		$this->config = $config;
 	}
 
 	protected function configure() {
@@ -68,6 +74,14 @@ class Enable extends Command {
 		if (!\OC_App::getAppPath($appId)) {
 			$output->writeln($appId . ' not found');
 			return 1;
+		}
+
+		if (\OC_App::isEnabled('enterprise_key')) {
+			$key = new \OCA\Enterprise_Key\EnterpriseKey(false, $this->config);
+			if ($key && !$key->isValid()) {
+				$output->writeln($appId . ' cannot be enabled because of invalid enterprise key');
+				return 1;
+			}
 		}
 
 		$groups = $input->getOption('groups');

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -77,7 +77,9 @@ class Enable extends Command {
 		}
 
 		if (\OC_App::isEnabled('enterprise_key')) {
+			/* @phan-suppress-next-line PhanUndeclaredClassMethod */
 			$key = new \OCA\Enterprise_Key\EnterpriseKey(false, $this->config);
+			/* @phan-suppress-next-line PhanUndeclaredClassMethod */
 			if ($key && !$key->isValid()) {
 				$output->writeln($appId . ' cannot be enabled because of invalid enterprise key');
 				return 1;

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -59,7 +59,7 @@ $application->add(new \OC\Core\Command\Integrity\CheckCore(
 
 if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager()));
+	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
 	

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,6 +34,9 @@ parameters:
     - '#Undefined variable: \$vendor#'
     - '#Undefined variable: \$baseuri#'
     - '#Instantiated class OC_Theme not found.#'
+    -
+      message: '#Instantiated class OCA\\Enterprise_Key\\EnterpriseKey not found.#'
+      path: core/Command/App/Enable.php
     # errors below are to be addressed by own pull requests - non trivial changes required
     - '#OCA\\DAV\\Connector\\Sabre\\ObjectTree::__construct\(\) does not call parent constructor from Sabre\\DAV\\Tree.#'
     - '#OC\\Files\\ObjectStore\\NoopScanner::__construct\(\) does not call parent constructor from OC\\Files\\Cache\\Scanner.#'

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -38,7 +38,10 @@ class AppsEnableTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$command = new Enable(\OC::$server->getAppManager());
+		$command = new Enable(
+			\OC::$server->getAppManager(),
+			\OC::$server->getConfig()
+		);
 		$this->commandTester = new CommandTester($command);
 	}
 


### PR DESCRIPTION
## Description

This PR fixes the current behaviour of the `app:enable` occ command in case of not valid/not existing enterprise key.

## Related Issue

- Fixes https://github.com/owncloud/core/issues/36351

## Motivation and Context

Currently, when running the `app:enable` occ command for enabling an enterprise app and the enterprise key is not valid/not existing, the command does not return any warning/error message. Still, the enterprise app stays disabled. Only when looking into the owncloud.log file one will see an error message about the invalid license key.

## How Has This Been Tested?

Manually, by: - disabling an enterprise app, - setting an invalid enteprise key, - trying to re-enable that enterprise app. Now, the `$appId cannot be enabled because of invalid enteprise key` message is shown.

Implemented for both cases in case groups are/are not given as input to the command.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised 
- [x] Changelog item