### PR TITLE
[For 10.4] Add share indicator in webUI

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -512,7 +512,7 @@ table td.filename .uploadtext {
 }
 
 /* File checkboxes */
-html:not(.ie8) #fileList tr td.filename > .selectCheckBox + label:before {
+#fileList tr td.filename > .selectCheckBox + label:before {
 	opacity: 0;
 	position: absolute;
 	bottom: 4px;
@@ -520,13 +520,21 @@ html:not(.ie8) #fileList tr td.filename > .selectCheckBox + label:before {
 	z-index: 10;
 }
 
-html.ie8 #fileList tr td.filename > .selectCheckBox {
-	filter: alpha(opacity=0);
-	opacity: 0;
-	float: left;
-	top: 0;
-	margin: 32px 0 4px 32px;
-	/* bigger clickable area doesn’t work in FF width:2.8em; height:2.4em;*/
+#fileList tr:not(:hover):not(.selected) td.filename .thumbnail.sharetree-item:after {
+	position: absolute;
+	display: block;
+	content: '';
+	bottom: 0px;
+	right: -5px;
+	z-index: 10;
+	background-image: url(../../../core/img/actions/shared.svg);
+	width: 14px;
+	height: 14px;
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: 10px;
+	background-color: #bfbfbf;
+	border-radius: 50%;
 }
 
 /* Show checkbox when hovering, checked, or selected */

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -169,6 +169,13 @@
 		_sortComparator: null,
 
 		/**
+		 * Stores shareTree items and infos
+		 * 
+		 * @type Array
+		 */
+		_shareTreeCache: {},
+
+		/**
 		 * Whether to do a client side sort.
 		 * When false, clicking on a table header will call reload().
 		 * When true, clicking on a table header will simply resort the list.
@@ -293,11 +300,11 @@
 				breadcrumbOptions.onDrop = _.bind(this._onDropOnBreadCrumb, this);
 				breadcrumbOptions.onOver = function() {
 					self.$el.find('td.filename.ui-droppable').droppable('disable');
-				}
+				};
 				breadcrumbOptions.onOut = function() {
 					self.$el.find('td.filename.ui-droppable').droppable('enable');
+				};
 				}
-			}
 			this.breadcrumb = new OCA.Files.BreadCrumb(breadcrumbOptions);
 
 			var $controls = this.$el.find('#controls');
@@ -379,6 +386,7 @@
 			// remove summary
 			this.$el.find('tfoot tr.summary').remove();
 			this.$fileList.empty();
+
 		},
 
 		/**
@@ -1048,6 +1056,7 @@
 			$(window).scrollTop(0);
 
 			this.$fileList.trigger(jQuery.Event('updated'));
+			
 			_.defer(function() {
 				self.$el.closest('#app-content').trigger(jQuery.Event('apprendered'));
 			});
@@ -1389,6 +1398,10 @@
 				tr.addClass('hidden-file');
 			}
 
+			if(_.keys(this._shareTreeCache).length) {
+				filenameTd.find('.thumbnail:not(.sharetree-item)').addClass('sharetree-item');
+			}
+
 			// display actions
 			this.fileActions.display(filenameTd, !options.silent, this);
 
@@ -1440,21 +1453,32 @@
 		 * @param {boolean} [changeUrl=true] if the URL must not be changed (defaults to true)
 		 * @param {boolean} [force=false] set to true to force changing directory
 		 * @param {string} [fileId] optional file id, if known, to be appended in the URL
+		 * @return {Promise} empty
 		 */
 		changeDirectory: function(targetDir, changeUrl, force, fileId) {
 			var self = this;
 			var currentDir = this.getCurrentDirectory();
 			targetDir = targetDir || '/';
-			if (!force && currentDir === targetDir) {
-				return;
-			}
-			this._setCurrentDir(targetDir, changeUrl, fileId);
-			// discard finished uploads list, we'll get it through a regular reload
-			this._uploads = {};
-			this.reload().then(function(success){
-				if (!success) {
-					self.changeDirectory(currentDir, true);
+
+			return new Promise(function(resolve, reject) {
+
+				if (!force && currentDir === targetDir) {
+					resolve();
+					return;
 				}
+				self._setCurrentDir(targetDir, changeUrl, fileId);
+				// discard finished uploads list, we'll get it through a regular reload
+				self._uploads = {};
+				self.reload().then(function(success){
+					if (!success) {
+						self.changeDirectory(currentDir, true);
+						reject();
+					}
+					self._updateShareTree().then(function() {
+						self._setShareTreeIcons();
+					});
+					resolve();
+				});
 			});
 		},
 		linkTo: function(dir) {
@@ -1721,6 +1745,207 @@
 			});
 			var uid = encodeURIComponent(OC.getCurrentUser().uid);
 			return OC.linkToRemoteBase('dav') + '/files/' + uid + encodedPath;
+		},
+
+		/**
+		 * Fetch shareTypes of a certain directory
+		 * @param {String} dir directory string
+		 * @return {Promise} object with name and shareTypes
+		 */
+		getDirShareInfo: function(dir) {
+			// Dir can't be empty
+			if (typeof dir !== 'string' || dir.length === 0) {
+				return Promise.reject('getDirShareInfo(). param must be typeof string and can not be empty!');
+			}
+
+			// avoiding a unnessesary API calls
+			if (typeof this._shareTreeCache[dir] !== 'undefined' || dir === '/') {
+				return Promise.resolve();
+			}
+
+			// trim trailing slashes
+			dir = dir.replace(/\/$/, "");
+
+			var self       = this;
+			var client     = this.filesClient;
+			var options    = {
+				properties : ['{' + OC.Files.Client.NS_OWNCLOUD + '}share-types']
+			};
+
+			return new Promise( function(resolve, reject) {
+				client.getFileInfo(dir, options).done(function(s, dir) {
+
+					var path = OC.joinPaths(dir.path, dir.name);
+
+					if (dir.shareTypes !== undefined) {
+						// Fetch all shares for directory in question
+						$.get( OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares?' + OC.buildQueryString({format: 'json', path: path, reshares : true }), function(e) {
+							self._shareTreeCache[path] = {
+								name : dir.name,
+								shares : e.ocs.data
+							};
+							resolve();
+						});
+					} else {
+						resolve();
+					}
+				}).fail(function(error) {
+					reject(error);
+				});
+			});
+		},
+
+		/**
+		 * Fetch shareInfos recursively from current
+		 * directory down to root
+		 * @param {String} dir directory string
+		 * @return {Promise} array of objects with name and shareTypes
+		 */
+		getPathShareInfo: function(path) {
+			if (typeof path !== 'string') {
+				console.error('getDirShareInfo(). param must be typeof string!');
+				return Promise.reject()
+			}
+
+			var crumbs     = [];
+			var pathToHere = '';
+			var parts      = (path === '/' || path.length === 0) ? ['/'] : path.split('/');
+
+			for (var i = 0; i < parts.length; i++) {
+				var part = parts[i];
+				pathToHere += part + '/';
+
+				crumbs.push(this.getDirShareInfo(pathToHere));
+			}
+
+			return Promise.all(crumbs);
+		},
+
+		_updateShareTree: function() {
+			var self = this;
+			var dir  = this.getCurrentDirectory();
+
+			// Purge shareTreeCache in root dir
+			if (dir === '/') {
+				this._purgeShareTreeCache();
+				return Promise.resolve();
+			}
+
+			return this.getPathShareInfo(dir).then(function () {
+				var breadcrumbs = dir.split('/');
+
+				// Diff keys in shareTreeCache agains the current dir
+				// removing deeper nested shares
+				var cache = _.omit(self._shareTreeCache, function(value, key) {
+					var diffs = _.difference(key.split('/'), breadcrumbs);
+					return diffs.length > 0;
+				});
+
+				self._setShareTreeCache(cache);
+			});
+		},
+
+		_setShareTreeCache: function(data) {
+			this._shareTreeCache = data;
+		},
+
+		_purgeShareTreeCache: function() {
+			this._setShareTreeCache({});
+		},
+
+		_setShareTreeIcons: function() {
+			// Add share-tree icon to files and folders
+			// each per <tr> in the table
+
+			if (_.keys(this._shareTreeCache).length > 0) {
+				this.$fileList.find('tr td.filename .thumbnail:not(.sharetree-item)').addClass('sharetree-item');
+			} else {
+				this.$fileList.find('tr td.filename .thumbnail.sharetree-item').removeClass('sharetree-item');
+			}
+		},
+
+		_setShareTreeUserGroupView: function() {
+			var self  = this;
+			var $list = $('<ul>', { id : 'shareTreeUserGroupList' });
+
+			if (! _.keys(self._shareTreeCache).length > 0) {
+				return;
+			}
+
+			$('.shareeTreeUserGroupListView').html($list);
+
+			// Shared folders
+			_.each(self._shareTreeCache, function(folder) {
+
+				var shares = _.filter(folder.shares, function(share) {
+					return (
+						share.share_type === OC.Share.SHARE_TYPE_USER ||
+						share.share_type === OC.Share.SHARE_TYPE_GROUP ||
+						share.share_type === OC.Share.SHARE_TYPE_GUEST ||
+						share.share_type === OC.Share.SHARE_TYPE_REMOTE );
+				});
+
+				_.each(shares, function(share) {
+
+					var shareWith = share.share_with_displayname;
+
+					if (share.share_type === OC.Share.SHARE_TYPE_GROUP) {
+						shareWith += ' (' + t('core', 'group') + ')';
+					} else if (share.share_type === OC.Share.SHARE_TYPE_REMOTE) {
+						shareWith += ' (' + t('files_sharing', 'Remote share') + ')';
+					}
+
+					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name });
+					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareWith });
+					var $icon = $('<div>',    { class : 'shareTree-item-avatar' });
+
+					$icon.avatar(share.share_with, 32);
+
+					$('<li class="shareTree-item">').append( $icon, $name, $path).appendTo($list).click(function() {
+						self.changeDirectory(share.path.replace(folder.name, ''), true).then(function() {
+							self._updateDetailsView(folder.name, true);
+						}).catch(function(e) {
+							console.error(e);
+						});
+					});
+				});
+			});
+		},
+
+		_setShareTreeLinkView: function() {
+			var self  = this;
+			var $list = $('<ul>', { id : 'shareTreeLinkList' });
+
+			if (! _.keys(self._shareTreeCache).length > 0) {
+				return;
+			}
+
+			$('.shareeTreeLinkListView').html($list);
+
+			// Shared folders
+			_.each(self._shareTreeCache, function(folder) {
+
+				var shares = _.filter(folder.shares, function(share) {
+					return share.share_type === OC.Share.SHARE_TYPE_LINK;
+				});
+
+				_.each(shares, function(share) {
+
+					var shareName = (!_.isEmpty(share.name)) ? share.name : share.token;
+
+					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('core', 'via') + " " + folder.name });
+					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareName });
+					var $icon = $('<span>',   { class : 'shareTree-item-icon link-entry--icon icon-public-white' });
+
+					$('<li class="shareTree-item">').append( $icon, $name, $path).appendTo($list).click(function() {
+						self.changeDirectory(share.path.replace(folder.name, ''), true).then(function() {
+							self._updateDetailsView(folder.name, true);
+						}).catch(function(e) {
+							console.error(e);
+						});
+					});
+				});
+			});
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1804,7 +1804,7 @@
 		getPathShareInfo: function(path) {
 			if (typeof path !== 'string') {
 				console.error('getDirShareInfo(). param must be typeof string!');
-				return Promise.reject()
+				return Promise.reject();
 			}
 
 			var crumbs     = [];

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1024,6 +1024,24 @@ describe('OCA.Files.FileList tests', function() {
 			expect($summary.find('.dirinfo').hasClass('hidden')).toEqual(true);
 			expect($summary.find('.fileinfo').text()).toEqual('1 file');
 		});
+		it('shows icon for shareTree items if parent is shared', function() {
+			fileList._setShareTreeCache({
+				'/folder' : {
+					name: "folder",
+					shares : [{
+						share_type: 0,
+						share_with_displayname: "Demo user",
+					}]
+				}
+			});
+			fileList.setFiles(testFiles)
+			expect($('#fileList tr:first-of-type td .sharetree-item').length).toEqual(1)
+		});
+		it('does not show shareTree items if shareTree is empty', function() {
+			fileList._purgeShareTreeCache()
+			fileList.setFiles(testFiles)
+			expect($('#fileList tr td .sharetree-item').length).toEqual(0)
+		})
 	});
 	describe('Filtered list rendering', function() {
 		it('filters the list of files using filter()', function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1034,14 +1034,14 @@ describe('OCA.Files.FileList tests', function() {
 					}]
 				}
 			});
