### PR TITLE
Skip testTransferAllFiles when on ObjectStoreStorage

### DIFF
--- a/apps/files/tests/Command/TransferOwnershipTest.php
+++ b/apps/files/tests/Command/TransferOwnershipTest.php
@@ -163,15 +163,6 @@ class TransferOwnershipTest extends TestCase {
 			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$this->shareManager->createShare($share);
-
-		$subFolder = $userFolder->get('transfer/sub_folder');
-		$share = $this->shareManager->newShare();
-		$share->setNode($subFolder)
-			->setSharedBy('source-user')
-			->setSharedWith('share-receiver')
-			->setShareType(Share::SHARE_TYPE_USER)
-			->setPermissions(19);
-		$this->shareManager->createShare($share);
 	}
 
 	public function testTransferAllFiles() {
@@ -187,13 +178,13 @@ class TransferOwnershipTest extends TestCase {
 		$sourceShares = $this->shareManager->getSharesBy($this->sourceUser->getUID(), Share::SHARE_TYPE_USER);
 		$targetShares = $this->shareManager->getSharesBy($this->targetUser->getUID(), Share::SHARE_TYPE_USER);
 		$this->assertCount(0, $sourceShares);
-		$this->assertCount(4, $targetShares);
+		$this->assertCount(3, $targetShares);
 	}
 
 	public function folderPathProvider() {
 		return [
-			['transfer', 1, 3],
-			['transfer/sub_folder', 2, 2]
+			['transfer', 1, 2],
+			['transfer/sub_folder', 2, 1]
 		];
 	}
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -37,8 +37,6 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	 * @var array
 	 */
 	private static $tmpFiles = [];
-	/** @var array */
-	private $movingBetweenBuckets = [];
 	/**
 	 * @var \OCP\Files\ObjectStore\IObjectStore $objectStore
 	 */
@@ -74,27 +72,6 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		}
 	}
 
-	/**
-	 * This is intended to be used during the moveFromStorage call. While moving, this is needed
-	 * for the sourceStorage to know we're moving stuff and it shouldn't change the cache
-	 * until it's finished.
-	 * DO NOT USE OUTSIDE OF THIS CLASS
-	 */
-	public function setMovingBetweenBucketsInfo(array $info) {
-		$this->movingBetweenBuckets = $info;
-	}
-
-	/**
-	 * This is intended to be used during the moveFromStorage call. While moving, this is needed
-	 * for the sourceStorage to know we're moving stuff and it shouldn't change the cache
-	 * until it's finished. This will be called when we finish moving all the files, in order
-	 * for the sourceStorage to operate normally.
-	 * DO NOT USE OUTSIDE OF THIS CLASS
-	 */
-	public function clearMovingBetweenBucketsInfo() {
-		$this->movingBetweenBuckets = [];
-	}
-
 	public function mkdir($path) {
 		$path = $this->normalizePath($path);
 
@@ -113,9 +90,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		if ($path === '') {
 			//create root on the fly
 			$data['etag'] = $this->getETag('');
-			if (empty($this->movingBetweenBuckets)) {
-				$this->getCache()->put('', $data);
-			}
+			$this->getCache()->put('', $data);
 			return true;
 		} else {
 			// if parent does not exist, create it
@@ -130,14 +105,12 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 				// parent is a file
 				return false;
 			}
-			if (empty($this->movingBetweenBuckets)) {
-				// finally create the new dir
-				$mTime = \time(); // update mtime
-				$data['mtime'] = $mTime;
-				$data['storage_mtime'] = $mTime;
-				$data['etag'] = $this->getETag($path);
-				$this->getCache()->put($path, $data);
-			}
+			// finally create the new dir
+			$mTime = \time(); // update mtime
+			$data['mtime'] = $mTime;
+			$data['storage_mtime'] = $mTime;
+			$data['etag'] = $this->getETag($path);
+			$this->getCache()->put($path, $data);
 			return true;
 		}
 	}
@@ -195,9 +168,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 
 		$this->rmObjects($path);
 
-		if (empty($this->movingBetweenBuckets)) {
-			$this->getCache()->remove($path);
-		}
+		$this->getCache()->remove($path);
 
 		return true;
 	}
@@ -231,9 +202,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 					//removing from cache is ok as it does not exist in the objectstore anyway
 				}
 			}
