### PR TITLE
unpin sabre/http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "patchwork/jsqueeze": "^2.0",
         "lukasreschke/id3parser": "^0.0.3",
         "sabre/dav": "^4.0",
-        "sabre/http": "5.0.5",
+        "sabre/http": "^5.0.5",
         "deepdiver/zipstreamer": "^1.1",
         "symfony/translation": "^3.4",
         "zendframework/zend-inputfilter": "^2.8",


### PR DESCRIPTION

## Description
After #36490 `sabre/http` is in good shape. It got pinned to a particular version for the last week. Now we can unpin it so that when we do `composer update` that composer will find new releases for us.

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
