### PR TITLE
Adjust Given-When steps in BasicStructure context

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1607,7 +1607,6 @@ trait BasicStructure {
 
 	/**
 	 * @When the administrator creates file :path with content :content in local storage using the testing API
-	 * @Given the administrator has created file :path with content :content in local storage using the testing API
 	 *
 	 * @param string $path
 	 * @param string $content
@@ -1623,8 +1622,23 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @Given the administrator has created file :path with content :content in local storage using the testing API
+	 *
+	 * @param string $path
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasCreatedFileUsingTheTestingApi($path, $content) {
+		$this->theAdministratorHasCreatedFileWithContentInLocalStorageUsingTheTestingApi(
+			$path,
+			$content,
+			'local_storage'
+		);
+	}
+
+	/**
 	 * @When the administrator creates file :path with content :content in local storage :mountPoint using the testing API
-	 * @Given the administrator has created file :path with content :content in local storage :mountPount
 	 *
 	 * @param string $path
 	 * @param string $content
@@ -1649,9 +1663,27 @@ trait BasicStructure {
 			$this->getOcsApiVersion()
 		);
 		$this->setResponse($response);
-		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
+	/**
+	 * @Given the administrator has created file :path with content :content in local storage :mountPount
+	 *
+	 * @param string $path
+	 * @param string $content
+	 * @param string $mountPoint
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasCreatedFileWithContentInLocalStorageUsingTheTestingApi(
+		$path, $content, $mountPoint
+	) {
+		$this->theAdministratorCreatesFileWithContentInLocalStorageUsingTheTestingApi(
+			$path,
+			$content,
+			$mountPoint
+		);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+	}
 	/**
 	 * @When the administrator deletes file :path in local storage using the testing API
 	 *


### PR DESCRIPTION
## Description
Adjusted Given steps in `BasicStructure` context with addition of `reasonable checks` and When steps are separated.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/635

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 
- CI

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
