### PR TITLE
Behat bootstrap.php does not need core lib/composer/autoload.php

### DIFF
--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -20,8 +20,6 @@
  *
  */
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
 $classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../TestHelpers", true);


### PR DESCRIPTION
## Description
The `bootstrap.php` in the acceptance tests folders is including the core `lib/composer/autoload.php` but actually the acceptance tests should be able to run independently of the system-under-test. They should not need to suck in some core composer dependency autoloader stuff.

In apps it would be good to minimize the dependencies that we have to install when setting up the test-runner. The apps need to find Gherkin step definitions/code from core, so they do need to use the core Behat `bootstrap.php`. But if that also includes `lib/composer/autoload.php` then we also have to do a full `composer install` of all the core stuff (when we only want the minimum needed ffor the test-runner)

I ran across this while doing some user_ldap tests and trying to get them to start quicker.

## How Has This Been Tested?
Local run of some acceptance tests - they still pass

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