-			fileList.setFiles(testFiles)
-			expect($('#fileList tr:first-of-type td .sharetree-item').length).toEqual(1)
+			fileList.setFiles(testFiles);
+			expect($('#fileList tr:first-of-type td .sharetree-item').length).toEqual(1);
 		});
 		it('does not show shareTree items if shareTree is empty', function() {
-			fileList._purgeShareTreeCache()
-			fileList.setFiles(testFiles)
-			expect($('#fileList tr td .sharetree-item').length).toEqual(0)
-		})
+			fileList._purgeShareTreeCache();
+			fileList.setFiles(testFiles);
+			expect($('#fileList tr td .sharetree-item').length).toEqual(0);
+		});
 	});
 	describe('Filtered list rendering', function() {
 		it('filters the list of files using filter()', function() {

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -89,9 +89,8 @@
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;
-
 	padding-top: 5px;
-    padding-bottom: 5px;
+	padding-bottom: 5px;
 }
 
 .shareTree-item * {

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -76,6 +76,46 @@
 	margin-right: 8px;
 }
 
+#shareDialogLinkList .link-shares + #shareTreeUserGroupList {
+	margin-top: -20px;
+}
+
+#shareWithList + #shareTreeUserGroupList {
+	margin-top: -16px;
+}
+
+#shareTreeLinkList .shareTree-item,
+#shareTreeUserGroupList .shareTree-item {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+
+	padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+.shareTree-item * {
+	cursor: pointer;
+}
+
+.shareTree-item-avatar {
+	border-radius: 50%;
+	float: left;
+	min-width: 32px;
+	min-height: 32px;
+}
+
+.shareTree-item-avatar + .shareTree-item-name,
+.shareTree-item-name + .shareTree-item-path {
+	margin-left: 8px;
+	white-space: nowrap;
+}
+
+.shareTree-item-avatar + .shareTree-item-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .shareTabView .icon-loading-small {
 	display         : inline-block;
 	z-index         : 1;

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -198,6 +198,9 @@
 					// (FIXME: yes, this is hacky)
 					icon: $tr.attr('data-icon')
 				});
