### PR TITLE
Update defaults.php

### DIFF
--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -58,7 +58,6 @@ class OC_Defaults {
 	public function __construct() {
 		$this->l = \OC::$server->getL10N('lib');
 		$this->config = \OC::$server->getConfig();
-		$version = \OCP\Util::getVersion();
 
 		$this->defaultEntity = 'ownCloud'; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = 'ownCloud'; /* short name, used when referring to the software */
@@ -69,7 +68,7 @@ class OC_Defaults {
 		$this->defaultiTunesAppId = '1359583808';
 		$this->defaultAndroidClientUrl = 'https://play.google.com/store/apps/details?id=com.owncloud.android';
 		$this->defaultDocBaseUrl = 'https://doc.owncloud.org';
-		$this->defaultDocVersion = $version[0] . '.' . $version[1]; // used to generate doc links
+		$this->defaultDocVersion = 'latest'; // used to generate doc links
 		$this->defaultSlogan = $this->l->t('A safe home for all your data');
 		$this->defaultLogoClaim = '';
 		$this->defaultMailHeaderColor = '#1d2d44'; /* header color of mail notifications */

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -66,10 +66,7 @@ class WebUIHelpAndTipsContext extends RawMinkContext implements Context {
 	 * @return string
 	 */
 	protected function generateHelpLinks($to) {
-		$version = $this->featureContext->getSystemConfigValue('version');
-		$version = \explode(".", $version);
-		$version = (string)$version[0] . "." . (string)$version[1];
-		return "https://doc.owncloud.org/server/$version/go.php?to=$to";
+		return "https://doc.owncloud.org/server/latest/go.php?to=$to";
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR changes the defaultDocVersion string from a calculated number to `latest`
`https://doc.owncloud.org/server/10.3` -->
`https://doc.owncloud.org/server/latest`

## Related Issue
- Fixes https://github.com/owncloud/core/issues/36512

## Motivation and Context
Documentation uses `latest` as part of the URL pointing always to the latest release number given by published core. Release numbers are a internal one time change in docs per published core release.

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
