### PR TITLE
[For 10.4] Filter app:list for just enabled or disabled apps

### DIFF
--- a/changelog/unreleased/36520
+++ b/changelog/unreleased/36520
@@ -1,0 +1,14 @@
+Enhancement: Add enabled and disabled filter options to occ app:list command
+
+The occ app:list command now supports the --enabled and --disabled options
+
+occ app:list --enabled
+Displays just the enabled apps.
+
+occ app:list --disabled
+Displays just the disabled apps.
+
+If a disabled app was enabled in the past, then the previously-enabled version
+of the app is now displayed in the disabled apps list.
+
+https://github.com/owncloud/core/pull/36520

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -103,7 +103,7 @@ class ListApps extends Base {
 
 		\sort($disabledApps);
 		foreach ($disabledApps as $app) {
-			$apps['disabled'][$app] = null;
+			$apps['disabled'][$app] = (isset($versions[$app])) ? $versions[$app] : null;
 		}
 
 		$this->writeAppList($input, $output, $apps);

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -60,7 +60,7 @@ class ListApps extends Base {
 				'disabled',
 				'd',
 				InputOption::VALUE_NONE,
-				'Only display disabled apps.'
+				'Only display disabled apps. If the app was previously enabled, the app version is also displayed. '
 			)
 			->addArgument(
 				'search-pattern',

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -50,6 +50,18 @@ class ListApps extends Base {
 		$this
 			->setName('app:list')
 			->setDescription('List all available apps.')
+			->addOption(
+				'enabled',
+				'e',
+				InputOption::VALUE_NONE,
+				'Only display enabled apps.'
+			)
+			->addOption(
+				'disabled',
+				'd',
+				InputOption::VALUE_NONE,
+				'Only display disabled apps.'
+			)
 			->addArgument(
 				'search-pattern',
 				InputArgument::OPTIONAL,
@@ -96,14 +108,19 @@ class ListApps extends Base {
 
 		$apps = ['enabled' => [], 'disabled' => []];
 
-		\sort($enabledApps);
-		foreach ($enabledApps as $app) {
-			$apps['enabled'][$app] = (isset($versions[$app])) ? $versions[$app] : true;
+		$neitherSpecified = !($input->getOption('enabled') || $input->getOption('disabled'));
+		if ($input->getOption('enabled') || $neitherSpecified) {
+			\sort($enabledApps);
+			foreach ($enabledApps as $app) {
+				$apps['enabled'][$app] = (isset($versions[$app])) ? $versions[$app] : true;
+			}
 		}
 
-		\sort($disabledApps);
-		foreach ($disabledApps as $app) {
-			$apps['disabled'][$app] = (isset($versions[$app])) ? $versions[$app] : null;
+		if ($input->getOption('disabled') || $neitherSpecified) {
+			\sort($disabledApps);
+			foreach ($disabledApps as $app) {
+				$apps['disabled'][$app] = ($input->getOption('disabled') && isset($versions[$app])) ? $versions[$app] : null;
+			}
 		}
 
 		$this->writeAppList($input, $output, $apps);

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -160,6 +160,152 @@ class AppManagementContext implements Context {
 	}
 
 	/**
+	 * @When the administrator lists the apps using the occ command
+	 *
+	 * @return void
+	 */
+	public function adminListsTheApps() {
+		$occStatus = $this->featureContext->runOcc(
+			['app:list', '--no-ansi']
+		);
+	}
+
+	/**
+	 * @When the administrator lists the enabled apps using the occ command
+	 *
+	 * @return void
+	 */
+	public function adminListsTheEnabledApps() {
+		$occStatus = $this->featureContext->runOcc(
+			['app:list', '--enabled', '--no-ansi']
+		);
+	}
+
+	/**
+	 * @When the administrator lists the disabled apps using the occ command
+	 *
+	 * @return void
+	 */
+	public function adminListsTheDisabledApps() {
+		$occStatus = $this->featureContext->runOcc(
+			['app:list', '--disabled', '--no-ansi']
+		);
+	}
+
+	/**
+	 * @When the administrator lists the enabled and disabled apps using the occ command
+	 *
+	 * @return void
+	 */
+	public function adminListsTheEnabledAndDisabledApps() {
+		$occStatus = $this->featureContext->runOcc(
+			['app:list', '--enabled', '--disabled', '--no-ansi']
+		);
+	}
+
+	/**
+	 * @Then app :appId with version :appVersion should have been listed in the enabled apps section
+	 *
+	 * @param string $appId
+	 * @param string $appVersion
+	 *
+	 * @return void
+	 */
+	public function appWithVersionShouldHaveBeenListedInTheEnabledAppsSection(
+		$appId, $appVersion
+	) {
+		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
+		$expectedStartOfOutput = "Enabled:";
+		Assert::assertEquals(
+			$expectedStartOfOutput,
+			\substr($commandOutput, 0, 8),
+			"app:list command output did not start with '$expectedStartOfOutput'"
+		);
+		$startOfDisabledSection = \strpos($commandOutput, "Disabled:");
+		if ($startOfDisabledSection) {
+			$commandOutput = \substr($commandOutput, 0, $startOfDisabledSection);
+		}
+		$expectedString = "- $appId: $appVersion";
+		Assert::assertNotFalse(
+			\strpos($commandOutput, $expectedString),
+			"app:list output did not contain '$expectedString' in the enabled section"
+		);
+	}
+
+	/**
+	 * @Then app :appId with version :appVersion should have been listed in the disabled apps section
+	 *
+	 * @param string $appId
+	 * @param string $appVersion
+	 *
+	 * @return void
+	 */
+	public function appWithVersionShouldHaveBeenListedInTheDisabledAppsSection(
+		$appId, $appVersion
+	) {
+		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
+		$startOfDisabledSection = \strpos($commandOutput, "Disabled:");
+		Assert::assertNotFalse(
+			$startOfDisabledSection,
+			"app:list output did not contain the disabled section"
+		);
+		$commandOutput = \substr($commandOutput, $startOfDisabledSection);
+		$expectedString = "- $appId: $appVersion";
+		Assert::assertNotFalse(
+			\strpos($commandOutput, $expectedString),
+			"app:list output did not contain '$expectedString' in the disabled section"
+		);
+	}
+
+	/**
+	 * @Then app :appId should have been listed in the disabled apps section
+	 *
+	 * @param string $appId
+	 *
+	 * @return void
+	 */
+	public function appShouldHaveBeenListedInTheDisabledAppsSection($appId) {
+		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
+		$startOfDisabledSection = \strpos($commandOutput, "Disabled:");
+		Assert::assertNotFalse(
+			$startOfDisabledSection,
+			"app:list output did not contain the disabled section"
+		);
+		$commandOutput = \substr($commandOutput, $startOfDisabledSection);
+		$expectedString = "- $appId";
+		Assert::assertNotFalse(
+			\strpos($commandOutput, $expectedString),
+			"app:list output did not contain '$expectedString' in the disabled section"
+		);
+	}
+
+	/**
+	 * @Then the enabled apps section should not exist
+	 *
+	 * @return void
+	 */
+	public function theEnabledAppsSectionShouldNotExist() {
+		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
+		Assert::assertFalse(
+			\strpos($commandOutput, "Enabled:"),
+			"app:list output contains the enabled section but it should not"
+		);
+	}
+
+	/**
+	 * @Then the disabled apps section should not exist
+	 *
+	 * @return void
+	 */
+	public function theDisabledAppsSectionShouldNotExist() {
+		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
+		Assert::assertFalse(
+			\strpos($commandOutput, "Disabled:"),
+			"app:list output contains the disabled section but it should not"
+		);
+	}
+
+	/**
 	 * @Then the path to :appId should be :dir
 	 *
 	 * @param string $appId

--- a/tests/acceptance/features/cliAppManagement/listApps.feature
+++ b/tests/acceptance/features/cliAppManagement/listApps.feature
@@ -1,0 +1,59 @@
+@cli @skipWhenTestingRemoteSystems
+Feature: list apps
+  As an admin
+  I want to be able to get a list of apps that are enabled and/or disabled
+  So that I can manage the apps in my ownCloud
+
+  Scenario: list all the apps
+    Given app "testapp1" with version "2.3.4" has been put in dir "apps"
+    And app "testapp1" has been enabled
+    And app "testapp2" with version "5.6.7" has been put in dir "apps"
+    And app "testapp2" has been disabled
+    When the administrator lists the apps using the occ command
+    Then the command should have been successful
+    And app "testapp1" with version "2.3.4" should have been listed in the enabled apps section
+    And app "testapp2" should have been listed in the disabled apps section
+
+  Scenario: list all the apps by specifying both "enabled" and "disabled"
+    Given app "testapp1" with version "2.3.4" has been put in dir "apps"
+    And app "testapp1" has been enabled
+    And app "testapp2" with version "5.6.7" has been put in dir "apps"
+    And app "testapp2" has been enabled
+    And app "testapp2" has been disabled
+    When the administrator lists the enabled and disabled apps using the occ command
+    Then the command should have been successful
+    And app "testapp1" with version "2.3.4" should have been listed in the enabled apps section
+    And app "testapp2" with version "5.6.7" should have been listed in the disabled apps section
+
+  Scenario: the version of a disabled app is not displayed on a full list even if it has previously been enabled
+    Given app "testapp1" with version "2.3.4" has been put in dir "apps"
+    And app "testapp1" has been enabled
+    And app "testapp1" has been disabled
+    When the administrator lists the apps using the occ command
+    Then the command should have been successful
+    And app "testapp1" should have been listed in the disabled apps section
+
+  Scenario: the version of a disabled app is displayed if disabled apps are specifically requested
+    Given app "testapp1" with version "2.3.4" has been put in dir "apps"
+    And app "testapp1" has been enabled
+    And app "testapp1" has been disabled
+    When the administrator lists the disabled apps using the occ command
+    Then the command should have been successful
+    And app "testapp1" with version "2.3.4" should have been listed in the disabled apps section
+
+  Scenario: list only the enabled apps
+    Given app "testapp1" with version "2.3.4" has been put in dir "apps"
+    And app "testapp1" has been enabled
+    When the administrator lists the enabled apps using the occ command
+    Then the command should have been successful
+    And app "testapp1" with version "2.3.4" should have been listed in the enabled apps section
+    And the disabled apps section should not exist
+
+  Scenario: list only the disabled apps
+    Given app "testapp1" with version "2.3.4" has been put in dir "apps"
+    And app "testapp1" has been enabled
+    And app "testapp1" has been disabled
+    When the administrator lists the disabled apps using the occ command
+    Then the command should have been successful
+    And app "testapp1" with version "2.3.4" should have been listed in the disabled apps section
+    And the enabled apps section should not exist


### PR DESCRIPTION
## Description
Add options to the `occ app:list` command to display just the enabled or disabled apps.

This is on top of #36165

## Motivation and Context
It is often convenient to be able to just display the enabled or disabled apps.

## How Has This Been Tested?
Running acceptance tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/2141
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
