### PR TITLE
Adjust new versions test and skip on object storage

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -310,6 +310,7 @@ Feature: dav-versions
     Then the HTTP status code should be "404"
     Then the value of the item "//s:exception" in the response should be "Sabre\DAV\Exception\NotFound"
 
+  @skipOnStorage:ceph @files_primary_s3-issue-161
   Scenario: Receiver tries get file versions of shared file from the sharer
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "version 1" to "textfile0.txt"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -386,13 +386,13 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theNumberOfVersionShouldBe($number) {
+	public function theNumberOfVersionsShouldBe($number) {
 		$resXml = $this->getResponseXmlObject();
 		if ($resXml === null) {
 			$resXml = HttpRequestHelper::getResponseXml($this->getResponse());
 		}
 		$xmlPart = $resXml->xpath("//d:getlastmodified");
-		Assert::assertEquals(\count($xmlPart), $number);
+		Assert::assertEquals($number, \count($xmlPart));
 	}
 
 	/**


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/files_primary_s3/1317/60/16
```
  Scenario: Receiver tries get file versions of shared file from the sharer                # /var/www/owncloud/testrunner/tests/acceptance/features/apiVersions/fileVersions.feature:313
    Given user "user1" has been created with default attributes and without skeleton files # FeatureContext::userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles()
    And user "user0" has uploaded file with content "version 1" to "textfile0.txt"         # FeatureContext::userHasUploadedAFileWithContentTo()
    And user "user0" has uploaded file with content "version 2" to "textfile0.txt"         # FeatureContext::userHasUploadedAFileWithContentTo()
    And user "user0" has uploaded file with content "version 3" to "textfile0.txt"         # FeatureContext::userHasUploadedAFileWithContentTo()
    And user "user0" has shared file "textfile0.txt" with user "user1"                     # FeatureContext::userHasSharedFileWithUserUsingTheSharingApi()
    When user "user1" tries to get versions of file "textfile0.txt" from "user0"           # FeatureContext::userTriesToGetFileVersions()
    Then the HTTP status code should be "207"                                              # FeatureContext::theHTTPStatusCodeShouldBe()
    And the number of versions should be "3"                                               # FeatureContext::theNumberOfVersionShouldBe()
      Failed asserting that '3' matches expected 4.

--- Failed scenarios:

    /var/www/owncloud/testrunner/tests/acceptance/features/apiVersions/fileVersions.feature:313

32 scenarios (31 passed, 1 failed)
410 steps (409 passed, 1 failed)
```

1) "expected" is 3 and the actual is 4 - so the parameters to the "assert" are around the wrong way. Fix it.

2) the test scenario is new, and is another test scenario that will (and does) fail in `files_primary_s3` due to issue https://github.com/owncloud/files_primary_s3/issues/161

This test scenario was added in PR #36391 

## Related Issue
- https://github.com/owncloud/files_primary_s3/issues/161

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
