### PR TITLE
Fix capabilities test scenarios so they can fail

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -59,13 +59,15 @@ Feature: capabilities
   Scenario: getting trashbin app capability with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
-      | files | undelete | 1 |
+      | capability | path_to_element | value |
+      | files      | undelete        | 1     |
 
   @files_versions-app-required
   Scenario: getting versions app capability with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
-      | files | versioning | 1 |
+      | capability | path_to_element | value |
+      | files      | versioning      | 1     |
 
 	#feature added in #31824 will be released in 10.0.10
   @smokeTest @skipOnOcV10.0.9

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -69,6 +69,19 @@ Feature: capabilities
       | capability | path_to_element | value |
       | files      | versioning      | 1     |
 
+  Scenario: getting default_permissions capability with admin user
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element     | value |
+      | files_sharing | default_permissions | 31    |
+
+  Scenario: default_permissions capability can be changed
+    Given parameter "shareapi_default_permissions" of app "core" has been set to "7"
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element     | value |
+      | files_sharing | default_permissions | 7     |
+
 	#feature added in #31824 will be released in 10.0.10
   @smokeTest @skipOnOcV10.0.9
   Scenario: getting capabilities with admin user

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -49,6 +49,7 @@ class CapabilitiesContext implements Context {
 	 */
 	public function checkCapabilitiesResponse(TableNode $formData) {
 		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
+		$assertedSomething = false;
 
 		foreach ($formData->getHash() as $row) {
 			$row['value'] = $this->featureContext->substituteInLineCodes($row['value']);
@@ -61,7 +62,13 @@ class CapabilitiesContext implements Context {
 				),
 				"Failed field {$row['capability']} {$row['path_to_element']}"
 			);
+			$assertedSomething = true;
 		}
+
+		Assert::assertTrue(
+			$assertedSomething,
+			'there was nothing in the table of expected capabilities'
+		);
 	}
 
 	/**
@@ -98,6 +105,7 @@ class CapabilitiesContext implements Context {
 	 */
 	public function theCapabilitiesShouldNotContain(TableNode $formData) {
 		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
+		$assertedSomething = false;
 
 		foreach ($formData->getHash() as $row) {
 			Assert::assertFalse(
@@ -108,7 +116,13 @@ class CapabilitiesContext implements Context {
 				),
 				"Capability {$row['capability']} {$row['path_to_element']} exists but it should not exist"
 			);
+			$assertedSomething = true;
 		}
+
+		Assert::assertTrue(
+			$assertedSomething,
+			'there was nothing in the table of not expected capabilities'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
`apiCapabilities/capabilities.feature` has some scenarios where the step `Then the capabilities should contain` is missing the table header row. The tests pass no matter what is in the data row :(

1) Add checks to the steps that process a table of capabilities so that they fail if no capabilities are processed (rather than passing by default)

2) Add the header rows to the scenarios where they are missing.

The `default_permissions` capability was not being tested.

3) Add test scenarios to check that the `default_permissions` capability is reported.

## Motivation and Context
Fix snake-oil tests

## How Has This Been Tested?
Local test runs with and without the table header row, and with wrong data - to confirm that the test scenarios will fail if something is wrong.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
