### PR TITLE
Implement coding-standard 2.0.0

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/PublicDavLocksPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicDavLocksPluginTest.php
@@ -55,9 +55,10 @@ class PublicDavLocksPluginTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
 	 */
 	public function testHttpLockForPublicWithoutLocks() {
+		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
+
 		$this->matcher->method('__invoke')->willReturn(true);
 
 		$request = $this->createMock(RequestInterface::class);
@@ -71,9 +72,10 @@ class PublicDavLocksPluginTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \Sabre\DAV\Exception\Locked
 	 */
 	public function testHttpLockForPublicWithLocks() {
+		$this->expectException(\Sabre\DAV\Exception\Locked::class);
+
 		$this->matcher->method('__invoke')->willReturn(true);
 
 		$request = $this->createMock(RequestInterface::class);
@@ -89,9 +91,10 @@ class PublicDavLocksPluginTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
 	 */
 	public function testHttpUnlockForPublic() {
+		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
+
 		$this->matcher->method('__invoke')->willReturn(true);
 
 		$request = $this->createMock(RequestInterface::class);

--- a/apps/dav/tests/unit/TrashBin/RootCollectionTest.php
+++ b/apps/dav/tests/unit/TrashBin/RootCollectionTest.php
@@ -51,9 +51,10 @@ class RootCollectionTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \Sabre\DAV\Exception\NotAuthenticated
 	 */
 	public function testGetChildForPrincipalWithUnauthorizedUser() {
+		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
+
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('john');
 		$userSession = $this->createMock(IUserSession::class);

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-      "owncloud/coding-standard": "^1.0"
+      "owncloud/coding-standard": "^2.0"
     }
   }
   


### PR DESCRIPTION
## Description
`owncloud/coding-standard` `2.0.0` adds fixers for things that are deprecated and being removed in future releases of `phpunit` - see https://github.com/owncloud/coding-standard/pull/20 and a core PR that recently applied these refactorings https://github.com/owncloud/core/pull/36501 for details.

Implement this in core CI so it will now be enforced.

Do `make test-php-style-fix` to refactor recent additions of `@expectedException` annotations.

Developers, whose unit test code now fails code style checks, can simply `make test-php-style-fix` to automatically apply the fixes.

Also see https://thephp.cc/news/2016/02/questioning-phpunit-best-practices for information/reasoning.

## Motivation and Context
Be ready when we need to move forward to phpunit8.

## How Has This Been Tested?
`make test-php-style-fix`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
