### PR TITLE
New option in files_external:list --mount-options

### DIFF
--- a/changelog/unreleased/36420
+++ b/changelog/unreleased/36420
@@ -1,0 +1,5 @@
+Enhancement: New option in occ command files_external:list --mount-options
+
+Using --mount-options shows all mount options independent if they are set to their default value or not.
+
+https://github.com/owncloud/core/pull/36420

--- a/changelog/unreleased/36420-1
+++ b/changelog/unreleased/36420-1
@@ -1,0 +1,6 @@
+Bug: Fix a php error for occ command files_external:list --output=
+
+Fix a php error of occ command files_external:list --output=json respectively --output=json_pretty,
+when using in conjunction with option --all
+
+https://github.com/owncloud/core/pull/36420


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adding a new option for the `files_external:list` command `--mount-options`.
Using `--mount-options` shows all mount options independent the fact if they are default or not.
I came across when working on #36397 where I wanted to see if an option is set or not.

```
./occ files_external:list  --output=json_pretty
[
    {
        "mount_id": 2,
        "mount_point": "\/ttt",
        "storage": "SMB \/ CIFS",
        "authentication_type": "Username and password",
        "configuration": "host: \"filer\", share: \"swwindows\", root: \"\", domain: \"mydomain\", user: \"martin\", password: \"***\"",
        "options": "",
        "applicable_users": "All",
        "applicable_groups": ""
    }
]
```
```
./occ files_external:list  --mount-options --output=json_pretty
[
    {
        "mount_id": 2,
        "mount_point": "\/ttt",
        "storage": "SMB \/ CIFS",
        "authentication_type": "Username and password",
        "configuration": "host: \"filer\", share: \"swwindows\", root: \"\", domain: \"mydomain\", user: \"martin\", password: \"***\"",
        "options": "encrypt: true, previews: true, filesystem_check_changes: 1, enable_sharing: false, encoding_compatibility: false",
        "applicable_users": "All",
        "applicable_groups": ""
    }
]
```
**NOTE:** during testing, I found a bug in the  `json`/ `json_pretty` output when using option `--all` causing a php error. This is now fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Helps identifying which options are present and in which state independent if they are set to default or not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running local

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: will be made on merge 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
