### PR TITLE
Include settings for the persistent locks

### DIFF
--- a/lib/private/Lock/Persistent/LockManager.php
+++ b/lib/private/Lock/Persistent/LockManager.php
@@ -57,13 +57,15 @@ class LockManager {
 		// default to 30 minutes if nothing is specified
 		$timeout = $this->config->getAppValue('core', 'lock_timeout_default', self::LOCK_TIMEOUT_DEFAULT);
 		if (isset($lockInfo['timeout'])) {
-			$maxTimeout = $this->config->getAppValue('core', 'lock_timeout_max', self::LOCK_TIMEOUT_MAX);
+			// set the requested timeout
 			$timeout = $lockInfo['timeout'];
-			// max one day, not infinie
-			if ($timeout < 0 || $timeout > $maxTimeout) {
-				$timeout = $maxTimeout;
-			}
 		}
+		$maxTimeout = $this->config->getAppValue('core', 'lock_timeout_max', self::LOCK_TIMEOUT_MAX);
+		if ($timeout < 0 || $timeout > $maxTimeout) {
+			// ensure the timeout isn't greater than the one configured as maximum
+			$timeout = $maxTimeout;
+		}
+
 		$owner = isset($lockInfo['owner']) ? $lockInfo['owner'] : null;
 		if ($owner === null && $this->userSession->isLoggedIn()) {
 			$user = $this->userSession->getUser();

--- a/lib/private/Lock/Persistent/LockManager.php
+++ b/lib/private/Lock/Persistent/LockManager.php
@@ -59,7 +59,13 @@ class LockManager {
 			// set the requested timeout
 			$timeout = $lockInfo['timeout'];
 		}
+
 		$maxTimeout = $this->config->getAppValue('core', 'lock_timeout_max', self::LOCK_TIMEOUT_MAX);
+		if ($maxTimeout < 0) {
+			// if the max timeout is set to negative, use the default maximum (1 day)
+			$maxTimeout = self::LOCK_TIMEOUT_MAX;
+		}
+
 		if ($timeout < 0 || $timeout > $maxTimeout) {
 			// ensure the timeout isn't greater than the one configured as maximum
 			$timeout = $maxTimeout;

--- a/lib/private/Lock/Persistent/LockManager.php
+++ b/lib/private/Lock/Persistent/LockManager.php
@@ -54,7 +54,6 @@ class LockManager {
 			throw new \InvalidArgumentException('No token provided in $lockInfo');
 		}
 
-		// default to 30 minutes if nothing is specified
 		$timeout = $this->config->getAppValue('core', 'lock_timeout_default', self::LOCK_TIMEOUT_DEFAULT);
 		if (isset($lockInfo['timeout'])) {
 			// set the requested timeout

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -57,6 +57,7 @@ use OC\Settings\Panels\Admin\Legal;
 use OC\Settings\Panels\Admin\License;
 use OC\Settings\Panels\Admin\Mail;
 use OC\Settings\Panels\Admin\Logging;
+use OC\Settings\Panels\Admin\PersistentLocking;
 use OC\Settings\Panels\Admin\SecurityWarning;
 use OC\Settings\Panels\Admin\Tips;
 use OC\Settings\Panels\Admin\Status;
@@ -242,6 +243,7 @@ class SettingsManager implements ISettingsManager {
 				FileSharing::class,
 				Encryption::class,
 				Certificates::class,
+				PersistentLocking::class,
 				Apps::class,
 				Legal::class,
 				License::class,
@@ -294,6 +296,7 @@ class SettingsManager implements ISettingsManager {
 			FileSharing::class => new FileSharing($this->config, $this->helper, $this->l),
 			Logging::class => new Logging($this->config, $this->urlGenerator, $this->helper),
 			Mail::class => new Mail($this->config, $this->helper),
+			PersistentLocking::class => new PersistentLocking($this->config),
 			SecurityWarning::class => new SecurityWarning(
 				$this->l,
 				$this->config,

--- a/settings/Panels/Admin/PersistentLocking.php
+++ b/settings/Panels/Admin/PersistentLocking.php
@@ -39,7 +39,7 @@ class PersistentLocking implements ISettings {
 	}
 
 	public function getSectionID() {
-		return 'storage';
+		return 'additional';
 	}
 
 	public function getPanel() {

--- a/settings/Panels/Admin/PersistentLocking.php
+++ b/settings/Panels/Admin/PersistentLocking.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Panels\Admin;
+
+use OC\Lock\Persistent\LockManager;
+use OCP\Settings\ISettings;
+use OCP\Template;
+use OCP\IConfig;
+
+class PersistentLocking implements ISettings {
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getPriority() {
+		return 0;
+	}
+
+	public function getSectionID() {
+		return 'storage';
+	}
+
+	public function getPanel() {
+		// we must use the same container
+		$tmpl = new Template('settings', 'panels/admin/persistentlocking');
+		$tmpl->assign('defaultTimeout', $this->config->getAppValue('core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT));
+		$tmpl->assign('maximumTimeout', $this->config->getAppValue('core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX));
+
+		return $tmpl;
+	}
+}

--- a/settings/js/panels/persistentlocking.js
+++ b/settings/js/panels/persistentlocking.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+
+	$('#persistentlocking input').change(function () {
+		var currentInput = $(this);
+		var name = currentInput.attr('name');
+		var value = currentInput.val();
+		OC.AppConfig.setValue('core', name, value);
+	});
+
+});

--- a/settings/js/panels/persistentlocking.js
+++ b/settings/js/panels/persistentlocking.js
@@ -4,7 +4,24 @@ $(document).ready(function() {
 		var currentInput = $(this);
 		var name = currentInput.attr('name');
 		var value = currentInput.val();
-		OC.AppConfig.setValue('core', name, value);
+
+		var minRange = currentInput.attr('min');
+		var maxRange = currentInput.attr('max');
+
+		// range validation (mainly for firefox) to prevent saving wrong values
+		var isValid = true;
+		if (minRange !== undefined && value < minRange) {
+			isValid = false;
+		}
+		if (maxRange !== undefined && value > maxRange) {
+			isValid = false;
+		}
+
+		if (isValid) {
+			OC.AppConfig.setValue('core', name, value);
+		}
+		// browser should take care of the visual indication if the value
+		// isn't in the range
 	});
 
 });

--- a/settings/templates/panels/admin/persistentlocking.php
+++ b/settings/templates/panels/admin/persistentlocking.php
@@ -1,0 +1,18 @@
+<?php
+script('settings', 'panels/persistentlocking');
+?>
+<div class="section" id="persistentlocking">
+	<h2 class="app-name"><?php p($l->t('Persistent Locking')); ?></h2>
+	<label for="lockTimeoutDefault"><?php p($l->t('Default timeout for the locks if not specified (in seconds)'));?></label>
+	<input type="number"
+		name="lock_timeout_default"
+		id="lockTimeoutDefault"
+		value="<?php p($_['defaultTimeout'])?>" />
+	<br/>
+	<label for="lockTimeoutMax"><?php p($l->t('Maximum timeout for the locks (in seconds)'));?></label>
+	<input type="number"
+		name="lock_timeout_max"
+		id="lockTimeoutMax"
+		value="<?php p($_['maximumTimeout'])?>" />
+	<br/>
+</div>

--- a/settings/templates/panels/admin/persistentlocking.php
+++ b/settings/templates/panels/admin/persistentlocking.php
@@ -2,7 +2,7 @@
 script('settings', 'panels/persistentlocking');
 ?>
 <div class="section" id="persistentlocking">
-	<h2 class="app-name"><?php p($l->t('Persistent Locking')); ?></h2>
+	<h2 class="app-name"><?php p($l->t('Manual File Locking')); ?></h2>
 	<label for="lockTimeoutDefault"><?php p($l->t('Default timeout for the locks if not specified (in seconds)'));?></label>
 	<input type="number"
 		name="lock_timeout_default"

--- a/settings/templates/panels/admin/persistentlocking.php
+++ b/settings/templates/panels/admin/persistentlocking.php
@@ -7,12 +7,14 @@ script('settings', 'panels/persistentlocking');
 	<input type="number"
 		name="lock_timeout_default"
 		id="lockTimeoutDefault"
+		min="0"
 		value="<?php p($_['defaultTimeout'])?>" />
 	<br/>
 	<label for="lockTimeoutMax"><?php p($l->t('Maximum timeout for the locks (in seconds)'));?></label>
 	<input type="number"
 		name="lock_timeout_max"
 		id="lockTimeoutMax"
+		min="0"
 		value="<?php p($_['maximumTimeout'])?>" />
 	<br/>
 </div>

--- a/tests/Settings/Panels/Admin/PersistentLockingTest.php
+++ b/tests/Settings/Panels/Admin/PersistentLockingTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Settings\Panels\Admin;
+
+use OC\Settings\Panels\Admin\PersistentLocking;
+use OC\Lock\Persistent\LockManager;
+use OCP\IConfig;
+
+/**
+ * @package Tests\Settings\Panels\Admin
+ */
+class PersistentLockingTest extends \Test\TestCase {
+	/** @var IConfig */
+	private $config;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->panel = new PersistentLocking($this->config);
+	}
+
+	public function testGetPriority() {
+		$this->assertSame(0, $this->panel->getPriority());
+	}
+
+	public function testGetSection() {
+		$this->assertEquals('additional', $this->panel->getSectionID());
+	}
+
+	public function testGetPanel() {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, 44],
+				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, 9999],
+			]));
+
+		$templateHtml = $this->panel->getPanel()->fetchPage();
+		// applied modifiers "m" for multiline and "s" to include newlines in the dot char
+		$this->assertRegExp('/input[[:space:]].*name="lock_timeout_default"[[:space:]].*value="44"/ms', $templateHtml);
+		$this->assertRegExp('/input[[:space:]].*name="lock_timeout_max"[[:space:]].*value="9999"/ms', $templateHtml);
+	}
+}

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -4,6 +4,31 @@ Feature: set timeouts of LOCKS
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
+  Scenario Outline: do not set timeout on folder and check the default timeout
+    Given using <dav-path> DAV path
+    #And the administrator sets parameter "lock_timeout_default" of app "core" to "<default-timeout>"
+    #And the administrator sets parameter "lock_timeout_max" of app "core" to "<max-timeout>"
+    And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
+    And parameter "lock_timeout_max" of app "core" has been set to "<max-timeout>"
+    When user "user0" locks folder "PARENT" using the WebDAV API setting following properties
+      | lockscope | exclusive |
+    And user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+      | d:lockdiscovery |
+    Then the value of the item "//d:timeout" in the response should match "<result>"
+    When user "user0" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+      | d:lockdiscovery |
+    Then the value of the item "//d:timeout" in the response should match "<result>"
+    When user "user0" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+      | d:lockdiscovery |
+    Then the value of the item "//d:timeout" in the response should match "<result>"
+    # consider a drift of 5 seconds between setting the lock and retrieving it
+    Examples:
+      | dav-path | default-timeout | max-timeout | result                    |
+      | old      | 120             | 3600        | /Second-(120\|11[5-9])$/   |
+      | old      | 99999           | 3600        | /Second-(3600\|359[5-9])$/ |
+      | new      | 120             | 3600        | /Second-(120\|11[5-9])$/   |
+      | new      | 99999           | 3600        | /Second-(3600\|359[5-9])$/ |
+
   Scenario Outline: set timeout on folder
     Given using <dav-path> DAV path
     When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
@@ -33,6 +58,37 @@ Feature: set timeouts of LOCKS
       | new      | infinite        | /Second-\d{5}$/ |
       | new      | second--1       | /Second-\d{5}$/ |
       | new      | second-0        | /Second-\d{4}$/ |
+
+  Scenario Outline: set timeout over the maximum on folder
+    Given using <dav-path> DAV path
+    And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
+    And parameter "lock_timeout_max" of app "core" has been set to "<max-timeout>"
+    When user "user0" locks folder "PARENT" using the WebDAV API setting following properties
+      | lockscope | shared    |
+      | timeout   | <timeout> |
+    And user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+      | d:lockdiscovery |
+    Then the value of the item "//d:timeout" in the response should match "<result>"
+    When user "user0" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+      | d:lockdiscovery |
+    Then the value of the item "//d:timeout" in the response should match "<result>"
+    When user "user0" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+      | d:lockdiscovery |
+    Then the value of the item "//d:timeout" in the response should match "<result>"
+    Examples:
+      | dav-path | timeout      | default-timeout | max-timeout | result                     |
+      | old      | second-600   | 120             | 3600        | /Second-(600\|59[5-9])$/   |
+      | old      | second-600   | 99999           | 3600        | /Second-(600\|59[5-9])$/   |
+      | old      | second-10000 | 120             | 3600        | /Second-(3600\|359[5-9])$/ |
+      | old      | second-10000 | 99999           | 3600        | /Second-(3600\|359[5-9])$/ |
+      | old      | infinite     | 120             | 3600        | /Second-(3600\|359[5-9])$/ |
+      | old      | infinite     | 99999           | 3600        | /Second-(3600\|359[5-9])$/ |
+      | new      | second-600   | 120             | 3600        | /Second-(600\|59[5-9])$/   |
+      | new      | second-600   | 99999           | 3600        | /Second-(600\|59[5-9])$/   |
+      | new      | second-10000 | 120             | 3600        | /Second-(3600\|359[5-9])$/ |
+      | new      | second-10000 | 99999           | 3600        | /Second-(3600\|359[5-9])$/ |
+      | new      | infinite     | 120             | 3600        | /Second-(3600\|359[5-9])$/ |
+      | new      | infinite     | 99999           | 3600        | /Second-(3600\|359[3-9])$/ |
 
   @files_sharing-app-required
   Scenario Outline: as owner set timeout on folder as receiver check it

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -6,24 +6,25 @@ Feature: set timeouts of LOCKS
 
   Scenario Outline: do not set timeout on folder and check the default timeout
     Given using <dav-path> DAV path
-    #And the administrator sets parameter "lock_timeout_default" of app "core" to "<default-timeout>"
-    #And the administrator sets parameter "lock_timeout_max" of app "core" to "<max-timeout>"
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
     And parameter "lock_timeout_max" of app "core" has been set to "<max-timeout>"
-    When user "user0" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
       | lockscope | exclusive |
-    And user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+    And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "user0" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+    When user "Alice" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "user0" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+    When user "Alice" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     # consider a drift of 5 seconds between setting the lock and retrieving it
     Examples:
-      | dav-path | default-timeout | max-timeout | result                    |
+      | dav-path | default-timeout | max-timeout | result                     |
       | old      | 120             | 3600        | /Second-(120\|11[5-9])$/   |
       | old      | 99999           | 3600        | /Second-(3600\|359[5-9])$/ |
       | new      | 120             | 3600        | /Second-(120\|11[5-9])$/   |
@@ -63,16 +64,19 @@ Feature: set timeouts of LOCKS
     Given using <dav-path> DAV path
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
     And parameter "lock_timeout_max" of app "core" has been set to "<max-timeout>"
-    When user "user0" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+    And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "user0" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+    When user "Alice" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "user0" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+    When user "Alice" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     Examples:

--- a/tests/lib/Lock/Persistent/LockManagerTest.php
+++ b/tests/lib/Lock/Persistent/LockManagerTest.php
@@ -27,6 +27,7 @@ use OC\Lock\Persistent\LockMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\IConfig;
 use OCP\Lock\Persistent\ILock;
 use Test\TestCase;
 
@@ -45,6 +46,8 @@ class LockManagerTest extends TestCase {
 	private $manager;
 	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
+	/** @var IConfig */
+	private $config;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -52,7 +55,8 @@ class LockManagerTest extends TestCase {
 		$this->lockMapper = $this->createMock(LockMapper::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->manager = new LockManager($this->lockMapper, $this->userSession, $this->timeFactory);
+		$this->config = $this->createMock(IConfig::class);
+		$this->manager = new LockManager($this->lockMapper, $this->userSession, $this->timeFactory, $this->config);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getDisplayName')->willReturn('Alice');
@@ -71,6 +75,12 @@ class LockManagerTest extends TestCase {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('No token provided in $lockInfo');
 
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, 120],
+				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, 150],
+			]));
+
 		$this->manager->lock(6, '/foo/bar', 123, []);
 	}
 
