### PR TITLE
Add API acceptance tests for moving in and out of a shared folder

### DIFF
--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -68,7 +68,97 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  Scenario Outline: Moving a file to a folder with no permissions
+  Scenario Outline: Moving a file into a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/testshare"
+    And user "user1" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | user0     |
+    And user "<mover>" has uploaded file with content "test data" to "/testfile.txt"
+    When user "<mover>" moves file "/testfile.txt" to "/testshare/testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testshare/testfile.txt" for user "user0" should be "test data"
+    And the content of file "/testshare/testfile.txt" for user "user1" should be "test data"
+    And as "<mover>" file "/testfile.txt" should not exist
+    Examples:
+      | dav_version | mover |
+      | old         | user0 |
+      | new         | user0 |
+      | old         | user1 |
+      | new         | user1 |
+
+  Scenario Outline: Moving a file out of a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/testshare"
+    And user "user1" has uploaded file with content "test data" to "/testshare/testfile.txt"
+    And user "user1" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | user0     |
+    When user "<mover>" moves file "/testshare/testfile.txt" to "/testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testfile.txt" for user "<mover>" should be "test data"
+    And as "user0" file "/testshare/testfile.txt" should not exist
+    And as "user1" file "/testshare/testfile.txt" should not exist
+    Examples:
+      | dav_version | mover |
+      | old         | user0 |
+      | new         | user0 |
+      | old         | user1 |
+      | new         | user1 |
+
+  Scenario Outline: Moving a folder into a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/testshare"
+    And user "user1" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | user0     |
+    And user "<mover>" has created folder "/testsubfolder"
+    And user "<mover>" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
+    When user "<mover>" moves folder "/testsubfolder" to "/testshare/testsubfolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testshare/testsubfolder/testfile.txt" for user "user0" should be "test data"
+    And the content of file "/testshare/testsubfolder/testfile.txt" for user "user1" should be "test data"
+    And as "<mover>" file "/testsubfolder" should not exist
+    Examples:
+      | dav_version | mover |
+      | old         | user0 |
+      | new         | user0 |
+      | old         | user1 |
+      | new         | user1 |
+
+  Scenario Outline: Moving a folder out of a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/testshare"
+    And user "user1" has created folder "/testshare/testsubfolder"
+    And user "user1" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
+    And user "user1" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | user0     |
+    When user "<mover>" moves folder "/testshare/testsubfolder" to "/testsubfolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testsubfolder/testfile.txt" for user "<mover>" should be "test data"
+    And as "user0" folder "/testshare/testsubfolder" should not exist
+    And as "user1" folder "/testshare/testsubfolder" should not exist
+    Examples:
+      | dav_version | mover |
+      | old         | user0 |
+      | new         | user0 |
+      | old         | user1 |
+      | new         | user1 |
+
+  Scenario Outline: Moving a file to a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"
@@ -86,7 +176,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  Scenario Outline: Moving a file to overwrite a file in a folder with no permissions
+  Scenario Outline: Moving a file to overwrite a file in a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "user1" has been created with default attributes and skeleton files
     And user "user1" has created folder "/testshare"


### PR DESCRIPTION
## Description
Add API acceptance test scenarios to cover moving a file and/or folder into and out of a shared folder, both as the sharee and as the sharer.

## Related Issue
- related to #36266 

## Motivation and Context
The current scenarios in `moveFile.feature` cover "ordinary" moving, and attempts to move into a share when the sharee does not have enough permission. But I don't see scenarios anywhere for "ordinary" moves in and out of shares when the sharee does have permission.

I looked for these because there are unit tests failing in `files_primary_s3` related to this sort of thing (when the sharer and sharee end up with different S3 storage buckets). So it would be useful to have these test scenarios in core, and they can get run from `files_primary_s3`

## How Has This Been Tested?
Local run of new test scenarios

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
