### PR TITLE
[For 10.4] Add share indicator in webUI

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -512,7 +512,7 @@ table td.filename .uploadtext {
 }
 
 /* File checkboxes */
-html:not(.ie8) #fileList tr td.filename > .selectCheckBox + label:before {
+#fileList tr td.filename > .selectCheckBox + label:before {
 	opacity: 0;
 	position: absolute;
 	bottom: 4px;
@@ -520,13 +520,21 @@ html:not(.ie8) #fileList tr td.filename > .selectCheckBox + label:before {
 	z-index: 10;
 }
 
-html.ie8 #fileList tr td.filename > .selectCheckBox {
-	filter: alpha(opacity=0);
-	opacity: 0;
-	float: left;
-	top: 0;
-	margin: 32px 0 4px 32px;
-	/* bigger clickable area doesn’t work in FF width:2.8em; height:2.4em;*/
+#fileList tr:not(:hover):not(.selected) td.filename .thumbnail.sharetree-item:after {
+	position: absolute;
+	display: block;
+	content: '';
+	bottom: 0px;
+	right: -5px;
+	z-index: 10;
+	background-image: url(../../../core/img/actions/shared.svg);
+	width: 14px;
+	height: 14px;
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: 10px;
+	background-color: #bfbfbf;
+	border-radius: 50%;
 }
 
 /* Show checkbox when hovering, checked, or selected */

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1779,7 +1779,7 @@
 
 					if (dir.shareTypes !== undefined) {
 						// Fetch all shares for directory in question
-						$.get( OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares?' + OC.buildQueryString({format: 'json', path: path }), function(e) {
+						$.get( OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares?' + OC.buildQueryString({format: 'json', path: path, reshares : true }), function(e) {
 							self._shareTreeCache[path] = {
 								name : dir.name,
 								shares : e.ocs.data
@@ -1888,9 +1888,16 @@
 
 				_.each(shares, function(share) {
 
+					var shareWith = share.share_with_displayname;
+
+					if (share.share_type === OC.Share.SHARE_TYPE_GROUP)
+						shareWith += ' (' + t('core', 'group') + ')';
+
 					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name })
-					var $name = $('<strong>', { class : 'shareTree-item-name', text : share.share_with_displayname })
+					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareWith })
 					var $icon = $('<div>',    { class : 'shareTree-item-avatar' })
+
+
 
 					$icon.avatar(share.share_with, 32)
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -169,6 +169,13 @@
 		_sortComparator: null,
 
 		/**
+		 * Stores shareTree items and infos
+		 * 
+		 * @type Array
+		 */
+		_shareTreeCache: {},
+
+		/**
 		 * Whether to do a client side sort.
 		 * When false, clicking on a table header will call reload().
 		 * When true, clicking on a table header will simply resort the list.
@@ -379,6 +386,7 @@
 			// remove summary
 			this.$el.find('tfoot tr.summary').remove();
 			this.$fileList.empty();
+
 		},
 
 		/**
@@ -1048,6 +1056,7 @@
 			$(window).scrollTop(0);
 
 			this.$fileList.trigger(jQuery.Event('updated'));
+			
 			_.defer(function() {
 				self.$el.closest('#app-content').trigger(jQuery.Event('apprendered'));
 			});
@@ -1389,6 +1398,10 @@
 				tr.addClass('hidden-file');
 			}
 
+			if(_.keys(this._shareTreeCache).length) {
+				filenameTd.find('.thumbnail:not(.sharetree-item)').addClass('sharetree-item');
+			}
+
 			// display actions
 			this.fileActions.display(filenameTd, !options.silent, this);
 
@@ -1445,17 +1458,28 @@
 			var self = this;
 			var currentDir = this.getCurrentDirectory();
 			targetDir = targetDir || '/';
-			if (!force && currentDir === targetDir) {
-				return;
-			}
-			this._setCurrentDir(targetDir, changeUrl, fileId);
-			// discard finished uploads list, we'll get it through a regular reload
-			this._uploads = {};
-			this.reload().then(function(success){
-				if (!success) {
-					self.changeDirectory(currentDir, true);
+
+			return new Promise(function(resolve, reject) {
+
+				if (!force && currentDir === targetDir) {
+					resolve()
+					return
 				}
-			});
+				self._setCurrentDir(targetDir, changeUrl, fileId);
+				// discard finished uploads list, we'll get it through a regular reload
+				self._uploads = {};
+				self.reload().then(function(success){
+					if (!success) {
+						self.changeDirectory(currentDir, true);
+						reject()
+					}
+					resolve()
+				});
+
+				self._updateShareTree().then(function() {
+					self._setShareTreeIcons();
+				})
+			})
 		},
 		linkTo: function(dir) {
 			return OC.linkTo('files', 'index.php')+"?dir="+ encodeURIComponent(dir).replace(/%2F/g, '/');
@@ -1721,6 +1745,197 @@
 			});
 			var uid = encodeURIComponent(OC.getCurrentUser().uid);
 			return OC.linkToRemoteBase('dav') + '/files/' + uid + encodedPath;
+		},
+
+		/**
+		 * Fetch shareTypes of a certain directory
+		 * @param {String} dir directory string
+		 * @return {Promise} object with name and shareTypes
+		 */
+		getDirShareInfo: function(dir) {
+			// Dir can't be empty
+			if (typeof dir !== 'string' || dir.length === 0) {
+				return Promise.reject('getDirShareInfo(). param must be typeof string and can not be empty!')
+			}
+
+			// avoiding a unnessesary API calls
+			if (typeof this._shareTreeCache[dir] !== 'undefined' || dir === '/') {
+				return Promise.resolve()
+			}
+
+			// trim trailing slashes
+			dir = dir.replace(/\/$/, "")
+
+			var self       = this;
+			var client     = this.filesClient;
+			var options    = {
+				properties : ['{' + OC.Files.Client.NS_OWNCLOUD + '}share-types']
+			}
+
+			return new Promise( function(resolve, reject) {
+				client.getFileInfo(dir, options).done(function(s, dir) {
+
+					var path = OC.joinPaths(dir.path, dir.name)
+
+					if (dir.shareTypes !== undefined) {
+						// Fetch all shares for directory in question
+						$.get( OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares?' + OC.buildQueryString({format: 'json', path: path }), function(e) {
+							self._shareTreeCache[path] = {
+								name : dir.name,
+								shares : e.ocs.data
+							}
+							resolve()
+						})
+					}
+					else {
+						resolve()
+					}
+				}).fail(function(error) {
+					reject(error)
+				})
+			})
+		},
+
+		/**
+		 * Fetch shareInfos recursively from current
+		 * directory down to root
+		 * @param {String} dir directory string
+		 * @return {Promise} array of objects with name and shareTypes
+		 */
+		getPathShareInfo: function(path) {
+			if (typeof path !== 'string') {
+				console.error('getDirShareInfo(). param must be typeof string!')
+				return false
+			}
+
+			var crumbs     = [];
+			var pathToHere = '';
+			var parts      = (path === '/' || path.length === 0) ? ['/'] : path.split('/')
+
+			for (var i = 0; i < parts.length; i++) {
+				var part = parts[i];
+				pathToHere += part + '/';
+
+				crumbs.push(this.getDirShareInfo(pathToHere))
+			}
+
+			return Promise.all(crumbs)
+		},
+
+		_updateShareTree: function() {
+			var self = this;
+			var dir  = this.getCurrentDirectory();
+
+			// Purge shareTreeCache in root dir
+			if (dir === '/') {
+				this._purgeShareTreeCache()
+				return Promise.resolve()
+			}
+
+			return this.getPathShareInfo(dir).then(function () {
+				var breadcrumbs = dir.split('/')
+
+				// Diff keys in shareTreeCache agains the current dir
+				// removing deeper nested shares
+				var cache = _.omit(self._shareTreeCache, function(value, key) {
+					var diffs = _.difference(key.split('/'), breadcrumbs)
+					return diffs.length > 0
+				});
+
+				self._setShareTreeCache(cache)
+			})
+
+		},
+
+		_setShareTreeCache: function(data) {
+			this._shareTreeCache = data;
+		},
+
+		_purgeShareTreeCache: function() {
+			this._setShareTreeCache({});
+		},
+
+		_setShareTreeIcons: function() {
+			// Add share-tree icon to files and folders
+			// each per <tr> in the table
+
+			if (_.keys(this._shareTreeCache).length > 0)
+				this.$fileList.find('tr td.filename .thumbnail:not(.sharetree-item)').addClass('sharetree-item')
+			else
+				this.$fileList.find('tr td.filename .thumbnail.sharetree-item').removeClass('sharetree-item')
+
+		},
+
+		_setShareTreeUserGroupView: function() {
+			var self  = this;
+			var $list = $('<ul>', { id : 'shareTreeUserGroupList' });
+
+			if (! _.keys(self._shareTreeCache).length > 0)
+				return
+
+			$('.shareeTreeUserGroupListView').html($list)
+
+			// Shared folders
+			_.each(self._shareTreeCache, function(folder) {
+
+				var shares = _.filter(folder.shares, function(share) {
+					return (
+						share.share_type === OC.Share.SHARE_TYPE_USER ||
+						share.share_type === OC.Share.SHARE_TYPE_GROUP ||
+						share.share_type === OC.Share.SHARE_TYPE_GUEST ||
+						share.share_type === OC.Share.SHARE_TYPE_REMOTE )
+				})
+
+				_.each(shares, function(share) {
+
+					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name })
+					var $name = $('<strong>', { class : 'shareTree-item-name', text : share.share_with_displayname })
+					var $icon = $('<div>',    { class : 'shareTree-item-avatar' })
+
+					$icon.avatar(share.share_with, 32)
+
+					$('<li class="shareTree-item">').append( $icon, $name, $path).appendTo($list).click(function() {
+						self.changeDirectory(share.path.replace(folder.name, ''), true).then(function() {
+							self._updateDetailsView(folder.name, true)
+						}).catch(function(e) {
+							console.error(e)
+						})
+					})
+				})
+			})
+		},
+
+		_setShareTreeLinkView: function() {
+			var self  = this;
+			var $list = $('<ul>', { id : 'shareTreeLinkList' });
+
+			if (! _.keys(self._shareTreeCache).length > 0)
+				return
+
+			$('.shareeTreeLinkListView').html($list)
+
+			// Shared folders
+			_.each(self._shareTreeCache, function(folder) {
+
+				var shares = _.filter(folder.shares, function(share) {
+					return share.share_type === OC.Share.SHARE_TYPE_LINK
+				})
+
+				_.each(shares, function(share) {
+
+					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name })
+					var $name = $('<strong>', { class : 'shareTree-item-name', text : share.name })
+					var $icon = $('<span>',   { class : 'shareTree-item-icon link-entry--icon icon-public-white' })
+
+					$('<li class="shareTree-item">').append( $icon, $name, $path).appendTo($list).click(function() {
+						self.changeDirectory(share.path.replace(folder.name, ''), true).then(function() {
+							self._updateDetailsView(folder.name, true)
+						}).catch(function(e) {
+							console.error(e)
+						})
+					})
+				})
+			})
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1893,11 +1893,12 @@
 					if (share.share_type === OC.Share.SHARE_TYPE_GROUP)
 						shareWith += ' (' + t('core', 'group') + ')';
 
