### PR TITLE
Remove '1 link share per file/folder' old test

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -678,17 +678,6 @@ Feature: sharing
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  @public_link_share-feature-required
-  Scenario: Only allow 1 link share per file/folder
-    Given using OCS API version "1"
-    And as user "user0"
-    And the user has created a public link share with settings
-      | path | welcome.txt |
-    And the last share id has been remembered
-    When the user creates a public link share using the sharing API with settings
-      | path | welcome.txt |
-    Then the share ids should match
-
   @smokeTest
   Scenario: unique target names for incoming shares
     Given using OCS API version "1"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1627,27 +1627,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given the last share id has been remembered
-	 *
-	 * @return void
-	 */
-	public function rememberLastShareId() {
-		$this->savedShareId = $this->lastShareData['data']['id'];
-	}
-
-	/**
-	 * @Then the share ids should match
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function shareIdsShouldMatch() {
-		if ($this->savedShareId !== $this->lastShareData['data']['id']) {
-			throw new \Exception('Expected the same link share to be returned');
-		}
-	}
-
-	/**
 	 * Returns shares of a file or folders as an array of elements
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
Delete an old test:
`Scenario: Only allow 1 link share per file/folder`

That was introduced by PR #22700 - which temporarily restricted ownCloud to only create 1 public link for any resource. That restriction is not true any more, but the test was snake oil and was still passing "by accident".

## Motivation and Context
PHP 7.4 reported a notice for the code that did 
`$this->savedShareId = $this->lastShareData['data']['id']`
because `lastShareData` is an XML Object, not an array.

In earlier PHP versions, `savedShareId` got silently set to the empty string.

The `Then` step compared a new `lastShareData['data']['id']` empty string to the saved empty string, and they matched. So the test passed!

Note: If the test had still been relevant, then the access of the share Id should have been done like:
```
$this->savedShareId = $this->lastShareData->data->id;
```
Doing that made the test fail (which is what we really expect).
There are already tests in `apiShareManagement/mutlilinksharing.feature` that check that that multiple public link shares of the same resource can be created.

## How Has This Been Tested?
Delete code is tested code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
