### PR TITLE
Skip new trashbin scenarios on objectstore

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -184,7 +184,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @issue-36378 @skipOnLDAP
+  @issue-36378 @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user40" has been created with default attributes and skeleton files
@@ -204,7 +204,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @issue-36378 @skipOnLDAP
+  @issue-36378 @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user60" has been created with default attributes and skeleton files
@@ -226,7 +226,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @issue-36378 @skipOnLDAP
+  @issue-36378 @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user504" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -195,7 +195,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And the last webdav response should contain the following elements
     # Then the HTTP status code should be "401"
     # And the last webdav response should not contain following elements
-      | path           | user  |
+      | path          | user   |
       | textfile1.txt | user40 |
     Examples:
       | dav-path |
@@ -216,9 +216,9 @@ Feature: files and folders exist in the trashbin after being deleted
     And the last webdav response should contain the following elements
     # Then the HTTP status code should be "401"
     # And the last webdav response should not contain the following elements
-      | path           | user   |
-      | textfile0.txt  | user60 |
-      | textfile2.txt  | user60 |
+      | path          | user   |
+      | textfile0.txt | user60 |
+      | textfile2.txt | user60 |
     Examples:
       | dav-path |
       | old      |
@@ -235,19 +235,19 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user504" has deleted file "/textfile2.txt"
     And the administrator deletes user "user504" using the provisioning API
     Given these users have been created with default attributes and skeleton files but not initialized:
-    | username    |
-    | user504     |
+      | username |
+      | user504  |
     And user "user504" has deleted file "/textfile3.txt"
     When user "user1" tries to list the trashbin content for user "user504"
     Then the HTTP status code should be "207"
     # Then the HTTP status code should be "401"
     And the last webdav response should contain the following elements
-      | path           | user    |
-      | textfile3.txt  | user504 |
+      | path          | user    |
+      | textfile3.txt | user504 |
     And the last webdav response should not contain the following elements
-      | path           | user    |
-      | textfile0.txt  | user504 |
-      | textfile2.txt  | user504 |
+      | path          | user    |
+      | textfile0.txt | user504 |
+      | textfile2.txt | user504 |
       # | textfile3.txt  | user504 |
     Examples:
       | dav-path |


### PR DESCRIPTION
## Description
Test scenarios were added in #36376 to demonstrate an issue with the new trashbin API.
Those tests are failing in `files_primary_s3` - https://drone.owncloud.com/owncloud/files_primary_s3/1277/59/16 - the status`207` comes back the same, but "expected" content in the response is not found. So this bug is behaving a little differently in objectstore from ordinary storage.

Probably it is best to get the main bug fixed in core, and these test scenarios will be adjusted anyway. Then we can see what happens in `files_primary_s3` when the core bug is fixed.

Skip these scenarios on objectstore.

## Related Issue
#36378 

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
