### PR TITLE
CI updates for 10.3.2 branch

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -30,7 +30,6 @@ config = {
 		},
 		'reducedDatabases' : {
 			'phpVersions': [
-				'7.0',
 				'7.2',
 				'7.3',
 			],
@@ -983,9 +982,9 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'oracle'
+			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -985,7 +985,7 @@ def phptests(testType):
 	default = {
 		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
+			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,
@@ -1418,7 +1418,7 @@ def notify():
 def databaseService(db):
 	dbName = getDbName(db)
 	if (dbName == 'mariadb') or (dbName == 'mysql'):
-		return [{
+		service = {
 			'name': dbName,
 			'image': db,
 			'pull': 'always',
@@ -1428,7 +1428,10 @@ def databaseService(db):
 				'MYSQL_DATABASE': getDbDatabase(db),
 				'MYSQL_ROOT_PASSWORD': getDbRootPassword()
 			}
-		}]
+		}
+		if (db == 'mysql:8.0'):
+			service['command'] = ['--default-authentication-plugin=mysql_native_password']
+		return [service]
 
 	if dbName == 'postgres':
 		return [{

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -985,7 +985,7 @@ def phptests(testType):
 	default = {
 		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
+			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1887,7 +1887,7 @@ def setupCeph(phpVersion, cephS3):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'wait-for-it -t 60 ceph:80',
+			'wait-for-it -t 120 ceph:80',
 			'cd /drone/src/apps/files_primary_s3',
 			'cp tests/drone/ceph.config.php /drone/src/config',
 			'cd /var/www/owncloud/server',
@@ -1912,7 +1912,7 @@ def setupScality(phpVersion, scalityS3):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'wait-for-it -t 60 scality:8000',
+			'wait-for-it -t 120 scality:8000',
 			'cp /drone/src/apps/files_primary_s3/tests/drone/%s /drone/src/config' % configFile,
 			'php occ s3:create-bucket owncloud --accept-warning'
 		] + ([

--- a/.drone.yml
+++ b/.drone.yml
@@ -1967,6 +1967,141 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: phpunit-php7.1-mysql8.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: mysql
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: mysql
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:8.0
+  command:
+  - --default-authentication-plugin=mysql_native_password
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: phpunit-php7.1-postgres9.4
 
 platform:
@@ -14491,6 +14626,7 @@ depends_on:
 - phpunit-php7.1-mariadb10.3
 - phpunit-php7.1-mysql5.5
 - phpunit-php7.1-mysql5.7
+- phpunit-php7.1-mysql8.0
 - phpunit-php7.1-postgres9.4
 - phpunit-php7.1-oracle
 - phpunit-php7.0-sqlite

--- a/.drone.yml
+++ b/.drone.yml
@@ -2234,6 +2234,138 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: phpunit-php7.1-postgres10.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: postgres
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: postgres
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:10.3
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: phpunit-php7.1-oracle
 
 platform:
@@ -2350,226 +2482,6 @@ services:
     ORACLE_DISABLE_ASYNCH_IO: true
     ORACLE_PASSWORD: oracle
     ORACLE_USER: system
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.3
-- phpstan-php7.1
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-sqlite
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /drone
-  path: src
-
-steps:
-- name: cache-restore
-  pull: always
-  image: plugins/s3-cache:1
-  settings:
-    access_key:
-      from_secret: cache_s3_access_key
-    endpoint:
-      from_secret: cache_s3_endpoint
-    restore: true
-    secret_key:
-      from_secret: cache_s3_secret_key
-  when:
-    instance:
-    - drone.owncloud.services
-    - drone.owncloud.com
-
-- name: composer-install
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make install-composer-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: vendorbin-install
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make vendor-bin-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: yarn-install
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make install-nodejs-deps
-  environment:
-    NPM_CONFIG_CACHE: /drone/src/.cache/npm
-    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
-    bower_storage__packages: /drone/src/.cache/bower
-
-- name: install-server
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - bash tests/drone/install-server.sh
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-  - php occ config:list
-  - php occ security:certificates:import /drone/server.crt
-  - php occ security:certificates
-  environment:
-    DB_TYPE: sqlite
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /drone/src
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /drone/src/data/owncloud.log
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - su-exec www-data bash tests/drone/test-phpunit.sh
-  environment:
-    COVERAGE: false
-    DB_TYPE: sqlite
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.3
-- phpstan-php7.1
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-mariadb10.2
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /drone
-  path: src
-
-steps:
-- name: cache-restore
-  pull: always
-  image: plugins/s3-cache:1
-  settings:
-    access_key:
-      from_secret: cache_s3_access_key
-    endpoint:
-      from_secret: cache_s3_endpoint
-    restore: true
-    secret_key:
-      from_secret: cache_s3_secret_key
-  when:
-    instance:
-    - drone.owncloud.services
-    - drone.owncloud.com
-
-- name: composer-install
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make install-composer-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: vendorbin-install
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make vendor-bin-deps
-  environment:
-    COMPOSER_HOME: /drone/src/.cache/composer
-
-- name: yarn-install
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make install-nodejs-deps
-  environment:
-    NPM_CONFIG_CACHE: /drone/src/.cache/npm
-    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
-    bower_storage__packages: /drone/src/.cache/bower
-
-- name: install-server
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - bash tests/drone/install-server.sh
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-  - php occ config:list
-  - php occ security:certificates:import /drone/server.crt
-  - php occ security:certificates
-  environment:
-    DB_TYPE: mariadb
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /drone/src
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /drone/src/data/owncloud.log
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - su-exec www-data bash tests/drone/test-phpunit.sh
-  environment:
-    COVERAGE: false
-    DB_TYPE: mariadb
-
-services:
-- name: mariadb
-  pull: always
-  image: mariadb:10.2
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
 
 trigger:
   ref:
@@ -14628,9 +14540,8 @@ depends_on:
 - phpunit-php7.1-mysql5.7
 - phpunit-php7.1-mysql8.0
 - phpunit-php7.1-postgres9.4
+- phpunit-php7.1-postgres10.3
 - phpunit-php7.1-oracle
-- phpunit-php7.0-sqlite
-- phpunit-php7.0-mariadb10.2
 - phpunit-php7.2-sqlite
 - phpunit-php7.2-mariadb10.2
 - phpunit-php7.3-sqlite

--- a/.drone.yml
+++ b/.drone.yml
@@ -1568,6 +1568,139 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: phpunit-php7.1-mariadb10.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: mariadb
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: mariadb
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.3
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: phpunit-php7.1-mysql5.5
 
 platform:
@@ -14355,6 +14488,7 @@ depends_on:
 - carddav-old-php7.1
 - phpunit-php7.1-sqlite
 - phpunit-php7.1-mariadb10.2
+- phpunit-php7.1-mariadb10.3
 - phpunit-php7.1-mysql5.5
 - phpunit-php7.1-mysql5.7
 - phpunit-php7.1-postgres9.4

--- a/.drone.yml
+++ b/.drone.yml
@@ -3555,7 +3555,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 60 scality:8000
+  - wait-for-it -t 120 scality:8000
   - cp /drone/src/apps/files_primary_s3/tests/drone/scality.config.php /drone/src/config
   - php occ s3:create-bucket owncloud --accept-warning
 

--- a/tests/drone/install-server.sh
+++ b/tests/drone/install-server.sh
@@ -83,8 +83,8 @@ case "${DB_TYPE}" in
     wait-for-it mysql:3306
     DB=mysql
     ;;
-  mysqlmb4)
-    wait-for-it mysqlmb4:3306
+  mysql8)
+    wait-for-it mysql8:3306
     DB=mysql
     ;;
   postgres)

--- a/tests/drone/install-server.sh
+++ b/tests/drone/install-server.sh
@@ -76,23 +76,23 @@ rm -rf ${DATA_DIRECTORY} config/config.php
 echo "waiting for database to be ready"
 case "${DB_TYPE}" in
   mariadb)
-    wait-for-it mariadb:3306
+    wait-for-it -t 120 mariadb:3306
     DB=mysql
     ;;
   mysql)
-    wait-for-it mysql:3306
+    wait-for-it -t 120 mysql:3306
     DB=mysql
     ;;
   mysql8)
-    wait-for-it mysql8:3306
+    wait-for-it -t 120 mysql8:3306
     DB=mysql
     ;;
   postgres)
-    wait-for-it postgres:5432
+    wait-for-it -t 120 postgres:5432
     DB=pgsql
     ;;
   oracle)
-    wait-for-it oracle:1521
+    wait-for-it -t 120 oracle:1521
     DB=oci
     DB_USERNAME=autotest
     DB_NAME='XE'


### PR DESCRIPTION
The `release-10.3.2` branch now has old CI that tries to run some CI drone pipelines with PHP 7.0.
That is a problem when we try to merge it back to master, because master has dropped PHP 7.0 support.

This PR cherry-picks the drone CI-related changes from master, so that CI here can be up-to-day - and hopefully even pass!