### PR TITLE
Drop default value for fileid in properties table migration

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20190823065724.php
+++ b/apps/dav/appinfo/Migrations/Version20190823065724.php
@@ -42,6 +42,15 @@ class Version20190823065724 implements ISchemaMigration {
 
 		$table = $schema->getTable("${prefix}properties");
 		$column = $table->getColumn('fileid');
+
+		/**
+		 * Doctrine DBAL does not have provision to drop default
+		 * value NULL from the column. Hence we have to execute an
+		 * SQL query to do this.
+		 */
+		$dropQuery = "ALTER TABLE oc_properties ALTER fileid DROP Default ";
+		$this->dbConnection->executeQuery($dropQuery);
+
 		/**
 		 * If the fileid column's notnull is set to false then
 		 * make sure before altering the column, that no entry


### PR DESCRIPTION
Drop the default value for fileid in properties table
during the dav migration.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When migration `Version20190823065724` was applied during the upgrade of dav app, an error was noticed in an instance:
```
Doctrine\DBAL\Exception\DriverException: An exception occurred while executing 'ALTER TABLE oc_properties CHANGE `fileid` fileid BIGINT UNSIGNED DEFAULT NULL NOT NULL':
SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'fileid'
```
This change set tries to solve the issue by dropping the default value of `fileid` column in the properties table. 
- The file name of the migration `Version20190823065724` is renamed to `Version20191113135818`
- dav app version is incremented
- An sql is executed to drop the default value of `fileid` column. I couldn't find an api in Doctrine/DBAL schema to drop the default value. Hence opted this approach.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change set should fix the error `Invalid default value for 'fileid'`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Installed 10.2.1 and before upgrade applied the change to 10.3.0
    - Copied the migration to the dav app and removed the 10.3.0 migration file `Version20190823065724` existed in dav app.
    - Upgrade to 10.3.0
    - Verified that migration `Version20191113135818` is executed successfully.

- Tested by upgrading oC version from 10.2.1 to 10.3.0
   - Later renamed the migration file with the one in the PR
   - Incremented the dav version
   - Incremented the oC version
   - Upgrade happened. Debugged if the code was executing the drop default.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
