### PR TITLE
Update capabilities tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -39,6 +39,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
+        - OccContext:
 
     apiComments:
       paths:

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -30,30 +30,48 @@ Feature: capabilities
     When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
     Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 
+  Scenario: Check that search_min_length can be changed
+    When the administrator updates system config key "user.search_min_length" with value "4" using the occ command
+    Then the capabilities setting of "files_sharing" path "search_min_length" should be "4"
+
   @smokeTest
-  Scenario: getting capabilities with admin user
+  Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
-      | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
-      | core          | webdav-root                           | remote.php/webdav |
-      | core          | status@@@edition                      | %edition%         |
-      | core          | status@@@productname                  | %productname%     |
-      | core          | status@@@version                      | %version%         |
-      | core          | status@@@versionstring                | %versionstring%   |
-      | files_sharing | api_enabled                           | 1                 |
-      | files_sharing | public@@@enabled                      | 1                 |
-      | files_sharing | public@@@upload                       | 1                 |
-      | files_sharing | public@@@send_mail                    | EMPTY             |
-      | files_sharing | public@@@social_share                 | 1                 |
-      | files_sharing | resharing                             | 1                 |
-      | files_sharing | federation@@@outgoing                 | 1                 |
-      | files_sharing | federation@@@incoming                 | 1                 |
-      | files_sharing | group_sharing                         | 1                 |
-      | files_sharing | share_with_group_members_only         | EMPTY             |
-      | files_sharing | user_enumeration@@@enabled            | 1                 |
-      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-      | files         | bigfilechunking                       | 1                 |
+      | capability    | path_to_element                           | value             |
+      | core          | pollinterval                              | 60                |
+      | core          | webdav-root                               | remote.php/webdav |
+      | core          | status@@@edition                          | %edition%         |
+      | core          | status@@@productname                      | %productname%     |
+      | core          | status@@@version                          | %version%         |
+      | core          | status@@@versionstring                    | %versionstring%   |
+      | files_sharing | api_enabled                               | 1                 |
+      | files_sharing | default_permissions                       | 31                |
+      | files_sharing | search_min_length                         | 2                 |
+      | files_sharing | public@@@enabled                          | 1                 |
+      | files_sharing | public@@@multiple                         | 1                 |
+      | files_sharing | public@@@upload                           | 1                 |
+      | files_sharing | public@@@supports_upload_only             | 1                 |
+      | files_sharing | public@@@send_mail                        | EMPTY             |
+      | files_sharing | public@@@social_share                     | 1                 |
+      | files_sharing | public@@@enforced                         | EMPTY             |
+      | files_sharing | public@@@enforced_for@@@read_only         | EMPTY             |
+      | files_sharing | public@@@enforced_for@@@read_write        | EMPTY             |
+      | files_sharing | public@@@enforced_for@@@upload_only       | EMPTY             |
+      | files_sharing | public@@@enforced_for@@@read_write_delete | EMPTY             |
+      | files_sharing | public@@@expire_date@@@enabled            | EMPTY             |
+      | files_sharing | public@@@defaultPublicLinkShareName       | Public link       |
+      | files_sharing | resharing                                 | 1                 |
+      | files_sharing | federation@@@outgoing                     | 1                 |
+      | files_sharing | federation@@@incoming                     | 1                 |
+      | files_sharing | group_sharing                             | 1                 |
+      | files_sharing | share_with_group_members_only             | EMPTY             |
+      | files_sharing | share_with_membership_groups_only         | EMPTY             |
+      | files_sharing | auto_accept_share                         | 1                 |
+      | files_sharing | user_enumeration@@@enabled                | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
+      | files_sharing | user@@@send_mail                          | EMPTY             |
+      | files         | bigfilechunking                           | 1                 |
 
   @files_trashbin-app-required
   Scenario: getting trashbin app capability with admin user
@@ -117,6 +135,7 @@ Feature: capabilities
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
       | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@multiple                     | 1                 |
       | files_sharing | public@@@upload                       | EMPTY             |
       | files_sharing | public@@@send_mail                    | EMPTY             |
       | files_sharing | public@@@social_share                 | 1                 |
@@ -139,6 +158,7 @@ Feature: capabilities
       | files_sharing | api_enabled           | EMPTY             |
       | files_sharing | can_share             | EMPTY             |
       | files_sharing | public@@@enabled      | EMPTY             |
+      | files_sharing | public@@@multiple     | EMPTY             |
       | files_sharing | public@@@upload       | EMPTY             |
       | files_sharing | resharing             | EMPTY             |
       | files_sharing | federation@@@outgoing | 1                 |
@@ -155,6 +175,7 @@ Feature: capabilities
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
       | files_sharing | public@@@enabled                      | EMPTY             |
+      | files_sharing | public@@@multiple                     | EMPTY             |
       | files_sharing | public@@@upload                       | EMPTY             |
       | files_sharing | resharing                             | 1                 |
       | files_sharing | federation@@@outgoing                 | 1                 |
@@ -442,6 +463,53 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  Scenario: Changing only share with membership groups
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | share_with_membership_groups_only     | 1                 |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+
+  Scenario: Changing auto accept share
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | share_with_membership_groups_only     | EMPTY             |
+      | files_sharing | auto_accept_share                     | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files         | bigfilechunking                       | 1                 |
+
   Scenario: Changing allow share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -483,6 +551,29 @@ Feature: capabilities
       | files_sharing | share_with_group_members_only         | EMPTY             |
       | files_sharing | user_enumeration@@@enabled            | 1                 |
       | files_sharing | user_enumeration@@@group_members_only | 1                 |
+      | files         | bigfilechunking                       | 1                 |
+
+  Scenario: Changing allow mail notification
+    Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                       | value             |
+      | core          | pollinterval                          | 60                |
+      | core          | webdav-root                           | remote.php/webdav |
+      | files_sharing | api_enabled                           | 1                 |
+      | files_sharing | can_share                             | 1                 |
+      | files_sharing | public@@@enabled                      | 1                 |
+      | files_sharing | public@@@upload                       | 1                 |
+      | files_sharing | public@@@send_mail                    | EMPTY             |
+      | files_sharing | public@@@social_share                 | 1                 |
+      | files_sharing | resharing                             | 1                 |
+      | files_sharing | federation@@@outgoing                 | 1                 |
+      | files_sharing | federation@@@incoming                 | 1                 |
+      | files_sharing | group_sharing                         | 1                 |
+      | files_sharing | share_with_group_members_only         | EMPTY             |
+      | files_sharing | user_enumeration@@@enabled            | 1                 |
+      | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+      | files_sharing | user@@@send_mail                      | 1                 |
       | files         | bigfilechunking                       | 1                 |
 
   Scenario: Changing exclude groups from sharing


### PR DESCRIPTION
## Description
The `capabilities.feature` scenarios have got a bit out-of-date with the addition of new capabilities in the report. Some of those have not been added to the tests.

- [x] update the list of default capabilities in the smokeTest scenario to include the full list of files_sharing capabilities as at now
- [x] add scenarios for switching on/off the capabilities that are not yet tested

## Motivation and Context
Have better test coverage.

I noticed this when preparing extra tests for features for 10.4 that will add capabilities. It will be easier if we get the tests up-to-date first, then add just the new things in the feature PRs.

## How Has This Been Tested?
Local runs of scenarios

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
