### PR TITLE
Request->getHeader('Authentication') returns ''

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -224,7 +224,7 @@ class Auth extends AbstractBasic {
 				//Fix for broken webdav clients
 				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === null) ||
 				//Well behaved clients that only send the cookie are allowed
-				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && $request->getHeader('Authorization') === null)
+				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && ($request->getHeader('Authorization') === null || $request->getHeader('Authorization') === ''))
 			) {
 				$user = $this->userSession->getUser();
 				$this->checkAccountModule($user);

--- a/changelog/unreleased/36465
+++ b/changelog/unreleased/36465
@@ -1,0 +1,5 @@
+Bugfix: the authentication header can also hold an empty string
+
+In some setups a not set authentication header can not only hold null but also an empty string
+
+https://github.com/owncloud/core/pull/36465


### PR DESCRIPTION
causes ugly to debug bugs

Fixes: https://github.com/owncloud/enterprise/issues/3591