### PR TITLE
[for 10.4] Receive multiple users from backend for user sync

### DIFF
--- a/changelog/unreleased/36576
+++ b/changelog/unreleased/36576
@@ -1,0 +1,11 @@
+Bugfix: Receive multiple users for user sync command
+
+Recieve multiple users for user sync command. Previously
+when multiple users were returned, an exception was thrown
+and the command was aborted. In this fix we allow multiple
+users to be returned, and we check for the uid provided by the
+admin matches with the returned users. And if we find matches
+of more than one users with same uid, then we throw the exception
+that was thrown previously. The messages are kept intact.
+
+https://github.com/owncloud/core/pull/36576

--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -252,15 +252,23 @@ class SyncBackend extends Command {
 		$missingAccountsAction
 	) {
 		$output->writeln("Syncing $uid ...");
-		$users = $backend->getUsers($uid, 2);
-		if (\count($users) > 1) {
-			throw new \LengthException("Multiple users returned from backend for: $uid. Cancelling sync.");
+		$userUids = $backend->getUsers('', null);
+		$userToSync = null;
+		foreach ($userUids as $userUid) {
+			if ($userUid === $uid) {
+				if ($userToSync === null) {
+					$userToSync = $userUid;
+				} else {
+					throw new \LengthException("Multiple users returned from backend for: $uid. Cancelling sync.");
+				}
+			}
 		}
 
 		$dummy = new Account(); // to prevent null pointer when writing messages
-		if (\count($users) === 1) {
+
+		if ($userToSync !== null) {
 			// Run the sync using the internal username if mapped
-			$syncService->run($backend, new \ArrayIterator([$users[0]]), function () {
+			$syncService->run($backend, new \ArrayIterator([$userToSync]), function () {
 			});
 		} else {
 			// Not found

--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -276,7 +276,9 @@ class SyncBackendTest extends TestCase {
 		$outputInterface = $this->createMock(OutputInterface::class);
 		$syncService = $this->createMock(SyncService::class);
 
-		$this->dummyBackend->method('getUsers')->willReturn(['existing-uid', 'should-explode']);
+		$this->dummyBackend->method('getUsers')->willReturn(['existing-uid', 'existing-uid']);
+		$this->dummyBackend->method('getDisplayName')
+			->willReturn('existing-uid');
 
 		$missingAccountsAction = 'disable';
 		$syncService->expects($this->never())->method('run');
@@ -297,6 +299,8 @@ class SyncBackendTest extends TestCase {
 		$syncService = $this->createMock(SyncService::class);
 
 		$this->dummyBackend->method('getUsers')->willReturn(['existing-uid']);
+		$this->dummyBackend->method('getDisplayName')
+			->willReturn('existing-uid');
 
 		$missingAccountsAction = 'disable';
 		$syncService->expects($this


### PR DESCRIPTION
Receive multiple users from the backend for user sync
instead of checking for single user. From the received
users check if the user to be synced is available in
the list.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Problem: When admin tries to sync a user say for ldap backend, there can be cases where names like `mhof`, `mhoff`, `mhoffg` exist in the ldap. And when admin tries to sync `mhof`, the admin gets Multiple user exists exception.

What this PR proposes:
Grab all the users available from the user backend, which the admin had searched for. And then try to match the users with the user to be searched for. If there are multiple users with same user name available then throw the exception. If only one user is available then sync it, else as usual show message saying user does not exist in the backend.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes enterprise ticket 3447

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not check for the count of users. Instead check if the users received from the backend contains the exact match or not. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created LDAP setup
- Created LDAP users `mhof`, `mhoff`, `mhoffg`
- Now as oC admin tried to sync the user `mhof`
```
sujith@sujith-ownCloud  ~/test/owncloud   fix-sync-user ●  ./occ user:sync "OCA\User_LDAP\User_Proxy" -u 'mhof'          
Cannot load Xdebug - it was already loaded
If unknown users are found, what do you want to do with their accounts? (removing the account will also remove its data)
  [0] disable
  [1] remove
  [2] ask later
 > 0
Syncing mhof ...

 sujith@sujith-ownCloud  ~/test/owncloud   fix-sync-user ● 
```
- As admin user try to sync `mhoffg123` which does not exist:
```
sujith@sujith-ownCloud  ~/test/owncloud   fix-sync-user ●  ./occ user:sync "OCA\User_LDAP\User_Proxy" -u 'mhoffg123'
Cannot load Xdebug - it was already loaded
If unknown users are found, what do you want to do with their accounts? (removing the account will also remove its data)
  [0] disable
  [1] remove
  [2] ask later
 > 0
Syncing mhoffg123 ...
Disabling accounts:
mhoffg123, ,  (no longer exists in the backend)

 sujith@sujith-ownCloud  ~/test/owncloud   fix-sync-user ● 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