+					else if (share.share_type === OC.Share.SHARE_TYPE_REMOTE)
+						shareWith += ' (' + t('files_sharing', 'Remote share') + ')';
+
 					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name })
 					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareWith })
 					var $icon = $('<div>',    { class : 'shareTree-item-avatar' })
-
-
 
 					$icon.avatar(share.share_with, 32)
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1931,8 +1931,10 @@
 
 				_.each(shares, function(share) {
 
+					var shareName = (!_.isEmpty(share.name)) ? share.name : share.token;
+
 					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name })
-					var $name = $('<strong>', { class : 'shareTree-item-name', text : share.name })
+					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareName })
 					var $icon = $('<span>',   { class : 'shareTree-item-icon link-entry--icon icon-public-white' })
 
 					$('<li class="shareTree-item">').append( $icon, $name, $path).appendTo($list).click(function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1024,6 +1024,24 @@ describe('OCA.Files.FileList tests', function() {
 			expect($summary.find('.dirinfo').hasClass('hidden')).toEqual(true);
 			expect($summary.find('.fileinfo').text()).toEqual('1 file');
 		});
+		it('shows icon for shareTree items if parent is shared', function() {
+			fileList._setShareTreeCache({
+				'/folder' : {
+					name: "folder",
+					shares : [{
+						share_type: 0,
+						share_with_displayname: "Demo user",
+					}]
+				}
+			});
+			fileList.setFiles(testFiles)
+			expect($('#fileList tr:first-of-type td .sharetree-item').length).toEqual(1)
+		});
+		it('does not show shareTree items if shareTree is empty', function() {
+			fileList._purgeShareTreeCache()
+			fileList.setFiles(testFiles)
+			expect($('#fileList tr td .sharetree-item').length).toEqual(0)
+		})
 	});
 	describe('Filtered list rendering', function() {
 		it('filters the list of files using filter()', function() {

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -76,6 +76,38 @@
 	margin-right: 8px;
 }
 
+#shareDialogLinkList .link-shares + #shareTreeUserGroupList {
+	margin-top: -20px;
+}
+
+#shareWithList + #shareTreeUserGroupList {
+	margin-top: -16px;
+}
+
+#shareTreeLinkList .shareTree-item,
+#shareTreeUserGroupList .shareTree-item {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+
+	padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+.shareTree-item * {
+	cursor: pointer;
+}
+
+.shareTree-item-avatar {
+	border-radius: 50%;
+	float: left;
+}
+
+.shareTree-item-avatar + .shareTree-item-name,
+.shareTree-item-name + .shareTree-item-path {
+	margin-left: 8px;
+}
+
 .shareTabView .icon-loading-small {
 	display         : inline-block;
 	z-index         : 1;

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -101,11 +101,19 @@
 .shareTree-item-avatar {
 	border-radius: 50%;
 	float: left;
+	min-width: 32px;
+	min-height: 32px;
 }
 
 .shareTree-item-avatar + .shareTree-item-name,
 .shareTree-item-name + .shareTree-item-path {
 	margin-left: 8px;
+	white-space: nowrap;
+}
+
+.shareTree-item-avatar + .shareTree-item-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .shareTabView .icon-loading-small {

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -198,6 +198,9 @@
 					// (FIXME: yes, this is hacky)
 					icon: $tr.attr('data-icon')
 				});
+
+				fileList._setShareTreeLinkView();
+				fileList._setShareTreeUserGroupView();
 			});
 			fileList.registerTabView(shareTab);
 		},

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -94,7 +94,7 @@ describe('OCA.Sharing.PublicApp tests', function() {
 			// uploader function messes up with fakeServer
 			var uploaderDetectStub = sinon.stub(OC.Uploader.prototype, '_supportAjaxUploadWithProgress');
 			App.initialize($('#preview'));
-			expect(fakeServer.requests.length).toEqual(1);
+			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].method).toEqual('PROPFIND');
 			expect(fakeServer.requests[0].url).toEqual('https://example.com:9876/owncloud/public.php/webdav/subdir');
 			expect(fakeServer.requests[0].requestHeaders.Authorization).toEqual('Basic c2g0dG9rOm51bGw=');

--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -45,6 +45,17 @@
 	};
 
 	/**
+	 * Check if sidebar is visible/hidden
+	 *
+	 * @param {Object} [$el] sidebar element to check, defaults to $('#app-sidebar')
+	 */
+
+	exports.Apps.AppSidebarVisible = function($el) {
+		var $appSidebar = $el || $('#app-sidebar');
+		return !$appSidebar.hasClass('disappear');
+	};
+
+	/**
 	 * Provides a way to slide down a target area through a button and slide it
 	 * up if the user clicks somewhere else. Used for the news app settings and
 	 * add new field.

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -53,6 +53,7 @@ OC.Share = _.extend(OC.Share || {}, {
 	 * @param fileList file list instance, defaults to OCA.Files.App.fileList
 	 * @param callback function to call after the shares were loaded
 	 */
