### PR TITLE
Fix warning when resetting user's password with masterkey encryption

### DIFF
--- a/changelog/unreleased/36523
+++ b/changelog/unreleased/36523
@@ -1,0 +1,5 @@
+Bugfix: suppress warning when resetting user password with masterkey encryption
+
+When an admin wanted to reset user's password over the Users management page with masterkey encryption in place, a warning was displayed about data recovery not being available. The behavior has now been fixed.  
+
+https://github.com/owncloud/core/pull/36523

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -84,8 +84,6 @@ class UsersController extends Controller {
 	private $fromMailAddress;
 	/** @var IURLGenerator */
 	private $urlGenerator;
-	/** @var bool contains the state of the encryption app */
-	private $isEncryptionAppEnabled;
 	/** @var bool contains the state of the admin recovery setting */
 	private $isRestoreEnabled = false;
 	/** @var IAvatarManager */
@@ -153,8 +151,7 @@ class UsersController extends Controller {
 		$this->eventDispatcher = $eventDispatcher;
 
 		// check for encryption state - TODO see formatUserForIndex
-		$this->isEncryptionAppEnabled = $appManager->isEnabledForUser('encryption');
-		if ($this->isEncryptionAppEnabled) {
+		if ($appManager->isEnabledForUser('encryption')) {
 			// putting this directly in empty is possible in PHP 5.5+
 			$result = $config->getAppValue('encryption', 'recoveryAdminEnabled', 0);
 			$this->isRestoreEnabled = !empty($result);
@@ -176,23 +173,17 @@ class UsersController extends Controller {
 		// below
 		$restorePossible = false;
 
-		if ($this->isEncryptionAppEnabled) {
-			if ($this->isRestoreEnabled) {
-				// check for the users recovery setting
-				$recoveryMode = $this->config->getUserValue($user->getUID(), 'encryption', 'recoveryEnabled', '0');
-				// method call inside empty is possible with PHP 5.5+
-				$recoveryModeEnabled = !empty($recoveryMode);
-				if ($recoveryModeEnabled) {
-					// user also has recovery mode enabled
-					$restorePossible = true;
-				}
-			} else {
-				// masterkey encryption is active
+		if ($this->isRestoreEnabled) {
+			// check for the users recovery setting
+			$recoveryMode = $this->config->getUserValue($user->getUID(), 'encryption', 'recoveryEnabled', '0');
+			// method call inside empty is possible with PHP 5.5+
+			$recoveryModeEnabled = !empty($recoveryMode);
+			if ($recoveryModeEnabled) {
+				// user also has recovery mode enabled
 				$restorePossible = true;
 			}
 		} else {
-			// recovery is possible if encryption is disabled (plain files are
-			// available)
+			// masterkey encryption or no encryption in place
 			$restorePossible = true;
 		}
 

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -186,6 +186,9 @@ class UsersController extends Controller {
 					// user also has recovery mode enabled
 					$restorePossible = true;
 				}
+			} else {
+				// masterkey encryption is active
+				$restorePossible = true;
 			}
 		} else {
 			// recovery is possible if encryption is disabled (plain files are

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -1715,7 +1715,7 @@ class UsersControllerTest extends \Test\TestCase {
 			)
 			->will($this->returnValue(true));
 
-		$expectedResult['isRestoreDisabled'] = true;
+		$expectedResult['isRestoreDisabled'] = false;
 
 		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Description

Suppress warning when resetting user's password over the Users management page with masterkey encryption enabled.

## Related Issue

- Fixes https://github.com/owncloud/enterprise/issues/3647

## Motivation and Context

This PR fixes the following warning displayed when the admin is about to reset user's password over the Users management page with masterkey encryption in place:

![70141012-5d090880-1696-11ea-90ad-476b4b1d648b](https://user-images.githubusercontent.com/12248713/70148161-ec69e800-16a5-11ea-8802-3b53feb4daa7.png)

The warning itself does not prevent resetting user's password but it is scary and makes no sense when masterkey encryption is in use.

## How Has This Been Tested?

Manually by enabling masterkey encryption and as admin hovering over the password field for one random user: the warning is not displayed anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised 
- [x] Changelog item