### PR TITLE
Acceptance tests: notify user with email

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -307,6 +307,22 @@ Feature: Sharing files and folders with internal users
       | Email notification not sent | Couldn't send mail to following recipient(s): user0 |
 
   @mailhog
+  Scenario: user who has not set up the email should get an error message when trying to send notification by email
+    Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
+    And these users have been created without skeleton files:
+      | username | password |
+      | user0    | 1234     |
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/FOLDER_TO_SHARE"
+    And user "user0" has logged in using the webUI
+    And user "user0" has shared folder "FOLDER_TO_SHARE" with user "user1"
+    And the user has opened the share dialog for folder "FOLDER_TO_SHARE"
+    When the user sends the share notification by email using the webUI
+    Then dialog should be displayed on the webUI
+      | title                       | content                                                |
+      | Email notification not sent | Couldn't send mail to following recipient(s): User One |
+
+  @mailhog
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -647,3 +647,18 @@ Feature: Share by public link
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "original content"
     And all the links to download the public share should be the same
+
+  @mailhog
+  Scenario: user shares a public link via email
+    Given these users have been created without skeleton files:
+      | username | password |
+      | user0    | 1234     |
+    And user "user0" has created folder "/simple-folder"
+    And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And user "user0" has logged in using the webUI
+    When the user tries to create a new public link for folder "simple-folder" using the webUI with
+      | email | foo@bar.co |
+    Then dialog should be displayed on the webUI
+      | title                                | content                                                  |
+      | An error occured while sending email | Couldn't send mail to following recipient(s): foo@bar.co |
+    And the email address "foo@bar.co" should not have received an email


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds acceptance test for PR: https://github.com/owncloud/core/pull/36505
i.e. adds acceptance test to notify user with email when sender email is not set and 
1. ```Allow users to send mail notification for shared files to other users``` is set
2. ```Allow users to send mail notification for shared files``` is set
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
