### PR TITLE
check for isset before accessing in toXML()

### DIFF
--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -460,7 +460,7 @@ class OC_API {
 	 */
 	private static function toXML($array, $writer) {
 		foreach ($array as $k => $v) {
-			if ($k[0] === '@') {
+			if (isset($k[0]) && ($k[0] === '@')) {
 				if (\is_array($v)) {
 					foreach ($v as $name => $value) {
 						$writer->writeAttribute($name, $value);


### PR DESCRIPTION
## Description
When running PHP 7.4 I noticed the server emit:
```
[Wed Dec 11 19:37:16 2019] Trying to access array offset on value of type int at /home/phil/git/owncloud/core/lib/private/legacy/api.php#463
```
I happened to be running an acceptance test:
```
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiWebdavProperties/setFileProperties.feature:12
```
But I suspect this can happen with anything that needs to call `toXML()`

Check that `$k[0]` is set before accessing `$k[0]` (PHP is happy with `isset($k[0])` when `$k` itself is an int...)

## Motivation and Context

## How Has This Been Tested?
Run the acceptance test again with PHP 7.4 and observe that the server does not emit the message.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
