### PR TITLE
Reformat the Changelog items according to spec

### DIFF
--- a/changelog/unreleased/36222
+++ b/changelog/unreleased/36222
@@ -1,4 +1,4 @@
-Bugfix: only collect shares inside the given path in files:transfer-ownership command
+Bugfix: Fix share transfer in files:transfer-ownership command
 
 Even when the path argument was given, files:transfer-ownership command was trying to transfer all shares of sourceUser.
 This situation caused random errors. We fixed this unintended behavior.

--- a/changelog/unreleased/36225
+++ b/changelog/unreleased/36225
@@ -1,4 +1,4 @@
-Bugfix: Respect accounts.enable_medial_search while searching for remote users in share autocomplete
+Bugfix: Respect accounts.enable_medial_search setting for remote search
 
 Users taken from a federated instance were always searched with medial search
 in the share autocomplete box. Config option accounts.enable_medial_search

--- a/changelog/unreleased/36281
+++ b/changelog/unreleased/36281
@@ -1,4 +1,4 @@
-Bugfix: Avoid unnecessary "Avatar not found" logs by initializing ViewOnlyPlugin only for files
+Bugfix: Avoid unnecessary "Avatar not found" logs
 
 ViewOnlyPlugin was producing too many warning logs for users who do not have an avatar. This problem has been resolved by registering ViewOnlyPlugin only for files.
 

--- a/changelog/unreleased/36288
+++ b/changelog/unreleased/36288
@@ -1,4 +1,4 @@
-Bugfix: Prevent Forbidden errors in the logs while scanning the home storages of guest users
+Bugfix: Prevent Forbidden errors in the logs during file scan
 
 When running files:scan exceptions were logged for guest users. This has been corrected.
 

--- a/changelog/unreleased/36337
+++ b/changelog/unreleased/36337
@@ -1,4 +1,4 @@
-Bugfix: Disallow sharing share_folder or it's parents, show share folder permission correctly.
+Bugfix: Disallow sharing share_folder or it's parents
 
 share_folder had share permission so it was possible for the user to share it along with some received shares.
 It caused weird behavior. So sharing share_folder (or any of it's parent folders) was prohibited.

--- a/changelog/unreleased/36343
+++ b/changelog/unreleased/36343
@@ -1,4 +1,4 @@
-Update: Update jQuery-File-Upload from 9.18 to 9.34
+Change: Update jQuery-File-Upload from 9.18 to 9.34
 
 Updated jQuery-File-Upload component to the v9.34 which fixed Edge garbage collection for huge files
 

--- a/changelog/unreleased/36359
+++ b/changelog/unreleased/36359
@@ -1,4 +1,4 @@
-Bugfix: Fix sharing behavior to distinguish user and group having the same name.
+Bugfix: Fix sharing behavior to distinguish user and group having the same name
 
 Sharing a node with user and group having the same name was impossible.
 This bug was resolved by adding a share type check for share creation controls.


### PR DESCRIPTION
# Description

- Fix Changelog Formatting

## Encountered Errors
- Error: Titles can not exceed 80 chars in length
- Error: `title ends with punctuation, e.g. a character out of ".!?"`
- Error: `entry type "Update" is invalid, valid types: Bugfix, Change, Enhancement, Security
`

## FYI
@phil-davis @individual-it @VicDeo @jvillafanez @karakayasemi @sharidas @DeepDiver1975 

