### PR TITLE
[For 10.4] Add validation for sender email address

### DIFF
--- a/changelog/unreleased/36505
+++ b/changelog/unreleased/36505
@@ -1,0 +1,5 @@
+Bugfix: enhance validation for sender e-mail address for e-mail notifications
+
+If a user wanted to use the e-mail notification mechanism in order to notify other users when creating public links as well as internal shares, an error was triggered if the e-mail address for this user was not set. The behavior has now been fixed.
+
+https://github.com/owncloud/core/pull/36505

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -183,6 +183,7 @@ class MailNotifications {
 				'internal',
 				$recipientL10N
 			);
+			$replyTo = $this->getReplyTo($sender->getEMailAddress());
 
 			// send it out now
 			try {
@@ -192,7 +193,7 @@ class MailNotifications {
 				$message->setHtmlBody($htmlBody);
 				$message->setPlainBody($textBody);
 				$message->setFrom($this->getFrom($this->l, $filter->getSenderDisplayName()));
-				$message->setReplyTo([$sender->getEMailAddress()]);
+				$message->setReplyTo([$replyTo]);
 
 				$this->mailer->send($message);
 			} catch (\Exception $e) {
@@ -263,7 +264,7 @@ class MailNotifications {
 			$l10n
 		);
 		$from = $this->getFrom($l10n, $filter->getSenderDisplayName());
-		$replyTo = $sender->getEMailAddress();
+		$replyTo = $this->getReplyTo($sender->getEMailAddress());
 
 		$event = new GenericEvent(null, ['link' => $link, 'to' => $recipientsAsString]);
 		$this->eventDispatcher->dispatch('share.sendmail', $event);
@@ -402,5 +403,16 @@ class MailNotifications {
 				]
 			)
 		];
+	}
+		
+	/**
+	 * @param string $senderMailAddress
+	 * @return string
+	 */
+	protected function getReplyTo($senderMailAddress) {
+		if (empty($senderMailAddress)) {
+			return Util::getDefaultEmailAddress('sharing-noreply');
+		}
+		return $senderMailAddress;
 	}
 }

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -659,3 +659,21 @@ Feature: Sharing files and folders with internal users
     And the option to delete file "lorem.txt" should not be available on the webUI
     When the user shares file "lorem.txt" with user "User Three" using the webUI
     Then as "user3" file "lorem.txt" should exist
+
+  @mailhog
+  Scenario: user without email should be able to send notification by email when allow share mail notification has been enabled
+    Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
+    And these users have been created without skeleton files:
+      | username | password |
+      | user0    | 1234     |
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And the user has opened the share dialog for folder "simple-folder"
+    When the user sends the share notification by email using the webUI
+    Then a notification should be displayed on the webUI with the text "Email notification was sent!"
+    And the email address "user1@example.org" should have received an email with the body containing
+      """
+      just letting you know that user0 shared simple-folder with you.
+      """

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -647,3 +647,19 @@ Feature: Share by public link
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "original content"
     And all the links to download the public share should be the same
+
+  @mailhog
+  Scenario: user without email shares a public link via email
+    Given these users have been created without skeleton files:
+      | username | password |
+      | user0    | 1234     |
+    And user "user0" has created folder "/simple-folder"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user0" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI with
+      | email           | foo@bar.co  |
+    Then the email address "foo@bar.co" should have received an email with the body containing
+			"""
+			user0 shared simple-folder with you
+			"""
+    And the email address "foo@bar.co" should have received an email containing the last shared public link


### PR DESCRIPTION
## Description

This PR adds validation for the sender e-mail address when using the e-mail notification mechanism for public links as well as internal shares.

## Motivation and Context

Given the following scenarios:

Scenario 1:

- User1 shares a folder with User2
- User1 does not have an e-mail address (`NULL` set in oc_accounts table)
- User2 has a valid e-mail address
- User1 clicks on the `notify by email` button: an error appears and the user cannot be notified

Scenario 2:

User1 (who does not have an email address) creates a brand new file or folder, creates a public link out of it and clicks on the `Send link via email` button in order to notify an external user. Also, in this case, the same error as above is returned.


## How Has This Been Tested?

Manually by testing the two scenarios above and make sure no error is returned and e-mail is correctly delivered. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised 
- [x] Changelog item