### PR TITLE
Remove dependency of acceptance tests on core lib/composer/autoload.php

### DIFF
--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -45,6 +45,13 @@ class SharingHelper {
 			'federated' => 6,
 	];
 
+	const SHARE_STATES = [
+			'accepted' => 0,
+			'pending' => 1,
+			'rejected' => 2,
+			'declined' => 2, // declined is a synonym for rejected
+	];
+
 	/**
 	 *
 	 * @param string $baseUrl baseURL of the ownCloud installation without /ocs.

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -29,8 +29,6 @@ use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use Behat\Gherkin\Node\TableNode;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * AppConfiguration trait
  */

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -25,8 +25,6 @@ use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * Context for steps that test apps_paths.
  */

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -23,8 +23,6 @@ use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
 use Behat\Gherkin\Node\TableNode;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * Authentication functions
  */

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -30,8 +30,6 @@ use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\HttpRequestHelper;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * Basic functions needed by mostly everything
  */

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -19,8 +19,6 @@
  *
  */
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -19,8 +19,6 @@
  *
  */
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -21,8 +21,6 @@
 
 use TestHelpers\SetupHelper;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * Command line functions
  */

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -28,8 +28,6 @@ use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
 use TestHelpers\HttpRequestHelper;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * Functions for provisioning of users and groups
  */

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1912,14 +1912,10 @@ trait Sharing {
 	private function getAllSharesSharedWithUser($user, $state = "all") {
 		switch ($state) {
 			case 'pending':
-				$stateCode = \OCP\Share::STATE_PENDING;
-				break;
 			case 'accepted':
-				$stateCode = \OCP\Share::STATE_ACCEPTED;
-				break;
 			case 'declined':
 			case 'rejected':
-				$stateCode = \OCP\Share::STATE_REJECTED;
+				$stateCode = SharingHelper::SHARE_STATES[$state];
 				break;
 			case 'all':
 				$stateCode = "all";

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -29,8 +29,6 @@ use TestHelpers\SetupHelper;
 use TestHelpers\SharingHelper;
 use TestHelpers\HttpRequestHelper;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * Sharing trait
  */

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -33,8 +33,6 @@ use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\Asserts\WebDav as WebDavAssert;
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 /**
  * WebDav functions
  */

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -20,6 +20,8 @@
  *
  */
 
+require __DIR__ . '/../../../../lib/composer/autoload.php';
+
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
 $classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../TestHelpers", true);

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -20,8 +20,6 @@
  *
  */
 
-require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
 $classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../TestHelpers", true);

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -8,6 +8,7 @@
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
         "symfony/translation": "^3.4",
+        "sabre/xml": "^2.1",
         "guzzlehttp/guzzle": "^5.3",
         "phpunit/phpunit": "^7.5"
     }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -7,6 +7,8 @@
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
-        "symfony/translation": "^3.4"
+        "symfony/translation": "^3.4",
+        "guzzlehttp/guzzle": "^5.3",
+        "phpunit/phpunit": "^7.5"
     }
 }


### PR DESCRIPTION
## Description
- Revert #36511 - I didn't do the full/proper job there.

-  Delete all `require __DIR__ . '/../../../../lib/composer/autoload.php';` from acceptance test code

- Add to `vendor-bin/behat/composer.json` the dependencies that the Behat acceptance test code was relying on from core `lib/composer` :
- `sabre/xml` `^2.1` - the acceptance test code makes use of this library when parsing XML in responses
- `guzzlehttp/guzzle` `^5.3` - the acceptance test code (as well as core code) still has guzzle v5-style code
- `phpunit/phpunit` `^7.5` - the acceptance test code makes use of `phpunit` `Assert`. That is an integrated part of `phpunit`, so we need to depend on the whole `phpunit`

- acceptance test code was finding out the share state constants directly from backend code `\OCP\Share::STATE_PENDING` etc. That is not a good thing anyway. Move the acceptance test knowledge about those numbers into `SharingHelper` because that is external behaviour and actually we want to know if the values of the numbers to be used in API calls are changed in the backend.

## Issue
#36514

## Motivation and Context
- have the acceptance test code less dependent on the core code
- have the possibility (e.g. in app repos) to have just the required Behat dependencies installed in the test runner, independently of the system-under-test (at the moment we get forced to do a `composer install` of the whole of core in the test-runner directory, which should not be necessary)

## How Has This Been Tested?
Local test run plus CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