+
+				fileList._setShareTreeLinkView();
+				fileList._setShareTreeUserGroupView();
 			});
 			fileList.registerTabView(shareTab);
 		},

--- a/changelog/unreleased/36572
+++ b/changelog/unreleased/36572
@@ -1,0 +1,8 @@
+Enhancement: Share indicator on webUI
+
+The file list in the webUI now shows a share indicator on files and folders that
+reside inside a shared folder. The sidebar sharing tab reveals a detailed view
+of the share-tree including share-recipients and the parent folder that has been
+shared.
+
+https://github.com/owncloud/core/pull/36572

--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -45,6 +45,17 @@
 	};
 
 	/**
+	 * Check if sidebar is visible/hidden
+	 *
+	 * @param {Object} [$el] sidebar element to check, defaults to $('#app-sidebar')
+	 */
+
+	exports.Apps.AppSidebarVisible = function($el) {
+		var $appSidebar = $el || $('#app-sidebar');
+		return !$appSidebar.hasClass('disappear');
+	};
+
+	/**
 	 * Provides a way to slide down a target area through a button and slide it
 	 * up if the user clicks somewhere else. Used for the news app settings and
 	 * add new field.

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -53,6 +53,7 @@ OC.Share = _.extend(OC.Share || {}, {
 	 * @param fileList file list instance, defaults to OCA.Files.App.fileList
 	 * @param callback function to call after the shares were loaded
 	 */
