### PR TITLE
Updating league/flysystem (1.0.57 => 1.0.61)

### DIFF
--- a/changelog/unreleased/36542
+++ b/changelog/unreleased/36542
@@ -1,0 +1,5 @@
+Change: Update league/flysystem (1.0.57 => 1.0.61)
+
+Includes changes to ensure emulating directories respects a directory named "0".
+
+https://github.com/owncloud/core/pull/36542

--- a/composer.lock
+++ b/composer.lock
@@ -949,16 +949,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.57",
+            "version": "1.0.61",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "0e9db7f0b96b9f12dcf6f65bc34b72b1a30ea55a"
+                "reference": "4fb13c01784a6c9f165a351e996871488ca2d8c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/0e9db7f0b96b9f12dcf6f65bc34b72b1a30ea55a",
-                "reference": "0e9db7f0b96b9f12dcf6f65bc34b72b1a30ea55a",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/4fb13c01784a6c9f165a351e996871488ca2d8c9",
+                "reference": "4fb13c01784a6c9f165a351e996871488ca2d8c9",
                 "shasum": ""
             },
             "require": {
@@ -1029,7 +1029,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2019-10-16T21:01:05+00:00"
+            "time": "2019-12-08T21:46:50+00:00"
         },
         {
             "name": "lukasreschke/id3parser",


### PR DESCRIPTION
## Description
```
composer update league/flysystem
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating league/flysystem (1.0.57 => 1.0.61): Loading from cache
```
https://github.com/thephpleague/flysystem/releases

There was a quick string of patch releases 58, 59, 60 and 61 just yesterday.
Some are for PHP 7.4. 
An interesting one is https://github.com/thephpleague/flysystem/commit/1426da21dae81e1f3fe1074a166eb6dd3045f810 - Ensure emulating directories respects a directory named "0"

## Motivation and Context
Run our CI to see if all passes.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
