### PR TITLE
Make settings page work in Phoenix

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -170,6 +170,9 @@ a.two-factor-cancel {
 #content .hascontrols {
 	margin-top: 45px;
 }
+.phoenix #content-wrapper {
+	padding-top: 0px;
+}
 #content-wrapper {
 	position: absolute;
 	height: 100%;

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -35,9 +35,17 @@
 			<script src="<?php print_unescaped($jsfile); ?>"></script>
 		<?php endforeach; ?>
 		<?php print_unescaped($_['headers']); ?>
+		<?php if (isset($_['isPhoenix']) && $_['isPhoenix']): ?>
+			<base target="_parent" />
+		<?php endif ?>
 	</head>
-	<body id="<?php p($_['bodyid']);?>">
+	<body id="<?php p($_['bodyid']);?>"
+		<?php if (isset($_['isPhoenix']) && $_['isPhoenix']): ?>
+		class="phoenix"
+		<?php endif ?>
+	>
 		<?php include('layout.noscript.warning.php'); ?>
+		<?php if (!isset($_['isPhoenix']) || !$_['isPhoenix']): ?>
 		<div id="notification-container">
 			<div id="notification"></div>
 		</div>
@@ -127,7 +135,7 @@
 				</div>
 			</div>
 		</nav>
-
+		<?php endif ?>
 		<div id="content-wrapper">
 			<div id="content" class="app-<?php p($_['appid']) ?>" role="main">
 				<?php print_unescaped($_['content']); ?>

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -799,4 +799,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 		return null;
 	}
+
+	public function isPhoenix() {
+		return (isset($this->get['phoenix']) && $this->get['phoenix'] === 'true' && $this->config->getSystemValue('phoenix.baseUrl', '') !== '');
+	}	
 }

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -152,6 +152,10 @@ class TemplateLayout extends \OC_Template {
 				$this->append('cssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
 			}
 		}
+
+		if (\OC::$server->getRequest()->isPhoenix()) {
+			$this->assign('isPhoenix', true);
+		}
 	}
 
 	/**

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -253,18 +253,25 @@ class OC_Response {
 			. 'font-src \'self\' data:; '
 			. 'media-src *; '
 			. 'connect-src *';
-		\header('Content-Security-Policy:' . $policy);
 
 		// Send fallback headers for installations that don't have the possibility to send
 		// custom headers on the webserver side
 		if (\getenv('modHeadersAvailable') !== 'true') {
 			\header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
 			\header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
-			\header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
+			$config = \OC::$server->getConfig();
+			$phoenixUrl = $config->getSystemValue('phoenix.baseUrl', '');
+			if ($phoenixUrl !== '') {
+				// TODO: double check if this is correct
+				$policy .= '; frame-ancestors \'self\' ' . $phoenixUrl;
+			} else {
+				\header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
+			}
 			\header('X-Robots-Tag: none'); // https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
 			\header('X-Download-Options: noopen'); // https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
 			\header('X-Permitted-Cross-Domain-Policies: none'); // https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
 		}
+		\header('Content-Security-Policy:' . $policy);
 	}
 
 	/**

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -238,4 +238,13 @@ interface IRequest {
 	 * @since 8.1.0
 	 */
 	public function getServerHost();
+
+	/**
+	 * Returns true if the current page has been called within the context
+	 * of the Phoenix frontend.
+	 *
+	 * @return bool
+	 * @since 10.4.0
+	 */
+	public function isPhoenix();
 }

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -73,7 +73,8 @@ class Application extends App {
 				$c->query('SettingsManager'),
 				$c->query('ServerContainer')->getURLGenerator(),
 				$c->query('GroupManager'),
-				$c->query('UserSession')
+				$c->query('UserSession'),
+				$c->query('Config')
 			);
 		});
 		$container->registerService('MailSettingsController', function (IContainer $c) {

--- a/settings/Controller/SettingsPageController.php
+++ b/settings/Controller/SettingsPageController.php
@@ -30,6 +30,7 @@ use OCP\Template;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IGroupManager;
 use OCP\IUserSession;
+use OCP\IConfig;
 
 /**
  * @package OC\Settings\Controller
@@ -44,6 +45,8 @@ class SettingsPageController extends Controller {
 	protected $groupManager;
 	/** @var IUserSession */
 	protected $userSession;
+	/** @var IConfig */
+	protected $config;
 
 	/**
 	 * @param string $appName
@@ -58,12 +61,14 @@ class SettingsPageController extends Controller {
 								ISettingsManager $settingsManager,
 								IURLGenerator $urlGenerator,
 								IGroupManager $groupManager,
-								IUserSession $userSession) {
+								IUserSession $userSession,
+								IConfig $config) {
 		parent::__construct($appName, $request);
 		$this->settingsManager = $settingsManager;
 		$this->urlGenerator = $urlGenerator;
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
+		$this->config = $config;
 	}
 
 	/**
@@ -142,12 +147,19 @@ class SettingsPageController extends Controller {
 		foreach ($sections as $section) {
 			$icon = $this->getIconForSettingsPanel($section);
 
-			$nav[] = [
-				'id' => $section->getID(),
-				'link' => $this->urlGenerator->linkToRoute(
+			if ($this->request->isPhoenix()) {
+				$url = rtrim($this->config->getSystemValue('phoenix.baseUrl'), '/') . '/index.html#/compat-settings?'
+					. \http_build_query(['sectionid' => $type . '/' . $section->getID()], '', '&');
+			} else {
+				$url = $this->urlGenerator->linkToRoute(
 					'settings.SettingsPage.get'.\ucwords($type),
 					['sectionid' => $section->getID()]
-				),
+				);
+			}
+
+			$nav[] = [
+				'id' => $section->getID(),
+				'link' => $url,
 				'name' => \ucfirst($section->getName()),
 				'active' => $section->getID() === $currentSectionID,
 				'icon' => $icon


### PR DESCRIPTION
## Description
Adjust CSP rules to allow iframing.
Receive "phoenix=true" URL parameter to signal that we're coming from
Phoenix.
Remove page header when in Phoenix mode.
Use different URLs for navigation sections.

## Related Issue
For https://github.com/owncloud/phoenix/issues/2598

## Motivation and Context
Make settings page accessible without leaving Phoenix frontend

## How Has This Been Tested?
Manual test, try switching sections, etc

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
