### PR TITLE
API acceptance test for creating a share with user for matching files

### DIFF
--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -550,6 +550,8 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2) (2) (2)/ | user1     |
 
   Scenario: user shares folder with matching name
+    Given user "user0" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API
+    And user "user0" uploads file with content "uploaded content" to "/FOLDER/abc.txt" using the WebDAV API
     When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
     And user "user0" shares folder "/FOLDER" with user "user1" using the sharing API
     Then the OCS status code should be "100"
@@ -558,12 +560,20 @@ Feature: accept/decline shares coming from internal users
       | /FOLDER/                 |
       | /PARENT/                 |
       | /PARENT%20(2)/           |
+      | /PARENT%20(2)/abc.txt    |
       | /FOLDER%20(2)/           |
+      | /FOLDER%20(2)/abc.txt    |
+    And user "user1" should not see the following elements
+      | /FOLDER/abc.txt |
+      | /PARENT/abc.txt |
+    And the content of file "/PARENT%20(2)/abc.txt" for user "user1" should be "uploaded content"
+    And the content of file "/FOLDER%20(2)/abc.txt" for user "user1" should be "uploaded content"
 
   Scenario: user shares folder with matching name in a group
-    Given user "user3" has been created with default attributes and skeleton files
-    When user "user3" shares folder "/PARENT" with group "grp1" using the sharing API
-    And user "user3" shares folder "/FOLDER" with group "grp1" using the sharing API
+    Given user "user0" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API
+    And user "user0" uploads file with content "uploaded content" to "/FOLDER/abc.txt" using the WebDAV API
+    When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "user0" shares folder "/FOLDER" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should see the following elements
@@ -571,11 +581,25 @@ Feature: accept/decline shares coming from internal users
       | /PARENT/                 |
       | /PARENT%20(2)/           |
       | /FOLDER%20(2)/           |
+      | /PARENT%20(2)/abc.txt    |
+      | /FOLDER%20(2)/abc.txt    |
+    And user "user1" should not see the following elements
+      | /FOLDER/abc.txt |
+      | /PARENT/abc.txt |
     And user "user2" should see the following elements
       | /FOLDER/                 |
       | /PARENT/                 |
       | /PARENT%20(2)/           |
       | /FOLDER%20(2)/           |
+      | /PARENT%20(2)/abc.txt    |
+      | /FOLDER%20(2)/abc.txt    |
+    And user "user2" should not see the following elements
+      | /FOLDER/abc.txt |
+      | /PARENT/abc.txt |
+    And the content of file "/PARENT%20(2)/abc.txt" for user "user1" should be "uploaded content"
+    And the content of file "/FOLDER%20(2)/abc.txt" for user "user1" should be "uploaded content"
+    And the content of file "/PARENT%20(2)/abc.txt" for user "user2" should be "uploaded content"
+    And the content of file "/FOLDER%20(2)/abc.txt" for user "user2" should be "uploaded content"
 
   Scenario: user shares file with matching name in a group
     When user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -549,7 +549,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2) (2)/     | user2     |
       | /PARENT (2) (2) (2)/ | user1     |
 
-  Scenario: user shares folder with matching name
+  Scenario: user shares folder with matching folder-name for both user involved in sharing
     Given user "user0" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API
     And user "user0" uploads file with content "uploaded content" to "/FOLDER/abc.txt" using the WebDAV API
     When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
@@ -569,7 +569,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/PARENT%20(2)/abc.txt" for user "user1" should be "uploaded content"
     And the content of file "/FOLDER%20(2)/abc.txt" for user "user1" should be "uploaded content"
 
-  Scenario: user shares folder with matching name in a group
+  Scenario: user shares folder in a group with matching folder-name for every users involved
     Given user "user0" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API
     And user "user0" uploads file with content "uploaded content" to "/FOLDER/abc.txt" using the WebDAV API
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -601,7 +601,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/PARENT%20(2)/abc.txt" for user "user2" should be "uploaded content"
     And the content of file "/FOLDER%20(2)/abc.txt" for user "user2" should be "uploaded content"
 
-  Scenario: user shares file with matching name in a group
+  Scenario: user shares files in a group with matching file-names for every users involved in sharing
     When user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
     And user "user0" shares file "/textfile1.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
@@ -617,7 +617,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile0%20(2).txt           |
       | /textfile1%20(2).txt           |
 
-  Scenario: user shares resource with matching name with another user when auto accept is disabled
+  Scenario: user shares resource with matching resource-name with another user when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
     And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
@@ -637,7 +637,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT%20(2)/           |
       | /textfile0%20(2).txt     |
 
-  Scenario: user shares file with matching name in a group when auto accept is disabled
+  Scenario: user shares file in a group with matching filename when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
@@ -659,7 +659,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile0.txt                 |
       | /textfile0%20(2).txt           |
 
-  Scenario: user shares matching folder with a user before that user has logged in
+  Scenario: user shares folder with matching folder name a user before that user has logged in
     Given these users have been created with skeleton files but not initialized:
       | username     |
       | user3        |
@@ -668,6 +668,11 @@ Feature: accept/decline shares coming from internal users
     Then user "user3" should see the following elements
       | /PARENT/          |
       | /PARENT/abc.txt   |
+      | /FOLDER/          |
+      | /textfile0.txt    |
+      | /textfile1.txt    |
+      | /textfile2.txt    |
+      | /textfile3.txt    |
     And user "user3" should not see the following elements
-      | /PARENT%20(2)/          |
+      | /PARENT%20(2)/    |
     And the content of file "/PARENT/abc.txt" for user "user3" should be "uploaded content"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
As stated in issue #35414, two users having matching files/folders are made involved in a share and one of the user shares such matching files to another user or a group. API test scenario for such case is added.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/35414
All remaining checkboxes except sharing matching 
`files` to uninitialised user

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