+
 	loadIcons:function(itemType, fileList, callback) {
 		var path = fileList.dirInfo.path;
 		if (path === '/') {
@@ -430,7 +431,5 @@ $(document).ready(function() {
 			OC.Share.hideDropDown();
 		}
 	});
-
-
 
 });

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -29,11 +29,15 @@
 		'        <div class="oneline">' +
 		'            <input id="shareWith-{{cid}}" class="shareWithField" type="text" placeholder="{{sharePlaceholder}}" />' +
 		'            <span class="shareWithLoading icon-loading-small hidden"></span>'+
-		'{{{remoteShareInfo}}}' +
+		'            {{{remoteShareInfo}}}' +
 		'        </div>' +
 		'        <div class="shareeListView subView"></div>' +
+		'        <div class="shareeTreeUserGroupListView subView"></div>' +
 		'    </div>' +
-		'    <div class="linkShareView subView tab hidden" style="padding-left:0;padding-right:0;"></div>' +
+		'    <div class="linkShareView tab hidden" style="padding-left:0;padding-right:0;">' +
+		'        <div class="linkListView"></div>' +
+		'        <div class="shareeTreeLinkListView subView"></div>' +
+		'    </div>' +
 		'</div>' +
 		'{{else}}' +
 		'<div class="noSharingPlaceholder">{{noSharingPlaceholder}}</div>' +
@@ -156,6 +160,7 @@
 			this.$('.localShareView').toggleClass('hidden', !$target.hasClass('subtab-localshare'));
 
 			var $linkShareView = this.$('.linkShareView');
+			var $linkListView = this.$('.linkListView');
 			if ($linkShareView.length) {
 				$linkShareView.toggleClass('hidden', !$target.hasClass('subtab-publicshare'));
 
@@ -166,7 +171,7 @@
 						itemModel: this.model
 					});
 					this.linkShareView.render();
-					$linkShareView.append(this.linkShareView.$el);
+					$linkListView.html(this.linkShareView.$el);
 				}
 			}
 		},

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -35,6 +35,7 @@ describe('OC.Share.ShareDialogView', function() {
 	var configModel;
 	var shareModel;
 	var fileInfoModel;
+	var fileList;
 	var dialog;
 
 	beforeEach(function() {
@@ -963,11 +964,55 @@ describe('OC.Share.ShareDialogView', function() {
 			expect(dialog.$('.tabsContainer>.tab:eq(1)').hasClass('hidden')).toEqual(false);
 		});
 		it('creates link share view only after selecting tab', function() {
-			expect(dialog.$('.linkShareView').is(':empty')).toEqual(true);
+			expect(dialog.$('.linkListView').is(':empty')).toEqual(true);
 			
 			dialog.$('.subTabHeaders>.subTabHeader:eq(1)').click();
 
-			expect(dialog.$('.linkShareView').is(':empty')).toEqual(false);
+			expect(dialog.$('.linkListView').is(':empty')).toEqual(false);
 		});
+	});
+	describe('shareTree', function() {
+		beforeEach(function() {
+			dialog.render();
+
+			$('#testArea').append('<div id="filelist"></div>')
+			fileList = new OCA.Files.FileList($('#filelist'));
+			fileList._setShareTreeCache({
+				'/folder' : {
+					name: "folder",
+					shares : [{
+						share_type: 0,
+						share_with_displayname: "Demo user",
+					}, {
+						share_type: 1,
+						share_with_displayname: "Demo group",
+					}, {
+						share_type: 3,
+						share_with_displayname: "Demo link #1",
+					}, {
+						share_type: 3,
+						share_with_displayname: "Demo link #2",
+					}, {
+						share_type: 4,
+						share_with_displayname: "Demo guest",
+					}, {
+						share_type: 6,
+						share_with_displayname: "Demo remote user",
+					}]
+				}
+			});
+		})
+		afterEach(function() {
+			fileList.destroy();
+			$('#filelist').remove()
+		});
+		it('renders parent user/groups shares', function() {
+			fileList._setShareTreeUserGroupView()
+			expect(dialog.$el.find('#shareTreeUserGroupList li').length).toEqual(4);
+		})
+		it('renders parent link shares', function() {
+			fileList._setShareTreeLinkView()
+			expect(dialog.$el.find('#shareTreeLinkList li').length).toEqual(2);
+		})
 	});
 });

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2230,4 +2230,18 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$shareTreeItem = $sharingDialog->getShareTreeItem($type, $name, $item);
 		Assert::assertTrue($shareTreeItem->isVisible());
 	}
+
+	/**
+	 * @Then public link with last share token should be listed as share receiver via :item on the webUI
+	 *
+	 * @param string $item
+	 *
+	 * @return void
+	 */
+	public function publicLinkWithLastShareTokenShouldBeListedAsShareReceiverViaOnTheWebUI($item) {
+		$token = $this->featureContext->getLastShareData()->data->token;
+		$sharingDialog = $this->filesPage->getSharingDialog();
+		$shareTreeItem = $sharingDialog->getShareTreeItem("public link", $token, $item);
+		Assert::assertTrue($shareTreeItem->isVisible());
+	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2213,7 +2213,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(?:user|group) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
+	 * @Then /^(?:user|group|public link with name) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
 	 *
 	 * @param string $name
 	 * @param string $item

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -32,6 +32,7 @@ use Page\SharedWithOthersPage;
 use Page\SharedWithYouPage;
 use Page\TagsPage;
 use Page\TrashbinPage;
+use Page\PublicLinkFilesPage;
 use Page\FilesPageElement\ConflictDialog;
 use Page\FilesPageElement\FileActionsMenu;
 use Page\GeneralExceptionPage;
@@ -82,6 +83,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @var SharedWithOthersPage
 	 */
 	private $sharedWithOthersPage;
+
+	/**
+	 * @var PublicLinkFilesPage
+	 */
+	private $publicLinkFilesPage;
 
 	/**
 	 *
@@ -165,6 +171,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @param SharedByLinkPage $sharedByLinkPage
 	 * @param SharedWithOthersPage $sharedWithOthersPage
 	 * @param GeneralExceptionPage $generalExceptionPage
+	 * @param PublicLinkFilesPage $publicLinkFilesPage
 	 *
 	 * @return void
 	 */
@@ -177,7 +184,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		TagsPage $tagsPage,
 		SharedByLinkPage $sharedByLinkPage,
 		SharedWithOthersPage $sharedWithOthersPage,
-		GeneralExceptionPage $generalExceptionPage
+		GeneralExceptionPage $generalExceptionPage,
+		PublicLinkFilesPage $publicLinkFilesPage
 	) {
 		$this->trashbinPage = $trashbinPage;
 		$this->filesPage = $filesPage;
@@ -188,6 +196,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$this->sharedByLinkPage = $sharedByLinkPage;
 		$this->sharedWithOthersPage = $sharedWithOthersPage;
 		$this->generalExceptionPage = $generalExceptionPage;
+		$this->publicLinkFilesPage = $publicLinkFilesPage;
 	}
 
 	/**
@@ -1121,7 +1130,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(files page|trashbin|favorites page|shared-with-you page|shared with others page|tags page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
+	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(files page|trashbin|favorites page|shared-with-you page|shared with others page|tags page|public link files page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
 	 *
 	 * @param string $name enclosed in single or double quotes
 	 * @param string $path
@@ -1289,6 +1298,13 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$failed = false;
 		foreach ($breadCrumbsForOpenFile as $breadCrumb) {
 			$pageObject->openFile($breadCrumb, $this->getSession());
+			if ($pageObject instanceof $this->trashbinPage) {
+				$pageObject = $this->trashbinPage;
+			} elseif ($pageObject instanceof $this->publicLinkFilesPage) {
+				$pageObject = $this->publicLinkFilesPage;
+			} else {
+				$pageObject = $this->filesPage;
+			}
 			try {
 				$pageObject->waitTillPageIsLoaded($this->getSession());
 			} catch (\Exception $e) {
@@ -1418,7 +1434,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			case "shared-by-link page":
 				$this->theUserBrowsesToThePage($this->sharedByLinkPage);
 				break;
-			case "shared with others page":
 			case "shared-with-others page":
 				$this->theUserBrowsesToThePage($this->sharedWithOthersPage);
 				break;

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -32,7 +32,6 @@ use Page\SharedWithOthersPage;
 use Page\SharedWithYouPage;
 use Page\TagsPage;
 use Page\TrashbinPage;
-use Page\PublicLinkFilesPage;
 use Page\FilesPageElement\ConflictDialog;
 use Page\FilesPageElement\FileActionsMenu;
 use Page\GeneralExceptionPage;
@@ -83,11 +82,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @var SharedWithOthersPage
 	 */
 	private $sharedWithOthersPage;
