### PR TITLE
public.php and public-files endpoints won't report locking support

### DIFF
--- a/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Connector\Sabre;
+
+use Sabre\DAV\Locks\Backend\BackendInterface;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\INode;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\Locked;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\DAV\Xml\Property\LockDiscovery;
+
+class PublicDavLocksPlugin extends \Sabre\DAV\Locks\Plugin {
+	protected $isPublicRequest;
+	public function __construct(BackendInterface $locksBackend, $isPublicRequest) {
+		parent::__construct($locksBackend);
+		$this->isPublicRequest = $isPublicRequest;
+	}
+
+	public function getPluginName() {
+		return 'PublicDavLockPlugin';
+	}
+
+	public function getHTTPMethods($uri) {
+		if (!$this->isPublicRequest) {
+			return parent::getHTTPMethods($uri);
+		} else {
+			return [];
+		}
+	}
+
+	public function httpLock(RequestInterface $request, ResponseInterface $response) {
+		if (!$this->isPublicRequest) {
+			return parent::httpLock($request, $response);
+		} else {
+			$uri = $request->getPath();
+			$existingLocks = $this->getLocks($uri);
+			if (empty($existingLocks)) {
+				throw new MethodNotAllowed('Lock not allowed in public requests');
+			} else {
+				throw new Locked(reset($existingLocks));
+			}
+		}
+	}
+
+	public function httpUnlock(RequestInterface $request, ResponseInterface $response) {
+		if (!$this->isPublicRequest) {
+			return parent::httpUnlock($request, $response);
+		} else {
+			throw new MethodNotAllowed('Lock not allowed in public requests');
+		}
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @author Juan Pablo Villafañez <jvillafanez@solidgear.es>
  *
  * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0

--- a/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
@@ -68,7 +68,7 @@ class PublicDavLocksPlugin extends \Sabre\DAV\Locks\Plugin {
 		} else {
 			$existingLocks = $this->getLocks($uri);
 			if (empty($existingLocks)) {
-				throw new MethodNotAllowed('Lock not allowed in public requests');
+				throw new MethodNotAllowed('Locking not allowed from public endpoint');
 			} else {
 				throw new Locked(\reset($existingLocks));
 			}
@@ -81,7 +81,7 @@ class PublicDavLocksPlugin extends \Sabre\DAV\Locks\Plugin {
 		if (!\call_user_func_array($this->publicRequestMatcher, [$uri])) {
 			return parent::httpUnlock($request, $response);
 		} else {
-			throw new MethodNotAllowed('Lock not allowed in public requests');
+			throw new MethodNotAllowed('Locking not allowed from public endpoint');
 		}
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -121,9 +121,9 @@ class ServerFactory {
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
-		if (!$isPublicAccess) {
-			$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess)));
-		}
+		//if (!$isPublicAccess) {
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin(new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess), $isPublicAccess));
+		//}
 
 		if (BrowserErrorPagePlugin::isBrowserRequest($this->request)) {
 			$server->addPlugin(new BrowserErrorPagePlugin());

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -120,8 +120,8 @@ class ServerFactory {
 		// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
 		if (!$isPublicAccess) {
-			$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
 			$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess)));
 		}
 

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -120,8 +120,10 @@ class ServerFactory {
 		// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
-		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
-		$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess)));
+		if (!$isPublicAccess) {
+			$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
+			$server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess)));
+		}
 
 		if (BrowserErrorPagePlugin::isBrowserRequest($this->request)) {
 			$server->addPlugin(new BrowserErrorPagePlugin());

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -121,9 +121,11 @@ class ServerFactory {
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
-		//if (!$isPublicAccess) {
-		$server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin(new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess), $isPublicAccess));
-		//}
+
+		$fileLocksBackend = new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess);
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, function ($uri) use ($isPublicAccess) {
+			return $isPublicAccess;
+		}));
 
 		if (BrowserErrorPagePlugin::isBrowserRequest($this->request)) {
 			$server->addPlugin(new BrowserErrorPagePlugin());

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -158,10 +158,14 @@ class Server {
 		$this->server->addPlugin(new ExceptionLoggerPlugin('webdav', $logger));
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 		$this->server->addPlugin(new LockPlugin());
-		//if (!$this->isRequestForSubtree(['public-files'])) {
-			// public files won't have locks
-			$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin(new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory()), $this->isRequestForSubtree(['public-files'])));
-		//}
+
+		$fileLocksBackend = new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory());
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, function ($uri) {
+			if (\strpos($uri, "public-files/") === 0) {
+				return true;
+			}
+			return false;
+		}));
 
 		// ACL plugin not used in files subtree, also it causes issues
 		// with performance and locking issues because it will query

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -157,9 +157,9 @@ class Server {
 
 		$this->server->addPlugin(new ExceptionLoggerPlugin('webdav', $logger));
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
+		$this->server->addPlugin(new LockPlugin());
 		if (!$this->isRequestForSubtree(['public-files'])) {
 			// public files won't have locks
-			$this->server->addPlugin(new LockPlugin());
 			$this->server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory())));
 		}
 

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -156,9 +156,12 @@ class Server {
 		}
 
 		$this->server->addPlugin(new ExceptionLoggerPlugin('webdav', $logger));
