### PR TITLE
skip new public link tests on 10.3

### DIFF
--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -64,8 +64,8 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @public_link_share-feature-required
-  Scenario: Access to the preview of password protected public link
+  @public_link_share-feature-required @skipOnOc10.3
+  Scenario: Access to the preview of password protected public link without providing the password is not allowed
     Given the administrator has enabled DAV tech_preview
     And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
     And user "user0" has created a public link share with settings
@@ -85,8 +85,8 @@ Feature: sharing
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "200"
 
-  @public_link_share-feature-required
-  Scenario: Access to the preview of password protected public shared file inside a folder
+  @public_link_share-feature-required @skipOnOc10.3
+  Scenario: Access to the preview of password protected public shared file inside a folder without providing the password is not allowed
     Given the administrator has enabled DAV tech_preview
     And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
     And user "user0" has moved file "textfile0.txt" to "FOLDER/textfile0.txt"


### PR DESCRIPTION
## Description
Some new test scenarios will fail when run against core 10.3, so skip them in that case.

## Related Issue
PR #36571 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