@@ -80,10 +90,22 @@ class LockManagerTest extends TestCase {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid file id');
 
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, 120],
+				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, 150],
+			]));
+
 		$this->manager->lock(6, '/foo/bar', -1, []);
 	}
 
 	public function testLockInsert() {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_DEFAULT],
+				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, LockManager::LOCK_TIMEOUT_MAX],
+			]));
+
 		$this->lockMapper->method('getLocksByPath')->willReturn([]);
 		$this->lockMapper->expects($this->once())
 			->method('insert')
@@ -110,6 +132,12 @@ class LockManagerTest extends TestCase {
 	}
 
 	public function testLockUpdate() {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_DEFAULT],
+				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, LockManager::LOCK_TIMEOUT_MAX],
+			]));
+
 		$this->lockMapper->expects($this->once())
 			->method('getLocksByPath')
 			->with(6, '/foo/bar', false)
@@ -167,6 +195,12 @@ class LockManagerTest extends TestCase {
 	 * @dataProvider lockTimeoutProvider
 	 */
 	public function testLockTimeout($givenTimeout, $expectedTimeout) {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_DEFAULT],
+				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, LockManager::LOCK_TIMEOUT_MAX],
+			]));
+
 		$this->lockMapper->method('getLocksByPath')->willReturn([]);
 		$lockInfo = [
 			'token' => 'qwertzuiopü',

--- a/tests/lib/Lock/Persistent/LockManagerTest.php
+++ b/tests/lib/Lock/Persistent/LockManagerTest.php
@@ -179,26 +179,62 @@ class LockManagerTest extends TestCase {
 	public function lockTimeoutProvider() {
 		return [
 			// default value
-			[null, 1800],
+			[null, LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_MAX, 1800],
 			// given value
-			[10, 10],
+			[10, LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_MAX, 10],
 			// given value higher than default
-			[2000, 2000],
+			[2000, LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_MAX, 2000],
 			// max value 1 day
-			[2*60*60*24, 60*60*24],
+			[2*60*60*24, LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_MAX, 60*60*24],
 			// max value 1 day, not infinite
-			[-1, 60*60*24],
+			[-1, LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_MAX, 60*60*24],
+
+			// with a negative default value (shouldn't happen)
+			// default value
+			[null, -1, LockManager::LOCK_TIMEOUT_MAX, 60*60*24],
+			// given value
+			[10, -1, LockManager::LOCK_TIMEOUT_MAX, 10],
+			// given value higher than default
+			[2000, -1, LockManager::LOCK_TIMEOUT_MAX, 2000],
+			// max value 1 day
+			[2*60*60*24, -1, LockManager::LOCK_TIMEOUT_MAX, 60*60*24],
+			// max value 1 day, not infinite
+			[-1, -1, LockManager::LOCK_TIMEOUT_MAX, 60*60*24],
+
+			// with a negative max value (shouldn't happen) should be a max of 1 day
+			// default value
+			[null, LockManager::LOCK_TIMEOUT_DEFAULT, -1, 1800],
+			// given value
+			[10, LockManager::LOCK_TIMEOUT_DEFAULT, -1, 10],
+			// given value higher than default
+			[2000, LockManager::LOCK_TIMEOUT_DEFAULT, -1, 2000],
+			// max value 1 day
+			[2*60*60*24, LockManager::LOCK_TIMEOUT_DEFAULT, -1, 60*60*24],
+			// max value 1 day, not infinite
+			[-1, LockManager::LOCK_TIMEOUT_DEFAULT, -1, 60*60*24],
+
+			// with a negative default value and also negative maximum (shouldn't happen)
+			// default value
+			[null, -1, -1, 60*60*24],
+			// given value
+			[10, -1, -1, 10],
+			// given value higher than default
+			[2000, -1, -1, 2000],
+			// max value 1 day
+			[2*60*60*24, -1, -1, 60*60*24],
+			// max value 1 day, not infinite
+			[-1, -1, -1, 60*60*24],
 		];
 	}
 
 	/**
 	 * @dataProvider lockTimeoutProvider
 	 */
-	public function testLockTimeout($givenTimeout, $expectedTimeout) {
+	public function testLockTimeout($givenTimeout, $default, $max, $expectedTimeout) {
 		$this->config->method('getAppValue')
 			->will($this->returnValueMap([
-				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_DEFAULT],
-				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, LockManager::LOCK_TIMEOUT_MAX],
+				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, $default],
+				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, $max],
 			]));
 
 		$this->lockMapper->method('getLocksByPath')->willReturn([]);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Include a configuration page in the "storage" section (to be reviewed) to configure the persistent locks.
