### PR TITLE
Cast path to string

### DIFF
--- a/changelog/unreleased/36610
+++ b/changelog/unreleased/36610
@@ -1,0 +1,7 @@
+Bugfix: Fix null for empty path on Oracle
+
+An empty path was fetched as null and not as an empty string. Due to 
+the strict comparison it caused the list of mounts for the existing fileId to be empty.
+So the higher level code relaying on the mounts list got an empty list and did nothing.
+
+https://github.com/owncloud/core/pull/36610

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -256,7 +256,7 @@ class UserMountCache implements IUserMountCache {
 			if (\is_array($row)) {
 				$this->cacheInfoCache[$fileId] = [
 					(int)$row['storage'],
-					$row['path']
+					(string)$row['path']
 				];
 			} else {
 				throw new NotFoundException('File with id "' . $fileId . '" not found');


### PR DESCRIPTION
## Description
it could be `null` under oracle and then `getMountsForFileId` returns an empty array after a deduplication.

## Motivation and Context
faulty logic 

## How Has This Been Tested?
1. not testable in the wild, spotted while investigating why a tag based retention doesn't work with OC 10.3.0 and Oracle (workflow app)
2. unit test.
3. or this snippet:
```
$someExistingFileId = 22;
$mountCache = \OC::$server->query('UserMountCache');
$mounts = $mountCache->getMountsForFileId($someExistingFileId);
var_dump($mounts);
``` 
##### expected
at least one item in this array
##### actual
empty array

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
