### PR TITLE
#36490 changelog extend

### DIFF
--- a/changelog/unreleased/36490
+++ b/changelog/unreleased/36490
@@ -1,5 +1,5 @@
 Change: Update sabre/http (5.0.2 => 5.0.5)
 
-Includes functionality to ignificantly improve file download speed by enabling mmap based stream_copy_to_stream.
+Includes functionality to significantly improve file download speed by enabling mmap based stream_copy_to_stream.
 
 https://github.com/owncloud/core/pull/36490

--- a/changelog/unreleased/36490
+++ b/changelog/unreleased/36490
@@ -1,3 +1,5 @@
 Change: Update sabre/http (5.0.2 => 5.0.5)
 
+Includes functionality to ignificantly improve file download speed by enabling mmap based stream_copy_to_stream.
+
 https://github.com/owncloud/core/pull/36490


### PR DESCRIPTION
#36490 include code done by https://github.com/sabre-io/http/pull/119, think worth mentioned excplicite:

> Directly reading a large file (let’s say 10GiB) on that server will get a read speed around 540-550 MiB/s. However the download speed with webdav is only about 240-260 MiB/s.

and

> After applying this PR, I got full download speed about just like reading that file locally (even faster than fpassthru).