### PR TITLE
Pin sabre/http to 5.0.2

### DIFF
--- a/changelog/unreleased/36263
+++ b/changelog/unreleased/36263
@@ -1,8 +1,0 @@
-Change: Update sabre/http from version 5.0.2 to 5.0.4
-
-sabre/http 5.0.4 was released. It improved performance when downloading files
-that are larger than 4MB.
-
-https://github.com/owncloud/core/pull/36260
-https://github.com/sabre-io/http/releases/tag/5.0.3
-https://github.com/sabre-io/http/releases/tag/5.0.4

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "patchwork/jsqueeze": "^2.0",
         "lukasreschke/id3parser": "^0.0.3",
         "sabre/dav": "^4.0",
+        "sabre/http": "5.0.2",
         "deepdiver/zipstreamer": "^1.1",
         "symfony/translation": "^3.4",
         "zendframework/zend-inputfilter": "^2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "799c8f05c3591ff31c33e75da588a2e5",
+    "content-hash": "c40ce033557c7f9b6dfd5976bbf43b4a",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -2111,16 +2111,16 @@
         },
         {
             "name": "sabre/http",
-            "version": "5.0.4",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/http.git",
-                "reference": "73e2fa1ef894eddff145b698b6b0e2e2c5bf1d72"
+                "reference": "c9833073175bf02c8550695860fe375e26b68709"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/http/zipball/73e2fa1ef894eddff145b698b6b0e2e2c5bf1d72",
-                "reference": "73e2fa1ef894eddff145b698b6b0e2e2c5bf1d72",
+                "url": "https://api.github.com/repos/sabre-io/http/zipball/c9833073175bf02c8550695860fe375e26b68709",
+                "reference": "c9833073175bf02c8550695860fe375e26b68709",
                 "shasum": ""
             },
             "require": {
@@ -2163,7 +2163,7 @@
             "keywords": [
                 "http"
             ],
-            "time": "2019-10-09T20:27:43+00:00"
+            "time": "2019-09-12T15:36:08+00:00"
         },
         {
             "name": "sabre/uri",


### PR DESCRIPTION
## Description
Reverts the version bump in #36263 
This downgrades `sabre/http` from 5.0.4 to 5.0.2

Somehow 5.0.4 is causing some acceptance tests to hang when run in `files_primary_s3` (see issue for the tests that hang)

I deleted the changelog of #36263 because it is no longer relevant.

Note: the tests that were added in #36263 are still fine - they cover test scenarios that are useful anyway, and must pass with or without `sabre/http` 5.0.4

## Related Issue
- https://github.com/owncloud/files_primary_s3/issues/270
- https://github.com/owncloud/files_primary_s3/pull/272

## Motivation and Context
This will "unlock" the hanging tests in `files_primary_s3`

## How Has This Been Tested?
TBD

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