Default values remain the same as they were before: 30 minutes by default and a maximum of 1 day

## Related Issue
Related to https://github.com/owncloud/enterprise/issues/3131#issuecomment-554302666

## Motivation and Context
Adjust lock timeouts in order to avoid the files to be locked forever

## How Has This Been Tested?
1. Change configuration values: default timeout 60 secs, maximum timeout 120 secs
2. Check that trying to lock a file with an infinite timeout sets the lock with 120 secs of timeout. Same for any timeout greater than 120 secs
```
$ curl -v -u admin:Password -X LOCK -H "Timeout: Infinite" 'http://10.0.2.27:6080/remote.php/webdav/welcome.txt' -d "<?xml version='1.0' encoding='UTF-8'?><d:lockinfo xmlns:d='DAV:'><d:lockscope><d:exclusive/></d:lockscope></d:lockinfo>"
<?xml version="1.0"?>
<d:prop xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
 <d:lockdiscovery>
  <d:activelock>
   <d:lockscope>
    <d:exclusive/>
   </d:lockscope>
   <d:locktype>
    <d:write/>
   </d:locktype>
   <d:lockroot>
    <d:href>welcome.txt</d:href>
   </d:lockroot>
   <d:depth>infinity</d:depth>
   <d:timeout>Second-120</d:timeout>
   <d:locktoken>
    <d:href>opaquelocktoken:7df9d844-b368-4705-849c-e0ef1d3a0f40</d:href>
   </d:locktoken>
  </d:activelock>
 </d:lockdiscovery>
</d:prop>
```
3. Check that setting a lock without a timeout sets the lock with a timeout of 60 secs
```
$ curl -v -u admin:Password -X LOCK 'http://10.0.2.27:6080/remote.php/webdav/welcome.txt' -d "<?xml version='1.0' encoding='UTF-8'?><d:lockinfo xmlns:d='DAV:'><d:lockscope><d:exclusive/></d:lockscope></d:lockinfo>"
<?xml version="1.0"?>
<d:prop xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
 <d:lockdiscovery>
  <d:activelock>
   <d:lockscope>
    <d:exclusive/>
   </d:lockscope>
   <d:locktype>
    <d:write/>
   </d:locktype>
   <d:lockroot>
    <d:href>welcome.txt</d:href>
   </d:lockroot>
   <d:depth>infinity</d:depth>
   <d:timeout>Second-60</d:timeout>
   <d:locktoken>
    <d:href>opaquelocktoken:ad772384-9e80-4b1d-bccf-d7abc0c0fd89</d:href>
   </d:locktoken>
  </d:activelock>
 </d:lockdiscovery>
</d:prop>
```
4. Check that setting a lock with a valid timeout within the maximum range set the right value
```
$ curl -v -u admin:Password -X LOCK -H "Timeout: Second-88" 'http://10.0.2.27:6080/remote.php/webdav/welcome.txt' -d "<?xml version='1.0' encoding='UTF-8'?><d:lockinfo xmlns:d='DAV:'><d:lockscope><d:exclusive/></d:lockscope></d:lockinfo>"
<?xml version="1.0"?>
<d:prop xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
 <d:lockdiscovery>
  <d:activelock>
   <d:lockscope>
    <d:exclusive/>
   </d:lockscope>
   <d:locktype>
    <d:write/>
   </d:locktype>
   <d:lockroot>
    <d:href>welcome.txt</d:href>
   </d:lockroot>
   <d:depth>infinity</d:depth>
   <d:timeout>Second-88</d:timeout>
   <d:locktoken>
    <d:href>opaquelocktoken:c500a662-cbf9-46a7-83a3-60360ee59cef</d:href>
   </d:locktoken>
  </d:activelock>
 </d:lockdiscovery>
</d:prop>
```

## Screenshots (if appropriate):

![Screenshot from 2019-11-20 13-30-13](https://user-images.githubusercontent.com/1477829/69239868-7f315f80-0b9b-11ea-88fc-0c538c688da9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

As said, default values are 30 minutes for the default timeout and 1 day for the maximum timeout. Note that it isn't possible to reset those values at the moment (the admin must set them again by himself if wanted)

@pmaier1 to check the placement, section, wording, and other things. Note sure if the storage section is the best place taking into account there are problems with the lock and external storages (all the users should use the same account for the locks to work properly, otherwise the locks will only lock the file "seen" by the user, but not the rest - the storages are different). It might be confusing.