### PR TITLE
Add webDav auth tests for sending password on different user and no password

### DIFF
--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -38,3 +38,21 @@ Feature: delete file/folder
       | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send DELETE requests to webDav endpoints using valid password and username of different user
+    When user "user1" requests these endpoints with "DELETE" including body using the password of user "user0" then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send DELETE requests to webDav endpoints without any authentication
+    When a user requests these endpoints with "DELETE" and no authentication then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -38,3 +38,21 @@ Feature: get file info using MKCOL
       | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send MKCOL requests to webDav endpoints using valid password and username of different user
+    When user "user1" requests these endpoints with "MKCOL" including body using the password of user "user0" then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send MKCOL requests to webDav endpoints without any authentication
+    When a user requests these endpoints with "MKCOL" and no authentication then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -38,3 +38,21 @@ Feature: MOVE file/folder
       | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send MOVE requests to webDav endpoints using valid password and username of different user
+    When user "user1" requests these endpoints with "MOVE" including body using the password of user "user0" then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send MOVE requests to webDav endpoints without any authentication
+    When a user requests these endpoints with "MOVE" and no authentication then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -38,3 +38,21 @@ Feature: get file info using POST
       | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send POST requests to webDav endpoints using valid password and username of different user
+    When user "user1" requests these endpoints with "POST" including body using the password of user "user0" then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send POST requests to webDav endpoints without any authentication
+    When a user requests these endpoints with "POST" and no authentication then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -38,3 +38,21 @@ Feature: get file info using PROPFIND
       | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send PROPFIND requests to webDav endpoints using valid password and username of different user
+    When user "user1" requests these endpoints with "PROPFIND" including body using the password of user "user0" then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send PROPFIND requests to webDav endpoints without any authentication
+    When a user requests these endpoints with "PROPFIND" and no authentication then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -38,3 +38,21 @@ Feature: get file info using PUT
       | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send PUT requests to webDav endpoints using valid password and username of different user
+    When user "user1" requests these endpoints with "PUT" including body using the password of user "user0" then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
+
+  Scenario: send PUT requests to webDav endpoints without any authentication
+    When a user requests these endpoints with "PUT" and no authentication then the status codes should be as listed
+      | endpoint                                      | http-code | body          |
+      | /remote.php/webdav/textfile0.txt              | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/textfile0.txt     | 401       | doesnotmatter |
+      | /remote.php/webdav/PARENT                     | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT            | 401       | doesnotmatter |
+      | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -141,7 +141,8 @@ trait Auth {
 	public function userRequestsEndpointsWithNoAuthentication($method, TableNode $table) {
 		foreach ($table->getHash() as $row) {
 			$this->sendRequest($row['endpoint'], $method);
-			$this->verifyStatusCode($row['ocs-code'], $row['http-code'], $row['endpoint']);
+			$ocsCode = $row['ocs-code'] ?? null;
+			$this->verifyStatusCode($ocsCode, $row['http-code'], $row['endpoint']);
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add API acceptance tests for checking the webDav endpoints with password on another existing user and without sending any authentication (no username and password)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related https://github.com/owncloud/QA/issues/632

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
