### PR TITLE
Changelogs for dependabot PRs 2019-12-10

### DIFF
--- a/changelog/unreleased/36552
+++ b/changelog/unreleased/36552
@@ -1,0 +1,3 @@
+Change: Update patchwork/utf8 (1.3.1 => 1.3.2)
+
+https://github.com/owncloud/core/pull/36552

--- a/changelog/unreleased/36553
+++ b/changelog/unreleased/36553
@@ -1,0 +1,3 @@
+Change: Update league/flysystem (1.0.57 => 1.0.61)
+
+https://github.com/owncloud/core/pull/36553

--- a/changelog/unreleased/36554
+++ b/changelog/unreleased/36554
@@ -1,0 +1,3 @@
+Change: Update pear/archive_tar (1.4.8 => 1.4.9)
+
+https://github.com/owncloud/core/pull/36554


### PR DESCRIPTION
dependabot made PR #36552 #36553 #36554 today.

This adds changelogs for those dependency bumps.