-
-	/**
-	 * @var PublicLinkFilesPage
-	 */
-	private $publicLinkFilesPage;
 
 	/**
 	 *
@@ -171,7 +165,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @param SharedByLinkPage $sharedByLinkPage
 	 * @param SharedWithOthersPage $sharedWithOthersPage
 	 * @param GeneralExceptionPage $generalExceptionPage
-	 * @param PublicLinkFilesPage $publicLinkFilesPage
 	 *
 	 * @return void
 	 */
@@ -184,8 +177,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		TagsPage $tagsPage,
 		SharedByLinkPage $sharedByLinkPage,
 		SharedWithOthersPage $sharedWithOthersPage,
-		GeneralExceptionPage $generalExceptionPage,
-		PublicLinkFilesPage $publicLinkFilesPage
+		GeneralExceptionPage $generalExceptionPage
 	) {
 		$this->trashbinPage = $trashbinPage;
 		$this->filesPage = $filesPage;
@@ -196,7 +188,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$this->sharedByLinkPage = $sharedByLinkPage;
 		$this->sharedWithOthersPage = $sharedWithOthersPage;
 		$this->generalExceptionPage = $generalExceptionPage;
-		$this->publicLinkFilesPage = $publicLinkFilesPage;
 	}
 
 	/**
@@ -1130,7 +1121,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(files page|trashbin|favorites page|shared-with-you page|shared with others page|tags page|public link files page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
+	 * @Then /^(?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with path ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(files page|trashbin|favorites page|shared-with-you page|shared with others page|tags page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
 	 *
 	 * @param string $name enclosed in single or double quotes
 	 * @param string $path
@@ -1298,13 +1289,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$failed = false;
 		foreach ($breadCrumbsForOpenFile as $breadCrumb) {
 			$pageObject->openFile($breadCrumb, $this->getSession());
-			if ($pageObject instanceof $this->trashbinPage) {
-				$pageObject = $this->trashbinPage;
-			} elseif ($pageObject instanceof $this->publicLinkFilesPage) {
-				$pageObject = $this->publicLinkFilesPage;
-			} else {
-				$pageObject = $this->filesPage;
-			}
 			try {
 				$pageObject->waitTillPageIsLoaded($this->getSession());
 			} catch (\Exception $e) {
@@ -1434,6 +1418,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			case "shared-by-link page":
 				$this->theUserBrowsesToThePage($this->sharedByLinkPage);
 				break;
+			case "shared with others page":
 			case "shared-with-others page":
 				$this->theUserBrowsesToThePage($this->sharedWithOthersPage);
 				break;

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2213,20 +2213,21 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(?:user|group|public link with name) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
+	 * @Then /^(user|group|public link with name) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
 	 *
+	 * @param string $type user|group|public link with name
 	 * @param string $name
 	 * @param string $item
 	 *
 	 * @return void
 	 */
-	public function userGroupShouldBeListedAsShareReceiver($name, $item) {
+	public function userGroupShouldBeListedAsShareReceiver($type, $name, $item) {
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
 		$name = \trim($name, $name[0]);
 		$item = \trim($item, $item[0]);
 		$sharingDialog = $this->filesPage->getSharingDialog();
-		$shareTreeItem = $sharingDialog->getShareTreeItem($name, $item);
+		$shareTreeItem = $sharingDialog->getShareTreeItem($type, $name, $item);
 		Assert::assertTrue($shareTreeItem->isVisible());
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2211,4 +2211,22 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$this->getSession()
 		);
 	}
+
+	/**
+	 * @Then /^(?:user|group) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
+	 *
+	 * @param string $name
+	 * @param string $item
+	 *
+	 * @return void
+	 */
+	public function userGroupShouldBeListedAsShareReceiver($name, $item) {
+		// The capturing group of the regex always includes the quotes at each
+		// end of the captured string, so trim them.
+		$name = \trim($name, $name[0]);
+		$item = \trim($item, $item[0]);
+		$sharingDialog = $this->filesPage->getSharingDialog();
+		$shareTreeItem = $sharingDialog->getShareTreeItem($name, $item);
+		Assert::assertTrue($shareTreeItem->isVisible());
+	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2213,9 +2213,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(user|group|public link with name) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
+	 * @Then /^(user|group|public link|federated user) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
 	 *
-	 * @param string $type user|group|public link with name
+	 * @param string $type user|group|public link|federated user
 	 * @param string $name
 	 * @param string $item
 	 *
@@ -2224,8 +2224,10 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function userGroupShouldBeListedAsShareReceiver($type, $name, $item) {
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
+		$name = $this->featureContext->substituteInLineCodes($name);
 		$name = \trim($name, $name[0]);
 		$item = \trim($item, $item[0]);
+
 		$sharingDialog = $this->filesPage->getSharingDialog();
 		$shareTreeItem = $sharingDialog->getShareTreeItem($type, $name, $item);
 		Assert::assertTrue($shareTreeItem->isVisible());

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1601,4 +1601,68 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			);
 		}
 	}
