### PR TITLE
Increase wait-for-db timeout from 120 to 600 seconds

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1887,7 +1887,7 @@ def setupCeph(phpVersion, cephS3):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'wait-for-it -t 120 ceph:80',
+			'wait-for-it -t 600 ceph:80',
 			'cd /drone/src/apps/files_primary_s3',
 			'cp tests/drone/ceph.config.php /drone/src/config',
 			'cd /var/www/owncloud/server',
@@ -1912,7 +1912,7 @@ def setupScality(phpVersion, scalityS3):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'wait-for-it -t 120 scality:8000',
+			'wait-for-it -t 600 scality:8000',
 			'cp /drone/src/apps/files_primary_s3/tests/drone/%s /drone/src/config' % configFile,
 			'php occ s3:create-bucket owncloud --accept-warning'
 		] + ([

--- a/.drone.yml
+++ b/.drone.yml
@@ -3555,7 +3555,7 @@ steps:
   pull: always
   image: owncloudci/php:7.1
   commands:
-  - wait-for-it -t 120 scality:8000
+  - wait-for-it -t 600 scality:8000
   - cp /drone/src/apps/files_primary_s3/tests/drone/scality.config.php /drone/src/config
   - php occ s3:create-bucket owncloud --accept-warning
 

--- a/tests/drone/install-server.sh
+++ b/tests/drone/install-server.sh
@@ -76,23 +76,23 @@ rm -rf ${DATA_DIRECTORY} config/config.php
 echo "waiting for database to be ready"
 case "${DB_TYPE}" in
   mariadb)
-    wait-for-it -t 120 mariadb:3306
+    wait-for-it -t 600 mariadb:3306
     DB=mysql
     ;;
   mysql)
-    wait-for-it -t 120 mysql:3306
+    wait-for-it -t 600 mysql:3306
     DB=mysql
     ;;
   mysql8)
-    wait-for-it -t 120 mysql8:3306
+    wait-for-it -t 600 mysql8:3306
     DB=mysql
     ;;
   postgres)
-    wait-for-it -t 120 postgres:5432
+    wait-for-it -t 600 postgres:5432
     DB=pgsql
     ;;
   oracle)
-    wait-for-it -t 120 oracle:1521
+    wait-for-it -t 600 oracle:1521
     DB=oci
     DB_USERNAME=autotest
     DB_NAME='XE'
@@ -111,7 +111,7 @@ declare -x PRIMARY_OBJECTSTORE
 if [[ ! -z "${PRIMARY_OBJECTSTORE}" ]]; then
   case "${PRIMARY_OBJECTSTORE}" in
     files_primary_s3)
-      wait-for-it -t 120 scality:8000
+      wait-for-it -t 600 scality:8000
       ;;
     *)
       echo "Unknown primary object storage!"

--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -18,22 +18,22 @@ set_up_external_storage() {
     php occ config:app:set core enable_external_storage --value=yes
     case "${FILES_EXTERNAL_TYPE}" in
     webdav)
-      wait-for-it -t 120 webdav:80
+      wait-for-it -t 600 webdav:80
       cp tests/drone/configs/config.files_external.webdav-apache.php apps/files_external/tests/config.webdav.php
       FILES_EXTERNAL_TEST_TO_RUN=WebdavTest.php
       ;;
     samba)
-      wait-for-it -t 120 samba:445
+      wait-for-it -t 600 samba:445
       cp tests/drone/configs/config.files_external.smb-samba.php apps/files_external/tests/config.smb.php
       FILES_EXTERNAL_TEST_TO_RUN=SmbTest.php
       ;;
     windows)
-      wait-for-it -t 120 fsweb.test.owncloud.com:445
+      wait-for-it -t 600 fsweb.test.owncloud.com:445
       cp tests/drone/configs/config.files_external.smb-windows.php apps/files_external/tests/config.smb.php
       FILES_EXTERNAL_TEST_TO_RUN=SmbTest.php
       ;;
     sftp)
-      wait-for-it -t 120 sftp:22
+      wait-for-it -t 600 sftp:22
       cp tests/drone/configs/config.files_external.sftp.php apps/files_external/tests/config.sftp.php
       FILES_EXTERNAL_TEST_TO_RUN=SftpTest.php
       ;;


### PR DESCRIPTION
## Description
The drone agents are sometimes taking "a long time" (tm) to pull docker images. In particular this is a problem when it takes a long time to pull the database image (mariadb, postgresql, oracle...). The `install-core` step waits 120 seconds for the database to become available. If the pull took more than 2 minutes, then we get a timeout in `install-core` and the pipeline fails. That means the whole build fails and it has to be started all over again. That is very annoying.

This is seen mostly first thing in the morning, when the autoscaler starts new drone agents. Specially if a lot of drone agents get started at a similar time, they seem to be slow to pull each docker image the first time. After that, they have the docker images cached, so later pulls of the docker images do not have this time delay.

Since we know there is a very variable delay here, set the timeout to a high value (10 minutes = 600 seconds). That will avoid annoying unnecessary fails, while still providing a reasonable time-to-failure in the rare case where the database really did fail on startup.

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
