### PR TITLE
Test scenarios for reshare by public link on webUI

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/reShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/reShareByPublicLink.feature
@@ -9,14 +9,43 @@ Feature: Reshare by public link
     And user "user2" has been created with default attributes and without skeleton files
 
   @smokeTest
-  Scenario: resharing by public link of a received share
+  Scenario: resharing by public link of a received shared folder
     Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/randomfile.txt"
     And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
     And user "user2" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the public accesses the last created public link using the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "randomfile.txt" should be listed on the webUI
+
+  Scenario: resharing by public link of a received shared file
+    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user1" has shared file "/randomfile.txt" with user "user2" with permissions "share,read"
+    And user "user2" has logged in using the webUI
+    When the user creates a new public link for file "randomfile.txt" using the webUI
+    And the public accesses the last created public link using the webUI
+    Then the text preview of the public link should contain "some content"
+
+  Scenario: resharing by public link of a sub-folder in a received shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file with content "some content" to "/simple-folder/sub-folder/randomfile.txt"
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a new public link for folder "sub-folder" using the webUI
+    And the public accesses the last created public link using the webUI
+    Then file "randomfile.txt" should be listed on the webUI
+
+  Scenario: resharing by public link of a file in a received shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a new public link for file "randomfile.txt" using the webUI
+    And the public accesses the last created public link using the webUI
+    Then the text preview of the public link should contain "some content"
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: user reshares a public link of a received share via email
@@ -29,5 +58,73 @@ Feature: Reshare by public link
     Then the email address "foo@bar.co" should have received an email with the body containing
       """
       User Two shared simple-folder with you
+      """
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
+
+  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  Scenario: user reshares a public link of a file in a received shared folder via email
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a new public link for file "randomfile.txt" using the webUI with
+      | email | foo@bar.co |
+    Then the email address "foo@bar.co" should have received an email with the body containing
+      """
+      User Two shared randomfile.txt with you
+      """
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
+
+  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  Scenario: user reshares a public link of a received shared file via email
+    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user1" has shared file "/randomfile.txt" with user "user2" with permissions "share,read"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user2" has logged in using the webUI
+    When the user creates a new public link for file "randomfile.txt" using the webUI with
+      | email | foo@bar.co |
+    Then the email address "foo@bar.co" should have received an email with the body containing
+      """
+      User Two shared randomfile.txt with you
+      """
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
+
+  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  Scenario: user reshares a public link of a received shared folder via email with multiple addresses
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user2" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI with
+      | email | foo@bar.co, foo@barr.co |
+    Then the email address "foo@bar.co" should have received an email with the body containing
+      """
+      User Two shared simple-folder with you
+      """
+    And the email address "foo@barr.co" should have received an email with the body containing
+      """
+      User Two shared simple-folder with you
+      """
+    And the email address "foo@bar.co" should have received an email containing the last shared public link
+    And the email address "foo@barr.co" should have received an email containing the last shared public link
+
+  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  Scenario: user reshares a public link of a received shared folder via email with a personal message
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user2" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI with
+      | email           | foo@bar.co  |
+      | personalMessage | lorem ipsum |
+    Then the email address "foo@bar.co" should have received an email with the body containing
+      """
+      User Two shared simple-folder with you
+      """
+    And the email address "foo@bar.co" should have received an email with the body containing
+      """
+      lorem ipsum
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -266,23 +266,6 @@ Feature: Share by public link
     And the public tries to access the last created public link with wrong password "qwertyui" using the webUI
     Then the public should not get access to the publicly shared file
 
-  Scenario: user shares a public link via email with a personal message
-    Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
-    When the user creates a new public link for folder "simple-folder" using the webUI with
-      | email           | foo@bar.co  |
-      | personalMessage | lorem ipsum |
-    Then the email address "foo@bar.co" should have received an email with the body containing
-			"""
-			User One shared simple-folder with you
-			"""
-    And the email address "foo@bar.co" should have received an email with the body containing
-			"""
-			lorem ipsum
-			"""
-    And the email address "foo@bar.co" should have received an email containing the last shared public link
-
   Scenario: user edits a name of an already existing public link
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"


### PR DESCRIPTION
## Description
Add acceptance test scenarios to cover some combinations of using the webUI to create public links of received shares, including sending email and personal message.

## Related Issue
- Fixes #36388 

## Motivation and Context
Provide better test coverage to avoid regressions.

## How Has This Been Tested?
Local run of test scenarios:
```
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/webUISharingPublic/reShareByPublicLink.feature
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
