### PR TITLE
fix user search problem happening after user deletion

### DIFF
--- a/changelog/unreleased/36431
+++ b/changelog/unreleased/36431
@@ -1,0 +1,5 @@
+Bugfix: Fix user search problem happening after user deletion
+
+After a user search in user management web-UI, if the search result has a single user entry and afterward the user was deleted from the interface, the search was no longer work until refreshing the page. This bug has been fixed.
+
+https://github.com/owncloud/core/pull/36431

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -177,10 +177,7 @@ var UserList = {
 		 */
 		$tr.appendTo($userList);
 		if(UserList.isEmpty === true) {
-			//when the list was emptied, one row was left, necessary to keep
-			//add working and the layout unbroken. We need to remove this item
 			$tr.show();
-			$userListBody.find('tr:first').remove();
 			UserList.isEmpty = false;
 			UserList.checkUsersToLoad();
 		}
@@ -407,7 +404,6 @@ var UserList = {
 			OC.generateUrl('/settings/users/users'),
 			{ offset: UserList.offset, limit: limit, gid: gid, pattern: pattern },
 			function (result) {
-				var loadedUsers = 0;
 				var trs = [];
 				//The offset does not mirror the amount of users available,
 				//because it is backend-dependent. For correct retrieval,
@@ -418,7 +414,6 @@ var UserList = {
 					}
 					var $tr = UserList.add(user, false);
 					trs.push($tr);
-					loadedUsers++;
 				});
 				if (result.length > 0) {
 					UserList.doSort();


### PR DESCRIPTION
## Description
In the web-UI user management page, When user make a search, if the search result has only one entry and the listed user is deleted from the search result page, the search does not work anymore until refreshing the page.

Reason for the problem, Js search function uses a hidden <tr> column to clone new rows from it. In our scenario, after user deletion, this row also being deleted. As a result, search functionality can not add a new row to the user list.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3585

## Motivation and Context
Fixing bugs.

## How Has This Been Tested?
Manually with the following steps:
- Open Menu Users
- Searching for a user (search result should be match with only one entry)
- Delete a user
- Make a new search for another user did not work, no result for the search.

This problem now fixed.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