-		$this->server->addPlugin(new LockPlugin());
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
-		$this->server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory())));
+		if (!$this->isRequestForSubtree(['public-files'])) {
+			// public files won't have locks
+			$this->server->addPlugin(new LockPlugin());
+			$this->server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory())));
+		}
 
 		// ACL plugin not used in files subtree, also it causes issues
 		// with performance and locking issues because it will query

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -158,10 +158,10 @@ class Server {
 		$this->server->addPlugin(new ExceptionLoggerPlugin('webdav', $logger));
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 		$this->server->addPlugin(new LockPlugin());
-		if (!$this->isRequestForSubtree(['public-files'])) {
+		//if (!$this->isRequestForSubtree(['public-files'])) {
 			// public files won't have locks
-			$this->server->addPlugin(new \Sabre\DAV\Locks\Plugin(new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory())));
-		}
+			$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin(new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory()), $this->isRequestForSubtree(['public-files'])));
+		//}
 
 		// ACL plugin not used in files subtree, also it causes issues
 		// with performance and locking issues because it will query

--- a/apps/dav/tests/unit/Connector/Sabre/PublicDavLocksPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicDavLocksPluginTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @author Juan Pablo Villafañez <jvillafanez@solidgear.es>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\PublicDavLocksPlugin;
+use Sabre\DAV\Locks\Backend\BackendInterface;
+use Sabre\DAV\Locks\LockInfo;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Test\TestCase;
+
+class PublicDavLocksPluginTest extends TestCase {
+	/** @var BackendInterface */
+	private $backendInterface;
+	/** @var callable */
+	private $matcher;
+	/** @var PublicDavLocksPlugin */
+	private $publicDavLocksPlugin;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->backendInterface = $this->createMock(BackendInterface::class);
+		$this->matcher = $this->getMockBuilder(\stdClass::class)
+			->setMethods(['__invoke'])
+			->getMock();
+
+		$this->publicDavLocksPlugin = new PublicDavLocksPlugin($this->backendInterface, $this->matcher);
+	}
+
+	public function testGetPluginName() {
+		$this->assertEquals('PublicDavLockPlugin', $this->publicDavLocksPlugin->getPluginName());
+	}
+
+	public function testGetHTTPMethodsForPublic() {
+		$this->matcher->method('__invoke')->willReturn(true);
+		$this->assertEmpty($this->publicDavLocksPlugin->getHTTPMethods('/route/01'));
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
+	 */
+	public function testHttpLockForPublicWithoutLocks() {
+		$this->matcher->method('__invoke')->willReturn(true);
+
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getPath')->willReturn('/requested/path');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->backendInterface->method('getLocks')->willReturn([]);
+
+		$this->publicDavLocksPlugin->httpLock($request, $response);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Locked
+	 */
+	public function testHttpLockForPublicWithLocks() {
+		$this->matcher->method('__invoke')->willReturn(true);
+
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getPath')->willReturn('/requested/path');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$lock1 = $this->createMock(LockInfo::class);
+		$lock2 = $this->createMock(LockInfo::class);
+		$this->backendInterface->method('getLocks')->willReturn([$lock1, $lock2]);
+
+		$this->publicDavLocksPlugin->httpLock($request, $response);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
+	 */
+	public function testHttpUnlockForPublic() {
+		$this->matcher->method('__invoke')->willReturn(true);
+
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getPath')->willReturn('/requested/path');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->publicDavLocksPlugin->httpLock($request, $response);
+	}
+
+	public function testGetHTTPMethodsForPrivate() {
+		$this->matcher->method('__invoke')->willReturn(false);
+		$this->assertEquals(['LOCK', 'UNLOCK'], $this->publicDavLocksPlugin->getHTTPMethods('/route/01'));
+	}
+
+	/*
+	 * Lock and Unlock tests for private paths can't be unittested with the current code
+	 */
+}

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -118,12 +118,12 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
-  Scenario Outline: Public locking is forbidden
+  Scenario Outline: Public locking is not supported
     Given user "user0" has created a public link share of folder "PARENT" with change permission
     When the public locks "/CHILD" in the last public shared folder using the <public-webdav-api-version> public WebDAV API setting following properties
       | lockscope | <lock-scope> |
-    Then the HTTP status code should be "403"
-    And the value of the item "//s:message" in the response should be "Forbidden to lock from public endpoint"
+    Then the HTTP status code should be "405"
+    And the value of the item "//s:message" in the response should be "Locking not allowed from public endpoint"
     Examples:
       | public-webdav-api-version | lock-scope |
       | old                       | shared     |

--- a/tests/acceptance/features/apiWebdavLocks2/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/unlock.feature
@@ -196,7 +196,7 @@ Feature: UNLOCK locked items
     And user "user0" has locked file "PARENT/parent.txt" setting following properties
       | lockscope | <lock-scope> |
     When the public unlocks file "/parent.txt" with the last created lock of file "PARENT/parent.txt" of user "user0" using the WebDAV API
-    Then the HTTP status code should be "409"
+    Then the HTTP status code should be "405"
     #Then the HTTP status code should be "403"
     And 1 locks should be reported for file "PARENT/parent.txt" of user "user0" by the WebDAV API
     Examples:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Remove support for persistent locking in the public endpoints. Requested in https://github.com/owncloud/core/issues/34394#issuecomment-460924172
Note that locking wasn't supported in public endpoints as seen in https://github.com/owncloud/core/blob/master/apps/dav/lib/Files/FileLocksBackend.php#L166-L168 . This PR will remove the lockdiscovery from the propfind response

## Related Issue
https://github.com/owncloud/core/issues/34394

## Motivation and Context
Libreoffice was showing an error trying to lock the file through the public endpoint. Now it won't try to lock the file.

## How Has This Been Tested?
Manually tested using the steps defined in https://github.com/owncloud/core/issues/34394

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
