### PR TITLE
Remove old 'stable' branch references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
 branches:
   only:
     - master
-    - /^stable\d+(\.\d+)?$/
 
 addons:
   apt: &common_apt


### PR DESCRIPTION
## Description
This is the last mention of `stable*` branches in the test configs. Remove it.

Note: we want to keep `.travis.yml` still because it enables us to "switch on" IE11 and Edge webUI tests if we want.

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/539

## Motivation and Context
Cleanup crud.

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
