### PR TITLE
Adjusted Given-When steps in AppManagementContext

### DIFF
--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -153,7 +153,7 @@ class AppManagementContext implements Context {
 		$this->putAppInDir($appId, $version, $dir);
 		$check = SetupHelper::runOcc(['app:list', '--output json']);
 		$appsDisabled = \json_decode($check['stdOut'], true)['disabled'];
-		assert::assertTrue(
+		Assert::assertTrue(
 			\array_key_exists($appId, $appsDisabled),
 			'Expected: ' . $appId . 'to be present in apps(disabled) list, but not found'
 		);


### PR DESCRIPTION
## Description
Adjust all `Given` steps in `AppManagementContext` so that they do a "reasonable" check for succes!

## Related Issue
- Part of owncloud/QA#635

