### PR TITLE
[For 10.4] On the public preview route the share password needs to be verified a…

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -48,6 +48,14 @@ if ($token === '') {
 $shareManager = \OC::$server->getShareManager();
 try {
 	$linkedItem = $shareManager->getShareByToken($token);
+	if ($linkedItem->getPassword() !== null) {
+		$session = \OC::$server->getSession();
+		if (! $session->exists('public_link_authenticated')
+			|| $session->get('public_link_authenticated') !== (string)$linkedItem->getId()) {
+			// sending back 404 in case access is not allowed - not 401 because this way we would expose existence of a share
+			throw new ShareNotFound();
+		}
+	}
 } catch (ShareNotFound $e) {
 	\OC_Response::setStatus(\OC_Response::STATUS_NOT_FOUND);
 	\OCP\Util::writeLog('core-preview', 'Passed token parameter is not valid', \OCP\Util::DEBUG);

--- a/changelog/unreleased/36571
+++ b/changelog/unreleased/36571
@@ -1,0 +1,5 @@
+Change: Protect public preview with password
+
+The preview route for password protected shares was accessible without the password.
+
+https://github.com/owncloud/core/pull/36571

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -63,3 +63,51 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @public_link_share-feature-required
+  Scenario: Access to the preview of password protected public link
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
+    And user "user0" has created a public link share with settings
+      | path        | /testavatar.jpg |
+      | permissions | change          |
+      | password    | testpass1       |
+    When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
+    Then the HTTP status code should be "404"
+
+  @public_link_share-feature-required
+  Scenario: Access to the preview of public shared file without password
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
+    And user "user0" has created a public link share with settings
+      | path        | /testavatar.jpg |
+      | permissions | change          |
+    When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
+    Then the HTTP status code should be "200"
+
+  @public_link_share-feature-required
+  Scenario: Access to the preview of password protected public shared file inside a folder
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
+    And user "user0" has moved file "textfile0.txt" to "FOLDER/textfile0.txt"
+    And user "user0" has created a public link share with settings
+      | path        | /FOLDER         |
+      | permissions | change          |
+      | password    | testpass1       |
+    When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
+    Then the HTTP status code should be "404"
+    When the public accesses the preview of file "textfile0.txt" from the last shared public link using the sharing API
+    Then the HTTP status code should be "404"
+
+  @public_link_share-feature-required
+  Scenario: Access to the preview of public shared file inside a folder without password
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
+    And user "user0" has moved file "textfile0.txt" to "FOLDER/textfile0.txt"
+    And user "user0" has created a public link share with settings
+      | path        | /FOLDER         |
+      | permissions | change          |
+    When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
+    Then the HTTP status code should be "200"
+    When the public accesses the preview of file "textfile0.txt" from the last shared public link using the sharing API
+    Then the HTTP status code should be "200"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1959,6 +1959,35 @@ trait Sharing {
 	}
 
 	/**
+	 * Send request for preview of a file in a public link
+	 *
+	 * @param string $fileName
+	 * @param string $token
+	 *
+	 * @return void
+	 */
+	public function getPublicPreviewOfFile($fileName, $token) {
+		$url = $this->getBaseUrl() .
+			"/index.php/apps/files_sharing/ajax/publicpreview.php" .
+			"?file=$fileName&t=$token";
+		$resp = HttpRequestHelper::get($url);
+		$this->setResponse($resp);
+	}
+
+	/**
+	 * @When the public accesses the preview of file :path from the last shared public link using the sharing API
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function thePublicAccessesThePreviewOfTheSharedFileUsingTheSharingApi($path) {
+		$shareData = $this->getLastShareData();
+		$token = (string)$shareData->data->token;
+		$this->getPublicPreviewOfFile($path, $token);
+	}
+
+	/**
 	 * replace values from table
 	 *
 	 * @param string $field


### PR DESCRIPTION
…gain to not grant unauthorized access

## Description
The public preview route did not check the share link password

## How Has This Been Tested?
1. test that it still works
- create public share of an image link with password
- open link in private browser
- enter password
- see image preview

2. proof that preview route is protected
- curl 'http://${INSTANCE}/index.php/apps/files_sharing/ajax/publicpreview.php?x=1043&y=546&a=true&file=${IMAGE_NAME}&t=${SHARE_TOKEN}&scalingup=0'
- response shall be 404/Not Found

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
