### PR TITLE
skip scenarios for 10.4 features/fixes when running on 10.3

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -54,6 +54,7 @@ Feature: files and folders can be deleted from the trashbin
       But as "user0" the file with original path "/textfile0.txt" should exist in trash
       And as "user0" the file with original path "/PARENT/child.txt" should exist in trash
 
+    @skipOnOcV10.3
     Scenario: User tries to delete another user's trashbin
       Given user "user0" has been created with default attributes and skeleton files
       Given user "user1" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -266,7 +266,7 @@ Feature: Restore deleted files/folders
     And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.3
   Scenario Outline: A deleted file cannot be restored by a different user
     Given using <dav-path> DAV path
     And user "user0" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -118,6 +118,7 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
+  @skipOnOcV10.3
   Scenario Outline: Public locking is not supported
     Given user "user0" has created a public link share of folder "PARENT" with change permission
     When the public locks "/CHILD" in the last public shared folder using the <public-webdav-api-version> public WebDAV API setting following properties

--- a/tests/acceptance/features/apiWebdavLocks2/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/unlock.feature
@@ -198,7 +198,7 @@ Feature: UNLOCK locked items
       | new      | shared     |
       | new      | exclusive  |
 
-  @issue-34302 @files_sharing-app-required
+  @issue-34302 @files_sharing-app-required @skipOnOcV10.3
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
     Given user "user0" has created a public link share of folder "PARENT" with change permission
     And user "user0" has locked file "PARENT/parent.txt" setting following properties

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -660,7 +660,7 @@ Feature: Sharing files and folders with internal users
     When the user shares file "lorem.txt" with user "User Three" using the webUI
     Then as "user3" file "lorem.txt" should exist
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
   Scenario: user without email should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And these users have been created without skeleton files:

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -648,7 +648,7 @@ Feature: Share by public link
     Then the text preview of the public link should contain "original content"
     And all the links to download the public share should be the same
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
   Scenario: user without email shares a public link via email
     Given these users have been created without skeleton files:
       | username | password |


### PR DESCRIPTION
Various new/fixed test scenarios have been added/changed for features/fixes in 10.4

e.g https://drone.owncloud.com/owncloud/files_primary_s3/1352/110/16 and other suites in that nightly job

These scenarios will not pass on core 10.3.* - so `@skipOnOcV10.3`

Note: they all passed in `files_primary_s3` running against current core master (which is 10.4 code) - so that is a good thing.