### PR TITLE
Check / log unsupported memcache by memcache.locking

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -441,10 +441,16 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;
 				$prefix = \md5($instanceId . '-' . $version . '-' . $path);
-				return new \OC\Memcache\Factory($prefix, $c->getLogger(),
+				$locking = $config->getSystemValue('memcache.locking', null);
+				$logger = $c->getLogger();
+				if ($locking !== null && \strpos($locking, 'Redis') === false) {
+					#$logger->warning('Only \OC\Memcache\Redis is supported by memcache.locking. See: ' . \OC::$server->getURLGenerator()->linkToDocs('admin-transactional-locking'), ['app' => 'core']);
+					$locking = null;
+				}
+				return new \OC\Memcache\Factory($prefix, $logger,
 					$config->getSystemValue('memcache.local', null),
 					$config->getSystemValue('memcache.distributed', null),
-					$config->getSystemValue('memcache.locking', null)
+					$locking
 				);
 			}
 


### PR DESCRIPTION
## Description
Check / log unsupported memcache by memcache.locking. https://doc.owncloud.com/server/10.3/admin_manual/configuration/server/caching_configuration.html#memcached reads by:

> Memcached is a reliable old-timer for shared caching on distributed servers. It performs well with ownCloud with one exception: it is **not suitable** to use with Transactional File Locking. This is because it does not store locks, and data can disappear from the cache at any time.

Memcached not also working in related issue.

## Related Issue
- #31350
- Fix #37094

## Motivation and Context
Better help to user, see:

https://github.com/owncloud/core/issues/31350#issuecomment-558725214 \
https://github.com/owncloud/core/issues/31350#issuecomment-558744278

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
