### PR TITLE
[For 10.4] Fix "files:transfer-ownership" in S3 multibucket setups

### DIFF
--- a/apps/files/tests/Command/TransferOwnershipTest.php
+++ b/apps/files/tests/Command/TransferOwnershipTest.php
@@ -22,12 +22,9 @@
 namespace OCA\Files\Tests\Command;
 
 use OC\Encryption\Manager;
-use OC\Files\ObjectStore\ObjectStoreStorage;
-use OC\Files\View;
 use OC\Share20\ProviderFactory;
 use OCA\Files\Command\TransferOwnership;
 use OCP\Files\Mount\IMountManager;
-use OCP\Files\Storage;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Share;
@@ -169,7 +166,6 @@ class TransferOwnershipTest extends TestCase {
 	}
 
 	public function testTransferAllFiles() {
-		$this->markTestSkippedIfMultiBucketObjectStorage();
 		$this->encryptionManager->method('isReadyForUser')->willReturn(true);
 		$input = [
 			'source-user' => $this->sourceUser->getUID(),
@@ -214,13 +210,5 @@ class TransferOwnershipTest extends TestCase {
 		$targetShares = $this->shareManager->getSharesBy($this->targetUser->getUID(), Share::SHARE_TYPE_USER);
 		$this->assertCount($expectedSourceShareCount, $sourceShares);
 		$this->assertCount($expectedTargetShareCount, $targetShares);
-	}
-	private function markTestSkippedIfMultiBucketObjectStorage() {
-		$sourceUserView = new View('/source-user/files/');
-		/** @var Storage $storage */
-		list($storage, $internalPath) = $sourceUserView->resolvePath('transfer/test_file1');
-		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
-			$this->markTestSkipped('transfer ownership may not work in a multi-bucket object store setup');
-		}
 	}
 }

--- a/apps/files/tests/Command/TransferOwnershipTest.php
+++ b/apps/files/tests/Command/TransferOwnershipTest.php
@@ -163,6 +163,15 @@ class TransferOwnershipTest extends TestCase {
 			->setShareType(Share::SHARE_TYPE_USER)
 			->setPermissions(19);
 		$this->shareManager->createShare($share);
+
+		$subFolder = $userFolder->get('transfer/sub_folder');
+		$share = $this->shareManager->newShare();
+		$share->setNode($subFolder)
+			->setSharedBy('source-user')
+			->setSharedWith('share-receiver')
+			->setShareType(Share::SHARE_TYPE_USER)
+			->setPermissions(19);
+		$this->shareManager->createShare($share);
 	}
 
 	public function testTransferAllFiles() {
@@ -178,13 +187,13 @@ class TransferOwnershipTest extends TestCase {
 		$sourceShares = $this->shareManager->getSharesBy($this->sourceUser->getUID(), Share::SHARE_TYPE_USER);
 		$targetShares = $this->shareManager->getSharesBy($this->targetUser->getUID(), Share::SHARE_TYPE_USER);
 		$this->assertCount(0, $sourceShares);
-		$this->assertCount(3, $targetShares);
+		$this->assertCount(4, $targetShares);
 	}
 
 	public function folderPathProvider() {
 		return [
-			['transfer', 1, 2],
-			['transfer/sub_folder', 2, 1]
+			['transfer', 1, 3],
+			['transfer/sub_folder', 2, 2]
 		];
 	}
 

--- a/changelog/unreleased/36464
+++ b/changelog/unreleased/36464
@@ -1,0 +1,9 @@
+Bugfix: Fix "files:transfer-ownership" in S3 multibucket setups
+
+There were problems using the files:transfer-ownership in setups using files_primary_s3
+against S3 storage with multibucket configuration, when some of the transferred files
+were shared with other people. This PR fixes that problem with the shares while
+transferring the files, allowing the files:transfer-ownership to finish correctly
+
+https://github.com/owncloud/core/pull/36464
+


### PR DESCRIPTION
## Description
Supersedes https://github.com/owncloud/core/pull/36326 , which was having problems and was reverted (in https://github.com/owncloud/core/pull/36460)

## Related Issue
https://github.com/owncloud/enterprise/issues/3520
#36266 

## Motivation and Context
Fix the original issue as well as additional problems found (which caused the revert)

## How Has This Been Tested?
`occ files:transfer-ownership` still works with shares without problems.
In addition, checked the following scenario which was failing with the previous PR:
1. Create 2 users and make sure both users use different S3 buckets (in a multibucket setup)
2. user1 creates a folder "foo1" and shares it with user2
3. user1 uploads a file in his root folder
4. user1 moves the uploaded file into the shared folder ("file1.txt" -> "foo1/file1.txt")
5. Check that the file is moved without a problem and that user 2 can access to the shared file.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
