### PR TITLE
[For 10.4] user is only allowed to see their own home trashbin

### DIFF
--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -60,7 +60,11 @@ class RootCollection extends SimpleCollection {
 		$filesCollection->disableListing = $disableListing;
 
 		if ($config->getSystemValue('dav.enable.tech_preview', false) === true) {
-			$trashBinCollection = new TrashBin\RootCollection($userPrincipalBackend, 'principals/users');
+			$trashBinCollection = new TrashBin\RootCollection(
+				$userPrincipalBackend,
+				\OC::$server->getUserSession(),
+				'principals/users'
+			);
 			$trashBinCollection->disableListing = $disableListing;
 		}
 

--- a/apps/dav/lib/TrashBin/TrashBinHome.php
+++ b/apps/dav/lib/TrashBin/TrashBinHome.php
@@ -34,13 +34,12 @@ class TrashBinHome extends Collection {
 	/**
 	 * TrashBinHome constructor.
 	 *
-	 * @param array $principalInfo
 	 * @param TrashBinManager $trashBinManager
+	 * @param string $user
 	 */
-	public function __construct(array $principalInfo, TrashBinManager $trashBinManager) {
+	public function __construct(TrashBinManager $trashBinManager, string $user) {
 		$this->trashBinManager = $trashBinManager;
-		list(, $name) = \Sabre\Uri\split($principalInfo['uri']);
-		$this->user = $name;
+		$this->user = $user;
 	}
 
 	public function getChild($name) {

--- a/apps/dav/tests/unit/TrashBin/TrashBinHomeTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinHomeTest.php
@@ -39,9 +39,7 @@ class TrashBinHomeTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 		$this->trashBinManager = $this->createMock(TrashBinManager::class);
-		$this->trashBinHome = new TrashBinHome([
-			'uri' => 'principals/alice'
-		], $this->trashBinManager);
+		$this->trashBinHome = new TrashBinHome($this->trashBinManager, 'alice');
 	}
 
 	/**

--- a/apps/dav/tests/unit/TrashBin/TrashBinPluginTest.php
+++ b/apps/dav/tests/unit/TrashBin/TrashBinPluginTest.php
@@ -22,14 +22,10 @@
 namespace OCA\DAV\Tests\Unit\TrashBin;
 
 use OCA\DAV\TrashBin\ITrashBinNode;
-use OCA\DAV\TrashBin\RootCollection;
-use OCA\DAV\TrashBin\TrashBinHome;
 use OCA\DAV\TrashBin\TrashBinPlugin;
-use phpDocumentor\Reflection\Types\This;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\DAV\Xml\Property\GetLastModified;
-use Sabre\DAVACL\PrincipalBackend\BackendInterface;
 use Test\TestCase;
 
 class TrashBinPluginTest extends TestCase {

--- a/changelog/unreleased/36488
+++ b/changelog/unreleased/36488
@@ -1,0 +1,6 @@
+Bugfix: Fix Trash-bin api to not allow users to see trash-bin content of other users
+
+Trash-bin API had allowed users to see the trash-bin content of other users.
+
+https://github.com/owncloud/core/issues/36378
+https://github.com/owncloud/core/pull/36488

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -62,7 +62,7 @@ Feature: files and folders can be deleted from the trashbin
       And user "user0" has deleted file "/PARENT/parent.txt"
       And user "user0" has deleted file "/PARENT/CHILD/child.txt"
       When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the trashbin API
-      Then the HTTP status code should be "404"
+      Then the HTTP status code should be "401"
       And as "user0" the file with original path "/textfile1.txt" should exist in trash
       And as "user0" the file with original path "/textfile0.txt" should exist in trash
       And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -188,17 +188,15 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @issue-36378 @skipOnLDAP @skip_on_objectstore
+  @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user40" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and skeleton files
     And user "user40" has deleted file "/textfile1.txt"
     When user "user1" tries to list the trashbin content for user "user40"
-    Then the HTTP status code should be "207"
-    And the last webdav response should contain the following elements
-    # Then the HTTP status code should be "401"
-    # And the last webdav response should not contain following elements
+    Then the HTTP status code should be "401"
+    And the last webdav response should not contain the following elements
       | path          | user   |
       | textfile1.txt | user40 |
     Examples:
@@ -208,7 +206,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @issue-36378 @skipOnLDAP @skip_on_objectstore
+  @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user60" has been created with default attributes and skeleton files
@@ -216,10 +214,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user60" has deleted file "/textfile0.txt"
     And user "user60" has deleted file "/textfile2.txt"
     When user "user1" tries to list the trashbin content for user "user60"
-    Then the HTTP status code should be "207"
-    And the last webdav response should contain the following elements
-    # Then the HTTP status code should be "401"
-    # And the last webdav response should not contain the following elements
+    Then the HTTP status code should be "401"
+    And the last webdav response should not contain the following elements
       | path          | user   |
       | textfile0.txt | user60 |
       | textfile2.txt | user60 |
@@ -230,7 +226,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @issue-36378 @skipOnLDAP @skip_on_objectstore
+  @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user504" has been created with default attributes and skeleton files
@@ -243,16 +239,12 @@ Feature: files and folders exist in the trashbin after being deleted
       | user504  |
     And user "user504" has deleted file "/textfile3.txt"
     When user "user1" tries to list the trashbin content for user "user504"
-    Then the HTTP status code should be "207"
-    # Then the HTTP status code should be "401"
-    And the last webdav response should contain the following elements
-      | path          | user    |
-      | textfile3.txt | user504 |
+    Then the HTTP status code should be "401"
     And the last webdav response should not contain the following elements
       | path          | user    |
       | textfile0.txt | user504 |
       | textfile2.txt | user504 |
-      # | textfile3.txt  | user504 |
+      | textfile3.txt  | user504 |
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -273,7 +273,7 @@ Feature: Restore deleted files/folders
     And user "user1" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     When user "user1" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the trashbin API
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "401"
     And as "user0" the folder with original path "/textfile0.txt" should exist in trash
     And user "user0" should not see the following elements
       | /textfile0.txt     |


### PR DESCRIPTION
## Description
User is only allowed to see their own home trashbin.

## Related Issue
- Fixes #36378

## Motivation and Context
Trashbin API had allowed users to see the trashbin content of other users. This bug has been resolved.

## How Has This Been Tested?
Followed #36378's reproduce steps. Also, acceptance tests already cover this issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
