### PR TITLE
Fix of typo "Datenschutzerkärung" in i18n files for German

### DIFF
--- a/lib/l10n/de.js
+++ b/lib/l10n/de.js
@@ -141,7 +141,7 @@ OC.L10N.register(
     "App \"%s\" cannot be installed because the following dependencies are not fulfilled: %s" : "Die App „%s“ kann nicht installiert werden, da die folgenden Abhängigkeiten nicht erfüllt sind: %s",
     "A safe home for all your data" : "Ein sicherer Speicherplatz für deine ganzen Daten.",
     "Imprint" : "Impressum",
-    "Privacy Policy" : "Datenschutzerkärung",
+    "Privacy Policy" : "Datenschutzerklärung",
     "File is currently busy, please try again later" : "Die Datei ist zur Zeit in Benutzung, bitte versuche es später noch einmal",
     "Access to this resource or one of its sub-items has been denied." : "Der Zugriff auf diese Ressource oder eine derer Unterelemente wurde verweigert.",
     "File cannot be downloaded" : "Datei kann nicht heruntergeladen werden",

--- a/lib/l10n/de.json
+++ b/lib/l10n/de.json
@@ -139,7 +139,7 @@
     "App \"%s\" cannot be installed because the following dependencies are not fulfilled: %s" : "Die App „%s“ kann nicht installiert werden, da die folgenden Abhängigkeiten nicht erfüllt sind: %s",
     "A safe home for all your data" : "Ein sicherer Speicherplatz für deine ganzen Daten.",
     "Imprint" : "Impressum",
-    "Privacy Policy" : "Datenschutzerkärung",
+    "Privacy Policy" : "Datenschutzerklärung",
     "File is currently busy, please try again later" : "Die Datei ist zur Zeit in Benutzung, bitte versuche es später noch einmal",
     "Access to this resource or one of its sub-items has been denied." : "Der Zugriff auf diese Ressource oder eine derer Unterelemente wurde verweigert.",
     "File cannot be downloaded" : "Datei kann nicht heruntergeladen werden",

--- a/lib/l10n/de_DE.js
+++ b/lib/l10n/de_DE.js
@@ -143,7 +143,7 @@ OC.L10N.register(
     "App \"%s\" cannot be installed because the following dependencies are not fulfilled: %s" : "Die App „%s“ kann nicht installiert werden, da die folgenden Abhängigkeiten nicht erfüllt sind: %s",
     "A safe home for all your data" : "Ein sicherer Speicherplatz für all Ihre Daten",
     "Imprint" : "Impressum",
-    "Privacy Policy" : "Datenschutzerkärung",
+    "Privacy Policy" : "Datenschutzerklärung",
     "File is currently busy, please try again later" : "Die Datei ist zur Zeit in Benutzung, bitte versuchen Sie es später noch einmal",
     "Access to this resource or one of its sub-items has been denied." : "Der Zugriff auf diese Ressource oder eine derer Unterelemente wurde verweigert.",
     "File cannot be downloaded" : "Datei kann nicht heruntergeladen werden",

--- a/lib/l10n/de_DE.json
+++ b/lib/l10n/de_DE.json
@@ -141,7 +141,7 @@
     "App \"%s\" cannot be installed because the following dependencies are not fulfilled: %s" : "Die App „%s“ kann nicht installiert werden, da die folgenden Abhängigkeiten nicht erfüllt sind: %s",
     "A safe home for all your data" : "Ein sicherer Speicherplatz für all Ihre Daten",
     "Imprint" : "Impressum",
-    "Privacy Policy" : "Datenschutzerkärung",
+    "Privacy Policy" : "Datenschutzerklärung",
     "File is currently busy, please try again later" : "Die Datei ist zur Zeit in Benutzung, bitte versuchen Sie es später noch einmal",
     "Access to this resource or one of its sub-items has been denied." : "Der Zugriff auf diese Ressource oder eine derer Unterelemente wurde verweigert.",
     "File cannot be downloaded" : "Datei kann nicht heruntergeladen werden",


### PR DESCRIPTION
## Description

This is a minor fix of a typo in the i18n files for German ("Datenschutzerkärung" with missing "l" instead of "Datenschutzerklärung" for "Privacy Policy").


The typo had already been fixed by @DeepDiver1975 back in 2018, see https://github.com/owncloud/core/commit/f42f0d93f74421117d24a6fabddd65105b60361c. It seems that the error had been accidentally reintroduced this year with an update from transifex, see https://github.com/owncloud/core/commit/d39cc18bb0390ff229b30393741c9e624ad92a7a.

Additionally, I have suggested the following corrections for "Privacy Policy" at transifex which await approval:

- de_DE: core, mobile-ios-app, lib
- de: mobile-ios-app, lib

## Motivation and Context

Unfortunately, this typo is prominently visible on the login page of ownCloud instances in German language with the most recent version 10.3.1.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
