### PR TITLE
webUI tests for user-group share expiration

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -470,6 +470,7 @@ default:
         - WebUISharingContext:
         - EmailContext:
         - WebUIAdminSharingSettingsContext:
+        - OccContext:
 
     webUISharingInternalUsers:
       paths:

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -34,10 +34,8 @@ Feature: capabilities
     When the administrator updates system config key "user.search_min_length" with value "4" using the occ command
     Then the capabilities setting of "files_sharing" path "search_min_length" should be "4"
 
-  @smokeTest @skipOnOcV10.4
+  @smokeTest
   Scenario: getting default capabilities with admin user
-    # These are the capabilities that existed in 10.3
-    # Delete this scenario when testing on 10.3 is no longer required
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                           | value             |
@@ -76,43 +74,11 @@ Feature: capabilities
       | files         | bigfilechunking                           | 1                 |
 
   @smokeTest @skipOnOcV10.3
+  # These are new capabilities in 10.4
   Scenario: getting default capabilities with admin user
-    # These are the capabilities that exist in 10.4
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                                          | value             |
-      | core          | pollinterval                                             | 60                |
-      | core          | webdav-root                                              | remote.php/webdav |
-      | core          | status@@@edition                                         | %edition%         |
-      | core          | status@@@productname                                     | %productname%     |
-      | core          | status@@@version                                         | %version%         |
-      | core          | status@@@versionstring                                   | %versionstring%   |
-      | files_sharing | api_enabled                                              | 1                 |
-      | files_sharing | default_permissions                                      | 31                |
-      | files_sharing | search_min_length                                        | 2                 |
-      | files_sharing | public@@@enabled                                         | 1                 |
-      | files_sharing | public@@@multiple                                        | 1                 |
-      | files_sharing | public@@@upload                                          | 1                 |
-      | files_sharing | public@@@supports_upload_only                            | 1                 |
-      | files_sharing | public@@@send_mail                                       | EMPTY             |
-      | files_sharing | public@@@social_share                                    | 1                 |
-      | files_sharing | public@@@enforced                                        | EMPTY             |
-      | files_sharing | public@@@enforced_for@@@read_only                        | EMPTY             |
-      | files_sharing | public@@@enforced_for@@@read_write                       | EMPTY             |
-      | files_sharing | public@@@enforced_for@@@upload_only                      | EMPTY             |
-      | files_sharing | public@@@enforced_for@@@read_write_delete                | EMPTY             |
-      | files_sharing | public@@@expire_date@@@enabled                           | EMPTY             |
-      | files_sharing | public@@@defaultPublicLinkShareName                      | Public link       |
-      | files_sharing | resharing                                                | 1                 |
-      | files_sharing | federation@@@outgoing                                    | 1                 |
-      | files_sharing | federation@@@incoming                                    | 1                 |
-      | files_sharing | group_sharing                                            | 1                 |
-      | files_sharing | share_with_group_members_only                            | EMPTY             |
-      | files_sharing | share_with_membership_groups_only                        | EMPTY             |
-      | files_sharing | auto_accept_share                                        | 1                 |
-      | files_sharing | user_enumeration@@@enabled                               | 1                 |
-      | files_sharing | user_enumeration@@@group_members_only                    | EMPTY             |
-      | files_sharing | user@@@send_mail                                         | EMPTY             |
       | files_sharing | user@@@expire_date@@@enabled                             | EMPTY             |
       | files_sharing | group@@@expire_date@@@enabled                            | EMPTY             |
       | files_sharing | providers_capabilities@@@ocinternal@@@user@@@element[0]  | shareExpiration   |
@@ -120,7 +86,6 @@ Feature: capabilities
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]  | shareExpiration   |
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]  | passwordProtected |
       | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote     | EMPTY             |
-      | files         | bigfilechunking                                          | 1                 |
 
   @files_trashbin-app-required
   Scenario: getting trashbin app capability with admin user

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1394,6 +1394,32 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then the information of the last share of user :user should include
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @throws \Exception
+	 *
+	 * @return void
+	 */
+	public function informationOfLastShareShouldInclude(
+		$user, $body
+	) {
+		$this->getListOfShares($user);
+		$share_id = $this->extractLastSharedIdFromLastResponse();
+		if ($share_id === null) {
+			throw new Exception("Could not find id in the last response.");
+		}
+		$this->getShareData($user, $share_id);
+		$this->theHTTPStatusCodeShouldBe(
+			200,
+			"Error getting info of last share for user $user"
+		);
+		$this->checkFields($body);
+	}
+
+	/**
 	 * @Then /^the last share_id should be included in the response/
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -90,12 +90,12 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @var string the original capabilities in XML format
 	 */
 	private $savedCapabilitiesXml;
