### PR TITLE
Fix samba tests

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -49,11 +49,9 @@ config = {
 			],
 			'externalTypes': [
 				'webdav',
-				# disable - see https://github.com/owncloud/core/issues/36322
-				# 'samba',
+				'samba',
 				'sftp',
-				# disable - see https://github.com/owncloud/core/issues/36322
-				# 'windows',
+				'windows',
 				'scality'
 			],
 			'coverage': True

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -40,7 +40,26 @@ config = {
 			],
 			'coverage': False
 		},
-		'external' : {
+		'external-samba-windows' : {
+			'phpVersions': [
+				'7.1',
+			],
+			'databases': [
+				'sqlite',
+			],
+			'externalTypes': [
+				'samba',
+				'windows',
+			],
+			'coverage': True,
+			'extraCommandsBeforeTestRun': [
+				'ls -l /var/cache',
+				'mkdir /var/cache/samba',
+				'ls -l /var/cache',
+				'ls -l /var/cache/samba',
+			]
+		},
+		'external-other' : {
 			'phpVersions': [
 				'7.1',
 			],
@@ -49,9 +68,7 @@ config = {
 			],
 			'externalTypes': [
 				'webdav',
-				'samba',
 				'sftp',
-				'windows',
 				'scality'
 			],
 			'coverage': True
@@ -1060,6 +1077,7 @@ def phptests(testType):
 							installServer(phpVersion, db, params['logLevel']) +
 							installExtraApps(phpVersion, extraAppsDict) +
 							setupScality(phpVersion, needScality) +
+							params['extraSetup'] +
 							fixPermissions(phpVersion, False) +
 							owncloudLog('server', 'src') +
 						[
@@ -1073,7 +1091,7 @@ def phptests(testType):
 									'FILES_EXTERNAL_TYPE': filesExternalType,
 									'PRIMARY_OBJECTSTORE': primaryObjectstore
 								},
-								'commands': [
+								'commands': params['extraCommandsBeforeTestRun'] + [
 									command
 								]
 							}

--- a/.drone.yml
+++ b/.drone.yml
@@ -2759,6 +2759,273 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: phpunit-php7.1-sqlite-samba
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: sqlite
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - ls -l /var/cache
+  - mkdir /var/cache/samba
+  - ls -l /var/cache
+  - ls -l /var/cache/samba
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: sqlite
+    FILES_EXTERNAL_TYPE: samba
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+services:
+- name: samba
+  pull: always
+  image: owncloudci/samba:latest
+  command:
+  - -u
+  - test;test
+  - -s
+  - public;/tmp;yes;no;no;test;none;test
+  - -S
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-sqlite-windows
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: sqlite
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - ls -l /var/cache
+  - mkdir /var/cache/samba
+  - ls -l /var/cache
+  - ls -l /var/cache/samba
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: sqlite
+    FILES_EXTERNAL_TYPE: windows
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: phpunit-php7.1-sqlite-webdav
 
 platform:
@@ -2894,141 +3161,6 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: phpunit-php7.1-sqlite-samba
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /drone
-  path: src
-
-steps:
-- name: cache-restore
-  pull: always
-  image: plugins/s3-cache:1
-  settings:
-    access_key:
-      from_secret: cache_s3_access_key
-    endpoint:
-      from_secret: cache_s3_endpoint
-    restore: true
-    secret_key:
-      from_secret: cache_s3_secret_key
-  when:
-    instance:
-    - drone.owncloud.services
-    - drone.owncloud.com
-
-- name: composer-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make install-composer-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: vendorbin-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make vendor-bin-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: yarn-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make install-nodejs-deps
-  environment:
-    NPM_CONFIG_CACHE: /drone/src/.cache/npm
-    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
-    bower_storage__packages: /drone/src/.cache/bower
-
-- name: install-server
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - bash tests/drone/install-server.sh
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-  - php occ config:list
-  - php occ security:certificates:import /drone/server.crt
-  - php occ security:certificates
-  environment:
-    DB_TYPE: sqlite
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - chown -R www-data /drone/src
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /drone/src/data/owncloud.log
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - su-exec www-data bash tests/drone/test-phpunit.sh
-  environment:
-    COVERAGE: true
-    DB_TYPE: sqlite
-    FILES_EXTERNAL_TYPE: samba
-
-- name: coverage-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    files:
-    - "*.xml"
-    flags:
-    - phpunit
-    paths:
-    - tests/output/coverage
-  environment:
-    CODECOV_TOKEN:
-      from_secret: codecov_token
-  when:
-    instance:
-    - drone.owncloud.services
-    - drone.owncloud.com
-
-services:
-- name: samba
-  pull: always
-  image: owncloudci/samba:latest
-  command:
-  - -u
-  - test;test
-  - -s
-  - public;/tmp;yes;no;no;test;none;test
-  - -S
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.3
-- phpstan-php7.1
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
 name: phpunit-php7.1-sqlite-sftp
 
 platform:
@@ -3143,130 +3275,6 @@ services:
   image: atmoz/sftp
   environment:
     SFTP_USERS: test:12345:1001::upload
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.3
-- phpstan-php7.1
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.1-sqlite-windows
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /drone
-  path: src
-
-steps:
-- name: cache-restore
-  pull: always
-  image: plugins/s3-cache:1
-  settings:
-    access_key:
-      from_secret: cache_s3_access_key
-    endpoint:
-      from_secret: cache_s3_endpoint
-    restore: true
-    secret_key:
-      from_secret: cache_s3_secret_key
-  when:
-    instance:
-    - drone.owncloud.services
-    - drone.owncloud.com
-
-- name: composer-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make install-composer-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: vendorbin-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make vendor-bin-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: yarn-install
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make install-nodejs-deps
-  environment:
-    NPM_CONFIG_CACHE: /drone/src/.cache/npm
-    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
-    bower_storage__packages: /drone/src/.cache/bower
-
-- name: install-server
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - bash tests/drone/install-server.sh
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-  - php occ config:list
-  - php occ security:certificates:import /drone/server.crt
-  - php occ security:certificates
-  environment:
-    DB_TYPE: sqlite
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - chown -R www-data /drone/src
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /drone/src/data/owncloud.log
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - su-exec www-data bash tests/drone/test-phpunit.sh
-  environment:
-    COVERAGE: true
-    DB_TYPE: sqlite
-    FILES_EXTERNAL_TYPE: windows
-
-- name: coverage-upload
-  pull: always
-  image: plugins/codecov:2
-  settings:
-    files:
-    - "*.xml"
-    flags:
-    - phpunit
-    paths:
-    - tests/output/coverage
-  environment:
-    CODECOV_TOKEN:
-      from_secret: codecov_token
-  when:
-    instance:
-    - drone.owncloud.services
-    - drone.owncloud.com
 
 trigger:
   ref:
@@ -14357,10 +14365,10 @@ depends_on:
 - phpunit-php7.2-mariadb10.2
 - phpunit-php7.3-sqlite
 - phpunit-php7.3-mariadb10.2
-- phpunit-php7.1-sqlite-webdav
 - phpunit-php7.1-sqlite-samba
-- phpunit-php7.1-sqlite-sftp
 - phpunit-php7.1-sqlite-windows
+- phpunit-php7.1-sqlite-webdav
+- phpunit-php7.1-sqlite-sftp
 - phpunit-php7.1-sqlite-scality
 - apiAuth-mariadb10.2-php7.1
 - apiAuthOcs-mariadb10.2-php7.1

--- a/.drone.yml
+++ b/.drone.yml
@@ -2894,6 +2894,141 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: phpunit-php7.1-sqlite-samba
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: sqlite
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: sqlite
+    FILES_EXTERNAL_TYPE: samba
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+services:
+- name: samba
+  pull: always
+  image: owncloudci/samba:latest
+  command:
+  - -u
+  - test;test
+  - -s
+  - public;/tmp;yes;no;no;test;none;test
+  - -S
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: phpunit-php7.1-sqlite-sftp
 
 platform:
@@ -3008,6 +3143,130 @@ services:
   image: atmoz/sftp
   environment:
     SFTP_USERS: test:12345:1001::upload
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-sqlite-windows
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: sqlite
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: sqlite
+    FILES_EXTERNAL_TYPE: windows
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
 
 trigger:
   ref:
@@ -14099,7 +14358,9 @@ depends_on:
 - phpunit-php7.3-sqlite
 - phpunit-php7.3-mariadb10.2
 - phpunit-php7.1-sqlite-webdav
+- phpunit-php7.1-sqlite-samba
 - phpunit-php7.1-sqlite-sftp
+- phpunit-php7.1-sqlite-windows
 - phpunit-php7.1-sqlite-scality
 - apiAuth-mariadb10.2-php7.1
 - apiAuthOcs-mariadb10.2-php7.1

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -39,9 +39,8 @@ use OCA\Files_External\Lib\Storage\SMB;
 class SmbTest extends \Test\Files\Storage\Storage {
 	protected function setUp() {
 		parent::setUp();
-
 		$id = $this->getUniqueID();
-		$config = include('files_external/tests/config.smb.php');
+		$config = include 'files_external/tests/config.smb.php';
 		if (!\is_array($config) or !$config['run']) {
 			$this->markTestSkipped('Samba backend not configured');
 		}
@@ -50,7 +49,7 @@ class SmbTest extends \Test\Files\Storage\Storage {
 		}
 		$config['root'] .= $id; //make sure we have an new empty folder to work in
 		$this->instance = new SMB($config);
-		$this->assertTrue($this->instance->mkdir('/'));
+		$this->assertTrue($this->instance->mkdir('/'), 'Failed to create a root dir');
 	}
 
 	protected function tearDown() {
@@ -70,9 +69,10 @@ class SmbTest extends \Test\Files\Storage\Storage {
 
 	public function testRenameWithSpaces() {
 		$this->instance->mkdir('with spaces');
+		$this->assertTrue($this->instance->is_dir('with spaces'), 'Failed to create directory with spaces');
 		$result = $this->instance->rename('with spaces', 'foo bar');
-		$this->assertTrue($result);
-		$this->assertTrue($this->instance->is_dir('foo bar'));
+		$this->assertTrue($result, 'Failed to rename dir');
+		$this->assertTrue($this->instance->is_dir('foo bar'), 'Failed to locate the dir with a new name');
 	}
 
 	public function testStorageId() {

--- a/tests/drone/configs/config.files_external.smb-samba.php
+++ b/tests/drone/configs/config.files_external.smb-samba.php
@@ -7,4 +7,5 @@ return [
 	'password'=>'test',
 	'root'=>'',
 	'share'=>'public',
+	'domain'=>'WORKGROUP',
 ];

--- a/tests/drone/configs/config.files_external.smb-windows.php
+++ b/tests/drone/configs/config.files_external.smb-windows.php
@@ -6,4 +6,5 @@ return [
 	'password'=>'Password123!',
 	'root'=>'',
 	'share'=>'test100',
+	'domain'=>'WORKGROUP',
 ];


### PR DESCRIPTION
## Description
- enable the samba "unit" tests again
- `mkdir /var/cache/samba` - this is needed in Ubuntu 18.04 (current drone) as reported at https://bugs.launchpad.net/ubuntu/+source/gvfs/+bug/1758653 Actually the tests can pass without it, but the unit test output is full of "Permission denied" errors. See comment https://github.com/owncloud/core/pull/36425#issuecomment-553354499
- enhance the test error messages in ` apps/files_external/tests/Storage/SmbTest.php` - this was useful to try and understand exactly where things failed
- add `'domain'=>'WORKGROUP'` to the smb config files. This is needed now, it seems that `smbclient` or samba-something may have provided this by default in the past, but it needs to be specified when using Ubuntu 18.04 with samba... - thanks to @jvillafanez for finding this.

## Related Issue
- Fixes #36322 

## Motivation and Context
Make CI great again.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
