### PR TITLE
Show link token if name is empty

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1931,8 +1931,10 @@
 
 				_.each(shares, function(share) {
 
+					var shareName = (!_.isEmpty(share.name)) ? share.name : share.token;
+
 					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name })
-					var $name = $('<strong>', { class : 'shareTree-item-name', text : share.name })
+					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareName })
 					var $icon = $('<span>',   { class : 'shareTree-item-icon link-entry--icon icon-public-white' })
 
 					$('<li class="shareTree-item">').append( $icon, $name, $path).appendTo($list).click(function() {

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2230,4 +2230,18 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$shareTreeItem = $sharingDialog->getShareTreeItem($type, $name, $item);
 		Assert::assertTrue($shareTreeItem->isVisible());
 	}
+
+	/**
+	 * @Then public link with last share token should be listed as share receiver via :item on the webUI
+	 *
+	 * @param string $item
+	 *
+	 * @return void
+	 */
+	public function publicLinkWithLastShareTokenShouldBeListedAsShareReceiverViaOnTheWebUI($item) {
+		$token = $this->featureContext->getLastShareData()->data->token;
+		$sharingDialog = $this->filesPage->getSharingDialog();
+		$shareTreeItem = $sharingDialog->getShareTreeItem("public link", $token, $item);
+		Assert::assertTrue($shareTreeItem->isVisible());
+	}
 }

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -699,6 +699,7 @@ Feature: Share by public link
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
+  @skipOnOcV10.3
   Scenario: sharing details of items inside a shared folder
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/sub-folder"
@@ -711,3 +712,15 @@ Feature: Share by public link
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
     Then public link with name "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing detail of items in the webUI shared by public links with empty name
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    And the user opens the public link share tab
+    Then public link with last share token should be listed as share receiver via "simple-folder" on the webUI


### PR DESCRIPTION
Show the link token, if there was no name given to a public link.

Adresses: https://github.com/owncloud/core/pull/36534#issuecomment-563883177