### PR TITLE
Reduce memory footprint of trash expiry jobs

### DIFF
--- a/apps/files_trashbin/ajax/list.php
+++ b/apps/files_trashbin/ajax/list.php
@@ -32,7 +32,7 @@ $data = [];
 
 // make filelist
 try {
-	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser(), $sortAttribute, $sortDirection);
+	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser(), $sortAttribute, $sortDirection, true);
 } catch (Exception $e) {
 	\http_response_code(404);
 	exit();

--- a/apps/files_trashbin/ajax/list.php
+++ b/apps/files_trashbin/ajax/list.php
@@ -32,7 +32,7 @@ $data = [];
 
 // make filelist
 try {
-	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser(), $sortAttribute, $sortDirection, true);
+	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser(), $sortAttribute, $sortDirection);
 } catch (Exception $e) {
 	\http_response_code(404);
 	exit();

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -41,7 +41,7 @@ if (isset($_POST['allfiles']) && (string)$_POST['allfiles'] === 'true') {
 	if ($dir === '' || $dir === '/') {
 		$dirListing = false;
 	}
-	foreach (OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser()) as $file) {
+	foreach (OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser(), '', false, false) as $file) {
 		$fileName = $file['name'];
 		if (!$dirListing) {
 			$fileName .= '.d' . $file['mtime'];

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -41,7 +41,7 @@ class Helper {
 	 * @param bool $addExtraData if true, file info will include original path
 	 * @return \OCP\Files\FileInfo[]
 	 */
-	public static function getTrashFiles($dir, $user, $sortAttribute = '', $sortDescending = false, $addExtraData = false) {
+	public static function getTrashFiles($dir, $user, $sortAttribute = '', $sortDescending = false, $addExtraData = true) {
 		$result = [];
 		$timestamp = null;
 

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -38,9 +38,10 @@ class Helper {
 	 * @param string $user
 	 * @param string $sortAttribute attribute to sort on or empty to disable sorting
 	 * @param bool $sortDescending true for descending sort, false otherwise
+	 * @param bool $addExtraData if true, file info will include original path
 	 * @return \OCP\Files\FileInfo[]
 	 */
-	public static function getTrashFiles($dir, $user, $sortAttribute = '', $sortDescending = false) {
+	public static function getTrashFiles($dir, $user, $sortAttribute = '', $sortDescending = false, $addExtraData = false) {
 		$result = [];
 		$timestamp = null;
 
@@ -55,9 +56,10 @@ class Helper {
 		$absoluteDir = $view->getAbsolutePath($dir);
 		$internalPath = $mount->getInternalPath($absoluteDir);
 
-		$originalLocations = \OCA\Files_Trashbin\Trashbin::getLocations($user);
+		$originalLocationsCache = null;
 		$dirContent = $storage->getCache()->getFolderContents($mount->getInternalPath($view->getAbsolutePath($dir)));
 		foreach ($dirContent as $entry) {
+			// construct base fileinfo entries
 			$entryName = $entry->getName();
 			$id = $entry->getId();
 			$name = $entryName;
@@ -70,14 +72,7 @@ class Helper {
 				$parts = \explode('/', \ltrim($dir, '/'));
 				$timestamp = \substr(\pathinfo($parts[0], PATHINFO_EXTENSION), 1);
 			}
-			$originalPath = '';
-			$originalName = \substr($entryName, 0, -\strlen($timestamp)-2);
-			if (isset($originalLocations[$originalName][$timestamp])) {
-				$originalPath = $originalLocations[$originalName][$timestamp];
-				if (\substr($originalPath, -1) === '/') {
-					$originalPath = \substr($originalPath, 0, -1);
-				}
-			}
+
 			$i = [
 				'name' => $name,
 				'mtime' => $timestamp,
@@ -88,15 +83,33 @@ class Helper {
 				'etag' => '',
 				'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE
 			];
-			if ($originalPath) {
-				$i['extraData'] = $originalPath . '/' . $originalName;
+
+			// if original file path of the trashed file required, add in extraData
+			if ($addExtraData) {
+				if (!$originalLocationsCache) {
+					$originalLocationsCache = \OCA\Files_Trashbin\Trashbin::getLocations($user);
+				}
+
+				$originalName = \substr($entryName, 0, -\strlen($timestamp)-2);
+				if (isset($originalLocationsCache[$originalName][$timestamp])) {
+					$originalPath = $originalLocationsCache[$originalName][$timestamp];
+					if (\substr($originalPath, -1) === '/') {
+						$originalPath = \substr($originalPath, 0, -1);
+					}
+
+					$i['extraData'] = $originalPath . '/' . $originalName;
+				}
 			}
+
+			// set FileInfo object on the constructed fileinfo array
 			$result[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i, $mount);
 		}
 
+		// if sorting enabled use selected sorting algorithm
 		if ($sortAttribute !== '') {
 			return \OCA\Files\Helper::sortFiles($result, $sortAttribute, $sortDescending);
 		}
+
 		return $result;
 	}
 

--- a/apps/files_trashbin/lib/TrashExpiryManager.php
+++ b/apps/files_trashbin/lib/TrashExpiryManager.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @author Piotr Mrowczynski piotr@owncloud.com
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Trashbin;
+
+use OCP\ILogger;
+
+class TrashExpiryManager {
+
+	/* @var Expiration */
+	private $expiration;
+
+	/* @var Quota */
+	private $quota;
+
+	/* @var ILogger */
+	private $logger;
+
+	public function __construct(Expiration $expiration,
+								Quota $quota,
+								Ilogger $logger) {
+		$this->logger = $logger;
+		$this->expiration = $expiration;
+		$this->quota = $quota;
+	}
+
+	/**
+	 * Check is expiration is enabled
+	 *
+	 * @return bool
+	 */
+	public function expiryEnabled() {
+		return $this->expiration->isEnabled();
+	}
+
+	/**
+	 * Check if retention expiration is allowed
+	 *
+	 * @return bool
+	 */
+	public function retentionEnabled() {
+		return $this->expiration->getMaxAgeAsTimestamp() !== false;
+	}
+
+	/**
+	 * Expire trashbin using only retention.
+	 *
+	 * @param string $uid
+	 */
+	public function expireTrashByRetention(string $uid) {
+		// get trashbin files for this user and sort ascending by mtime
+		// sorting will allow us to stop expiring early
+		$userTrashbinContent = Helper::getTrashFiles('/', $uid, 'mtime', false);
+		foreach ($userTrashbinContent as $key => $trashbinEntry) {
+			if ($this->expiration->isExpired($trashbinEntry->getMtime())) {
+				Trashbin::delete($trashbinEntry->getName(), $uid, $trashbinEntry->getMtime());
+				$this->logger->info(
+					"Remove {$trashbinEntry->getName()} from {$uid} trashbin because it exceeds max retention obligation term.",
+					['app' => 'files_trashbin']
+				);
+			} else {
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Expire trashbin using both retention and space.
+	 * Retention expiry will be applied first, and if space used by user still
+	 * over the  quota (available space would be still negative for the user),
+	 * trashbin will be cleaned by space expiry.
+	 *
+	 * @param string $uid
+	 */
+	public function expireTrash(string $uid) {
+		$trashBinSize = Trashbin::getTrashbinSize($uid);
+		$availableSpace = $this->quota->calculateFreeSpace($trashBinSize, $uid);
+
+		// delete all files older then $retention_obligation
+		// get trashbin files for this user and sort ascending by mtime
+		// sorting will allow us to stop expiring early
+		$remainingUserTrashbinContent = Helper::getTrashFiles('/', $uid, 'mtime', false);
+		for ($i = 0; $i < \count($remainingUserTrashbinContent); $i++) {
+			$trashbinEntry = $remainingUserTrashbinContent[$i];
+			if ($this->expiration->isExpired($trashbinEntry->getMtime())) {
+				$availableSpace += Trashbin::delete($trashbinEntry->getName(), $uid, $trashbinEntry->getMtime());
+				$this->logger->info(
+					"Remove {$trashbinEntry->getName()} from {$uid} trashbin because it exceeds max retention obligation term.",
+					['app' => 'files_trashbin']
+				);
+
+				// unset the deleted file as it was already processed
+				unset($remainingUserTrashbinContent[$i]);
+			} else {
+				break;
+			}
+		}
+
+		// if space is still negative, purge remaining files
+		if ($availableSpace < 0) {
+			foreach ($remainingUserTrashbinContent as $trashbinEntry) {
+				if ($availableSpace < 0 && $this->expiration->isExpired($trashbinEntry->getMtime(), true)) {
+					$deletedSize = Trashbin::delete($trashbinEntry->getName(), $uid, $trashbinEntry->getMtime());
+					$this->logger->info(
+						"Remove {$trashbinEntry->getMtime()} ({$deletedSize}) to meet the limit of trash bin size ({$this->quota->getPurgeLimit()}% of available quota",
+						['app' => 'files_trashbin']
+					);
+
+					$availableSpace += $deletedSize;
+				} else {
+					break;
+				}
+			}
+		}
+	}
+}

--- a/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
@@ -3,8 +3,9 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ * @author Piotr Mrowczynski piotr@owncloud.com
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -22,20 +23,153 @@
  */
 
 namespace OCA\Files_Trashbin\Tests\BackgroundJob;
- 
+
+use Closure;
 use OCA\Files_Trashbin\BackgroundJob\ExpireTrash;
+use OCA\Files_Trashbin\TrashExpiryManager;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserManager;
+use Test\TestCase;
 
-class ExpireTrashTest extends \Test\TestCase {
-	public function testConstructAndRun() {
-		$backgroundJob = new ExpireTrash(
-			$this->createMock('OCP\IUserManager'),
-			$this->getMockBuilder('OCA\Files_Trashbin\Expiration')->disableOriginalConstructor()->getMock()
-		);
+/**
+ * Test ExpireTrashTest
+ */
+class ExpireTrashTest extends TestCase {
 
-		$jobList = $this->createMock('\OCP\BackgroundJob\IJobList');
+	/**
+	 * @var TrashExpiryManager | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $trashExpiryManager;
 
-		/** @var \OC\BackgroundJob\JobList $jobList */
-		$backgroundJob->execute($jobList);
+	/**
+	 * @var IConfig | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $config;
+
+	/**
+	 * @var IUserManager | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $userManager;
+
+	/**
+	 * @var ExpireTrash | \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $backgroundJob;
+
+	/**
+	 * Setup testcase
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->trashExpiryManager = $this->createMock(TrashExpiryManager::class);
+		$this->backgroundJob = $this->getMockBuilder(ExpireTrash::class)
+			->enableOriginalConstructor()
+			->setConstructorArgs([$this->config, $this->userManager, $this->trashExpiryManager])
+			->setMethods(['setupFS', 'tearDownFS'])
+			->getMock();
+	}
+
+	/**
+	 * Test that command will not be executed when no retention enabled
+	 */
+	public function testExpiryByRetentionDisabled() {
+		$this->trashExpiryManager->expects($this->once())
+			->method('retentionEnabled')
+			->willReturn(false);
+
+		$this->trashExpiryManager->expects($this->never())
+			->method('expireTrashByRetention');
+
+		$this->config->expects($this->never())
+			->method('getAppValue');
+
+		$this->backgroundJob->execute($this->createMock(IJobList::class));
+		$this->assertTrue(true);
+	}
+
+	/**
+	 * Test cases for testExpiryByRetention
+	 */
+	public function providesExpiryByRetention() {
+		return [
+			// test that only 500 users out of 600 will be scanned,
+			// and offset will be set to 500
+			[600, 0, true, 500, 500],
+			// test that only 200 users out of 600 will be scanned,
+			// and offset will be reset to 0
+			[600, 400, true, 0, 200],
+			// test that if there is no trashbin folder for user,
+			// no expiry is called
+			[600, 0, false, 500, 0],
+		];
+	}
+
+	/**
+	 * @param $usersCount
+	 * @param $usersOffset
+	 * @param $usersHaveTrashbin
+	 * @param $expectedEndOffset
+	 * @param
+	 *
+	 * @dataProvider providesExpiryByRetention
+	 */
+	public function testExpiryByRetention($usersCount, $usersOffset, $usersHaveTrashbin, $expectedEndOffset, $expectedExpiries) {
+		$this->trashExpiryManager->expects($this->once())
+			->method('retentionEnabled')
+			->willReturn(true);
+		$this->trashExpiryManager->expects($this->exactly($expectedExpiries))
+			->method('expireTrashByRetention');
+
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('files_trashbin', 'cronjob_trash_expiry_offset', '0')
+			->willReturn($usersOffset);
+
+		$offsetSetCalls = 0;
+		$this->config->expects($this->any())
+			->method('setAppValue')
+			->with('files_trashbin', 'cronjob_trash_expiry_offset')
+			->willReturnCallback(function ($app, $key, $value) use (&$offsetSetCalls, $usersOffset, $expectedExpiries, $expectedEndOffset) {
+				$offsetSetCalls++;
+				if ($offsetSetCalls <= $expectedExpiries) {
+					// assert that offset is increased while expiration progresses
+					$this->assertEquals($usersOffset+$offsetSetCalls, $value);
+				} else {
+					// if there are more calls then expected expiries,
+					// assert expected end offset
+					$this->assertEquals($expectedEndOffset, $value);
+				}
+			});
+
+		$this->userManager->expects($this->once())
+			->method('callForUsers')
+			->willReturnCallback(function (Closure $callback, $search, $onlySeen, $limit, $offset) use ($usersCount) {
+				for ($i = $offset; $i < $usersCount; ++$i) {
+					if ($i >= $offset + $limit) {
+						break;
+					}
+					$user = $this->createMock(IUser::class);
+					$user->expects($this->once())
+						->method('getUID')
+						->willReturn('user'.$i);
+					$callback($user);
+				}
+				return true;
+			});
+
+		$this->backgroundJob->expects($this->any())
+			->method('setupFS')
+			->willReturn($usersHaveTrashbin);
+		$this->backgroundJob->expects($this->once())
+			->method('tearDownFS');
+
+		$this->backgroundJob->execute($this->createMock(IJobList::class));
+
 		$this->assertTrue(true);
 	}
 }

--- a/apps/files_trashbin/tests/Command/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/Command/ExpireTrashTest.php
@@ -22,7 +22,7 @@
 namespace OCA\Files_Trashbin\Tests\Command;
 
 use OCA\Files_Trashbin\Command\ExpireTrash;
-use OCA\Files_Trashbin\Expiration;
+use OCA\Files_Trashbin\TrashExpiryManager;
 use OCP\IUserManager;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
@@ -47,13 +47,13 @@ class ExpireTrashTest extends TestCase {
 		parent::setUp();
 
 		$this->userManager = $this->createMock(IUserManager::class);
-		$this->expiration = $this->createMock(Expiration::class);
+		$this->expiration = $this->getMockBuilder(TrashExpiryManager::class)->disableOriginalConstructor()->getMock();
 		$command = new ExpireTrash($this->userManager, $this->expiration);
 		$this->commandTester = new CommandTester($command);
 	}
 
 	public function testExpireNoMaxRetention() {
-		$this->expiration->expects($this->any())->method('getMaxAgeAsTimestamp')
+		$this->expiration->expects($this->any())->method('retentionEnabled')
 			->willReturn(false);
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();

--- a/apps/files_trashbin/tests/TestCase.php
+++ b/apps/files_trashbin/tests/TestCase.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @author Piotr Mrowczynski piotr@owncloud.com
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Trashbin\Tests;
+
+use OC\Files\Cache\Watcher;
+use OC\Files\Filesystem;
+use OC\Files\View;
+use OCA\Files_Sharing\AppInfo\Application;
+use OCA\Files_Trashbin\Expiration;
+use OCA\Files_Trashbin\Trashbin;
+
+/**
+ * Class TrashbinTestCase
+ *
+ * @group DB
+ */
+abstract class TestCase extends \Test\TestCase {
+	const TEST_TRASHBIN_USER1 = "test-trashbin-user1";
+	const TEST_TRASHBIN_USER2 = "test-trashbin-user2";
+
+	protected $trashRoot1;
+	protected $trashRoot2;
+
+	/**
+	 * @var View
+	 */
+	protected $rootView;
+
+	private static $rememberRetentionObligation;
+
+	/**
+	 * @var bool
+	 */
+	private static $trashBinStatus;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		$appManager = \OC::$server->getAppManager();
+		self::$trashBinStatus = $appManager->isEnabledForUser('files_trashbin');
+
+		// clear share hooks
+		\OC_Hook::clear('OCP\\Share');
+		\OC::registerShareHooks();
+		$application = new Application();
+		$application->registerMountProviders();
+
+		//disable encryption
+		\OC_App::disable('encryption');
+
+		$config = \OC::$server->getConfig();
+		//configure trashbin
+		self::$rememberRetentionObligation = $config->getSystemValue('trashbin_retention_obligation', Expiration::DEFAULT_RETENTION_OBLIGATION);
+		$config->setSystemValue('trashbin_retention_obligation', 'auto, 2');
+
+		// register hooks
+		Trashbin::registerHooks();
+
+		// create test user
+		self::loginHelper(self::TEST_TRASHBIN_USER2, true);
+		self::loginHelper(self::TEST_TRASHBIN_USER1, true);
+	}
+
+	public static function tearDownAfterClass(): void {
+		// cleanup test user
+		$user = \OC::$server->getUserManager()->get(self::TEST_TRASHBIN_USER1);
+		if ($user !== null) {
+			$user->delete();
+		}
+		$user = \OC::$server->getUserManager()->get(self::TEST_TRASHBIN_USER2);
+		if ($user !== null) {
+			$user->delete();
+		}
+
+		\OC::$server->getConfig()->setSystemValue('trashbin_retention_obligation', self::$rememberRetentionObligation);
+
+		\OC_Hook::clear();
+
+		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+
+		if (self::$trashBinStatus) {
+			\OC::$server->getAppManager()->enableApp('files_trashbin');
+		}
+
+		parent::tearDownAfterClass();
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		\OC::$server->getAppManager()->enableApp('files_trashbin');
+		$config = \OC::$server->getConfig();
+		$mockConfig = $this->createMock('\OCP\IConfig');
+		$mockConfig->expects($this->any())
+			->method('getSystemValue')
+			->will($this->returnCallback(function ($key, $default) use ($config) {
+				if ($key === 'filesystem_check_changes') {
+					return Watcher::CHECK_ONCE;
+				} else {
+					return $config->getSystemValue($key, $default);
+				}
+			}));
+		$this->overwriteService('AllConfig', $mockConfig);
+
+		$this->trashRoot1 = '/' . self::TEST_TRASHBIN_USER1 . '/files_trashbin';
+		$this->trashRoot2 = '/' . self::TEST_TRASHBIN_USER2 . '/files_trashbin';
+		$this->rootView = new View();
+	}
+
+	protected function tearDown(): void {
+		$this->restoreService('AllConfig');
+		// disable trashbin to be able to properly clean up
+		\OC::$server->getAppManager()->disableApp('files_trashbin');
+
+		$this->rootView->deleteAll('/' . self::TEST_TRASHBIN_USER1 . '/files');
+		$this->rootView->deleteAll('/' . self::TEST_TRASHBIN_USER2 . '/files');
+		$this->rootView->deleteAll($this->trashRoot1);
+		$this->rootView->deleteAll($this->trashRoot2);
+
+		// clear trash table
+		$connection = \OC::$server->getDatabaseConnection();
+		$connection->executeUpdate('DELETE FROM `*PREFIX*files_trash`');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @param string $user
+	 * @param bool $create
+	 */
+	protected static function loginHelper($user, $create = false) {
+		if ($create) {
+			try {
+				\OC::$server->getUserManager()->createUser($user, $user);
+			} catch (\Exception $e) { // catch username is already being used from previous aborted runs
+			}
+		}
+
+		\OC_Util::tearDownFS();
+		\OC_User::setUserId('');
+		Filesystem::tearDown();
+		\OC_User::setUserId($user);
+		\OC_Util::setupFS($user);
+		\OC::$server->getUserFolder($user);
+	}
+}

--- a/apps/files_trashbin/tests/TrashbinExpiryManagerTest.php
+++ b/apps/files_trashbin/tests/TrashbinExpiryManagerTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * @author Piotr Mrowczynski piotr@owncloud.com
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Trashbin\Tests;
+
+use OCA\Files_Trashbin\Expiration;
+use OCA\Files_Trashbin\Helper;
+use OCA\Files_Trashbin\Quota;
+use OCA\Files_Trashbin\TrashExpiryManager;
+use OCP\ILogger;
+
+/**
+ * Class TrashbinExpiryManagerTest
+ *
+ * Extend TrashbinTestCase as we need to use Trashbin class that
+ * has static functions that cannot be mocked
+ *
+ * @group DB
+ */
+class TrashbinExpiryManagerTest extends TestCase {
+
+	/**
+	 * @var Expiration| \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $expiration;
+
+	/**
+	 * @var Quota| \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $quota;
+
+	/**
+	 * @var TrashExpiryManager
+	 */
+	private $trashExpiryManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->expiration = $this->createMock(Expiration::class);
+		$this->quota = $this->createMock(Quota::class);
+		$logger = $this->createMock(ILogger::class);
+		$this->trashExpiryManager = new TrashExpiryManager(
+			$this->expiration,
+			$this->quota,
+			$logger
+		);
+
+		self::loginHelper(self::TEST_TRASHBIN_USER1);
+	}
+
+	public function providesExpiryEnabled() {
+		return [
+			[true, true],
+			[false, false]
+		];
+	}
+
+	/**
+	 * @dataProvider providesExpiryEnabled
+	 */
+	public function testExpiryEnabled($expirationEnabled, $result) {
+		$this->expiration->expects($this->once())
+			->method('isEnabled')
+			->willReturn($expirationEnabled);
+
+		$this->assertEquals($result, $this->trashExpiryManager->expiryEnabled());
+	}
+
+	public function providesRetentionEnabled() {
+		return [
+			[1000000, true],
+			[false, false]
+		];
+	}
+
+	/**
+	 * @dataProvider providesRetentionEnabled
+	 */
+	public function testRetentionEnabled($expirationTimestamp, $result) {
+		$this->expiration->expects($this->once())
+			->method('getMaxAgeAsTimestamp')
+			->willReturn($expirationTimestamp);
+
+		$this->assertEquals($result, $this->trashExpiryManager->retentionEnabled());
+	}
+
+	/**
+	 * test expiration of files older then the max storage time defined for the trash
+	 */
+	public function testExpireTrashByRetention() {
+		// create some files
+		\OC\Files\Filesystem::file_put_contents('file1.txt', 'file1');
+		\OC\Files\Filesystem::file_put_contents('file2.txt', 'file2');
+		\OC\Files\Filesystem::file_put_contents('file3.txt', 'file3');
+
+		// delete them so that they end up in the trash bin
+		\OC\Files\Filesystem::unlink('file1.txt');
+		\OC\Files\Filesystem::unlink('file2.txt');
+		\OC\Files\Filesystem::unlink('file3.txt');
+
+		//make sure that files are in the trash bin
+		$filesInTrash = Helper::getTrashFiles('/', self::TEST_TRASHBIN_USER1, 'mtime', false);
+		$this->assertCount(3, $filesInTrash);
+
+		// simulate as 1 out of 3 files expired,
+		// and next 2 do not need expiration
+		$this->expiration->expects($this->exactly(2))
+			->method('isExpired')
+			->willReturnOnConsecutiveCalls(
+				true,
+				false
+			);
+
+		// call expire by retention
+		$this->trashExpiryManager->expireTrashByRetention(self::TEST_TRASHBIN_USER1);
+
+		$remainingFiles = Helper::getTrashFiles('/', self::TEST_TRASHBIN_USER1, 'mtime', false);
+		$this->assertCount(2, $remainingFiles);
+
+		$this->assertEquals(
+			\array_slice($filesInTrash, 1),
+			$remainingFiles
+		);
+	}
+	
+	/**
+	 * test expiration of files older then the max storage time defined for the trash
+	 */
+	public function testExpireTrashByRetentionAndSpace() {
+		// create some files
+		\OC\Files\Filesystem::file_put_contents('file1.txt', 'file1');
+		\OC\Files\Filesystem::file_put_contents('file2.txt', 'file2');
+		\OC\Files\Filesystem::file_put_contents('file3.txt', 'file3');
+
+		// delete them so that they end up in the trash bin
+		\OC\Files\Filesystem::unlink('file1.txt');
+		\OC\Files\Filesystem::unlink('file2.txt');
+		\OC\Files\Filesystem::unlink('file3.txt');
+
+		//make sure that files are in the trash bin
+		$filesInTrash = Helper::getTrashFiles('/', self::TEST_TRASHBIN_USER1, 'mtime', false);
+		$this->assertCount(3, $filesInTrash);
+
+		// simulate as 1 out of 3 files expired
+		$this->expiration->expects($this->exactly(3))
+			->method('isExpired')
+			->willReturnOnConsecutiveCalls(
+				true,
+				false,
+				// in this case we are over quota, so true will be returned
+				// even though file expiration date is ok
+				true
+			);
+
+		// simulate as only 2 files need to be cleaned to satisfy quota
+		$this->quota->expects($this->exactly(1))
+			->method('calculateFreeSpace')
+			->willReturn(-8);
+
+		// call expire by retention
+		$this->trashExpiryManager->expireTrash(self::TEST_TRASHBIN_USER1);
+
+		$remainingFiles = Helper::getTrashFiles('/', self::TEST_TRASHBIN_USER1, 'mtime', false);
+		$this->assertCount(1, $remainingFiles);
+
+		$this->assertEquals(
+			\array_slice($filesInTrash, 2),
+			$remainingFiles
+		);
+	}
+}

--- a/changelog/unreleased/36602
+++ b/changelog/unreleased/36602
@@ -1,0 +1,11 @@
+Enhancement: reduce memory footprint of trash expiry jobs
+
+The trash expiry job now expires the files in batches of users per script execution,
+instead of all users at once. This prevents growing memory related to how PHP PDO
+handles memory for many consequtive large queries. The trash expiry has been also
+moved to a dedicated trash expiry manager class that is optimized for
+background job access, while trash manager is used for online queries. Also some
+other minor memory optimizations have been applied.
+
+https://github.com/owncloud/core/pull/36602
+https://github.com/owncloud/core/pull/36565

--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -214,7 +214,7 @@ class AccountMapper extends Mapper {
 		return (int) $data['count'];
 	}
 
-	public function callForAllUsers($callback, $search, $onlySeen) {
+	public function callForUsers($callback, $search, $onlySeen, $limit = null, $offset = null) {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select(['*'])
 			->from($this->getTableName());
@@ -226,6 +226,18 @@ class AccountMapper extends Mapper {
 		if ($onlySeen) {
 			$qb->where($qb->expr()->gt('last_login', new Literal(0)));
 		}
+
+		if ($limit !== null || $offset !== null) {
+			$qb->orderBy('user_id'); // needed for predictable limit & offset
+		}
+
+		if ($limit !== null) {
+			$qb->setMaxResults($limit);
+		}
+		if ($offset !== null) {
+			$qb->setFirstResult($offset);
+		}
+
 		$stmt = $qb->execute();
 		while ($row = $stmt->fetch()) {
 			$return = $callback($this->mapRowToEntity($row));

--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -214,6 +214,10 @@ class AccountMapper extends Mapper {
 		return (int) $data['count'];
 	}
 
+	public function callForAllUsers($callback, $search, $onlySeen) {
+		return $this->callForUsers($callback, $search, $onlySeen);
+	}
+
 	public function callForUsers($callback, $search, $onlySeen, $limit = null, $offset = null) {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select(['*'])

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -435,10 +435,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 9.0.0
 	 */
 	public function callForAllUsers(\Closure $callback, $search = '', $onlySeen = false) {
-		$this->accountMapper->callForAllUsers(function (Account $account) use ($callback) {
-			$user = $this->getUserObject($account);
-			return $callback($user);
-		}, $search, $onlySeen);
+		return $this->callForUsers($callback, '', $onlySeen, null, null);
 	}
 
 	/**
@@ -459,6 +456,21 @@ class Manager extends PublicEmitter implements IUserManager {
 		$this->callForAllUsers($callback, '', true);
 	}
 
+	/**
+	 * @param \Closure $callback
+	 * @param string $search
+	 * @param boolean $onlySeen when true only users that have a lastLogin entry
+	 *                in the preferences table will be affected
+	 * @param int $limit
+	 * @param int $offset
+	 * @since 10.4.0
+	 */
+	public function callForUsers(\Closure $callback, $search = '', $onlySeen = false, $limit = null, $offset = null) {
+		$this->accountMapper->callForUsers(function (Account $account) use ($callback) {
+			$user = $this->getUserObject($account);
+			return $callback($user);
+		}, $search, $onlySeen, $limit, $offset);
+	}
 	/**
 	 * @param string $email
 	 * @return IUser[]

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -85,11 +85,11 @@ class SyncService {
 		$removed = [];
 		$reappeared = [];
 		$backendClass = \get_class($backend);
-		$this->mapper->callForAllUsers(function (Account $a) use (&$removed, &$reappeared, $backend, $backendClass, $callback) {
+		$this->mapper->callForUsers(function (Account $a) use (&$removed, &$reappeared, $backend, $backendClass, $callback) {
 			// Check if the backend matches handles this user
 			$this->checkIfAccountReappeared($a, $removed, $reappeared, $backend, $backendClass);
 			$callback($a);
-		}, '', false);
+		}, '', false, null, null);
 		return [$removed, $reappeared];
 	}
 

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -156,6 +156,16 @@ interface IUserManager {
 	public function callForAllUsers(\Closure $callback, $search = '');
 
 	/**
+	 * @param \Closure $callback
+	 * @param string $search
+	 * @param boolean $onlySeen
+	 * @param int $limit
+	 * @param int $offset
+	 * @since 10.4.0
+	 */
+	public function callForUsers(\Closure $callback, $search = '', $onlySeen = false, $limit = null, $offset = null);
+
+	/**
 	 * returns how many users have logged in once
 	 *
 	 * @return int

--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -212,4 +212,28 @@ class AccountMapperTest extends TestCase {
 		$result = $this->mapper->findUserIds($backend, true, $limit, $offset);
 		$this->assertSame($expected, $result);
 	}
+
+	public function testCallForUsersLimit() {
+		// don use offset and limit
+		$i = 1;
+		$this->mapper->callForUsers(function (Account $account) use (&$i) {
+			$this->assertEquals("TestFind".$i, $account->getUserId());
+			$i++;
+		}, 'TestFind', false, null, null);
+		$this->assertEquals(5, $i);
+
+		// use offset and limit
+		$i = 1;
+		$this->mapper->callForUsers(function (Account $account) use (&$i) {
+			$this->assertEquals("TestFind".$i, $account->getUserId());
+			$i++;
+		}, 'TestFind', false, 2, 0);
+		$this->assertEquals(3, $i);
+
+		$this->mapper->callForUsers(function (Account $account) use (&$i) {
+			$this->assertEquals("TestFind".$i, $account->getUserId());
+			$i++;
+		}, 'TestFind', false, 2, 2);
+		$this->assertEquals(5, $i);
+	}
 }

--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -213,16 +213,30 @@ class AccountMapperTest extends TestCase {
 		$this->assertSame($expected, $result);
 	}
 
-	public function testCallForUsersLimit() {
-		// don use offset and limit
-		$i = 1;
-		$this->mapper->callForUsers(function (Account $account) use (&$i) {
-			$this->assertEquals("TestFind".$i, $account->getUserId());
-			$i++;
-		}, 'TestFind', false, null, null);
-		$this->assertEquals(5, $i);
+	/**
+	 * callForAllUser that should return all users,
+	 * in any order as there is no need for sorting
+	 */
+	public function testCallForAllUsers() {
+		$expectedAccounts = [
+			"TestFind1",
+			"TestFind2",
+			"TestFind3",
+			"TestFind4",
+		];
 
-		// use offset and limit
+		$accounts = [];
+		$this->mapper->callForAllUsers(function (Account $account) use (&$accounts) {
+			$accounts[] = $account->getUserId();
+		}, 'TestFind', false);
+		\sort($accounts);
+		$this->assertSame($expectedAccounts, $accounts);
+	}
+
+	/**
+	 * callForUsers using offset and limit of 2 users at the same time
+	 */
+	public function testCallForUsersLimit() {
 		$i = 1;
 		$this->mapper->callForUsers(function (Account $account) use (&$i) {
 			$this->assertEquals("TestFind".$i, $account->getUserId());

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -272,7 +272,7 @@ class ManagerTest extends TestCase {
 		$function = function (IUser $user) use (&$users) {
 			$users[] = $user->getUID();
 		};
-		$this->manager->callForAllUsers($function, '', true);
+		$this->manager->callForUsers($function, '', true, null, null);
 		$usersBefore = $users;
 
 		//Add test users
@@ -288,7 +288,7 @@ class ManagerTest extends TestCase {
 		$user4->updateLastLoginTimestamp();
 
 		$users = [];
-		$this->manager->callForAllUsers($function, '', true);
+		$this->manager->callForUsers($function, '', true, null, null);
 		$this->assertCount(\count($usersBefore) + 3, $users, \join(', ', $usersBefore) . " !== " . \join(', ', $users));
 
 		//cleanup

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -179,7 +179,7 @@ class SyncServiceTest extends TestCase {
 	public function testAnalyseExistingUsers() {
 		$s = new SyncService($this->config, $this->logger, $this->mapper);
 		$this->mapper->expects($this->once())
-			->method('callForAllUsers')
+			->method('callForUsers')
 			->with($this->callback(function ($param) {
 				return \is_callable($param);
 			}));

--- a/tests/lib/Util/User/MemoryAccountMapper.php
+++ b/tests/lib/Util/User/MemoryAccountMapper.php
@@ -82,12 +82,16 @@ class MemoryAccountMapper extends AccountMapper {
 		return $match;
 	}
 
-	public function callForAllUsers($callback, $search, $onlySeen) {
+	public function callForUsers($callback, $search, $onlySeen, $limit = null, $offset = null) {
 		foreach (self::$accounts as $account) {
 			$return =$callback($account);
 			if ($return === false) {
 				return;
 			}
 		}
+	}
+
+	public function callForAllUsers($callback, $search, $onlySeen) {
+		return $this->callForUsers($callback, $search, $onlySeen);
 	}
 }


### PR DESCRIPTION
Related issue: https://github.com/owncloud/enterprise/issues/2925

Main problem: PHP PDO driver leaks memory - https://www.dragonbe.com/2015/07/speeding-up-database-calls-with-pdo-and.html when used in long running jobs (php pdo works well in online request where scrips live short). We cannot have scrollable PDO cursor (and it is not good idea either sometimes), and thus whole resultset is returned to memory causing memory allocation peak, when calling execute. This causes memory to cumulate and memory allocated to script is not released in long running jobs like trash expiry.

We also steadily leak memory in below when run 1000 times for 1000 users.
```
\OC_Util::tearDownFS();
\OC_Util::setupFS($user);
```

Solution: 
- reduce memory footprint where possible for single user
- In order not to keep memory when it is not used after resulting large result set, PHP script has to terminate. Thus, do not process all users at once within 1 PHP script, we need to chunk expiry for users (chunk according to max number of files processed for user?)

- [x] do not fetch trashbin locations for background jobs (as it is not used)
- [x] split trashbin manager (online queries mostly) and trash expiry manager (background jobs only) to optimize for each case
- [x] do not keep memory for results of functions that potentially can return large results sets and keep them for duration of function, causing memory to grow further
- [x] callForUser with limit and offset to allow page users
- [x] add user/account unit tests
- [x] do not allow cron to process all the users at once (run many php crons instead, chunk users)
- [x] add trashbin expiry unit tests

@DeepDiver1975 @jvillafanez @PVince81 