+
 	loadIcons:function(itemType, fileList, callback) {
 		var path = fileList.dirInfo.path;
 		if (path === '/') {
@@ -430,7 +431,5 @@ $(document).ready(function() {
 			OC.Share.hideDropDown();
 		}
 	});
-
-
 
 });

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -29,11 +29,15 @@
 		'        <div class="oneline">' +
 		'            <input id="shareWith-{{cid}}" class="shareWithField" type="text" placeholder="{{sharePlaceholder}}" />' +
 		'            <span class="shareWithLoading icon-loading-small hidden"></span>'+
-		'{{{remoteShareInfo}}}' +
+		'            {{{remoteShareInfo}}}' +
 		'        </div>' +
 		'        <div class="shareeListView subView"></div>' +
+		'        <div class="shareeTreeUserGroupListView subView"></div>' +
 		'    </div>' +
-		'    <div class="linkShareView subView tab hidden" style="padding-left:0;padding-right:0;"></div>' +
+		'    <div class="linkShareView tab hidden" style="padding-left:0;padding-right:0;">' +
+		'        <div class="linkListView"></div>' +
+		'        <div class="shareeTreeLinkListView subView"></div>' +
+		'    </div>' +
 		'</div>' +
 		'{{else}}' +
 		'<div class="noSharingPlaceholder">{{noSharingPlaceholder}}</div>' +
