### PR TITLE
Make sure to filter filecache subfolders in sql query instead of memory

### DIFF
--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -684,6 +684,38 @@ class CacheTest extends TestCase {
 		$this->assertEmpty($entry['checksum']);
 	}
 
+	public function testRemoveChildren() {
+		$parent1 = 'parent1';
+		$parent2 = 'parent1/parent2';
+		$file1 = 'parent1/file1';
+		$file2 = 'parent1/parent2/file2';
+		$file3 = 'parent1/parent2/file3';
+
+		// path /parent1/file1
+		$this->cache->put($parent1, ['size' => 0, 'mtime' => 5, 'mimetype' => 'httpd/unix-directory']);
+		$this->cache->put($file1, ['size' => 25, 'mtime' => 10, 'mimetype' => 'text/plain']);
+
+		// path /parent1/parent2/file1
+		// path /parent1/parent2/file2
+		$this->cache->put($parent2, ['size' => 0, 'mtime' => 15, 'mimetype' => 'httpd/unix-directory']);
+		$this->cache->put($file2, ['size' => 1000, 'mtime' => 20, 'mimetype' => 'text/plain']);
+		$this->cache->put($file3, ['size' => 20, 'mtime' => 25, 'mimetype' => 'text/plain']);
+		
+		$content = $this->cache->getFolderContents($parent1);
+		$this->assertEquals(2, \count($content));
+
+		$content = $this->cache->getFolderContents($parent2);
+		$this->assertEquals(2, \count($content));
+
+		$this->cache->remove($parent1);
+
+		$content = $this->cache->getFolderContents($parent1);
+		$this->assertEquals(0, \count($content));
+
+		$content = $this->cache->getFolderContents($parent2);
+		$this->assertEquals(0, \count($content));
+	}
+
 	protected function tearDown(): void {
 		if ($this->cache) {
 			$this->cache->clear();


### PR DESCRIPTION
Related issue: https://github.com/owncloud/enterprise/issues/2925 
Goal: avoid having peaks in memory for large directory contents

While deleting directories with a lot of files inside using`view->unlink`, we do not need to put in memory unnecessarily records. Filter for directories when only subdirs needed.

Example:
- we have folder with 50k files and 100 subfolders
- some parent function already loaded all 50100 records in memory
- now we are going to run `unlink` on that folder contents
- previously, all 50100 records were in memory in `unlink`
- now, only 100 records are in memory `unlink`
- resulting peak memory is 50200 instead of 100200
