### PR TITLE
Allow extra ampersands on BEHAT_FILTER_TAGS in acceptance tests

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -678,6 +678,11 @@ if [ -z "${BEHAT_FILTER_TAGS}" ]
 then
 	BEHAT_FILTER_TAGS="${TEST_TYPE_TAG}"
 else
+	# Be nice to the caller
+	# Remove any extra "&&" at the end of their tags list
+	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS%&&}"
+	# Remove any extra "&&" at the beginning of their tags list
+	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS#&&}"
 	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&${TEST_TYPE_TAG}"
 fi
 


### PR DESCRIPTION
## Description
In some places (e.g. the referenced issue in user_ldap) we want to be able to build up lists of tags by appending multiple tags (or lists of tags) together with `&&`. Sometimes we want to do that in a 1-line `behat` command in a `Makefile`. Doing it the "easy" way with bash variable insertion, if the variable being inserted happens to be empty, can result in a `BEHAT_FILTER_TAGS` that has `&&` by itself at the start or end of the tags list.

Rather than have to try to handle all that in the callers logic (that might be trying to do a 1-liner), we can be nice in `run.sh` and strip off any `&&` that is passed at the beginning or end of the tags string.

## Related Issue
https://github.com/owncloud/user_ldap/issues/478

## How Has This Been Tested?
Try commands like:
```
./tests/acceptance/run.sh --remote --type api --tags "@smokeTest"
./tests/acceptance/run.sh --remote --type api --tags "&&@smokeTest"
./tests/acceptance/run.sh --remote --type api --tags "@smokeTest&&"
./tests/acceptance/run.sh --remote --type api --tags "&&@smokeTest&&"
./tests/acceptance/run.sh --remote --type api --tags "@smokeTest&&~@random"
./tests/acceptance/run.sh --remote --type api --tags "&&@smokeTest&&~@random"
./tests/acceptance/run.sh --remote --type api --tags "@smokeTest&&~@random&&"
./tests/acceptance/run.sh --remote --type api --tags "&&@smokeTest&&~@random&&"
```
They all work - `&&` is stripped from front and/or back and not stripped from the middle.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