@@ -156,6 +160,7 @@
 			this.$('.localShareView').toggleClass('hidden', !$target.hasClass('subtab-localshare'));
 
 			var $linkShareView = this.$('.linkShareView');
+			var $linkListView = this.$('.linkListView');
 			if ($linkShareView.length) {
 				$linkShareView.toggleClass('hidden', !$target.hasClass('subtab-publicshare'));
 
@@ -166,7 +171,7 @@
 						itemModel: this.model
 					});
 					this.linkShareView.render();
-					$linkShareView.append(this.linkShareView.$el);
+					$linkListView.html(this.linkShareView.$el);
 				}
 			}
 		},

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -965,7 +965,7 @@ describe('OC.Share.ShareDialogView', function() {
 		});
 		it('creates link share view only after selecting tab', function() {
 			expect(dialog.$('.linkListView').is(':empty')).toEqual(true);
-			
+
 			dialog.$('.subTabHeaders>.subTabHeader:eq(1)').click();
 
 			expect(dialog.$('.linkListView').is(':empty')).toEqual(false);
@@ -1001,18 +1001,18 @@ describe('OC.Share.ShareDialogView', function() {
 					}]
 				}
 			});
-		})
+		});
 		afterEach(function() {
 			fileList.destroy();
-			$('#filelist').remove()
+			$('#filelist').remove();
 		});
 		it('renders parent user/groups shares', function() {
-			fileList._setShareTreeUserGroupView()
+			fileList._setShareTreeUserGroupView();
 			expect(dialog.$el.find('#shareTreeUserGroupList li').length).toEqual(4);
-		})
+		});
 		it('renders parent link shares', function() {
-			fileList._setShareTreeLinkView()
+			fileList._setShareTreeLinkView();
 			expect(dialog.$el.find('#shareTreeLinkList li').length).toEqual(2);
-		})
+		});
 	});
 });

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -35,6 +35,7 @@ describe('OC.Share.ShareDialogView', function() {
 	var configModel;
 	var shareModel;
 	var fileInfoModel;
+	var fileList;
 	var dialog;
 
 	beforeEach(function() {
@@ -963,11 +964,55 @@ describe('OC.Share.ShareDialogView', function() {
 			expect(dialog.$('.tabsContainer>.tab:eq(1)').hasClass('hidden')).toEqual(false);
 		});
 		it('creates link share view only after selecting tab', function() {
-			expect(dialog.$('.linkShareView').is(':empty')).toEqual(true);
+			expect(dialog.$('.linkListView').is(':empty')).toEqual(true);
 			
 			dialog.$('.subTabHeaders>.subTabHeader:eq(1)').click();
 
-			expect(dialog.$('.linkShareView').is(':empty')).toEqual(false);
+			expect(dialog.$('.linkListView').is(':empty')).toEqual(false);
 		});
+	});
+	describe('shareTree', function() {
+		beforeEach(function() {
+			dialog.render();
+
+			$('#testArea').append('<div id="filelist"></div>')
+			fileList = new OCA.Files.FileList($('#filelist'));
+			fileList._setShareTreeCache({
+				'/folder' : {
+					name: "folder",
+					shares : [{
+						share_type: 0,
+						share_with_displayname: "Demo user",
+					}, {
+						share_type: 1,
+						share_with_displayname: "Demo group",
+					}, {
+						share_type: 3,
+						share_with_displayname: "Demo link #1",
+					}, {
+						share_type: 3,
+						share_with_displayname: "Demo link #2",
+					}, {
+						share_type: 4,
+						share_with_displayname: "Demo guest",
+					}, {
+						share_type: 6,
+						share_with_displayname: "Demo remote user",
+					}]
+				}
+			});
+		})
+		afterEach(function() {
+			fileList.destroy();
+			$('#filelist').remove()
+		});
+		it('renders parent user/groups shares', function() {
+			fileList._setShareTreeUserGroupView()
+			expect(dialog.$el.find('#shareTreeUserGroupList li').length).toEqual(4);
+		})
+		it('renders parent link shares', function() {
+			fileList._setShareTreeLinkView()
+			expect(dialog.$el.find('#shareTreeLinkList li').length).toEqual(2);
+		})
 	});
 });

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2211,4 +2211,39 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$this->getSession()
 		);
 	}
