### PR TITLE
[DO NOT MERGE] adjust timestamps in VersioningTest

### DIFF
--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -160,8 +160,10 @@ class VersioningTest extends TestCase {
 		$v1 = $versionsFolder2 . '/test.txt.v' . $t1;
 		$v2 = $versionsFolder2 . '/test.txt.v' . $t2;
 
-		$this->rootView->file_put_contents($v1, 'version1');
 		$this->rootView->file_put_contents($v2, 'version2');
+		// do not write both files in the same second
+		\sleep(1);
+		$this->rootView->file_put_contents($v1, 'version1');
 
 		// move file into the shared folder as recipient
 		\OC\Files\Filesystem::rename('/test.txt', '/folder1/test.txt');

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -149,7 +149,8 @@ class VersioningTest extends TestCase {
 		$versionsFolder2 = '/' . $this->user2 . '/files_versions';
 		\OC\Files\Filesystem::file_put_contents('test.txt', 'test file');
 
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
@@ -330,7 +331,8 @@ class VersioningTest extends TestCase {
 	public function testRename() {
 		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
 
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
@@ -361,7 +363,8 @@ class VersioningTest extends TestCase {
 		\OC\Files\Filesystem::mkdir('folder1/folder2');
 		\OC\Files\Filesystem::file_put_contents("folder1/test.txt", "test file");
 
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
@@ -410,7 +413,8 @@ class VersioningTest extends TestCase {
 		\OC\Files\Filesystem::mkdir('folder2');
 		\OC\Files\Filesystem::file_put_contents('folder1/test.txt', 'test file');
 
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
@@ -454,7 +458,8 @@ class VersioningTest extends TestCase {
 		\OC\Files\Filesystem::mkdir('folder2');
 		\OC\Files\Filesystem::file_put_contents('folder2/test.txt', 'test file');
 
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
@@ -490,7 +495,8 @@ class VersioningTest extends TestCase {
 	public function testRenameSharedFile() {
 		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
 
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
@@ -538,7 +544,8 @@ class VersioningTest extends TestCase {
 	public function testCopy() {
 		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
 
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
@@ -569,7 +576,8 @@ class VersioningTest extends TestCase {
 	 * the correct 'path' and 'name'
 	 */
 	public function testGetVersions() {
-		$t1 = \time();
+		// not exactly the same timestamp as the file
+		$t1 = \time() - 60;
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;


### PR DESCRIPTION
## Description
`VersioningTest` is failing intermittently in `files_primary_s3` - see comment https://github.com/owncloud/core/issues/36266#issuecomment-554883019

I seems to fail "about half the time". The tests create "fake" versions at the current Unix timestamp and for 14 days ago. That creates a "version" "right now". If the test goes on to create a new file, or do "something interesting" then it could try to create another version of the file, which might sometimes happen in the same "unix second" and sometimes in the next "unix second". We know that `files_versions` does not support multiple versions in the same second.

In another test case, the timestamp of the latest version was being set to 60 seconds ago. We may as well do the same in all test cases (we could just make in 1 second ago).

This PR adjusts the time of the latest file version to be 60 seconds ago.

I am not sure why these test cases all seem to pass reliably in core, but 1 of them fails in `files_primary_s3`. So the `files_primary_s3` cause might be deeper than the fix here.

## Related Issue
- #36266 

## Motivation and Context
Make tests reliable.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
