### PR TITLE
Bump core version to 10.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/10.3/admin_manual/installation/
+https://doc.owncloud.org/server/10.4/admin_manual/installation/
 
 ## Contribution Guidelines
 https://owncloud.org/contribute/
@@ -38,4 +38,4 @@ Please submit translations via Transifex:
 https://www.transifex.com/projects/p/owncloud/
 
 For detailed information about translations:
-https://doc.owncloud.org/server/10.3/developer_manual/core/translation.html
+https://doc.owncloud.org/server/10.4/developer_manual/core/translation.html

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 3, 2, 2];
+$OC_Version = [10, 4, 0, 0];
 
 // The human readable string
-$OC_VersionString = '10.3.2';
+$OC_VersionString = '10.4.0 alpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
Bump the core master version to 10.4.0

We have started merging feature branches to core for 10.4. It will be good if automated app tests etc. are running using a `daily-master-qa` tarball that says it is 10.4

(We could wait a few days to actually merge this change, until we first merge back the `release-10.3.2` branch which has the official change to 10.3.2)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
