### PR TITLE
Add limit and offset for callForAllUsers

### DIFF
--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -212,4 +212,18 @@ class AccountMapperTest extends TestCase {
 		$result = $this->mapper->findUserIds($backend, true, $limit, $offset);
 		$this->assertSame($expected, $result);
 	}
+
+	public function testCallForAllUsersLimit() {
+		// force to chunk by 3 users (1st should return 3, 2nd 1, 3rd 0)
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with($this->equalTo('accounts.call_for_all_users_limit'), $this->equalTo(1000))
+			->willReturn(3);
+
+		$count = 0;
+		$this->mapper->callForAllUsers(function (Account $account) use (&$count) {
+			$count++;
+		}, 'TestFind', false);
+		$this->assertEquals(4, $count);
+	}
 }


### PR DESCRIPTION
I think this was somehow lost during the refactor - https://github.com/owncloud/core/blob/f10d105ea2f2d0822693313ddcd6f9b2eaac6ebe/lib/private/User/Manager.php#L396-L419

Due to the problem with PHP PDO, even using `fetch`, query returns and caches result at the driver. This can be problematic with instances that have over 10k+ users