### PR TITLE
change wait-for-it time in CI to 120 seconds

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1887,7 +1887,7 @@ def setupCeph(phpVersion, cephS3):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'wait-for-it -t 60 ceph:80',
+			'wait-for-it -t 120 ceph:80',
 			'cd /drone/src/apps/files_primary_s3',
 			'cp tests/drone/ceph.config.php /drone/src/config',
 			'cd /var/www/owncloud/server',
@@ -1912,7 +1912,7 @@ def setupScality(phpVersion, scalityS3):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'wait-for-it -t 60 scality:8000',
+			'wait-for-it -t 120 scality:8000',
 			'cp /drone/src/apps/files_primary_s3/tests/drone/%s /drone/src/config' % configFile,
 			'php occ s3:create-bucket owncloud --accept-warning'
 		] + ([

--- a/.drone.yml
+++ b/.drone.yml
@@ -3555,7 +3555,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 60 scality:8000
+  - wait-for-it -t 120 scality:8000
   - cp /drone/src/apps/files_primary_s3/tests/drone/scality.config.php /drone/src/config
   - php occ s3:create-bucket owncloud --accept-warning
 

--- a/tests/drone/install-server.sh
+++ b/tests/drone/install-server.sh
@@ -76,23 +76,23 @@ rm -rf ${DATA_DIRECTORY} config/config.php
 echo "waiting for database to be ready"
 case "${DB_TYPE}" in
   mariadb)
-    wait-for-it mariadb:3306
+    wait-for-it -t 120 mariadb:3306
     DB=mysql
     ;;
   mysql)
-    wait-for-it mysql:3306
+    wait-for-it -t 120 mysql:3306
     DB=mysql
     ;;
   mysql8)
-    wait-for-it mysql8:3306
+    wait-for-it -t 120 mysql8:3306
     DB=mysql
     ;;
   postgres)
-    wait-for-it postgres:5432
+    wait-for-it -t 120 postgres:5432
     DB=pgsql
     ;;
   oracle)
-    wait-for-it oracle:1521
+    wait-for-it -t 120 oracle:1521
     DB=oci
     DB_USERNAME=autotest
     DB_NAME='XE'


### PR DESCRIPTION
## Description
Recently it has been taking longer to pull images from `docker.io`. So we sometimes get drone pipelines fails like https://drone.owncloud.com/owncloud/core/21572/80/10
```
+ wait-for-it mariadb:3306
waiting for database to be ready
services aren't ready in 20s
```
Last week we extended that wait time to 120 seconds in the app repos.

Do it in core also.

## Motivation and Context
More reliable CI

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