+
+	/**
+	 * @Then /^(user|group|public link|federated user) ((?:'[^']*')|(?:"[^"]*")) should be listed as share receiver via ((?:'[^']*')|(?:"[^"]*")) on the webUI$/
+	 *
+	 * @param string $type user|group|public link|federated user
+	 * @param string $name
+	 * @param string $item
+	 *
+	 * @return void
+	 */
+	public function userGroupShouldBeListedAsShareReceiver($type, $name, $item) {
+		// The capturing group of the regex always includes the quotes at each
+		// end of the captured string, so trim them.
+		$name = $this->featureContext->substituteInLineCodes($name);
+		$name = \trim($name, $name[0]);
+		$item = \trim($item, $item[0]);
+
+		$sharingDialog = $this->filesPage->getSharingDialog();
+		$shareTreeItem = $sharingDialog->getShareTreeItem($type, $name, $item);
+		Assert::assertTrue($shareTreeItem->isVisible());
+	}
+
+	/**
+	 * @Then public link with last share token should be listed as share receiver via :item on the webUI
+	 *
+	 * @param string $item
+	 *
+	 * @return void
+	 */
+	public function publicLinkWithLastShareTokenShouldBeListedAsShareReceiverViaOnTheWebUI($item) {
+		$token = $this->featureContext->getLastShareData()->data->token;
+		$sharingDialog = $this->filesPage->getSharingDialog();
+		$shareTreeItem = $sharingDialog->getShareTreeItem("public link", $token, $item);
+		Assert::assertTrue($shareTreeItem->isVisible());
+	}
 }

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1601,4 +1601,48 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			);
 		}
 	}
+
+	/**
+	 * @Then the following resources should have share indicators on the webUI
+	 *
+	 * @param TableNode $resourceTable
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theFollowingResourcesShouldHaveShareIndicatorOnTheWebUI(TableNode $resourceTable) {
+		$elementRows = $resourceTable->getRows();
+		$elements = $this->featureContext->simplifyArray($elementRows);
+		foreach ($elements as $filename) {
+			$isMarked = $this->filesPage->isSharedIndicatorPresent(
+				$filename, $this->getSession()
+			);
+			Assert::assertTrue(
+				$isMarked,
+				"Expected: " . $filename . " to be marked as shared but it's not"
+			);
+		}
+	}
+
+	/**
+	 * @Then the following resources should not have share indicators on the webUI
+	 *
+	 * @param TableNode $resourceTable
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theFollowingResourcesShouldNotHaveShareIndicatorOnTheWebUI(TableNode $resourceTable) {
+		$elementRows = $resourceTable->getRows();
+		$elements = $this->featureContext->simplifyArray($elementRows);
+		foreach ($elements as $filename) {
+			$isMarked = $this->filesPage->isSharedIndicatorPresent(
+				$filename, $this->getSession()
+			);
+			Assert::assertFalse(
+				$isMarked,
+				"Expected: " . $filename . " not to be marked as shared but it is"
+			);
+		}
+	}
 }

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -399,4 +399,17 @@ class FilesPage extends FilesPageBasic {
 	public function waitForUploadProgressbarToFinish() {
 		$this->filesPageCRUDFunctions->waitForUploadProgressbarToFinish();
 	}
+
+	/**
+	 * checks whether given resource is marked as shared or not
+	 *
+	 * @param string $fileName
+	 * @param Session $session
+	 *
+	 * @return bool
+	 */
+	public function isSharedIndicatorPresent($fileName, $session) {
+		$fileRow = $this->findFileRowByName($fileName, $session);
+		return $fileRow->isSharedIndicatorPresent();
+	}
 }

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -533,7 +533,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 					);
 					$fileListIsVisible = false;
 				}
