### PR TITLE
Cleanup remote

### DIFF
--- a/apps/federatedfilesharing/lib/Address.php
+++ b/apps/federatedfilesharing/lib/Address.php
@@ -134,6 +134,8 @@ class Address {
 		//Origin is the last part
 		$parts = \explode('@', $this->cloudId);
 		$rawOrigin = \array_pop($parts);
+		// cut query and|or anchor part off
+		$rawOrigin = \strtok($rawOrigin, '?#');
 		if ($fileNamePosition = \strpos($rawOrigin, '/index.php')) {
 			$rawOrigin = \substr($rawOrigin, 0, $fileNamePosition);
 		}

--- a/apps/federatedfilesharing/tests/AddressTest.php
+++ b/apps/federatedfilesharing/tests/AddressTest.php
@@ -45,7 +45,11 @@ class AddressTest extends \Test\TestCase {
 		return [
 			['john@domain.com', 'john'],
 			['john@domain.com@some.host', 'john@domain.com'],
-			['john@domain.com@http://some.host', 'john@domain.com']
+			['john@domain.com@http://some.host', 'john@domain.com'],
+			['john@domain.com@http://some.host?app=files', 'john@domain.com'],
+			['john@domain.com@http://some.host?app=files?garbage', 'john@domain.com'],
+			['john@domain.com@http://some.host#content', 'john@domain.com'],
+			['john@domain.com@http://some.host?app=files#content', 'john@domain.com']
 		];
 	}
 

--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -42,7 +42,8 @@ if ($federatedShareProvider->isIncomingServer2serverShareEnabled() === false) {
 }
 
 $token = $_POST['token'];
-$remote = $_POST['remote'];
+// cut query and|or anchor part off
+$remote = \strtok($_POST['remote'], '?#');
 $owner = $_POST['owner'];
 $ownerDisplayName = $_POST['ownerDisplayName'];
 $name = $_POST['name'];

--- a/apps/files_sharing/lib/Controllers/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controllers/ExternalSharesController.php
@@ -160,6 +160,8 @@ class ExternalSharesController extends Controller {
 	 * @return DataResponse
 	 */
 	public function testRemote($remote) {
+		// cut query and|or anchor part off
+		$remote = \strtok($remote, '?#');
 		if (
 			$this->testUrl('https://' . $remote . '/ocs-provider/') ||
 			$this->testUrl('https://' . $remote . '/ocs-provider/index.php') ||

--- a/apps/files_sharing/tests/Controllers/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ExternalShareControllerTest.php
@@ -26,7 +26,9 @@ namespace OCA\Files_Sharing\Tests\Controllers;
 use OCA\Files_Sharing\Controllers\ExternalSharesController;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
 use OCP\IRequest;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -171,5 +173,29 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->will($this->returnValue($client));
 
 		$this->assertEquals(new DataResponse(false), $this->getExternalShareController()->testRemote('owncloud.org'));
+	}
+
+	public function testRemoteIsCleanedUp() {
+		$client = $this->createMock(IClient::class);
+		$response = $this->createMock(IResponse::class);
+		$response
+			->expects($this->exactly(2))
+			->method('getBody')
+			->will($this->onConsecutiveCalls('Certainly not a JSON string', '{"installed":true,"maintenance":false,"version":"8.1.0.8","versionstring":"8.1.0","edition":""}'));
+		$client
+			->expects($this->any())
+			->method('get')
+			->withConsecutive(
+				['https://owncloud.org/ocs-provider/'],
+				['https://owncloud.org/ocs-provider/index.php']
+			)
+			->will($this->returnValue($response));
+
+		$this->clientService
+			->expects($this->exactly(2))
+			->method('newClient')
+			->will($this->returnValue($client));
+		$response = $this->getExternalShareController()->testRemote('owncloud.org?app=files#anchor');
+		$this->assertEquals(new DataResponse('https'), $response);
 	}
 }

--- a/changelog/10.3.2/36487
+++ b/changelog/10.3.2/36487
@@ -1,0 +1,5 @@
+Bugfix: Remove query and/or anchor part in remote url
+
+Remote server URL may potentially contain query or anchor part. This pull request strips these parts for proper server name detection.
+
+https://github.com/owncloud/core/pull/36487


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
remove query and|or anchor part in remote url


## Motivation and Context
Better remote sharing

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
