### PR TITLE
skipOnOcV10.3 the trashbin scenarios fixed in 10.4

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -188,7 +188,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @skipOnLDAP @skip_on_objectstore
+  @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user40" has been created with default attributes and skeleton files
@@ -206,7 +206,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @skipOnLDAP @skip_on_objectstore
+  @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user60" has been created with default attributes and skeleton files
@@ -226,7 +226,7 @@ Feature: files and folders exist in the trashbin after being deleted
 
   # This issue makes this scenario behave differently based on previously created users.
   # So we use user that has not been created in any other scenarios.
-  @skipOnLDAP @skip_on_objectstore
+  @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user504" has been created with default attributes and skeleton files


### PR DESCRIPTION
## Description
PR #36488 fixed some trashbin access issues and adjusted the acceptance test scenarios. That will be released in core 10.4. The adjusted scenarios are not expected to pass when run against core 10.3, so skip them in that case.

This will stop "false"  fails being reported in e.g. encryption app nightly tests that also run against core latest (currently 10.3). e.g. https://drone.owncloud.com/owncloud/encryption/1025/63/14

## Related Issue
#36378 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
