### PR TITLE
Expire share after end of day

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -2304,7 +2304,8 @@ Feature: sharing
       | permissions | read,share    |
     Then the fields of the last response should include
       | expiration | today |
-    And user "user1" should not have any received shares
+    And the response when user "user1" gets the info of the last share should include
+      | expiration | today |
     Examples:
       | ocs_api_version |
       | 1               |

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -590,7 +590,7 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods(['deleteShare'])
 			->getMock();
 
-		$date = new \DateTime();
+		$date = new \DateTime("yesterday");
 		$date->setTime(0, 0, 0);
 
 		$share = $this->manager->newShare();
@@ -2655,8 +2655,8 @@ class ManagerTest extends \Test\TestCase {
 		$shareExpired = $this->createMock(IShare::class);
 		$shareExpired->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
 		$shareExpired->method('getNodeId')->willReturn(201);
-		$today = new \DateTime();
-		$shareExpired->method('getExpirationDate')->willReturn($today);
+		$yesterday = new \DateTime("yesterday");
+		$shareExpired->method('getExpirationDate')->willReturn($yesterday);
 
 		$node = $this->createMock('OCP\Files\Folder');
 		$node->expects($this->any())
@@ -2755,16 +2755,16 @@ class ManagerTest extends \Test\TestCase {
 			$shares[] = $share;
 		}
 
-		$today = new \DateTime();
-		$today->setTime(0, 0, 0);
+		$yesterday = new \DateTime("yesterday");
+		$yesterday->setTime(0, 0, 0);
 
 		/*
-		 * Set the expiration date to today for some shares
+		 * Set the expiration date to yesterday for some shares
 		 */
-		$shares[2]->setExpirationDate($today);
-		$shares[3]->setExpirationDate($today);
-		$shares[4]->setExpirationDate($today);
-		$shares[5]->setExpirationDate($today);
+		$shares[2]->setExpirationDate($yesterday);
+		$shares[3]->setExpirationDate($yesterday);
+		$shares[4]->setExpirationDate($yesterday);
+		$shares[5]->setExpirationDate($yesterday);
 
 		/** @var \OCP\Share\IShare[] $i */
 		$shares2 = [];
@@ -2808,7 +2808,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals(1, $shares2[1]->getId());
 		$this->assertEquals(6, $shares2[2]->getId());
 		$this->assertEquals(7, $shares2[3]->getId());
-		$this->assertSame($today, $shares[3]->getExpirationDate());
+		$this->assertSame($yesterday, $shares[3]->getExpirationDate());
 	}
 
 	public function testGetShareByToken() {
@@ -2898,7 +2898,7 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods(['deleteShare'])
 			->getMock();
 
-		$date = new \DateTime();
+		$date = new \DateTime("yesterday");
 		$date->setTime(0, 0, 0);
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($date);


### PR DESCRIPTION
## Description
With the current code in #36573 the share expires at the very start of the day specified. e.g. set the expiration date to "2019-12-20" and when you get to the office on 2019-12-20 the share is already expired and gone.

You can set the expiry date to today (and set the default expiry days to 0, and enforce that - any of those). If you then create a share that expires today, then the share gets created but effectively expires at the beginning of today. As soon as the share receiver goes to access the share, the backend code detects that the share is already expired and it deletes the share. That is all a bit silly.

This PR changes the meaning of the expiry so that "expire date 2019-12-20" means that the share expires at the end of "2019-12-20" - i.e. the moment that the date ticks over to "2019-12-21" then the share will get deleted.

That allows shares created with expire date "today" to work in a reasonable fashion.

And also maybe users will be happier that a share expiring on some future date will still work until the end of that day.

Edit: see https://github.com/owncloud/product/blob/master/modules/ROOT/examples/oc10/collaborators/expiration_date_for_collaborators.feature#L35 which specifies `WHEN the specified day has just ended` - that is the behaviour that this PR is implementing.

## Related Issue
- #36569 

## Motivation and Context
Adjust weird behaviour.

## How Has This Been Tested?
Local test runs of the acceptance test and unit tests that were changed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
