### PR TITLE
Revert "Skip 'Do not allow sharing of the entire share_folder' on LDAP and encryption

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1453,7 +1453,6 @@ Feature: sharing
     And the content of file "randomfile.txt" for user "user2" should be "user0 file"
     And the content of file "randomfile.txt" for user "user1" should be "user0 file"
 
-  @skipOnLDAP @user_ldap-issue-461 @skipOnEncryption @encryption-issue-157
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
This reverts commit 15e38ed3a66e8cc5bb63514713b30e3871482e9e. PR #36377 

There were problems with "out of disk space" for the `daily-master-qa` build on 2019-11-04, so the "problem" may have been that the `daily-master-qa` tarball was not current when the tests ran on 2019-11-05.

Unskip the test scenario and we will see in the nightly CI if everything passes in user_ldap and encryption.


## Related Issue
- https://github.com/owncloud/encryption/issues/157
- https://github.com/owncloud/user_ldap/issues/461

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