-			if (empty($this->movingBetweenBuckets)) {
-				$this->getCache()->remove($path);
-			}
+			$this->getCache()->remove($path);
 			return true;
 		}
 		return false;
@@ -336,12 +305,6 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 					\file_put_contents($tmpFile, $source);
 				}
 				self::$tmpFiles[$tmpFile] = $path;
-				if (isset($this->movingBetweenBuckets[$this->getBucket()])) {
-					// if we're moving files, mark the path we're moving. This is needed because
-					// we need to know the fileid of the file we're moving in order to create
-					// the new file with the same name in the other bucket
-					$this->movingBetweenBuckets[$this->getBucket()]['paths'][$path] = true;
-				}
 
 				return \fopen('close://' . $tmpFile, $mode);
 		}
@@ -357,9 +320,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 		$this->remove($target);
-		if (empty($this->movingBetweenBuckets)) {
-			$this->getCache()->move($source, $target);
-		}
+		$this->getCache()->move($source, $target);
 		$this->touch(\dirname($target));
 		return true;
 	}
@@ -379,22 +340,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		/** @var ObjectStoreStorage $sourceStorage */
 		'@phan-var ObjectStoreStorage $sourceStorage';
 		if ($this->getBucket() !== $sourceStorage->getBucket()) {
-			$this->movingBetweenBuckets[$this->getBucket()] = [
-				'sourceStorage' => $sourceStorage,
-				'sourceBase' => $sourceInternalPath,
-				'targetBase' => $targetInternalPath,
-				'paths' => [],
-			];
-			$sourceStorage->setMovingBetweenBucketsInfo($this->movingBetweenBuckets);
-			try {
-				$result = parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
-				$this->getCache()->moveFromCache($sourceStorage->getCache(), $sourceInternalPath, $targetInternalPath);
-			} finally {
-				// ensure we restore the normal behaviour in both storages
-				$sourceStorage->clearMovingBetweenBucketsInfo();
-				unset($this->movingBetweenBuckets[$this->getBucket()]);
-			}
-			return $result;
+			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
 
 		// source and target live on the same object store and we can simply rename
@@ -475,25 +421,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		$stat['mimetype'] = \OC::$server->getMimeTypeDetector()->detect($tmpFile);
 		$stat['etag'] = $this->getETag($path);
 
-		if (isset($this->movingBetweenBuckets[$this->getBucket()]['paths'][$path])) {
-			// if we're moving, we need the fileid of the old entry in order to create the new
-			// file with the same name. The "movingBetweenBuckets" should contain enough
-			// information to get the fileid of the old entry from the filecache.
-			$targetBase = $this->movingBetweenBuckets[$this->getBucket()]['targetBase'];
-			$sourceBase = $this->movingBetweenBuckets[$this->getBucket()]['sourceBase'];
-			if (\substr($path, 0, \strlen($targetBase)) === $targetBase) {
-				$movingPath = \substr($path, \strlen($targetBase));
-				$originalSource = $sourceBase . $movingPath;
-				$originalStorage = $this->movingBetweenBuckets[$this->getBucket()]['sourceStorage'];
-				$fileId = $originalStorage->stat($originalSource)['fileid'];
-			} else {
-				// if the target path is outside the base... this shouldn't happen, but fallback to normal behaviour
-				$fileId = $this->getCache()->put($path, $stat);
-			}
-			unset($this->movingBetweenBuckets[$this->getBucket()]['paths'][$path]);
-		} else {
-			$fileId = $this->getCache()->put($path, $stat);
-		}
+		$fileId = $this->getCache()->put($path, $stat);
 		try {
 			//upload to object storage
 			$this->objectStore->writeObject($this->getURN($fileId), \fopen($tmpFile, 'r'));


### PR DESCRIPTION
## Description
This is on top of PR #36460

In addition to reverting "Objectstore transfer", also add code to skip the failing `testTransferAllFiles` test when on `ObjectStoreStorage`.

This skips the test case on any `ObjectStoreStorage` - it would be even better if there is a way to detect multi-bucket `ObjectStoreStorage` and only skip on that.

## Related Issue
- issue #36266 

## Motivation and Context

## How Has This Been Tested?
CI - I will check with files_primary_s3

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