-	
+
 	/**
 	 * @var array the changes made to capabilities for the test scenario
 	 */
 	private $savedCapabilitiesChanges = [];
-	
+
 	/**
 	 * table of capabilities to map the human readable terms from the settings page
 	 * to terms in the capabilities XML and testing app
@@ -458,7 +458,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$title, $this->generalErrorPage->getPageTitle()
 		);
 	}
-	
+
 	/**
 	 * @Then an error should be displayed on the general error webUI page saying :error
 	 *
@@ -553,7 +553,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				"$value can only be 'disabled' or 'enabled'"
 			);
 		}
-		
+
 		$capability = $this->capabilities[\strtolower($section)][$setting];
 		$change = AppConfigHelper::setCapability(
 			$this->featureContext->getBaseUrl(),
@@ -664,7 +664,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getOcPath()
 		);
-		
+
 		$response = AppConfigHelper::getCapabilities(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
@@ -797,7 +797,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				}
 			}
 		);
-		
+
 		if ($this->oldCSRFSetting === "") {
 			$this->featureContext->deleteSystemConfig('csrf.disabled');
 		} elseif ($this->oldCSRFSetting !== null) {
@@ -805,7 +805,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				'csrf.disabled', $this->oldCSRFSetting, 'boolean'
 			);
 		}
-		
+
 		foreach ($this->createdFiles as $file) {
 			\unlink($file);
 		}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -170,6 +170,152 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the user shares (?:file|folder) "([^"]*)" with (?:(remote|federated)\s)?user "([^"]*)" using the webUI without closing the share dialog$/
+	 *
+	 * @param string $folder
+	 * @param string $remote (remote|federated|)
+	 * @param string $name
+	 * @param int $maxRetries
+	 * @param bool $quiet
+	 *
+	 * @throws \Exception
+	 *
+	 * @return void
+	 */
+	public function theUserSharesWithUserWithoutClosingDialog(
+		$folder, $remote, $name, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
+	) {
+		$this->theUserSharesUsingWebUIWithoutClosingDialog($folder, "user", $remote, $name, $maxRetries, $quiet);
+	}
+
+	/**
+	 * @When /^the user shares (?:file|folder) "([^"]*)" with group "([^"]*)" using the webUI without closing the share dialog$/
+	 *
+	 * @param string $folder
+	 * @param string $name
+	 * @param int $maxRetries
+	 * @param bool $quiet
+	 *
+	 * @throws \Exception
+	 *
+	 * @return void
+	 *
+	 */
+	public function theUserSharesWithGroupWithoutClosingDialog(
+		$folder, $name, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
+	) {
+		$this->theUserSharesUsingWebUIWithoutClosingDialog($folder, "group", "", $name, $maxRetries, $quiet);
+	}
+
+	/**
+	 * @Then /^the expiration date input field should (not |)be visible for the (user|group) "([^"]*)" in the share dialog$/
+	 *
+	 * @param string $shouldOrNot
+	 * @param string $type
+	 * @param string $receiver
+	 *
+	 * @return void
+	 */
+	public function expirationFieldVisibleForUser($shouldOrNot, $type, $receiver) {
+		$expected = ($shouldOrNot === "");
+		Assert::assertEquals($this->sharingDialog->isExpirationFieldVisible($receiver, $type), $expected);
+	}
+
+	/**
+	 * @Then /^the expiration date input field should be empty for the (user|group) "([^"]*)" in the share dialog$/
+	 *
+	 * @param string $type
+	 * @param string $receiver
+	 *
+	 * @return void
+	 */
+	public function expirationFieldValueForUser($type, $receiver) {
+		Assert::assertEquals($this->sharingDialog->getExpirationDateFor($receiver, $type), "");
+	}
+
+	/**
+	 * @When /^the user changes expiration date for share of (user|group) "([^"]*)" to "([^"]*)" in the share dialog$/
+	 *
+	 * @param string $type
+	 * @param string $receiver
+	 * @param string $days
+	 *
+	 * @return void
+	 */
+	public function expirationDateChangedTo($type, $receiver, $days) {
+		$expectedDate = \date('d-m-Y', \strtotime($days));
+		$this->sharingDialog->setExpirationDateFor($this->getSession(), $receiver, $type, $expectedDate);
+	}
+
+	/**
+	 * @Then /^the expiration date input field should be "([^"]*)" for the (user|group) "([^"]*)" in the share dialog$/
+	 *
+	 * @param string $days
+	 * @param string $type
+	 * @param string $receiver
+	 *
+	 * @return void
+	 */
+	public function expirationDateShouldBe($days, $type, $receiver) {
+		$expectedDate = \date('d-m-Y', \strtotime($days));
+		Assert::assertEquals($this->sharingDialog->getExpirationDateFor($receiver, $type), $expectedDate);
+	}
+
+	/**
+	 * @When /^the user clears the expiration date input field for share of (user|group) "([^"]*)" in the share dialog$/
+	 *
+	 * @param string $userOrGroup
+	 * @param string $receiver
+	 *
+	 * @return void
+	 */
+	public function clearExpirationDate($userOrGroup, $receiver) {
+		$this->sharingDialog->clearExpirationDateFor($this->getSession(), $receiver, $userOrGroup);
+	}
+
+	/**
+	 * @param string $folder
+	 * @param string $userOrGroup (user|group)
+	 * @param string $remote (remote|federated|)
+	 * @param string $name
+	 * @param int $maxRetries
+	 * @param bool $quiet
+	 *
+	 * @throws \Exception
+	 *
+	 * @return void
+	 */
+	public function theUserSharesUsingWebUIWithoutClosingDialog(
+		$folder, $userOrGroup, $remote, $name, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
+	) {
+		$this->filesPage->waitTillPageIsloaded($this->getSession());
+		try {
+			$this->filesPage->closeDetailsDialog();
+		} catch (Exception $e) {
+			//we don't care
+		}
+		$this->sharingDialog = $this->filesPage->openSharingDialog(
+			$folder, $this->getSession()
+		);
+		if ($userOrGroup === "user") {
+			$user = $this->featureContext->substituteInLineCodes($name);
+			if ($remote === "remote") {
+				$this->sharingDialog->shareWithRemoteUser(
+					$user, $this->getSession(), $maxRetries, $quiet
+				);
+			} else {
+				$this->sharingDialog->shareWithUser(
+					$user, $this->getSession(), $maxRetries, $quiet
+				);
+			}
+		} else {
+			$this->sharingDialog->shareWithGroup(
+				$name, $this->getSession(), $maxRetries, $quiet
+			);
+		}
+	}
+
+	/**
 	 * @When the user shares file/folder :folder with group :group using the webUI
 	 * @Given the user has shared file/folder :folder with group :group using the webUI
 	 *
@@ -203,31 +349,9 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function theUserSharesFileFolderWithUserOrGroupUsingTheWebUI(
 		$folder, $userOrGroup, $remote, $name, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
 	) {
-		$this->filesPage->waitTillPageIsloaded($this->getSession());
-		try {
-			$this->filesPage->closeDetailsDialog();
-		} catch (Exception $e) {
-			//we don't care
-		}
-		$this->sharingDialog = $this->filesPage->openSharingDialog(
-			$folder, $this->getSession()
+		$this->theUserSharesUsingWebUIWithoutClosingDialog(
+			$folder, $userOrGroup, $remote, $name, $maxRetries, $quiet
 		);
-		if ($userOrGroup === "user") {
-			$user = $this->featureContext->substituteInLineCodes($name);
-			if ($remote === "remote") {
-				$this->sharingDialog->shareWithRemoteUser(
-					$user, $this->getSession(), $maxRetries, $quiet
-				);
-			} else {
-				$this->sharingDialog->shareWithUser(
-					$user, $this->getSession(), $maxRetries, $quiet
-				);
-			}
-		} else {
-			$this->sharingDialog->shareWithGroup(
-				$name, $this->getSession(), $maxRetries, $quiet
-			);
-		}
 		$this->theUserClosesTheShareDialog();
 	}
 
@@ -1084,7 +1208,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $username
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function userShouldBeListedInTheAutocompleteListOnTheWebui($username) {
 		$names = $this->sharingDialog->getAutocompleteItemsList();
@@ -1101,7 +1225,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $username
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function userShouldNotBeListedInTheAutocompleteListOnTheWebui($username) {
 		$names = $this->sharingDialog->getAutocompleteItemsList();

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -62,7 +62,8 @@ class SharingDialog extends OwncloudPage {
 	private $publicLinkRemoveBtnXpath = "//div[contains(@class, 'removeLink')]";
 	private $publicLinkTitleXpath = "//span[@class='link-entry--title']";
 	private $notifyByEmailBtnXpath = "//input[@name='mailNotification']";
-
+	private $shareWithExpirationFieldXpath = "//*[@id='shareWithList']//span[@class='has-tooltip username' and .='%s']/..//input[contains(@class, 'expiration')]";
+	private $shareWithClearExpirationFieldXpath = "/following-sibling::button[@class='removeExpiration']"; // in relation to $shareWithExpirationFieldXpath
 	private $shareWithListXpath = "//ul[@id='shareWithList']/li";
 	private $userOrGroupNameSpanXpath = "//span[contains(@class,'username')]";
 	private $unShareTabXpath = "//a[contains(@class,'unshare')]";
@@ -87,6 +88,86 @@ class SharingDialog extends OwncloudPage {
 			" xpath $this->shareWithFieldXpath could not find share-with-field"
 		);
 		return $shareWithField;
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $type
+	 *
+	 * @return null|NodeElement
+	 */
+	private function getExpirationFieldFor($user, $type = 'user') {
+		if ($type === "group") {
+			$user = \sprintf($this->groupFramework, $user);
+		}
+		return $this->find("xpath", \sprintf($this->shareWithExpirationFieldXpath, $user));
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $type
+	 *
+	 * @return bool
+	 */
+	public function isExpirationFieldVisible($user, $type = 'user') {
+		$field = $this->getExpirationFieldFor($user, $type);
+		return $field and $field->isVisible();
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $type
+	 *
+	 * @throws \Exception
+	 * @return string
+	 */
+	public function getExpirationDateFor($user, $type = 'user') {
+		$field = $this->getExpirationFieldFor($user, $type);
+		$this->assertElementNotNull(
+			$field,
+			"Could not find expiration field for " . $type . " '$user'"
+		);
+		return $field->getValue();
+	}
+
+	/**
+	 * @param Session $session
+	 * @param string $user
+	 * @param string $type
+	 * @param string $value
+	 *
+	 * @return void
+	 */
+	public function setExpirationDateFor(Session $session, $user, $type = 'user', $value = '') {
+		$field = $this->getExpirationFieldFor($user, $type);
+		$this->assertElementNotNull(
+			$field,
+			"Could not find expiration field for " . $type . " '$user'"
+		);
+		$field->setValue($value . "\n");
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * @param Session $session
+	 * @param string $user
+	 * @param string $type
+	 *
+	 * @return void
+	 */
+	public function clearExpirationDateFor(Session $session, $user, $type = 'user') {
+		$field = $this->getExpirationFieldFor($user, $type);
+		$this->assertElementNotNull(
+			$field,
+			"Could not find expiration field for " . $type . " '$user'"
+		);
+		$removeBtn = $field->find("xpath", $this->shareWithClearExpirationFieldXpath);
+		$this->assertElementNotNull(
+			$removeBtn,
+			"Could not find expiration field remove button for " . $type . " '$user'"
+		);
+		$removeBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupUsingExpirationDate.feature
@@ -1,0 +1,257 @@
+@webUI @insulated @disablePreviews @skipOnOcV10.3
+Feature: Sharing files and folders with internal groups with expiration date set/unset
+  As a user
+  I want to share files and folders with groups and set an expiration date
+  So that I can provide them temporary access
+
+  As a administrator
+  I want to set default expiration dates and be able to enforce them
+  So that a user cannot have endless shares
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user3" has been created with default attributes and skeleton files
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+
+  Scenario: expiration date is disabled for sharing with groups, user shares with a group
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "no"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should not be visible for the group "grp1" in the share dialog
+
+  Scenario: expiration date is disabled for sharing with groups but enabled for sharing with users, user shares with a group
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "no"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should not be visible for the group "grp1" in the share dialog
+
+  Scenario: expiration date is enabled for sharing with groups, user shares a file with a group
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the group "grp1" in the share dialog
+    Then the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
+    When the user changes expiration date for share of group "grp1" to "+3 days" in the share dialog
+    Then the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | expiration  | +3 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enforced for group, user shares a file
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "3"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the group "grp1" in the share dialog
+    And the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
+    Then the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | expiration  | +3 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enforced for group, user shares  and tries to change expiration date more than allowed
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "3"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    And the user changes expiration date for share of group "grp1" to "+4 days" in the share dialog
+    Then the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | expiration  | +3 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enforced for group, user reshares received file with the group
+    Given user "user3" has shared file "lorem.txt" with user "user1"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "3"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the group "grp1" in the share dialog
+    And the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
+    Then the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | expiration  | +3 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enabled but not enforced for group, user reshares received file with group
+    Given user "user3" has shared file "lorem.txt" with user "user1"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the group "grp1" in the share dialog
+    And the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
+    Then the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | expiration  | +7 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enabled but not enforced for group, user reshares received file with group, but removes default expiration date
+    Given user "user3" has shared file "lorem.txt" with user "user1"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    And the user clears the expiration date input field for share of group "grp1" in the share dialog
+    Then the expiration date input field should be empty for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  |            |
+
+  Scenario: expiration date is enabled but not enforced for group, user reshares received file with user, but changes expiration date
+    Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
+    And user "user3" has shared file "lorem.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    And the user changes expiration date for share of group "grp1" to "+15 days" in the share dialog
+    Then the expiration date input field should be "+15 days" for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +15 days   |
+
+  Scenario: expiration date is enabled but not enforced for group, user shares to group through api and checks the expiration date on webUI
+    Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | group      |
+      | shareWith   | grp1       |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user3" has logged in using the webUI
+    When the user opens the share dialog for file "lorem.txt"
+    Then the expiration date input field should be "+15 days" for the group "grp1" in the share dialog
+
+  Scenario: expiration date is enabled but not enforced for group, user receives a share with expiration date and reshares with expiration date less than the original
+    Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
+    When the user changes expiration date for share of group "grp1" to "+10 days" in the share dialog
+    Then the expiration date input field should be "+10 days" for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +10 days   |
+
+  Scenario: expiration date is enabled but not enforced for group, user receives a share with expiration date and reshares with expiration date in future than the original
+    Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
+    When the user changes expiration date for share of group "grp1" to "+20 days" in the share dialog
+    Then the expiration date input field should be "+20 days" for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +20 days   |
+
+  Scenario: expiration date is enabled and enforced for group, user receives a share with expiration date and tries to reshare with expiration date less than the original
+    Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
+    When the user changes expiration date for share of group "grp1" to "+20 days" in the share dialog
+    Then the expiration date input field should be "+20 days" for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +20 days   |
+
+  Scenario: expiration date is enabled and enforced for group, user receives a share with expiration date and tries to reshare with expiration date further in future than the original
+    Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
+    When the user changes expiration date for share of group "grp1" to "+40 days" in the share dialog
+    Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group      |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +30 days   |
+
+  Scenario: expiration date is enabled and enforced for group, user receives a folder from a group share with expiration date and shares sub-folder with group
+    Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
+    And group "grp2" has been created
+    And user "user1" has been added to group "grp2"
+    And user "user3" has created a share with settings
+      | path        | /simple-folder |
+      | shareType   | group          |
+      | shareWith   | grp2           |
+      | permissions | read,share     |
+      | expireDate  | +15 days       |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user shares file "simple-empty-folder" with group "grp1" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
+    When the user changes expiration date for share of group "grp1" to "+20 days" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | group                |
+      | file_target | /simple-empty-folder |
+      | uid_owner   | user1                |
+      | expiration  | +20 days             |
+      | share_with  | grp1                 |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -316,4 +316,3 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
-

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUserUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUserUsingExpirationDate.feature
@@ -1,0 +1,244 @@
+@webUI @insulated @disablePreviews @skipOnOcV10.3
+Feature: Sharing files and folders with internal users with expiration date set/unset
+  As a user
+  I want to share files and folders with users with expiration date set
+  So that I can provide them temporary access
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user3" has been created with default attributes and skeleton files
+
+  Scenario: expiration date is disabled for sharing with users, user shares with an other user
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "no"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should not be visible for the user "User Two" in the share dialog
+
+  Scenario: expiration date is disabled for sharing with users but enabled for sharing with groups, user shares with an other user
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "no"
+    And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should not be visible for the user "User Two" in the share dialog
+
+  Scenario: expiration date is enabled for sharing with users, user shares file with another user
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User Two" in the share dialog
+    And the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | expiration  | +7 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enforced for user, user shares file
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "3"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User Two" in the share dialog
+    And the expiration date input field should be "+3 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | expiration  | +3 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enforced for user, user shares  and tries to change expiration date more than allowed
+    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "3"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    And the user changes expiration date for share of user "User Two" to "+4 days" in the share dialog
+    Then the expiration date input field should be "+3 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | expiration  | +3 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enforced for user, user reshares received file with another user
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "3"
+    And user "user3" has shared file "lorem.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User Two" in the share dialog
+    And the expiration date input field should be "+3 days" for the user "User Two" in the share dialog
+    Then the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | expiration  | +3 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
+    And user "user3" has shared file "lorem.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User Two" in the share dialog
+    And the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
+    Then the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | expiration  | +7 days    |
+      | uid_owner   | user1      |
+
+  Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user, but removes default expiration date
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
+    And user "user3" has shared file "lorem.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    And the user clears the expiration date input field for share of user "User Two" in the share dialog
+    Then the expiration date input field should be empty for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  |            |
+
+  Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user, but changes expiration date
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
+    And user "user3" has shared file "lorem.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    And the user changes expiration date for share of user "User Two" to "+15 days" in the share dialog
+    Then the expiration date input field should be "+15 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +15 days   |
+
+  Scenario: expiration date is enabled but not enforced, user shares through api and checks the expiration date on webUI
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user3" has logged in using the webUI
+    When the user opens the share dialog for file "lorem.txt"
+    Then the expiration date input field should be "+15 days" for the user "User One" in the share dialog
+
+  Scenario: expiration date is enabled but not enforced, user receives a share with expiration date and reshares with expiration date less than the original
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
+    When the user changes expiration date for share of user "User Two" to "+10 days" in the share dialog
+    Then the expiration date input field should be "+10 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +10 days   |
+
+  Scenario: expiration date is enabled but not enforced, user receives a share with expiration date and reshares it, setting a date further in future than the original
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
+    When the user changes expiration date for share of user "User Two" to "+20 days" in the share dialog
+    Then the expiration date input field should be "+20 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +20 days   |
+
+  Scenario: expiration date is enabled and enforced, user receives a share with expiration date and tries to reshare with expiration date less than the original
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
+    When the user changes expiration date for share of user "User Two" to "+20 days" in the share dialog
+    Then the expiration date input field should be "+20 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +20 days   |
+
+  Scenario: expiration date is enabled and enforced, user receives a share with expiration date and tries to reshare it with a date further in future than the original
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "user3" has created a share with settings
+      | path        | /lorem.txt |
+      | shareType   | user       |
+      | shareWith   | user1      |
+      | permissions | read,share |
+      | expireDate  | +15 days   |
+    And user "user1" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
+    When the user changes expiration date for share of user "User Two" to "+40 days" in the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user       |
+      | file_target | /lorem.txt |
+      | uid_owner   | user1      |
+      | expiration  | +30 days   |
+
+  Scenario: expiration date is enabled and enforced, user receives a folder from a user share with expiration date and shares sub-folder with another user
+    Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "user3" has created a share with settings
+      | path        | /simple-folder |
+      | shareType   | user           |
+      | shareWith   | user1          |
+      | permissions | read,share     |
+      | expireDate  | +15 days       |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user shares file "simple-empty-folder" with user "User Two" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
+    When the user changes expiration date for share of user "User Two" to "+20 days" in the share dialog
+    And the information of the last share of user "user1" should include
+      | share_type  | user                 |
+      | file_target | /simple-empty-folder |
+      | uid_owner   | user1                |
+      | expiration  | +20 days             |
+      | share_with  | user2                |


### PR DESCRIPTION
## Description
tests to check the behaviour of the expiration dates 

more corner-cases to be done in API tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- tests for  owncloud/enterprise#2001

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
