### PR TITLE
sanitize trailing / in propfind requests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2839,10 +2839,11 @@ trait WebDav {
 				HttpRequestHelper::parseResponseAsXml($this->response)
 			);
 		}
-		$fullWebDavPath = \ltrim(
-			\parse_url($this->response->getEffectiveUrl(), PHP_URL_PATH) . "/",
+		$fullWebDavPath = \trim(
+			\parse_url($this->response->getEffectiveUrl(), PHP_URL_PATH),
 			"/"
-		);
+		) . "/" ;
+
 		$multistatusResults = $this->responseXml["value"];
 		$results = [];
 		if ($multistatusResults !== null) {


### PR DESCRIPTION
## Description
make sure there is only one `/` when sending the `PROPFIND` request

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #36434

## Motivation and Context
make sure there is always a trailing slash, but only one

## How Has This Been Tested?
```
  Scenario: check propfind function
    When user "user0" requests "/remote.php/dav/files/user0/PARENT" with "PROPFIND" using basic auth
    Then the propfind result should contain these entries:
      | /parent.txt |
    When user "user0" requests "/remote.php/dav/files/user0/PARENT/" with "PROPFIND" using basic auth
    Then the propfind result should contain these entries:
      | /parent.txt |
    When user "user0" requests "/remote.php/dav/files/user0" with "PROPFIND" using basic auth
    Then the propfind result should contain these entries:
      | /textfile0.txt |
    When user "user0" requests "/remote.php/dav/files/user0/" with "PROPFIND" using basic auth
    Then the propfind result should contain these entries:
      | /textfile0.txt |
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
