### PR TITLE
Changelog entries related to 'drop PHP 7.0'

### DIFF
--- a/changelog/unreleased/36290-1
+++ b/changelog/unreleased/36290-1
@@ -1,0 +1,8 @@
+Change: Drop PHP 7.0 support across the platform
+
+Support for security fixes for PHP 7.0 ended 1 Jan 2019
+ownCloud core no longer supports PHP 7.0.
+Ensure that you are using PHP 7.1 or later.
+
+https://github.com/owncloud/core/pull/36290
+https://www.php.net/supported-versions.php

--- a/changelog/unreleased/36290-2
+++ b/changelog/unreleased/36290-2
@@ -1,0 +1,6 @@
+Enhancement: MariaDb 10.3 support
+
+MariaDb 10.3 is now supported
+
+https://github.com/owncloud/core/issues/29483
+https://github.com/owncloud/core/pull/36290

--- a/changelog/unreleased/36290-3
+++ b/changelog/unreleased/36290-3
@@ -1,0 +1,6 @@
+Enhancement: PostgreSQL 10 support
+
+PostgreSQL 10 is now supported
+
+https://github.com/owncloud/core/issues/33187
+https://github.com/owncloud/core/pull/36290


### PR DESCRIPTION
## Description
Add changelogs for the things merged in #36290 
- drop PHP 7.0 support
- MariaDb 10.3 support
- PostgreSQL 10 support

## Related Issue
#29483 MariaDB
#33187 PostgreSQL 10
#36290 Drop PHP 7.0

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
