### PR TITLE
update app no signature text in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1318,11 +1318,11 @@ $CONFIG = array(
 
 /**
  * Define apps or themes that are excluded from integrity checking
- * The list of apps that are allowed to have no signature.json. Besides
- * ownCloud apps, this is particularly useful when creating ownCloud themes,
+ * The list of apps that are allowed and must not have a signature.json file present.
+ * Besides ownCloud apps, this is particularly useful when creating ownCloud themes,
  * because themes are treated as apps. The app is identified with it´s app-id.
  * The app-id can be identified by the foldername of the app in your apps directory.
- * The following example allows app-1 and theme-2 to have no signature.
+ * The following example allows app-1 and theme-2 to have no signature.json file.
  */
 'integrity.ignore.missing.app.signature' => [
 	'app-id of app-1',


### PR DESCRIPTION
## Description
This is just a small text change for config.sample.php to better describe that a signature.json file must not be present when the config `integrity.ignore.missing.app.signature` is used.

## Related Issue
- no issue present

## Motivation and Context
If a signature.json is present, the particular app id in config parameter is not ignored.
This small change helps preventing confusion.

## How Has This Been Tested?
Text change only

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
