### PR TITLE
Skip 'Do not allow sharing of the entire share_folder' for old core v10.3

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1453,6 +1453,7 @@ Feature: sharing
     And the content of file "randomfile.txt" for user "user2" should be "user0 file"
     And the content of file "randomfile.txt" for user "user1" should be "user0 file"
 
+  @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
This is a new test scenario for a bug fixed in `master` (PR #36337 ). The fix is not in 10.3.0 or 10.3.1 but will be released in 10.3.2

Skip the scenario on 10.3.0 and 10.3.1

Example of fail: https://drone.owncloud.com/owncloud/encryption/989/60/14 and https://drone.owncloud.com/owncloud/encryption/989/110/14

## Related Issue
https://github.com/owncloud/user_ldap/issues/461
https://github.com/owncloud/encryption/issues/157

## Motivation and Context
Make CI great

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