-				
+
 				if ($fileListIsVisible
 					&& $fileList->has("xpath", "//a")
 				) {
@@ -638,7 +638,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
-		
+
 		$showHiddenFilesCheckBox = $this->find(
 			'xpath', $this->showHiddenFilesCheckboxXpath
 		);

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -62,6 +62,7 @@ class FileRow extends OwncloudPage {
 	protected $sharingDialogXpath = ".//div[@class='dialogContainer']";
 	protected $lockDialogId = "lockTabView";
 	protected $highlightsXpath = "//div[@class='highlights']";
+	protected $sharedIndicatorXpath = "//div[contains(@class, 'sharetree-item')]";
 
 	/**
 	 *
@@ -405,7 +406,7 @@ class FileRow extends OwncloudPage {
 		$this->findFileLink()->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
-	
+
 	/**
 	 * restore the current deleted file and folder by clicking on the restore link
 	 *
@@ -446,14 +447,14 @@ class FileRow extends OwncloudPage {
 		$checkFavorite = $this->rowElement->find(
 			"xpath", $this->markedFavoriteXpath
 		);
-		
+
 		if ($checkFavorite === null) {
 			return false;
 		} else {
 			return true;
 		}
 	}
-	
+
 	/**
 	 * unmarks the current file or folder off favorite by clicking the star icon
 	 *
@@ -584,5 +585,18 @@ class FileRow extends OwncloudPage {
 	public function isActionLabelAvailable($actionLabel, Session $session) {
 		$actionMenu = $this->openFileActionsMenu($session);
 		return $actionMenu->isActionLabelVisible($actionLabel);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isSharedIndicatorPresent() {
+		if ($this->rowElement->find(
+			"xpath", $this->sharedIndicatorXpath
+		) === null
+		) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -68,6 +68,7 @@ class SharingDialog extends OwncloudPage {
 	private $unShareTabXpath = "//a[contains(@class,'unshare')]";
 	private $sharedWithGroupAndSharerName = null;
 	private $publicLinkRemoveDeclineMsg = "No";
+	private $shareTreeItemByNameAndPathXpath = "//li[@class='shareTree-item' and strong/text()='%s' and span/text()='via %s']";
 
 	/**
 	 * @var string
@@ -763,6 +764,27 @@ class SharingDialog extends OwncloudPage {
 		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
+	/**
+	 * @param string $type user|group|public link with name
+	 * @param string $name user or group name
+	 * @param string $path
+	 *
+	 * @return NodeElement
+	 */
+	public function getShareTreeItem($type, $name, $path) {
+		if ($type === "group") {
+			$name = \sprintf($this->groupFramework, $name);
+		}
+		$fullXpath = \sprintf($this->shareTreeItemByNameAndPathXpath, $name, $path);
+		$item = $this->find("xpath", $fullXpath);
+		$this->assertElementNotNull(
+			$item,
+			__METHOD__ .
+			"\ncannot find item with name '$name' and path '$path'"
+		);
+		return $item;
+	}
+	
 	/**
 	 * waits for the dialog to appear
 	 *

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -28,7 +28,7 @@ use Behat\Mink\Session;
  * Shared with you page.
  */
 class SharedWithYouPage extends FilesPageBasic {
-	
+
 	/**
 	 *
 	 * @var string $path
@@ -38,28 +38,28 @@ class SharedWithYouPage extends FilesPageBasic {
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext')) and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-sharingin']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-sharingin']//div[@id='emptycontent']";
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileListXpath() {
 		return $this->fileListXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNamesXpath() {
 		return $this->fileNamesXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNameMatchXpath() {
 		return $this->fileNameMatchXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
@@ -95,7 +95,7 @@ class SharedWithYouPage extends FilesPageBasic {
 	) {
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
-		
+
 		for ($counter = 0; $counter < $maxRetries; $counter++) {
 			$row = $this->findFileRowByName($name, $session);
 			try {

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -372,3 +372,51 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then using server "REMOTE"
     And as "user1" folder "simple-folder" should exist
     And as "user1" folder "simple-folder (3)" should exist
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator inside folder shared using federated sharing
+    Given user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | lorem.txt  |
+      | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside folder shared using federated sharing
+    Given user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside folder shared using federated sharing
+    Given user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing details inside folder shared using federated sharing
+    Given user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the share dialog for file "textfile.txt"
+    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder shared with local user and federated user
+    Given user "user2" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" has shared folder "simple-folder/sub-folder" with user "user2"
+    When the user opens folder "simple-folder/sub-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    And user "User Two" should be listed as share receiver via "sub-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -316,4 +316,82 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
+  @skipOnOcV10.3
+  Scenario: sharing indicator of items inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
 
+  @skipOnOcV10.3
+  Scenario: sharing indicator of items inside a shared folder two levels down
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder/"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens folder "simple-empty-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-folder |
+      | lorem.txt  |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator of items inside a re-shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with group "grp1"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  @skipOnOcV10.3
+  Scenario: no sharing indicator of items inside a not shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-sub-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-sub-folder |
+      | lorem.txt         |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside a shared folder
+    Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user3" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside a shared folder
+    Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user3" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder shared with user and group
+    Given user "user3" has created folder "/simple-folder/sub-folder"
+    And user "user3" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user3" has shared folder "simple-folder" with user "user2"
+    And user "user3" has shared folder "/simple-folder/sub-folder" with group "grp1"
+    And user "user3" has logged in using the webUI
+    When the user opens folder "simple-folder/sub-folder" using the webUI
+    And the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
+    And group "grp1" should be listed as share receiver via "sub-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -677,3 +677,141 @@ Feature: Sharing files and folders with internal users
       """
       just letting you know that user0 shared simple-folder with you.
       """
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator of items inside a shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator of items inside a shared folder two levels down
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens folder "simple-empty-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-folder |
+      | lorem.txt  |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator of items inside a re-shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+    And these users have been created without skeleton files:
+      | username |
+      | user2    |
+      | user3    |
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with user "user3"
+    And user "user2" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  @skipOnOcV10.3
+  Scenario: no sharing indicator of items inside a not shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder
+    Given these users have been created without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "simple-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a re-shared folder
+    Given these users have been created without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with user "user3"
+    And user "user2" has logged in using the webUI
+    And the user has opened folder "simple-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
+    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside a shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside a shared folder
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder shared with multiple users
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has shared folder "/simple-folder/sub-folder" with user "user3"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "simple-folder/sub-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
+    And user "User Three" should be listed as share receiver via "sub-folder" on the webUI
+

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -663,3 +663,86 @@ Feature: Share by public link
 			user0 shared simple-folder with you
 			"""
     And the email address "foo@bar.co" should have received an email containing the last shared public link
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder   |
+      | textfile.txt |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for file uploaded inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | new-lorem.txt |
+
+  @skipOnOcV10.3
+  Scenario: sharing indicator for folder created inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | sub-folder |
+
+  @skipOnOcV10.3
+  Scenario: sharing details of items inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+      | name | Public Link    |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    And the user opens the public link share tab
+    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing details of multiple public link shares with different link names
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+      | name | Public Link    |
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder/sub-folder        |
+      | name | strängé लिंक नाम (#2 &).नेपाली      |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    And the user opens the public link share tab
+    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens folder "sub-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    And the user opens the public link share tab
+    Then public link "strängé लिंक नाम (#2 &).नेपाली" should be listed as share receiver via "sub-folder" on the webUI
+    And public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skipOnOcV10.3
+  Scenario: sharing detail of items in the webUI shared by public links with empty name
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    And the user opens the public link share tab
+    Then public link with last share token should be listed as share receiver via "simple-folder" on the webUI


### PR DESCRIPTION
## Description
This is a rebased and squashed version of #36254 (which has many commits) and then #36534 

Filelist shows share indicators on files and folders, that reside inside a shared folder / shared folders.
The sidebar share-tab reveals a detailed view of the share-tree including share-recipients and the respective folders the life in.

![2019-11-12-21-23-13](https://user-images.githubusercontent.com/12717530/68707852-d54a4580-0592-11ea-9585-819370243361.gif)

## Related Issue
https://github.com/owncloud/enterprise/issues/3453 (Discussion)
https://github.com/owncloud/enterprise/issues/3556 (Vis. Concept)

## How Has This Been Tested?
Manual testing in
- Google Chome
- Mozilla Firefox
- MSIE 11

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](../changelog/README.md)
