### PR TITLE
php unit test changes to address issues that php7.4 will report

### DIFF
--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -64,7 +64,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 			if (\method_exists($param, 'getType')) {
 				$type = $param->getType();
 				if ($type !== null) {
-					$this->types[$param->getName()] = (string) $type;
+					$this->types[$param->getName()] = $type->getName();
 				}
 			}
 

--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -63,6 +63,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 			// over phpdoc annotations
 			if (\method_exists($param, 'getType')) {
 				$type = $param->getType();
+				'@phan-var \ReflectionNamedType $type';
 				if ($type !== null) {
 					$this->types[$param->getName()] = $type->getName();
 				}

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -111,7 +111,7 @@ class Cache implements ICache {
 	 * get the stored metadata of a file or folder
 	 *
 	 * @param string | int $file either the path of a file or folder or the file id for a file or folder
-	 * @return ICacheEntry|false the cache entry as array of false if the file is not found in the cache
+	 * @return ICacheEntry|false the cache entry as array or false if the file is not found in the cache
 	 */
 	public function get($file) {
 		if (\is_string($file) or $file == '') {

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -84,8 +84,8 @@ class FileCacheTest extends TestCache {
 	}
 
 	protected function tearDown(): void {
-		if ($this->instance) {
-			$this->instance->remove('hack', 'hack');
+		if ($this->instance->get('hack') !== null) {
+			$this->instance->remove('hack');
 		}
 
 		parent::tearDown();

--- a/tests/lib/Command/Integrity/SignAppTest.php
+++ b/tests/lib/Command/Integrity/SignAppTest.php
@@ -221,23 +221,23 @@ class SignAppTest extends TestCase {
 			->expects($this->at(1))
 			->method('getOption')
 			->with('privateKey')
-			->will($this->returnValue('privateKey'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
 		$inputInterface
 			->expects($this->at(2))
 			->method('getOption')
 			->with('certificate')
-			->will($this->returnValue('certificate'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
 
 		$this->fileAccessHelper
 			->expects($this->at(0))
 			->method('file_get_contents')
-			->with('privateKey')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')));
 		$this->fileAccessHelper
 			->expects($this->at(1))
 			->method('file_get_contents')
-			->with('certificate')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')));
 
 		$this->checker
 			->expects($this->once())

--- a/tests/lib/Command/Integrity/SignCoreTest.php
+++ b/tests/lib/Command/Integrity/SignCoreTest.php
@@ -172,12 +172,12 @@ class SignCoreTest extends TestCase {
 			->expects($this->at(0))
 			->method('getOption')
 			->with('privateKey')
-			->will($this->returnValue('privateKey'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
 		$inputInterface
 			->expects($this->at(1))
 			->method('getOption')
 			->with('certificate')
-			->will($this->returnValue('certificate'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
 		$inputInterface
 				->expects($this->at(2))
 				->method('getOption')
@@ -187,13 +187,13 @@ class SignCoreTest extends TestCase {
 		$this->fileAccessHelper
 			->expects($this->at(0))
 			->method('file_get_contents')
-			->with('privateKey')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')));
 		$this->fileAccessHelper
 			->expects($this->at(1))
 			->method('file_get_contents')
-			->with('certificate')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')));
 
 		$this->checker
 			->expects($this->once())

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -248,8 +248,12 @@ class CacheTest extends TestCase {
 
 		// clean up
 		$this->cache->remove('');
-		$this->cache->remove($dir1);
-		$this->cache->remove($dir2);
+		if ($this->cache->get($dir1)) {
+			$this->cache->remove($dir1);
+		}
+		if ($this->cache->get($dir2)) {
+			$this->cache->remove($dir2);
+		}
 
 		$this->assertFalse($this->cache->inCache($dir1));
 		$this->assertFalse($this->cache->inCache($dir2));

--- a/tests/lib/Files/Cache/HomeCacheTest.php
+++ b/tests/lib/Files/Cache/HomeCacheTest.php
@@ -102,9 +102,15 @@ class HomeCacheTest extends \Test\TestCase {
 
 		// clean up
 		$this->cache->remove('');
-		$this->cache->remove('files');
-		$this->cache->remove($dir1);
-		$this->cache->remove($dir2);
+		if ($this->cache->get('files')) {
+			$this->cache->remove('files');
+		}
+		if ($this->cache->get($dir1)) {
+			$this->cache->remove($dir1);
+		}
+		if ($this->cache->get($dir2)) {
+			$this->cache->remove($dir2);
+		}
 
 		$this->assertFalse($this->cache->inCache('files'));
 		$this->assertFalse($this->cache->inCache($dir1));
@@ -132,7 +138,9 @@ class HomeCacheTest extends \Test\TestCase {
 
 		// clean up
 		$this->cache->remove('');
-		$this->cache->remove($dir1);
+		if ($this->cache->get($dir1)) {
+			$this->cache->remove($dir1);
+		}
 
 		$this->assertFalse($this->cache->inCache($dir1));
 	}

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -30,6 +30,12 @@ class CacheJailTest extends CacheTest {
 		$this->cache = new \OC\Files\Cache\Wrapper\CacheJail($this->sourceCache, 'foo');
 	}
 
+	protected function tearDown(): void {
+		if ($this->sourceCache) {
+			$this->sourceCache->clear();
+		}
+	}
+
 	public function testSearchOutsideJail() {
 		$file1 = 'foo/foobar';
 		$file2 = 'folder/foobar';

--- a/tests/lib/Util/User/MemoryAccountMapper.php
+++ b/tests/lib/Util/User/MemoryAccountMapper.php
@@ -76,7 +76,7 @@ class MemoryAccountMapper extends AccountMapper {
 			return self::$accounts;
 		}
 		$match = \array_filter(self::$accounts, function (Account $a) use ($pattern) {
-			return \stripos($a->getUserId(), $pattern);
+			return \stripos($a->getUserId(), (string) $pattern);
 		});
 
 		return $match;


### PR DESCRIPTION
I am finding things in the unit tests that PHP7.4 complains about (PR #36500 )
Also put them here to see that the fixes/changes still pass with an older version(s) of PHP 7.1 7.2 7.3

1) Fix 'Function ReflectionType::__toString() is deprecated' - in `ControllerMethodReflector.php` we will not be able to "just cast to string", use the `getName()` method.
2) Fix 'stripos(): Non-string needles will be interpreted as strings in the future - `$pattern` might look like something other than a string. Cast it to string because we really want it to be a string.
3) Fix 'Trying to access array offset on value of type bool' - the file called "hack" that was being put in the cache is sometimes cleaned out of the cache already by the test and the attempt to `instance->remove('hack')` complained because actually hack does not always exits. Only remove it if it still exists.
4) Pass real core.key core.crt in `SignAppTest` and `SignCoreTest` to fix 'Trying to access array offset on value of type bool' - the mocking was not actually reading in the test key and crt files. Somehow the test was passing with the privateKey being literally `privateKey` and the certificate being the literal string `certificate`
5) And similar stuff in other files.