### PR TITLE
Update Encryption.php to fix issue #34599 "encrypted remote storage"

### DIFF
--- a/changelog/unreleased/36546
+++ b/changelog/unreleased/36546
@@ -1,0 +1,8 @@
+Bugfix: stream_read not returning requested length for encrypted remote storage
+
+stream_read was not always returning the requested length for encrypted remote
+storage. This could result in errors when downloading files. The issue has been
+corrected.
+
+https://github.com/owncloud/core/issues/34599
+https://github.com/owncloud/core/pull/36546

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -305,6 +305,25 @@ class Encryption extends Wrapper {
 		return $result;
 	}
 
+	/**
+	* stream_read wrapper to read a block of the requested size
+	* There is a problem with the underlying php functions not returning the requested amount of data in any case.
+	* Thus, this function will call the read mechanism of its parent until it has read the correct amount.
+	*/
+	private function stream_read_block($blockSize) {
+		$remaining = $blockSize;
+		$data = "";
+
+		do {
+			$chunk = parent::stream_read($remaining);
+			$chunk_len = \strlen($chunk);
+			$data .= $chunk;
+			$remaining -= $chunk_len;
+		} while (($remaining > 0) && ($chunk_len > 0));
+
+		return $data;
+	}
+
 	public function stream_write($data) {
 		$length = 0;
 		// loop over $data to fit it in 6126 sized unencrypted blocks
@@ -445,7 +464,7 @@ class Encryption extends Wrapper {
 		// don't try to fill the cache when trying to write at the end of the unencrypted file when it coincides with new block
 		if ($this->cache === '' && !($this->position === $this->unencryptedSize && ($this->position % $this->unencryptedBlockSize) === 0)) {
 			// Get the data from the file handle
-			$data = parent::stream_read($this->util->getBlockSize());
+			$data = $this->stream_read_block($this->util->getBlockSize());
 			$position = (int)\floor($this->position/$this->unencryptedBlockSize);
 			$numberOfChunks = (int)($this->unencryptedSize / $this->unencryptedBlockSize);
 			if ($numberOfChunks === $position) {
@@ -470,7 +489,7 @@ class Encryption extends Wrapper {
 	 * read first block to skip the header
 	 */
 	protected function skipHeader() {
-		parent::stream_read($this->headerSize);
+		$this->stream_read_block($this->headerSize);
 	}
 
 	/**


### PR DESCRIPTION
## Description
This is an updated rebase of PR #36179 with the commits squashed.

The commit still has @martink-p as author, so that will be good for giving proper credit to the author.

It adds a wrapper function to "stream_read" which reads (and checks) until the required block size is available or there is no remaining data.

## Issue
- fixes #34599

## Motivation and Context
This pull request fixes an issue with encrypted external WebDAV storage and was verified as a solution with nextcloud issue nextcloud/server#9792

## How Has This Been Tested?
Text from #36179 :
- test environment: running owncloud docker system with external WebDAV storage at Strato HiDrive
- test case 1: several files. uploaded, checked encryption, downloaded, checked decryption.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
