### PR TITLE
Do not count shared files on trashbin free space calculation

### DIFF
--- a/changelog/unreleased/36494
+++ b/changelog/unreleased/36494
@@ -1,0 +1,5 @@
+Bugfix: Files shared with user cause purge of the trashbin content
+
+Files_thrashbin app counted incoming shares on calculation of the occupied space. It caused purge of the trashbin content when trashbin_retention_obligation is auto, user has quota set and incoming shares exceed 50% of this quota.
+
+https://github.com/owncloud/core/pull/36494


### PR DESCRIPTION
##  Description
Get free space directly instead of calculating it as `quota - occupied`

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3610

## Motivation and Context
Trash bin is emptied if the user has large files shared with him

## How Has This Been Tested?
1. create user1 with 5 GB quota and user2 with 1 GB quota local storage
2. upload a 1.7 GB file to user1 and share it with user2
3. **login as user2 and create a text file and delete that text file** NOT THE BIG SHARED FILE!
4. set `'trashbin_retention_obligation' => 'auto,180',`
5. run cron.php
6. look in logs.

# Expected Result
the shared file should not count in the quota for user2 and the new created text file should remain in the trash bin of user2

# Actual Result
The file is deleted from trash bin
```
{
  "reqId": "dV1TZBjg6TFOw4xok0Qu",
  "level": 0,
  "time": "2019-11-18T16:40:04+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "cron",
  "method": "--",
  "url": "--",
  "message": "Started background job of class : OC\\Command\\CommandJob with arguments : O:33:\"OCA\\Files_Trashbin\\Command\\Expire\":1:{s:39:\"\u0000OCA\\Files_Trashbin\\Command\\Expire\u0000user\";s:5:\"user2\";}"
}
{
  "reqId": "dV1TZBjg6TFOw4xok0Qu",
  "level": 1,
  "time": "2019-11-18T16:40:04+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "files_trashbin",
  "method": "--",
  "url": "--",
  "message": "remove \"carlos.txt\" (19B) to meet the limit of trash bin size (50% of available quota)"
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