+
+	/**
+	 * @Then /^(file|folder) "([^"]*)" should have share indicator on the webUI$/
+	 *
+	 * @param string $fileOrFolder
+	 * @param string $filename name of resource
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function folderShouldHaveShareIndicatorOnTheWebUI($fileOrFolder, $filename) {
+		$isMarked = $this->filesPage->isShareIndicatorPresent(
+			$filename
+		);
+		Assert::assertEquals(true, $isMarked, "Expected: " . $fileOrFolder . " to be marked as shared but found: " . \strval($isMarked));
+	}
+
+	/**
+	 * @Then /^(file|folder) "([^"]*)" should not have share indicator on the webUI$/
+	 *
+	 * @param string $fileOrFolder
+	 * @param string $filename name of resource
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function folderShouldNotHaveShareIndicatorOnTheWebUI($fileOrFolder, $filename) {
+		$isMarked = $this->filesPage->isShareIndicatorPresent(
+			$filename
+		);
+		Assert::assertEquals(false, $isMarked, "Expected: " . $fileOrFolder . " not to be marked as shared but found: " . \strval($isMarked));
+	}
+
+	/**
+	 * @Then the following resources should have share indicators on the webUI
+	 *
+	 * @param TableNode $resourceTable
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theFollowingResourcesShouldHaveShareIndicatorOnTheWebUI(TableNode $resourceTable) {
+		$elementRows = $resourceTable->getRows();
+		$elements = $this->featureContext->simplifyArray($elementRows);
+		foreach ($elements as $element) {
+			$this->folderShouldHaveShareIndicatorOnTheWebUI(null, $element);
+		}
+	}
+
+	/**
+	 * @Then the following resources should not have share indicators on the webUI
+	 *
+	 * @param TableNode $resourceTable table headings: must be: |name|
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theFollowingResourcesShouldNotHaveShareIndicatorOnTheWebUI(TableNode $resourceTable) {
+		$elementRows = $resourceTable->getRows();
+		$elements = $this->featureContext->simplifyArray($elementRows);
+		foreach ($elements as $element) {
+			$this->folderShouldNotHaveShareIndicatorOnTheWebUI(null, $element);
+		}
+	}
 }

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1603,66 +1603,46 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(file|folder) "([^"]*)" should have share indicator on the webUI$/
-	 *
-	 * @param string $fileOrFolder
-	 * @param string $filename name of resource
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function folderShouldHaveShareIndicatorOnTheWebUI($fileOrFolder, $filename) {
-		$isMarked = $this->filesPage->isShareIndicatorPresent(
-			$filename
-		);
-		Assert::assertEquals(true, $isMarked, "Expected: " . $fileOrFolder . " to be marked as shared but found: " . \strval($isMarked));
-	}
-
-	/**
-	 * @Then /^(file|folder) "([^"]*)" should not have share indicator on the webUI$/
-	 *
-	 * @param string $fileOrFolder
-	 * @param string $filename name of resource
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function folderShouldNotHaveShareIndicatorOnTheWebUI($fileOrFolder, $filename) {
-		$isMarked = $this->filesPage->isShareIndicatorPresent(
-			$filename
-		);
-		Assert::assertEquals(false, $isMarked, "Expected: " . $fileOrFolder . " not to be marked as shared but found: " . \strval($isMarked));
-	}
-
-	/**
 	 * @Then the following resources should have share indicators on the webUI
 	 *
 	 * @param TableNode $resourceTable
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function theFollowingResourcesShouldHaveShareIndicatorOnTheWebUI(TableNode $resourceTable) {
 		$elementRows = $resourceTable->getRows();
 		$elements = $this->featureContext->simplifyArray($elementRows);
-		foreach ($elements as $element) {
-			$this->folderShouldHaveShareIndicatorOnTheWebUI(null, $element);
+		foreach ($elements as $filename) {
+			$isMarked = $this->filesPage->isSharedIndicatorPresent(
+				$filename, $this->getSession()
+			);
+			Assert::assertTrue(
+				$isMarked,
+				"Expected: " . $filename . " to be marked as shared but it's not"
+			);
 		}
 	}
 
 	/**
 	 * @Then the following resources should not have share indicators on the webUI
 	 *
-	 * @param TableNode $resourceTable table headings: must be: |name|
+	 * @param TableNode $resourceTable
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function theFollowingResourcesShouldNotHaveShareIndicatorOnTheWebUI(TableNode $resourceTable) {
 		$elementRows = $resourceTable->getRows();
 		$elements = $this->featureContext->simplifyArray($elementRows);
-		foreach ($elements as $element) {
-			$this->folderShouldNotHaveShareIndicatorOnTheWebUI(null, $element);
+		foreach ($elements as $filename) {
+			$isMarked = $this->filesPage->isSharedIndicatorPresent(
+				$filename, $this->getSession()
+			);
+			Assert::assertFalse(
+				$isMarked,
+				"Expected: " . $filename . " not to be marked as shared but it is"
+			);
 		}
 	}
 }

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -43,6 +43,7 @@ class FilesPage extends FilesPageBasic {
 	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
 	protected $homePageIconXpath = "//div[@class='breadcrumb']//img[@alt='Home']";
 	protected $folderBreadCrumbXpath = "//div[@class='breadcrumb']//a[contains(@href,'%s')]";
+	protected $resourceSharedIndicatorXpath = "//table[@id='filestable']//span[normalize-space(.)='%s']/../..//div[contains(@class, 'sharetree-item')]";
 
 	/**
 	 *
@@ -398,5 +399,18 @@ class FilesPage extends FilesPageBasic {
 	 */
 	public function waitForUploadProgressbarToFinish() {
 		$this->filesPageCRUDFunctions->waitForUploadProgressbarToFinish();
+	}
+
+	/**
+	 * checks whether given resource is marked as shared or not
+	 *
+	 * @param $fileName
+	 *
+	 * @return bool
+	 */
+	public function isShareIndicatorPresent($fileName) {
+		$resourceMarkedSharedXpath = \sprintf($this->resourceSharedIndicatorXpath, $fileName);
+		$markedElement = $this->find("xpath", $resourceMarkedSharedXpath);
+		return $markedElement !== null;
 	}
 }

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -43,7 +43,6 @@ class FilesPage extends FilesPageBasic {
 	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
 	protected $homePageIconXpath = "//div[@class='breadcrumb']//img[@alt='Home']";
 	protected $folderBreadCrumbXpath = "//div[@class='breadcrumb']//a[contains(@href,'%s')]";
-	protected $resourceSharedIndicatorXpath = "//table[@id='filestable']//span[normalize-space(.)='%s']/../..//div[contains(@class, 'sharetree-item')]";
 
 	/**
 	 *
@@ -404,13 +403,13 @@ class FilesPage extends FilesPageBasic {
 	/**
 	 * checks whether given resource is marked as shared or not
 	 *
-	 * @param $fileName
+	 * @param string $fileName
+	 * @param Session $session
 	 *
 	 * @return bool
 	 */
-	public function isShareIndicatorPresent($fileName) {
-		$resourceMarkedSharedXpath = \sprintf($this->resourceSharedIndicatorXpath, $fileName);
-		$markedElement = $this->find("xpath", $resourceMarkedSharedXpath);
-		return $markedElement !== null;
+	public function isSharedIndicatorPresent($fileName, $session) {
+		$fileRow = $this->findFileRowByName($fileName, $session);
+		return $fileRow->isSharedIndicatorPresent();
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -533,7 +533,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 					);
 					$fileListIsVisible = false;
 				}
-				
+
 				if ($fileListIsVisible
 					&& $fileList->has("xpath", "//a")
 				) {
@@ -638,7 +638,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
-		
+
 		$showHiddenFilesCheckBox = $this->find(
 			'xpath', $this->showHiddenFilesCheckboxXpath
 		);

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -405,7 +405,7 @@ class FileRow extends OwncloudPage {
 		$this->findFileLink()->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
-	
+
 	/**
 	 * restore the current deleted file and folder by clicking on the restore link
 	 *
@@ -446,14 +446,14 @@ class FileRow extends OwncloudPage {
 		$checkFavorite = $this->rowElement->find(
 			"xpath", $this->markedFavoriteXpath
 		);
-		
+
 		if ($checkFavorite === null) {
 			return false;
 		} else {
 			return true;
 		}
 	}
-	
+
 	/**
 	 * unmarks the current file or folder off favorite by clicking the star icon
 	 *

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -62,6 +62,7 @@ class FileRow extends OwncloudPage {
 	protected $sharingDialogXpath = ".//div[@class='dialogContainer']";
 	protected $lockDialogId = "lockTabView";
 	protected $highlightsXpath = "//div[@class='highlights']";
+	protected $sharedIndicatorXpath = "//div[contains(@class, 'sharetree-item')]";
 
 	/**
 	 *
@@ -584,5 +585,18 @@ class FileRow extends OwncloudPage {
 	public function isActionLabelAvailable($actionLabel, Session $session) {
 		$actionMenu = $this->openFileActionsMenu($session);
 		return $actionMenu->isActionLabelVisible($actionLabel);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isSharedIndicatorPresent() {
+		if ($this->rowElement->find(
+			"xpath", $this->sharedIndicatorXpath
+		) === null
+		) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -765,12 +765,16 @@ class SharingDialog extends OwncloudPage {
 	}
 
 	/**
+	 * @param string $type user|group|public link with name
 	 * @param string $name user or group name
 	 * @param string $path
 	 *
 	 * @return NodeElement
 	 */
-	public function getShareTreeItem($name, $path) {
+	public function getShareTreeItem($type, $name, $path) {
+		if ($type === "group") {
+			$name = \sprintf($this->groupFramework, $name);
+		}
 		$fullXpath = \sprintf($this->shareTreeItemByNameAndPathXpath, $name, $path);
 		$item = $this->find("xpath", $fullXpath);
 		$this->assertElementNotNull(

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -68,6 +68,7 @@ class SharingDialog extends OwncloudPage {
 	private $unShareTabXpath = "//a[contains(@class,'unshare')]";
 	private $sharedWithGroupAndSharerName = null;
 	private $publicLinkRemoveDeclineMsg = "No";
+	private $shareTreeItemByNameAndPathXpath = "//li[@class='shareTree-item' and strong/text()='%s' and span/text()='via %s']";
 
 	/**
 	 * @var string
@@ -763,6 +764,23 @@ class SharingDialog extends OwncloudPage {
 		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
+	/**
+	 * @param string $name user or group name
+	 * @param string $path
+	 *
+	 * @return NodeElement
+	 */
+	public function getShareTreeItem($name, $path) {
+		$fullXpath = \sprintf($this->shareTreeItemByNameAndPathXpath, $name, $path);
+		$item = $this->find("xpath", $fullXpath);
+		$this->assertElementNotNull(
+			$item,
+			__METHOD__ .
+			"\ncannot find item with name '$name' and path '$path'"
+		);
+		return $item;
+	}
+	
 	/**
 	 * waits for the dialog to appear
 	 *

--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -23,9 +23,7 @@
 namespace Page;
 
 use Behat\Mink\Session;
-use Behat\Mink\Element\NodeElement;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
-use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
  * Shared By Link page.
@@ -40,7 +38,6 @@ class SharedByLinkPage extends FilesPageCRUD {
 	protected $fileNamesXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext'))]";
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext')) and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-sharinglinks']//tbody[@id='fileList']";
-	protected $fileByPathAndNameXpath = "//div[@id='app-content-sharinglinks']//tr[@data-file=%s and @data-path=%s]";
 	protected $emptyContentXpath = ".//div[@id='app-content-sharinglinks']//div[@id='emptycontent']";
 	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
 	/**
@@ -89,13 +86,6 @@ class SharedByLinkPage extends FilesPageCRUD {
 	}
 
 	/**
-	 * @return string
-	 */
-	protected function getFileByNameAndPathXpath() {
-		return $this->fileByPathAndNameXpath;
-	}
-
-	/**
 	 * @param Session $session
 	 * @param Factory $factory
 	 * @param array   $parameters
@@ -112,25 +102,6 @@ class SharedByLinkPage extends FilesPageCRUD {
 			$this->fileNamesXpath,
 			$this->deleteAllSelectedBtnXpath
 		);
-	}
-
-	/**
-	 * @param string $name
-	 * @param string $path
-	 * @param Session $session
-	 *
-	 * @return NodeElement
-	 *
-	 * @throws ElementNotFoundException
-	 */
-	public function findFileRowByNameAndPath($name, $path, Session $session) {
-		$elementXpath = \sprintf($this->getFileByNameAndPathXpath(), $this->quotedText($name), $this->quotedText($path));
-		$element = $this->find("xpath", $elementXpath);
-		if ($element !== null) {
-			return $element;
-		} else {
-			throw new ElementNotFoundException('Expected: element with xpath' . $elementXpath . 'to be not null but found: null');
-		}
 	}
 
 	/**

--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -23,7 +23,9 @@
 namespace Page;
 
 use Behat\Mink\Session;
+use Behat\Mink\Element\NodeElement;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Factory;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
  * Shared By Link page.
@@ -38,6 +40,7 @@ class SharedByLinkPage extends FilesPageCRUD {
 	protected $fileNamesXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext'))]";
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext')) and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-sharinglinks']//tbody[@id='fileList']";
+	protected $fileByPathAndNameXpath = "//div[@id='app-content-sharinglinks']//tr[@data-file=%s and @data-path=%s]";
 	protected $emptyContentXpath = ".//div[@id='app-content-sharinglinks']//div[@id='emptycontent']";
 	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
 	/**
@@ -86,6 +89,13 @@ class SharedByLinkPage extends FilesPageCRUD {
 	}
 
 	/**
+	 * @return string
+	 */
+	protected function getFileByNameAndPathXpath() {
+		return $this->fileByPathAndNameXpath;
+	}
+
+	/**
 	 * @param Session $session
 	 * @param Factory $factory
 	 * @param array   $parameters
@@ -102,6 +112,25 @@ class SharedByLinkPage extends FilesPageCRUD {
 			$this->fileNamesXpath,
 			$this->deleteAllSelectedBtnXpath
 		);
+	}
+
+	/**
+	 * @param string $name
+	 * @param string $path
+	 * @param Session $session
+	 *
+	 * @return NodeElement
+	 *
+	 * @throws ElementNotFoundException
+	 */
+	public function findFileRowByNameAndPath($name, $path, Session $session) {
+		$elementXpath = \sprintf($this->getFileByNameAndPathXpath(), $this->quotedText($name), $this->quotedText($path));
+		$element = $this->find("xpath", $elementXpath);
+		if ($element !== null) {
+			return $element;
+		} else {
+			throw new ElementNotFoundException('Expected: element with xpath' . $elementXpath . 'to be not null but found: null');
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -28,7 +28,7 @@ use Behat\Mink\Session;
  * Shared with you page.
  */
 class SharedWithYouPage extends FilesPageBasic {
-	
+
 	/**
 	 *
 	 * @var string $path
@@ -38,28 +38,28 @@ class SharedWithYouPage extends FilesPageBasic {
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext')) and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-sharingin']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-sharingin']//div[@id='emptycontent']";
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileListXpath() {
 		return $this->fileListXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNamesXpath() {
 		return $this->fileNamesXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNameMatchXpath() {
 		return $this->fileNameMatchXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
@@ -95,7 +95,7 @@ class SharedWithYouPage extends FilesPageBasic {
 	) {
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
-		
+
 		for ($counter = 0; $counter < $maxRetries; $counter++) {
 			$row = $this->findFileRowByName($name, $session);
 			try {

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -372,3 +372,28 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then using server "REMOTE"
     And as "user1" folder "simple-folder" should exist
     And as "user1" folder "simple-folder (3)" should exist
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator inside folder shared using federated sharing
+    Given user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | lorem.txt  |
+      | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside folder shared using federated sharing
+    Given user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside folder shared using federated sharing
+    Given user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder |

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -397,3 +397,26 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing details inside folder shared using federated sharing
+    Given user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the share dialog for file "textfile.txt"
+    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder shared with local user and federated user
+    Given user "user2" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" has shared folder "simple-folder/sub-folder" with user "user2"
+    When the user opens folder "simple-folder/sub-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    And user "User Two" should be listed as share receiver via "sub-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -354,6 +354,7 @@ Feature: Sharing files and folders with internal groups
 
   Scenario: no sharing indicator of items inside a not shared folder
     Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should not have share indicators on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -316,6 +316,7 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
+  @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/simple-empty-folder"
@@ -327,6 +328,7 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder |
       | lorem.txt           |
 
+  @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder two levels down
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/simple-empty-folder/"
@@ -340,6 +342,7 @@ Feature: Sharing files and folders with internal groups
       | new-folder |
       | lorem.txt  |
 
+  @skipOnOcV10.3
   Scenario: sharing indicator of items inside a re-shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/simple-empty-folder"
@@ -352,6 +355,7 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder |
       | lorem.txt           |
 
+  @skipOnOcV10.3
   Scenario: no sharing indicator of items inside a not shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -316,4 +316,47 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
+  Scenario: sharing indicator of items inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  Scenario: sharing indicator of items inside a shared folder two levels down
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder/"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens folder "simple-empty-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-folder |
+      | lorem.txt  |
+
+  Scenario: sharing indicator of items inside a re-shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with group "grp1"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  Scenario: no sharing indicator of items inside a not shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
 

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -316,7 +316,6 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
-<<<<<<< HEAD
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder
     Given user "user1" has created folder "/simple-folder"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -358,12 +358,13 @@ Feature: Sharing files and folders with internal groups
   @skipOnOcV10.3
   Scenario: no sharing indicator of items inside a not shared folder
     Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-sub-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should not have share indicators on the webUI
-      | simple-empty-folder |
-      | lorem.txt           |
+      | simple-sub-folder |
+      | lorem.txt         |
 
   @skipOnOcV10.3
   Scenario: sharing indicator for file uploaded inside a shared folder

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -382,3 +382,15 @@ Feature: Sharing files and folders with internal groups
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder shared with user and group
+    Given user "user3" has created folder "/simple-folder/sub-folder"
+    And user "user3" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user3" has shared folder "simple-folder" with user "user2"
+    And user "user3" has shared folder "/simple-folder/sub-folder" with group "grp1"
+    And user "user3" has logged in using the webUI
+    When the user opens folder "simple-folder/sub-folder" using the webUI
+    And the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
+    And group "grp1" should be listed as share receiver via "sub-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -316,6 +316,7 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
+<<<<<<< HEAD
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder
     Given user "user1" has created folder "/simple-folder"
@@ -365,3 +366,18 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder |
       | lorem.txt           |
 
+  Scenario: user uploads file inside a shared folder
+    Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user3" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt           |
+
+  Scenario: user creates folder inside a shared folder
+    Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user3" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder           |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -365,18 +365,20 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder |
       | lorem.txt           |
 
-  Scenario: user uploads file inside a shared folder
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside a shared folder
     Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
     And user "user3" has logged in using the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
-      | new-lorem.txt           |
+      | new-lorem.txt |
 
-  Scenario: user creates folder inside a shared folder
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside a shared folder
     Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
     And user "user3" has logged in using the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
-      | sub-folder           |
+      | sub-folder |

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -678,6 +678,7 @@ Feature: Sharing files and folders with internal users
       just letting you know that user0 shared simple-folder with you.
       """
 
+  @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -690,6 +691,7 @@ Feature: Sharing files and folders with internal users
       | simple-empty-folder |
       | lorem.txt           |
 
+  @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder two levels down
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -705,6 +707,7 @@ Feature: Sharing files and folders with internal users
       | new-folder |
       | lorem.txt  |
 
+  @skipOnOcV10.3
   Scenario: sharing indicator of items inside a re-shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -721,6 +724,7 @@ Feature: Sharing files and folders with internal users
       | simple-empty-folder |
       | lorem.txt           |
 
+  @skipOnOcV10.3
   Scenario: no sharing indicator of items inside a not shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -678,191 +678,55 @@ Feature: Sharing files and folders with internal users
       just letting you know that user0 shared simple-folder with you.
       """
 
-  Scenario: Create share with internal users and view those shared resources in files page and shared-with-others page
+  Scenario: sharing indicator of items inside a shared folder
     Given these users have been created with default attributes and skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user shares file "lorem.txt" with user "User One" using the webUI
-    Then folder "simple-folder" should not have share indicator on the webUI
-    And file "lorem.txt" should not have share indicator on the webUI
-    When the user opens folder "simple-folder" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user opens folder "simple-empty-folder" using the webUI
-    And the user uploads file "new-lorem.txt" using the webUI
-    And the user creates a folder with the name "XYZ" using the webUI
-    Then file "new-lorem.txt" should have share indicator on the webUI
-    And folder "XYZ" should have share indicator on the webUI
-    When the user browses to the shared-with-others page
-    Then the following resources should not have share indicators on the webUI
-      | simple-folder                   |
-      | lorem.txt                       |
-    When the user opens folder "simple-folder" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-
-  Scenario: Create share for a folder within a group and view the shared folder in files page and shared-with-others page
-    Given these users have been created with default attributes and skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-    And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user2" has shared folder "simple-folder" with group "grp1"
-    And user "user2" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user opens folder "simple-empty-folder" using the webUI
-    And the user uploads file "new-lorem.txt" using the webUI
-    And the user creates a folder with the name "XYZ" using the webUI
-    Then file "new-lorem.txt" should have share indicator on the webUI
-    And folder "XYZ" should have share indicator on the webUI
-    When the user browses to the shared-with-others page
-    Then the following resources should not have share indicators on the webUI
-      | simple-folder                   |
-
-  Scenario: user receives a share from another user and views that received share in files page and shared-wih-you page when auto-accept-share is enabled
-    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has logged in using the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
-    Then the following resources should not have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user browses to the shared-with-you page
-    Then the following resources should not have share indicators on the webUI
-      | simple-folder (2)                     |
-    When the user opens folder "simple-folder (2)" using the webUI
-    Then the following resources should not have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-
-  Scenario: user creates a public link for a folder and views the shared folder from files page, shared-with-others page
-    and shared-by-link page
-    Given these users have been created with default attributes and skeleton files:
-      | username |
-      | user1    |
-    And user "user1" has logged in using the webUI
-    When the user creates a new public link for folder "simple-folder" using the webUI
-    And the user closes the share dialog
-    And the user opens folder "simple-folder" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user browses to the shared-with-others page
-    And the user opens folder "simple-folder" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user browses to the shared-by-link page
-    And the user opens folder "simple-folder" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-
-  Scenario: resharing by public link and view the shared resource from different pages
-    Given these users have been created with default attributes and skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
-    And user "user2" has logged in using the webUI
-    When the user creates a new public link for folder "simple-folder (2)" using the webUI with
-      | name | Public link |
-    And the user closes the share dialog
-    And the user opens folder "simple-folder (2)" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user browses to the shared-with-you page
-    And the user opens folder "simple-folder (2)" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user browses to the shared-by-link page
-    And the user opens folder "simple-folder (2)" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-    When the user browses to the shared-with-others page
-    And the user opens folder "simple-folder (2)" using the webUI
-    Then the following resources should have share indicators on the webUI
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | block-aligned.txt                     |
-      | testavatar.png                        |
-      | testapp.zip                           |
-
-  Scenario: share a sub folder and view the received share from files page and shared-with-you page
-    Given these users have been created with default attributes and skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/simple-empty-folder/lorem.txt"
-    And user "user1" has shared folder "/simple-folder/simple-empty-folder" with user "user2"
-    And user "user2" has logged in using the webUI
-    When the user opens folder "simple-empty-folder (2)" using the webUI
-    Then file "lorem.txt" should not have share indicator on the webUI
-    When the user browses to the shared-with-you page
-    And the user opens folder "simple-empty-folder (2)" using the webUI
-    Then file "lorem.txt" should not have share indicator on the webUI
-
-  Scenario: share a sub folder and view the shared resource from files page and shared-with-others page
-    Given these users have been created with default attributes and skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/simple-empty-folder/lorem.txt"
-    And user "user1" has shared folder "/simple-folder/simple-empty-folder" with user "user2" with permissions "share,read"
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    Then folder "simple-empty-folder" should not have share indicator on the webUI
-    When the user opens folder "simple-empty-folder" using the webUI
-    Then file "lorem.txt" should have share indicator on the webUI
-    When the user browses to the shared-with-others page
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  Scenario: sharing indicator of items inside a shared folder two levels down
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
     And the user opens folder "simple-empty-folder" using the webUI
-    Then file "lorem.txt" should have share indicator on the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-folder |
+      | lorem.txt  |
+
+  Scenario: sharing indicator of items inside a re-shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+    And these users have been created without skeleton files:
+      | username |
+      | user2    |
+      | user3    |
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with user "user3"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  Scenario: no sharing indicator of items inside a not shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -734,3 +734,39 @@ Feature: Sharing files and folders with internal users
     Then the following resources should not have share indicators on the webUI
       | simple-empty-folder |
       | lorem.txt           |
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder
+    Given these users have been created without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "simple-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a re-shared folder
+    Given these users have been created without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with user "user3"
+    And user "user2" has logged in using the webUI
+    And the user has opened folder "simple-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
+    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -677,3 +677,192 @@ Feature: Sharing files and folders with internal users
       """
       just letting you know that user0 shared simple-folder with you.
       """
+
+  Scenario: Create share with internal users and view those shared resources in files page and shared-with-others page
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user2" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
+    And the user shares file "lorem.txt" with user "User One" using the webUI
+    Then folder "simple-folder" should not have share indicator on the webUI
+    And file "lorem.txt" should not have share indicator on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    And the user creates a folder with the name "XYZ" using the webUI
+    Then file "new-lorem.txt" should have share indicator on the webUI
+    And folder "XYZ" should have share indicator on the webUI
+    When the user browses to the shared-with-others page
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder                   |
+      | lorem.txt                       |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+
+  Scenario: Create share for a folder within a group and view the shared folder in files page and shared-with-others page
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has shared folder "simple-folder" with group "grp1"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    And the user creates a folder with the name "XYZ" using the webUI
+    Then file "new-lorem.txt" should have share indicator on the webUI
+    And folder "XYZ" should have share indicator on the webUI
+    When the user browses to the shared-with-others page
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder                   |
+
+  Scenario: user receives a share from another user and views that received share in files page and shared-wih-you page when auto-accept-share is enabled
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user browses to the shared-with-you page
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder (2)                     |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+
+  Scenario: user creates a public link for a folder and views the shared folder from files page, shared-with-others page
+    and shared-by-link page
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+    And user "user1" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI
+    And the user closes the share dialog
+    And the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user browses to the shared-with-others page
+    And the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user browses to the shared-by-link page
+    And the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+
+  Scenario: resharing by public link and view the shared resource from different pages
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    And user "user2" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder (2)" using the webUI with
+      | name | Public link |
+    And the user closes the share dialog
+    And the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user browses to the shared-with-you page
+    And the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user browses to the shared-by-link page
+    And the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+    When the user browses to the shared-with-others page
+    And the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder                   |
+      | lorem.txt                             |
+      | block-aligned.txt                     |
+      | testavatar.png                        |
+      | testapp.zip                           |
+
+  Scenario: share a sub folder and view the received share from files page and shared-with-you page
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/simple-empty-folder/lorem.txt"
+    And user "user1" has shared folder "/simple-folder/simple-empty-folder" with user "user2"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-empty-folder (2)" using the webUI
+    Then file "lorem.txt" should not have share indicator on the webUI
+    When the user browses to the shared-with-you page
+    And the user opens folder "simple-empty-folder (2)" using the webUI
+    Then file "lorem.txt" should not have share indicator on the webUI
+
+  Scenario: share a sub folder and view the shared resource from files page and shared-with-others page
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/simple-empty-folder/lorem.txt"
+    And user "user1" has shared folder "/simple-folder/simple-empty-folder" with user "user2" with permissions "share,read"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then folder "simple-empty-folder" should not have share indicator on the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    Then file "lorem.txt" should have share indicator on the webUI
+    When the user browses to the shared-with-others page
+    And the user opens folder "simple-empty-folder" using the webUI
+    Then file "lorem.txt" should have share indicator on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -771,7 +771,8 @@ Feature: Sharing files and folders with internal users
     When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
     Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
 
-  Scenario: user uploads file inside a shared folder
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside a shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
@@ -781,9 +782,10 @@ Feature: Sharing files and folders with internal users
     When the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
-      | new-lorem.txt           |
+      | new-lorem.txt |
 
-  Scenario: user creates folder inside a shared folder
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside a shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
@@ -793,4 +795,4 @@ Feature: Sharing files and folders with internal users
     When the user opens folder "simple-empty-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
-      | sub-folder           |
+      | sub-folder |

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -746,7 +746,6 @@ Feature: Sharing files and folders with internal users
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "user1" has shared folder "simple-folder" with user "user2"
     And user "user1" has logged in using the webUI
-<<<<<<< HEAD
     And the user has opened folder "simple-folder" using the webUI
     When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
     Then user "user2" should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -796,3 +796,22 @@ Feature: Sharing files and folders with internal users
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder shared with multiple users
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has shared folder "/simple-folder/sub-folder" with user "user3"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "simple-folder/sub-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
+    And user "User Three" should be listed as share receiver via "sub-folder" on the webUI
+

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -746,6 +746,7 @@ Feature: Sharing files and folders with internal users
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "user1" has shared folder "simple-folder" with user "user2"
     And user "user1" has logged in using the webUI
+<<<<<<< HEAD
     And the user has opened folder "simple-folder" using the webUI
     When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
     Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
@@ -770,3 +771,27 @@ Feature: Sharing files and folders with internal users
     Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
     When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
     Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+
+  Scenario: user uploads file inside a shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt           |
+
+  Scenario: user creates folder inside a shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder           |

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -699,6 +699,7 @@ Feature: Share by public link
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
+  @skipOnOcV10.3
   Scenario: sharing details of items inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/sub-folder"
@@ -711,3 +712,15 @@ Feature: Share by public link
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
     Then public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing detail of items in the webUI shared by public links with empty name
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    And the user opens the public link share tab
+    Then public link with last share token should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -710,4 +710,4 @@ Feature: Share by public link
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
-    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    Then public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -664,6 +664,18 @@ Feature: Share by public link
 			"""
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
+  Scenario: share indicator inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder   |
+      | textfile.txt |
+
   Scenario: user uploads file inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created a public link share with settings

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -711,3 +711,25 @@ Feature: Share by public link
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
     Then public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing details of multiple public link shares with different link names
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+      | name | Public Link    |
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder/sub-folder        |
+      | name | strängé लिंक नाम (#2 &).नेपाली      |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    And the user opens the public link share tab
+    Then public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens folder "sub-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    And the user opens the public link share tab
+    Then public link with name "strängé लिंक नाम (#2 &).नेपाली" should be listed as share receiver via "sub-folder" on the webUI
+    And public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -727,7 +727,7 @@ Feature: Share by public link
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
-    Then public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
     When the user opens folder "sub-folder" using the webUI
     And the user opens the share dialog for file "textfile.txt"
     And the user opens the public link share tab

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -664,7 +664,8 @@ Feature: Share by public link
 			"""
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
-  Scenario: share indicator inside a shared folder
+  @skipOnOcV10.3
+  Scenario: sharing indicator inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/sub-folder"
     And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
@@ -676,22 +677,24 @@ Feature: Share by public link
       | sub-folder   |
       | textfile.txt |
 
-  Scenario: user uploads file inside a shared folder
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created a public link share with settings
-      | path         | /simple-folder |
+      | path | /simple-folder |
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
-      | new-lorem.txt           |
+      | new-lorem.txt |
 
-  Scenario: user creates folder inside a shared folder
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created a public link share with settings
-      | path         | /simple-folder |
+      | path | /simple-folder |
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
-      | sub-folder           |
+      | sub-folder |

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -368,8 +368,8 @@ Feature: Share by public link
     And the user opens folder "simple-folder" using the webUI
     And the user creates a new public link for file "lorem.txt" using the webUI
     And the user browses to the shared-by-link page
-    Then file "lorem.txt" with path "" should be listed in the public link files page on the webUI
-    And file "lorem.txt" with path "/simple-folder" should be listed in the public link files page on the webUI
+    Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
+    And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
 
   Scenario: user removes the public link of a file
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -699,6 +699,7 @@ Feature: Share by public link
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
+  @skipOnOcV10.3
   Scenario: sharing details of items inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/sub-folder"

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -710,4 +710,4 @@ Feature: Share by public link
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
-    Then public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -368,8 +368,8 @@ Feature: Share by public link
     And the user opens folder "simple-folder" using the webUI
     And the user creates a new public link for file "lorem.txt" using the webUI
     And the user browses to the shared-by-link page
-    Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
-    And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
+    Then file "lorem.txt" with path "" should be listed in the public link files page on the webUI
+    And file "lorem.txt" with path "/simple-folder" should be listed in the public link files page on the webUI
 
   Scenario: user removes the public link of a file
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -698,3 +698,16 @@ Feature: Share by public link
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | sub-folder |
+
+  Scenario: sharing details of items inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+      | name | Public Link    |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    And the user opens the public link share tab
+    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -663,3 +663,23 @@ Feature: Share by public link
 			user0 shared simple-folder with you
 			"""
     And the email address "foo@bar.co" should have received an email containing the last shared public link
+
+  Scenario: user uploads file inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created a public link share with settings
+      | path         | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt           |
+
+  Scenario: user creates folder inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created a public link share with settings
+      | path         | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder           |


### PR DESCRIPTION
## Description
This is a rebased and squashed version of #36254 (which has many commits)

Filelist shows share indicators on files and folders, that reside inside a shared folder / shared folders.
The sidebar share-tab reveals a detailed view of the share-tree including share-recipients and the respective folders the life in.

![2019-11-12-21-23-13](https://user-images.githubusercontent.com/12717530/68707852-d54a4580-0592-11ea-9585-819370243361.gif)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/enterprise/issues/3453 (Discussion)
https://github.com/owncloud/enterprise/issues/3556 (Vis. Concept)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing in
- Google Chome
- Mozilla Firefox
- MSIE 11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](../changelog/README.md)
