### PR TITLE
Reformat feature files

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,5 +1,6 @@
 @api @TestAlsoOnExternalUserBackend
 Feature: CORS headers
+
   Background:
     Given user "user0" has been created with default attributes and skeleton files
 
@@ -8,33 +9,33 @@ Feature: CORS headers
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has added "https://aphno.badal" to the list of personal CORS domains
     When user "user0" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
-      | header | value |
+      | header | value               |
       | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
     Then the following headers should be set
       | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
-      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
-      | Access-Control-Allow-Origin   | https://aphno.badal |
-      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     Examples:
-      | ocs_api_version |endpoint                                         | ocs-code | http-code |
-      | 1               |/apps/files_external/api/v1/mounts               | 100      | 200       |
-      | 2               |/apps/files_external/api/v1/mounts               | 200      | 200       |
-      | 1               |/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
-      | 1               |/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-      | 1               |/apps/files_sharing/api/v1/shares                | 100      | 200       |
-      | 2               |/apps/files_sharing/api/v1/shares                | 200      | 200       |
-      | 1               |/privatedata/getattribute                        | 100      | 200       |
-      | 2               |/privatedata/getattribute                        | 200      | 200       |
-      | 1               |/cloud/apps                                      | 997      | 401       |
-      | 2               |/cloud/apps                                      | 997      | 401       |
-      | 1               |/cloud/groups                                    | 997      | 401       |
-      | 2               |/cloud/groups                                    | 997      | 401       |
-      | 1               |/cloud/users                                     | 997      | 401       |
-      | 2               |/cloud/users                                     | 997      | 401       |
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
+      | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
+      | 2               | /apps/files_external/api/v1/mounts               | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
+      | 1               | /privatedata/getattribute                        | 100      | 200       |
+      | 2               | /privatedata/getattribute                        | 200      | 200       |
+      | 1               | /cloud/apps                                      | 997      | 401       |
+      | 2               | /cloud/apps                                      | 997      | 401       |
+      | 1               | /cloud/groups                                    | 997      | 401       |
+      | 2               | /cloud/groups                                    | 997      | 401       |
+      | 1               | /cloud/users                                     | 997      | 401       |
+      | 2               | /cloud/users                                     | 997      | 401       |
 
   #merge into previous scenario when fixed
   @issue-34664
@@ -42,7 +43,7 @@ Feature: CORS headers
     Given using OCS API version "<ocs_api_version>"
     And user "user0" has added "https://aphno.badal" to the list of personal CORS domains
     When user "user0" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
-      | header | value |
+      | header | value               |
       | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
@@ -52,9 +53,9 @@ Feature: CORS headers
       | Access-Control-Allow-Origin   |
       | Access-Control-Allow-Methods  |
     Examples:
-      | ocs_api_version |endpoint                                         | ocs-code | http-code |
-      | 1               |/config                                          | 100      | 200       |
-      | 2               |/config                                          | 200      | 200       |
+      | ocs_api_version | endpoint | ocs-code | http-code |
+      | 1               | /config  | 100      | 200       |
+      | 2               | /config  | 200      | 200       |
 
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
@@ -66,17 +67,17 @@ Feature: CORS headers
     And the HTTP status code should be "<http-code>"
     Then the following headers should be set
       | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
-      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
-      | Access-Control-Allow-Origin   | https://aphno.badal |
-      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     Examples:
-      | ocs_api_version |endpoint      | ocs-code | http-code |
-      | 1               |/cloud/apps   | 100      | 200       |
-      | 2               |/cloud/apps   | 200      | 200       |
-      | 1               |/cloud/groups | 100      | 200       |
-      | 2               |/cloud/groups | 200      | 200       |
-      | 1               |/cloud/users  | 100      | 200       |
-      | 2               |/cloud/users  | 200      | 200       |
+      | ocs_api_version | endpoint      | ocs-code | http-code |
+      | 1               | /cloud/apps   | 100      | 200       |
+      | 2               | /cloud/apps   | 200      | 200       |
+      | 1               | /cloud/groups | 100      | 200       |
+      | 2               | /cloud/groups | 200      | 200       |
+      | 1               | /cloud/users  | 100      | 200       |
+      | 2               | /cloud/users  | 200      | 200       |
 
   @files_sharing-app-required
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header
@@ -93,25 +94,25 @@ Feature: CORS headers
       | Access-Control-Allow-Origin   |
       | Access-Control-Allow-Methods  |
     Examples:
-      | ocs_api_version |endpoint                                         | ocs-code | http-code |
-      | 1               |/apps/files_external/api/v1/mounts               | 100      | 200       |
-      | 2               |/apps/files_external/api/v1/mounts               | 200      | 200       |
-      | 1               |/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
-      | 1               |/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-      | 1               |/apps/files_sharing/api/v1/shares                | 100      | 200       |
-      | 2               |/apps/files_sharing/api/v1/shares                | 200      | 200       |
-      | 1               |/config                                          | 100      | 200       |
-      | 2               |/config                                          | 200      | 200       |
-      | 1               |/privatedata/getattribute                        | 100      | 200       |
-      | 2               |/privatedata/getattribute                        | 200      | 200       |
-      | 1               |/cloud/apps                                      | 997      | 401       |
-      | 2               |/cloud/apps                                      | 997      | 401       |
-      | 1               |/cloud/groups                                    | 997      | 401       |
-      | 2               |/cloud/groups                                    | 997      | 401       |
-      | 1               |/cloud/users                                     | 997      | 401       |
-      | 2               |/cloud/users                                     | 997      | 401       |
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
+      | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
+      | 2               | /apps/files_external/api/v1/mounts               | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
+      | 1               | /config                                          | 100      | 200       |
+      | 2               | /config                                          | 200      | 200       |
+      | 1               | /privatedata/getattribute                        | 100      | 200       |
+      | 2               | /privatedata/getattribute                        | 200      | 200       |
+      | 1               | /cloud/apps                                      | 997      | 401       |
+      | 2               | /cloud/apps                                      | 997      | 401       |
+      | 1               | /cloud/groups                                    | 997      | 401       |
+      | 2               | /cloud/groups                                    | 997      | 401       |
+      | 1               | /cloud/users                                     | 997      | 401       |
+      | 2               | /cloud/users                                     | 997      | 401       |
 
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
@@ -127,13 +128,13 @@ Feature: CORS headers
       | Access-Control-Allow-Origin   |
       | Access-Control-Allow-Methods  |
     Examples:
-      | ocs_api_version |endpoint      | ocs-code | http-code |
-      | 1               |/cloud/apps   | 100      | 200       |
-      | 2               |/cloud/apps   | 200      | 200       |
-      | 1               |/cloud/groups | 100      | 200       |
-      | 2               |/cloud/groups | 200      | 200       |
-      | 1               |/cloud/users  | 100      | 200       |
-      | 2               |/cloud/users  | 200      | 200       |
+      | ocs_api_version | endpoint      | ocs-code | http-code |
+      | 1               | /cloud/apps   | 100      | 200       |
+      | 2               | /cloud/apps   | 200      | 200       |
+      | 1               | /cloud/groups | 100      | 200       |
+      | 2               | /cloud/groups | 200      | 200       |
+      | 1               | /cloud/users  | 100      | 200       |
+      | 2               | /cloud/users  | 200      | 200       |
 
   @issue-34679 @files_sharing-app-required
   Scenario Outline: CORS headers should be returned when invalid password is used
@@ -155,23 +156,23 @@ Feature: CORS headers
     #  | Access-Control-Allow-Origin   | https://aphno.badal |
     #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
     Examples:
-      | ocs_api_version |endpoint                                         | ocs-code | http-code |
-      | 1               |/apps/files_external/api/v1/mounts               | 997      | 401       |
-      | 2               |/apps/files_external/api/v1/mounts               | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
-      | 1               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
-      | 2               |/apps/files_sharing/api/v1/shares                | 997      | 401       |
-      | 1               |/privatedata/getattribute                        | 997      | 401       |
-      | 2               |/privatedata/getattribute                        | 997      | 401       |
-      | 1               |/cloud/apps                                      | 997      | 401       |
-      | 2               |/cloud/apps                                      | 997      | 401       |
-      | 1               |/cloud/groups                                    | 997      | 401       |
-      | 2               |/cloud/groups                                    | 997      | 401       |
-      | 1               |/cloud/users                                     | 997      | 401       |
-      | 2               |/cloud/users                                     | 997      | 401       |
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
+      | 1               | /apps/files_external/api/v1/mounts               | 997      | 401       |
+      | 2               | /apps/files_external/api/v1/mounts               | 997      | 401       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
+      | 1               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 2               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 1               | /privatedata/getattribute                        | 997      | 401       |
+      | 2               | /privatedata/getattribute                        | 997      | 401       |
+      | 1               | /cloud/apps                                      | 997      | 401       |
+      | 2               | /cloud/apps                                      | 997      | 401       |
+      | 1               | /cloud/groups                                    | 997      | 401       |
+      | 2               | /cloud/groups                                    | 997      | 401       |
+      | 1               | /cloud/users                                     | 997      | 401       |
+      | 2               | /cloud/users                                     | 997      | 401       |
 
   @issue-34679
   Scenario Outline: CORS headers should be returned when invalid password is used (admin only endpoints)
@@ -193,10 +194,10 @@ Feature: CORS headers
     #  | Access-Control-Allow-Origin   | https://aphno.badal |
     #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
     Examples:
-      | ocs_api_version |endpoint      | ocs-code | http-code |
-      | 1               |/cloud/apps   | 997      | 401       |
-      | 2               |/cloud/apps   | 997      | 401       |
-      | 1               |/cloud/groups | 997      | 401       |
-      | 2               |/cloud/groups | 997      | 401       |
-      | 1               |/cloud/users  | 997      | 401       |
-      | 2               |/cloud/users  | 997      | 401       |
+      | ocs_api_version | endpoint      | ocs-code | http-code |
+      | 1               | /cloud/apps   | 997      | 401       |
+      | 2               | /cloud/apps   | 997      | 401       |
+      | 1               | /cloud/groups | 997      | 401       |
+      | 2               | /cloud/groups | 997      | 401       |
+      | 1               | /cloud/users  | 997      | 401       |
+      | 2               | /cloud/users  | 997      | 401       |

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -1,5 +1,6 @@
 @api @TestAlsoOnExternalUserBackend @files_sharing-app-required
 Feature: auth
+
   Background:
     Given user "user0" has been created with default attributes and skeleton files
 
@@ -29,25 +30,25 @@ Feature: auth
   @issue-32068
   Scenario: using OCS with non-admin basic auth
     When the user "user0" requests these endpoints with "GET" with basic auth then the status codes should be as listed
-      |endpoint                                                    | ocs-code | http-code |
-      |/ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
-      |/ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
-      |/ocs/v1.php/cloud/apps                                      | 997      | 401       |
-      |/ocs/v2.php/cloud/apps                                      | 997      | 401       |
-      |/ocs/v1.php/cloud/groups                                    | 997      | 401       |
-      |/ocs/v2.php/cloud/groups                                    | 997      | 401       |
-      |/ocs/v1.php/cloud/users                                     | 997      | 401       |
-      |/ocs/v2.php/cloud/users                                     | 997      | 401       |
-      |/ocs/v1.php/config                                          | 100      | 200       |
-      |/ocs/v2.php/config                                          | 200      | 200       |
-      |/ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
-      |/ocs/v2.php/privatedata/getattribute                        | 200      | 200       |
+      | endpoint                                                    | ocs-code | http-code |
+      | /ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
+      | /ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
+      | /ocs/v1.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v2.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v1.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v2.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v1.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v2.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v1.php/config                                          | 100      | 200       |
+      | /ocs/v2.php/config                                          | 200      | 200       |
+      | /ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
+      | /ocs/v2.php/privatedata/getattribute                        | 200      | 200       |
 
   @issue-32068
   Scenario: using OCS as normal user with wrong password
@@ -74,13 +75,13 @@ Feature: auth
 
   Scenario:using OCS with admin basic auth
     When the administrator requests these endpoint with "GET" then the status codes should be as listed
-      |endpoint                                                    | ocs-code | http-code |
-      |/ocs/v1.php/cloud/apps                                      | 100      | 200       |
-      |/ocs/v2.php/cloud/apps                                      | 200      | 200       |
-      |/ocs/v1.php/cloud/groups                                    | 100      | 200       |
-      |/ocs/v2.php/cloud/groups                                    | 200      | 200       |
-      |/ocs/v1.php/cloud/users                                     | 100      | 200       |
-      |/ocs/v2.php/cloud/users                                     | 200      | 200       |
+      | endpoint                 | ocs-code | http-code |
+      | /ocs/v1.php/cloud/apps   | 100      | 200       |
+      | /ocs/v2.php/cloud/apps   | 200      | 200       |
+      | /ocs/v1.php/cloud/groups | 100      | 200       |
+      | /ocs/v2.php/cloud/groups | 200      | 200       |
+      | /ocs/v1.php/cloud/users  | 100      | 200       |
+      | /ocs/v2.php/cloud/users  | 200      | 200       |
 
   Scenario: using OCS as admin user with wrong password
     When the administrator requests these endpoints with "GET" using password "invalid" then the status codes should be as listed
@@ -107,69 +108,69 @@ Feature: auth
   Scenario: using OCS with token auth of a normal user
     Given a new client token for "user0" has been generated
     When user "user0" requests these endpoints with "GET" using basic token auth then the status codes should be as listed
-      |endpoint                                                    | ocs-code | http-code |
-      |/ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
-      |/ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
-      |/ocs/v1.php/cloud/apps                                      | 997      | 401       |
-      |/ocs/v2.php/cloud/apps                                      | 997      | 401       |
-      |/ocs/v1.php/cloud/groups                                    | 997      | 401       |
-      |/ocs/v2.php/cloud/groups                                    | 997      | 401       |
-      |/ocs/v1.php/cloud/users                                     | 997      | 401       |
-      |/ocs/v2.php/cloud/users                                     | 997      | 401       |
-      |/ocs/v1.php/config                                          | 100      | 200       |
-      |/ocs/v2.php/config                                          | 200      | 200       |
-      |/ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
-      |/ocs/v2.php/privatedata/getattribute                        | 200      | 200       |
+      | endpoint                                                    | ocs-code | http-code |
+      | /ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
+      | /ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
+      | /ocs/v1.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v2.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v1.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v2.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v1.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v2.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v1.php/config                                          | 100      | 200       |
+      | /ocs/v2.php/config                                          | 200      | 200       |
+      | /ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
+      | /ocs/v2.php/privatedata/getattribute                        | 200      | 200       |
 
-    Scenario: using OCS with browser session of normal user
-      Given a new browser session for "user0" has been started
-      When the user requests these endpoints with "GET" using a new browser session then the status codes should be as listed
-        |endpoint                                                    | ocs-code | http-code |
-        |/ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
-        |/ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
-        |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
-        |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
-        |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
-        |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-        |/ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
-        |/ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
-        |/ocs/v1.php/cloud/apps                                      | 997      | 401       |
-        |/ocs/v2.php/cloud/apps                                      | 997      | 401       |
-        |/ocs/v1.php/cloud/groups                                    | 997      | 401       |
-        |/ocs/v2.php/cloud/groups                                    | 997      | 401       |
-        |/ocs/v1.php/cloud/users                                     | 997      | 401       |
-        |/ocs/v2.php/cloud/users                                     | 997      | 401       |
-        |/ocs/v1.php/config                                          | 100      | 200       |
-        |/ocs/v2.php/config                                          | 200      | 200       |
-        |/ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
-        |/ocs/v2.php/privatedata/getattribute                        | 200      | 200       |
+  Scenario: using OCS with browser session of normal user
+    Given a new browser session for "user0" has been started
+    When the user requests these endpoints with "GET" using a new browser session then the status codes should be as listed
+      | endpoint                                                    | ocs-code | http-code |
+      | /ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
+      | /ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
+      | /ocs/v1.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v2.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v1.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v2.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v1.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v2.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v1.php/config                                          | 100      | 200       |
+      | /ocs/v2.php/config                                          | 200      | 200       |
+      | /ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
+      | /ocs/v2.php/privatedata/getattribute                        | 200      | 200       |
 
   Scenario: using OCS with an app password of a normal user
     Given a new browser session for "user0" has been started
     And the user has generated a new app password named "my-client"
     When the user requests these endpoints with "GET" using the generated app password then the status codes should be as listed
-      |endpoint                                                    | ocs-code | http-code |
-      |/ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
-      |/ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-      |/ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
-      |/ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
-      |/ocs/v1.php/cloud/apps                                      | 997      | 401       |
-      |/ocs/v2.php/cloud/apps                                      | 997      | 401       |
-      |/ocs/v1.php/cloud/groups                                    | 997      | 401       |
-      |/ocs/v2.php/cloud/groups                                    | 997      | 401       |
-      |/ocs/v1.php/cloud/users                                     | 997      | 401       |
-      |/ocs/v2.php/cloud/users                                     | 997      | 401       |
-      |/ocs/v1.php/config                                          | 100      | 200       |
-      |/ocs/v2.php/config                                          | 200      | 200       |
-      |/ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
-      |/ocs/v2.php/privatedata/getattribute                        | 200      | 200       |
+      | endpoint                                                    | ocs-code | http-code |
+      | /ocs/v1.php/apps/files_external/api/v1/mounts               | 100      | 200       |
+      | /ocs/v2.php/apps/files_external/api/v1/mounts               | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                | 100      | 200       |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                | 200      | 200       |
+      | /ocs/v1.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v2.php/cloud/apps                                      | 997      | 401       |
+      | /ocs/v1.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v2.php/cloud/groups                                    | 997      | 401       |
+      | /ocs/v1.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v2.php/cloud/users                                     | 997      | 401       |
+      | /ocs/v1.php/config                                          | 100      | 200       |
+      | /ocs/v2.php/config                                          | 200      | 200       |
+      | /ocs/v1.php/privatedata/getattribute                        | 100      | 200       |
+      | /ocs/v2.php/privatedata/getattribute                        | 200      | 200       |

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -5,27 +5,27 @@ Feature: auth
     Given user "user0" has been created with default attributes and skeleton files
 
   Scenario: send POST requests to OCS endpoints as normal user with wrong password
-      When user "user0" requests these endpoints with "POST" including body using password "invalid" then the status codes should be as listed
-       | endpoint                                                        | ocs-code | http-code | body          |
-       | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/apps/files_sharing/api/v1/shares                    | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/apps/files_sharing/api/v1/shares                    | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/cloud/apps/testing                                  | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/cloud/apps/testing                                  | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/cloud/groups                                        | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/cloud/groups                                        | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/cloud/users                                         | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/cloud/users                                         | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/cloud/users/user0/groups                            | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/cloud/users/user0/groups                            | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/cloud/users/user0/subadmins                         | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/cloud/users/user0/subadmins                         | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/person/check                                        | 101      | 200       | doesnotmatter |
-       | /ocs/v2.php/person/check                                        | 400      | 400       | doesnotmatter |
-       | /ocs/v1.php/privatedata/deleteattribute/testing/test            | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/privatedata/deleteattribute/testing/test            | 997      | 401       | doesnotmatter |
-       | /ocs/v1.php/privatedata/setattribute/testing/test               | 997      | 401       | doesnotmatter |
-       | /ocs/v2.php/privatedata/setattribute/testing/test               | 997      | 401       | doesnotmatter |
+    When user "user0" requests these endpoints with "POST" including body using password "invalid" then the status codes should be as listed
+      | endpoint                                                        | ocs-code | http-code | body          |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                    | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                    | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares/pending/123        | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/cloud/apps/testing                                  | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/apps/testing                                  | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/cloud/groups                                        | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/groups                                        | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/cloud/users                                         | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/users                                         | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/cloud/users/user0/groups                            | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/users/user0/groups                            | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/cloud/users/user0/subadmins                         | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/users/user0/subadmins                         | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/person/check                                        | 101      | 200       | doesnotmatter |
+      | /ocs/v2.php/person/check                                        | 400      | 400       | doesnotmatter |
+      | /ocs/v1.php/privatedata/deleteattribute/testing/test            | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/privatedata/deleteattribute/testing/test            | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/privatedata/setattribute/testing/test               | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/privatedata/setattribute/testing/test               | 997      | 401       | doesnotmatter |

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -1,14 +1,14 @@
 @api @TestAlsoOnExternalUserBackend @files_sharing-app-required
 Feature: auth
 
-    Scenario: send PUT request to OCS endpoints as admin with wrong password
-      When the administrator requests these endpoints with "PUT" with body using password "invalid" then the status codes should be as listed
-        | endpoint                                         | ocs-code | http-code | body          |
-        | /ocs/v1.php/cloud/users/user0                    | 997      | 401       | doesnotmatter |
-        | /ocs/v2.php/cloud/users/user0                    | 997      | 401       | doesnotmatter |
-        | /ocs/v1.php/cloud/users/user0/disable            | 997      | 401       | doesnotmatter |
-        | /ocs/v2.php/cloud/users/user0/disable            | 997      | 401       | doesnotmatter |
-        | /ocs/v1.php/cloud/users/user0/enable             | 997      | 401       | doesnotmatter |
-        | /ocs/v2.php/cloud/users/user0/enable             | 997      | 401       | doesnotmatter |
-        | /ocs/v1.php/apps/files_sharing/api/v1/shares/123 | 997      | 401       | doesnotmatter |
-        | /ocs/v2.php/apps/files_sharing/api/v1/shares/123 | 997      | 401       | doesnotmatter |
+  Scenario: send PUT request to OCS endpoints as admin with wrong password
+    When the administrator requests these endpoints with "PUT" with body using password "invalid" then the status codes should be as listed
+      | endpoint                                         | ocs-code | http-code | body          |
+      | /ocs/v1.php/cloud/users/user0                    | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/users/user0                    | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/cloud/users/user0/disable            | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/users/user0/disable            | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/cloud/users/user0/enable             | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/cloud/users/user0/enable             | 997      | 401       | doesnotmatter |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares/123 | 997      | 401       | doesnotmatter |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares/123 | 997      | 401       | doesnotmatter |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -74,7 +74,7 @@ Feature: get file info using PROPFIND
     And a new browser session for "user0" has been started
     And the user has generated a new app password named "my-client"
     When the user "user0" requests these endpoints with "PROPFIND" using the basic auth and generated app password then the status codes should be as listed
-      | endpoint                                      | http-code | body          |
+      | endpoint                                      | http-code | body                                                                                                                           |
       | /remote.php/dav/files/user0/textfile0.txt     | 207       | <?xml version="1.0"?><d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:prop><d:getetag /></d:prop></d:propfind> |
       | /remote.php/dav/files/user0/PARENT            | 207       | <?xml version="1.0"?><d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:prop><d:getetag /></d:prop></d:propfind> |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 207       | <?xml version="1.0"?><d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:prop><d:getetag /></d:prop></d:propfind> |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -74,7 +74,7 @@ Feature: PROPPATCH file/folder
     And a new browser session for "user0" has been started
     And the user has generated a new app password named "my-client"
     When the user "user0" requests these endpoints with "PROPPATCH" using the basic auth and generated app password then the status codes should be as listed
-      | endpoint                                      | http-code | body                                                                                                                  |
+      | endpoint                                      | http-code | body                                                                                                                                                                                                      |
       | /remote.php/webdav/textfile0.txt              | 207       | <?xml version="1.0"?><d:propertyupdate xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:set><d:prop><oc:favorite xmlns:oc="http://owncloud.org/ns">1</oc:favorite></d:prop></d:set></d:propertyupdate> |
       | /remote.php/dav/files/user0/textfile1.txt     | 207       | <?xml version="1.0"?><d:propertyupdate xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:set><d:prop><oc:favorite xmlns:oc="http://owncloud.org/ns">1</oc:favorite></d:prop></d:set></d:propertyupdate> |
       | /remote.php/dav/files/user0/PARENT/parent.txt | 207       | <?xml version="1.0"?><d:propertyupdate xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:set><d:prop><oc:favorite xmlns:oc="http://owncloud.org/ns">1</oc:favorite></d:prop></d:set></d:propertyupdate> |

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -162,7 +162,7 @@ Feature: capabilities
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
-      | capability    | path_to_element               | value |
+      | capability    | path_to_element                | value |
       | files_sharing | group@@@expire_date@@@enabled  | 1     |
       | files_sharing | group@@@expire_date@@@days     | 7     |
       | files_sharing | group@@@expire_date@@@enforced | 1     |

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -283,7 +283,7 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "user1" should not see the following elements
-      | /textfile0%20(2).txt      |
+      | /textfile0%20(2).txt |
     When user "user1" gets the list of federated cloud shares using the sharing API
     Then the response should contain 0 entries
     When user "user1" gets the list of pending federated cloud shares using the sharing API
@@ -302,7 +302,7 @@ Feature: federated
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "user1" should see the following elements
-      | /textfile0%20(2).txt      |
+      | /textfile0%20(2).txt |
     When user "user1" gets the list of federated cloud shares using the sharing API
     Then the fields of the last response should include
       | id          | A_NUMBER                 |
@@ -330,7 +330,7 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "user1" should not see the following elements
-      | /textfile0%20(2).txt      |
+      | /textfile0%20(2).txt |
     When user "user1" gets the list of federated cloud shares using the sharing API
     Then the response should contain 0 entries
     When user "user1" gets the list of pending federated cloud shares using the sharing API
@@ -348,7 +348,7 @@ Feature: federated
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "user1" should not see the following elements
-      | /textfile0%20(2).txt      |
+      | /textfile0%20(2).txt |
     When user "user1" gets the list of pending federated cloud shares using the sharing API
     Then the fields of the last response should include
       | id          | A_NUMBER                                   |

--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -15,8 +15,8 @@ Feature: AppManagement
 
   Scenario: Three app instances, including apps-external, exist. The first one is more recent
     Given these apps' path has been configured additionally with following attributes:
-      | dir           | is_writable  |
-      | apps-custom   | true         |
+      | dir         | is_writable |
+      | apps-custom | true        |
     And app "multidirtest" with version "1.0.2" has been put in dir "apps"
     And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
     And app "multidirtest" with version "1.0.0" has been put in dir "apps-custom"
@@ -25,8 +25,8 @@ Feature: AppManagement
 
   Scenario: Three app instances, including apps-external, exist. The second one is more recent
     Given these apps' path has been configured additionally with following attributes:
-      | dir           | is_writable  |
-      | apps-custom   | true         |
+      | dir         | is_writable |
+      | apps-custom | true        |
     And app "multidirtest" with version "1.0.2" has been put in dir "apps"
     And app "multidirtest" with version "1.0.10" has been put in dir "apps-external"
     And app "multidirtest" with version "1.0.0" has been put in dir "apps-custom"
@@ -35,8 +35,8 @@ Feature: AppManagement
 
   Scenario: Three app instances, including apps-external, exist. The third one is more recent
     Given these apps' path has been configured additionally with following attributes:
-      | dir           | is_writable  |
-      | apps-custom   | true         |
+      | dir         | is_writable |
+      | apps-custom | true        |
     And app "multidirtest" with version "1.0.2" has been put in dir "apps"
     And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
     And app "multidirtest" with version "1.0.10" has been put in dir "apps-custom"
@@ -45,8 +45,8 @@ Feature: AppManagement
 
   Scenario: Update of patch version of an app
     Given these apps' path has been configured additionally with following attributes:
-      | dir           | is_writable  |
-      | apps-custom   | true         |
+      | dir         | is_writable |
+      | apps-custom | true        |
     And app "updatetest" with version "2.0.0" has been put in dir "apps"
     And app "updatetest" has been enabled
     And app "updatetest" has been disabled
@@ -56,8 +56,8 @@ Feature: AppManagement
 
   Scenario: Update of patch version of an app in apps-external, previous version in apps folder
     Given these apps' path has been configured additionally with following attributes:
-      | dir           | is_writable  |
-      | apps-custom   | true         |
+      | dir         | is_writable |
+      | apps-custom | true        |
     And app "updatetest" with version "2.0.0" has been put in dir "apps"
     And app "updatetest" has been enabled
     And app "updatetest" has been disabled
@@ -67,8 +67,8 @@ Feature: AppManagement
 
   Scenario: Update of patch version of an app in apps-external
     Given these apps' path has been configured additionally with following attributes:
-      | dir           | is_writable  |
-      | apps-custom   | true         |
+      | dir         | is_writable |
+      | apps-custom | true        |
     And app "updatetest" with version "2.0.0" has been put in dir "apps-external"
     And app "updatetest" has been enabled
     And app "updatetest" has been disabled
@@ -89,8 +89,8 @@ Feature: AppManagement
 
   Scenario: Update of patch version of an app previously in apps-external but update is put in alternative folder
     Given these apps' path has been configured additionally with following attributes:
-      | dir           | is_writable  |
-      | apps-custom   | true         |
+      | dir         | is_writable |
+      | apps-custom | true        |
     And app "updatetest" with version "2.0.0" has been put in dir "apps-external"
     And app "updatetest" has been enabled
     And app "updatetest" has been disabled

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -78,12 +78,12 @@ Feature: add user
     And user "BrAnD-nEw-UsEr" should exist
     And the display name of user "brand-new-user" should be "<display-name>"
     Examples:
-      |  display-name   |
-      | Brand-New-User  |
-      | BRAND-NEW-USER  |
-      | brand-new-user  |
-      | brand-NEW-user  |
-      | BrAnD-nEw-UsEr  |
+      | display-name   |
+      | Brand-New-User |
+      | BRAND-NEW-USER |
+      | brand-new-user |
+      | brand-NEW-user |
+      | BrAnD-nEw-UsEr |
 
   Scenario: admin tries to create an existing user but with username containing capital letters
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -82,8 +82,8 @@ Feature: edit users
       | displayname | <display-name> |
     And the display name of user "brand-new-user" should be "<display-name>"
     Examples:
-      | display-name   |
-      | Alan Border    |
+      | display-name    |
+      | Alan Border     |
       | Phil Cyclist 🚴 |
 
   Scenario: a normal user should not be able to change their quota

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -41,9 +41,9 @@ Feature: get subadmins
 
   Scenario: normal user tries to get the subadmins of the group
     Given these users have been created with default attributes and skeleton files:
-      | username    |
-      | subadmin    |
-      | newuser     |
+      | username |
+      | subadmin |
+      | newuser  |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "newuser" gets all the subadmins of group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -34,7 +34,7 @@ Feature: remove subadmin
     Given these users have been created with default attributes and skeleton files:
       | username |
       | subadmin |
-      | newuser |
+      | newuser  |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newuser" has been added to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -83,8 +83,8 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
     Examples:
-      | password        | comment  |
-      | 😛 😜           | smileys  |
-      | 🐶🐱 🐭           | Animals  |
-      | ⌚️ 📱 📲 💻           | objects  |
-      | 🚴🏿‍♀️ 🚴‍♂️            | cycling |
+      | password      | comment |
+      | 😛 😜         | smileys |
+      | 🐶🐱 🐭       | Animals |
+      | ⌚️ 📱 📲 💻   | objects |
+      | 🚴🏿‍♀️ 🚴‍♂️ | cycling |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -78,12 +78,12 @@ Feature: add user
     And user "BrAnD-nEw-UsEr" should exist
     And the display name of user "brand-new-user" should be "<display-name>"
     Examples:
-      |  display-name   |
-      | Brand-New-User  |
-      | BRAND-NEW-USER  |
-      | brand-new-user  |
-      | brand-NEW-user  |
-      | BrAnD-nEw-UsEr  |
+      | display-name   |
+      | Brand-New-User |
+      | BRAND-NEW-USER |
+      | brand-new-user |
+      | brand-NEW-user |
+      | BrAnD-nEw-UsEr |
 
   Scenario: admin tries to create an existing user but with username containing capital letters
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -82,8 +82,8 @@ Feature: edit users
       | displayname | <display-name> |
     And the display name of user "brand-new-user" should be "<display-name>"
     Examples:
-      | display-name   |
-      | Alan Border    |
+      | display-name    |
+      | Alan Border     |
       | Phil Cyclist 🚴 |
 
   Scenario: a normal user should not be able to change their quota

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -44,9 +44,9 @@ Feature: get subadmins
   @issue-31276
   Scenario: normal user tries to get the subadmins of the group
     Given these users have been created with default attributes and skeleton files:
-      | username    |
-      | subadmin    |
-      | newuser     |
+      | username |
+      | subadmin |
+      | newuser  |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "newuser" gets all the subadmins of group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -37,7 +37,7 @@ Feature: remove subadmin
     Given these users have been created with default attributes and skeleton files:
       | username |
       | subadmin |
-      | newuser |
+      | newuser  |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     And user "newuser" has been added to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -83,8 +83,8 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
     Examples:
-      | password        | comment  |
-      | 😛 😜           | smileys  |
-      | 🐶🐱 🐭           | Animals  |
-      | ⌚️ 📱 📲 💻           | objects  |
-      | 🚴🏿‍♀️ 🚴‍♂️            | cycling |
+      | password      | comment |
+      | 😛 😜         | smileys |
+      | 🐶🐱 🐭       | Animals |
+      | ⌚️ 📱 📲 💻   | objects |
+      | 🚴🏿‍♀️ 🚴‍♂️ | cycling |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -14,10 +14,10 @@ Feature: add groups
     And the HTTP status code should be "200"
     And group "<group_id>" should exist
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: admin creates a group
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -15,10 +15,10 @@ Feature: add users to group
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -15,10 +15,10 @@ Feature: delete groups
     And the HTTP status code should be "200"
     And group "<group_id>" should not exist
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: admin deletes a group
     Given group "<group_id>" has been created
@@ -57,7 +57,7 @@ Feature: delete groups
     But group "<group_id2>" should exist
     And group "<group_id3>" should exist
     Examples:
-      | group_id1            | group_id2            | group_id3 |
+      | group_id1            | group_id2            | group_id3            |
       | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -17,7 +17,7 @@ Feature: get subadmin groups
     When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
     Then the subadmin groups returned by the API should be
       | new-group |
-      | 😅 😆      |
+      | 😅 😆     |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -29,7 +29,7 @@ Feature: get user groups
       | 0                    |
       | Admin & Finance (NP) |
       | admin:Pokhara@Nepal  |
-      | नेपाली                 |
+      | नेपाली               |
       | 😅 😆                |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -17,10 +17,10 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: admin removes a user from a group
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -14,10 +14,10 @@ Feature: add groups
     And the HTTP status code should be "200"
     And group "<group_id>" should exist
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: admin creates a group
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -15,10 +15,10 @@ Feature: add users to group
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: adding a user to a group
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -15,10 +15,10 @@ Feature: delete groups
     And the HTTP status code should be "200"
     And group "<group_id>" should not exist
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: admin deletes a group
     Given group "<group_id>" has been created
@@ -57,7 +57,7 @@ Feature: delete groups
     But group "<group_id2>" should exist
     And group "<group_id3>" should exist
     Examples:
-      | group_id1            | group_id2            | group_id3 |
+      | group_id1            | group_id2            | group_id3            |
       | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -17,7 +17,7 @@ Feature: get subadmin groups
     When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
     Then the subadmin groups returned by the API should be
       | new-group |
-      | 😅 😆      |
+      | 😅 😆     |
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -17,12 +17,12 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
-   Scenario Outline: admin removes a user from a group
+  Scenario Outline: admin removes a user from a group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -579,12 +579,12 @@ Feature: accept/decline shares coming from internal users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should see the following elements
-      | /FOLDER/                 |
-      | /PARENT/                 |
-      | /PARENT%20(2)/           |
-      | /PARENT%20(2)/abc.txt    |
-      | /FOLDER%20(2)/           |
-      | /FOLDER%20(2)/abc.txt    |
+      | /FOLDER/              |
+      | /PARENT/              |
+      | /PARENT%20(2)/        |
+      | /PARENT%20(2)/abc.txt |
+      | /FOLDER%20(2)/        |
+      | /FOLDER%20(2)/abc.txt |
     And user "user1" should not see the following elements
       | /FOLDER/abc.txt |
       | /PARENT/abc.txt |
@@ -599,22 +599,22 @@ Feature: accept/decline shares coming from internal users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should see the following elements
-      | /FOLDER/                 |
-      | /PARENT/                 |
-      | /PARENT%20(2)/           |
-      | /FOLDER%20(2)/           |
-      | /PARENT%20(2)/abc.txt    |
-      | /FOLDER%20(2)/abc.txt    |
+      | /FOLDER/              |
+      | /PARENT/              |
+      | /PARENT%20(2)/        |
+      | /FOLDER%20(2)/        |
+      | /PARENT%20(2)/abc.txt |
+      | /FOLDER%20(2)/abc.txt |
     And user "user1" should not see the following elements
       | /FOLDER/abc.txt |
       | /PARENT/abc.txt |
     And user "user2" should see the following elements
-      | /FOLDER/                 |
-      | /PARENT/                 |
-      | /PARENT%20(2)/           |
-      | /FOLDER%20(2)/           |
-      | /PARENT%20(2)/abc.txt    |
-      | /FOLDER%20(2)/abc.txt    |
+      | /FOLDER/              |
+      | /PARENT/              |
+      | /PARENT%20(2)/        |
+      | /FOLDER%20(2)/        |
+      | /PARENT%20(2)/abc.txt |
+      | /FOLDER%20(2)/abc.txt |
     And user "user2" should not see the following elements
       | /FOLDER/abc.txt |
       | /PARENT/abc.txt |
@@ -629,15 +629,15 @@ Feature: accept/decline shares coming from internal users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should see the following elements
-      | /textfile0.txt                 |
-      | /textfile1.txt                 |
-      | /textfile0%20(2).txt           |
-      | /textfile1%20(2).txt           |
+      | /textfile0.txt       |
+      | /textfile1.txt       |
+      | /textfile0%20(2).txt |
+      | /textfile1%20(2).txt |
     And user "user2" should see the following elements
-      | /textfile0.txt                 |
-      | /textfile1.txt                 |
-      | /textfile0%20(2).txt           |
-      | /textfile1%20(2).txt           |
+      | /textfile0.txt       |
+      | /textfile1.txt       |
+      | /textfile0%20(2).txt |
+      | /textfile1%20(2).txt |
 
   Scenario: user shares resource with matching resource-name with another user when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -646,18 +646,18 @@ Feature: accept/decline shares coming from internal users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should see the following elements
-      | /PARENT/                 |
-      | /textfile0.txt           |
+      | /PARENT/       |
+      | /textfile0.txt |
     But user "user1" should not see the following elements
-      | /textfile0%20(2).txt     |
-      | /PARENT%20(2)/           |
+      | /textfile0%20(2).txt |
+      | /PARENT%20(2)/       |
     When user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
     And user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
     Then user "user1" should see the following elements
-      | /PARENT/                 |
-      | /textfile0.txt           |
-      | /PARENT%20(2)/           |
-      | /textfile0%20(2).txt     |
+      | /PARENT/             |
+      | /textfile0.txt       |
+      | /PARENT%20(2)/       |
+      | /textfile0%20(2).txt |
 
   Scenario: user shares file in a group with matching filename when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -665,37 +665,37 @@ Feature: accept/decline shares coming from internal users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "user1" should see the following elements
-      | /textfile0.txt                 |
+      | /textfile0.txt |
     But user "user1" should not see the following elements
-      | /textfile0%20(2).txt           |
+      | /textfile0%20(2).txt |
     And user "user2" should see the following elements
-      | /textfile0.txt                 |
+      | /textfile0.txt |
     But user "user2" should not see the following elements
-      | /textfile0%20(2).txt           |
+      | /textfile0%20(2).txt |
     When user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
     Then user "user1" should see the following elements
-      | /textfile0.txt                 |
-      | /textfile0%20(2).txt           |
+      | /textfile0.txt       |
+      | /textfile0%20(2).txt |
     When user "user2" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
     Then user "user2" should see the following elements
-      | /textfile0.txt                 |
-      | /textfile0%20(2).txt           |
+      | /textfile0.txt       |
+      | /textfile0%20(2).txt |
 
   @skipOnLDAP
   Scenario: user shares folder with matching folder name a user before that user has logged in
     Given these users have been created with skeleton files but not initialized:
-      | username     |
-      | user3        |
+      | username |
+      | user3    |
     And user "user0" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API
     When user "user0" shares folder "/PARENT" with user "user3" using the sharing API
     Then user "user3" should see the following elements
-      | /PARENT/          |
-      | /PARENT/abc.txt   |
-      | /FOLDER/          |
-      | /textfile0.txt    |
-      | /textfile1.txt    |
-      | /textfile2.txt    |
-      | /textfile3.txt    |
+      | /PARENT/        |
+      | /PARENT/abc.txt |
+      | /FOLDER/        |
+      | /textfile0.txt  |
+      | /textfile1.txt  |
+      | /textfile2.txt  |
+      | /textfile3.txt  |
     And user "user3" should not see the following elements
-      | /PARENT%20(2)/    |
+      | /PARENT%20(2)/ |
     And the content of file "/PARENT/abc.txt" for user "user3" should be "uploaded content"

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -6,7 +6,7 @@ Feature: sharing
     And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
-  @skipOnEncryptionType:user-keys @issue-32322
+    @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -91,9 +91,9 @@ Feature: sharing
     And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
     And user "user0" has moved file "textfile0.txt" to "FOLDER/textfile0.txt"
     And user "user0" has created a public link share with settings
-      | path        | /FOLDER         |
-      | permissions | change          |
-      | password    | testpass1       |
+      | path        | /FOLDER   |
+      | permissions | change    |
+      | password    | testpass1 |
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "404"
     When the public accesses the preview of file "textfile0.txt" from the last shared public link using the sharing API
@@ -105,8 +105,8 @@ Feature: sharing
     And user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
     And user "user0" has moved file "textfile0.txt" to "FOLDER/textfile0.txt"
     And user "user0" has created a public link share with settings
-      | path        | /FOLDER         |
-      | permissions | change          |
+      | path        | /FOLDER |
+      | permissions | change  |
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "200"
     When the public accesses the preview of file "textfile0.txt" from the last shared public link using the sharing API

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -228,10 +228,10 @@ Feature: sharing
     And user "user1" has been added to group "grp1"
     And user "user0" has created folder "/tmp"
     And user "user0" has created a share with settings
-      | path        | tmp                        |
-      | shareType   | group                      |
-      | shareWith   | grp1                       |
-      | permissions | share,create,update,read   |
+      | path        | tmp                      |
+      | shareType   | group                    |
+      | shareWith   | grp1                     |
+      | permissions | share,create,update,read |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "23"

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -36,7 +36,7 @@ Feature: sharing
     And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
   @public_link_share-feature-required
-  @issue-36055
+    @issue-36055
   Scenario Outline: Uploading file to a public upload-only share that was deleted does not work
     Given using <dav-path> DAV path
     And user "user0" has created a public link share with settings

--- a/tests/acceptance/features/apiShareReshare/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare/reShare.feature
@@ -733,11 +733,11 @@ Feature: sharing
     And the response when user "user3" gets the info of the last share should include
       | expiration | +20 days |
     Examples:
-      | ocs_api_version | default-expire-date | enforce-expire-date | ocs_status_code  |
-      | 1               | yes                 | yes                 | 100              |
-      | 2               | yes                 | yes                 | 200              |
-      | 1               | no                  | yes                 | 100              |
-      | 2               | no                  | yes                 | 200              |
+      | ocs_api_version | default-expire-date | enforce-expire-date | ocs_status_code |
+      | 1               | yes                 | yes                 | 100             |
+      | 2               | yes                 | yes                 | 200             |
+      | 1               | no                  | yes                 | 100             |
+      | 2               | no                  | yes                 | 200             |
 
   @skipOnOcV10.3
   Scenario Outline: Setting default expiry date and enforcement after the share is created
@@ -784,11 +784,11 @@ Feature: sharing
     And the response when user "user2" gets the info of the last share should include
       | expiration | <expected-expire-date> |
     Examples:
-      | ocs_api_version | default-expire-date | enforce-expire-date | expected-expire-date | ocs_status_code  |
-      | 1               | yes                 | yes                 | +30 days             | 100              |
-      | 2               | yes                 | yes                 | +30 days             | 200              |
-      | 1               | no                  | yes                 |                      | 100              |
-      | 2               | no                  | yes                 |                      | 200              |
+      | ocs_api_version | default-expire-date | enforce-expire-date | expected-expire-date | ocs_status_code |
+      | 1               | yes                 | yes                 | +30 days             | 100             |
+      | 2               | yes                 | yes                 | +30 days             | 200             |
+      | 1               | no                  | yes                 |                      | 100             |
+      | 2               | no                  | yes                 |                      | 200             |
 
   @skipOnOcV10.3
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and specifying expiration on share and with combinations of default/enforce expire date enabled

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -66,7 +66,7 @@ Feature: sharing
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     When user "user0" creates a public link share using the sharing API with settings
       | path     | randomfile.txt |
-      | password | %public%    |
+      | password | %public%       |
     And user "user0" updates the last share using the sharing API with
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
@@ -569,15 +569,15 @@ Feature: sharing
     And the HTTP status code should be "<http_status_code>"
     When user "user0" gets the info of the last share using the sharing API
     Then the fields of the last response should include
-      | item_type         | file           |
-      | item_source       | A_NUMBER       |
-      | share_type        | group          |
-      | file_target       | /textfile0.txt |
-      | permissions       | read, update, share  |
-      | mail_send         | 0              |
-      | uid_owner         | user0          |
-      | file_parent       | A_NUMBER       |
-      | displayname_owner | User Zero      |
+      | item_type         | file                |
+      | item_source       | A_NUMBER            |
+      | share_type        | group               |
+      | file_target       | /textfile0.txt      |
+      | permissions       | read, update, share |
+      | mail_send         | 0                   |
+      | uid_owner         | user0               |
+      | file_parent       | A_NUMBER            |
+      | displayname_owner | User Zero           |
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |

--- a/tests/acceptance/features/apiTrashbin/trashbinAPIDisabled.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinAPIDisabled.feature
@@ -40,4 +40,4 @@ Feature: the trashbin API is not available when the tech preview setting is disa
       | /textfile3.txt     |
       | /textfile4.txt     |
     But user "user0" should not see the following elements
-      | /textfile0.txt     |
+      | /textfile0.txt |

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -24,75 +24,75 @@ Feature: files and folders can be deleted from the trashbin
       | old      |
       | new      |
 
-    Scenario: delete a single file from the trashbin
-      Given user "user0" has been created with default attributes and skeleton files
-      And user "user0" has deleted file "/textfile0.txt"
-      And user "user0" has deleted file "/textfile1.txt"
-      And user "user0" has deleted file "/PARENT/parent.txt"
-      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
-      When user "user0" deletes the file with original path "textfile1.txt" from the trashbin using the trashbin API
-      Then the HTTP status code should be "204"
-      And as "user0" the file with original path "/textfile1.txt" should not exist in trash
-      But as "user0" the file with original path "/textfile0.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+  Scenario: delete a single file from the trashbin
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    And user "user0" has deleted file "/PARENT/parent.txt"
+    And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+    When user "user0" deletes the file with original path "textfile1.txt" from the trashbin using the trashbin API
+    Then the HTTP status code should be "204"
+    And as "user0" the file with original path "/textfile1.txt" should not exist in trash
+    But as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
 
-    Scenario: delete multiple files from the trashbin and make sure the correct ones are gone
-      Given user "user0" has been created with default attributes and skeleton files
-      And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
-      And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/child.txt"
-      And user "user0" has deleted file "/textfile0.txt"
-      And user "user0" has deleted file "/textfile1.txt"
-      And user "user0" has deleted file "/PARENT/parent.txt"
-      And user "user0" has deleted file "/PARENT/child.txt"
-      And user "user0" has deleted file "/PARENT/textfile0.txt"
-      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
-      When user "user0" deletes the file with original path "/PARENT/textfile0.txt" from the trashbin using the trashbin API
-      And user "user0" deletes the file with original path "/PARENT/CHILD/child.txt" from the trashbin using the trashbin API
-      Then as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in trash
-      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should not exist in trash
-      But as "user0" the file with original path "/textfile0.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/child.txt" should exist in trash
+  Scenario: delete multiple files from the trashbin and make sure the correct ones are gone
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/child.txt"
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    And user "user0" has deleted file "/PARENT/parent.txt"
+    And user "user0" has deleted file "/PARENT/child.txt"
+    And user "user0" has deleted file "/PARENT/textfile0.txt"
+    And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+    When user "user0" deletes the file with original path "/PARENT/textfile0.txt" from the trashbin using the trashbin API
+    And user "user0" deletes the file with original path "/PARENT/CHILD/child.txt" from the trashbin using the trashbin API
+    Then as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in trash
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should not exist in trash
+    But as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/child.txt" should exist in trash
 
-    @skipOnOcV10.3
-    Scenario: User tries to delete another user's trashbin
-      Given user "user0" has been created with default attributes and skeleton files
-      Given user "user1" has been created with default attributes and skeleton files
-      And user "user0" has deleted file "/textfile0.txt"
-      And user "user0" has deleted file "/textfile1.txt"
-      And user "user0" has deleted file "/PARENT/parent.txt"
-      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
-      When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the trashbin API
-      Then the HTTP status code should be "401"
-      And as "user0" the file with original path "/textfile1.txt" should exist in trash
-      And as "user0" the file with original path "/textfile0.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+  @skipOnOcV10.3
+  Scenario: User tries to delete another user's trashbin
+    Given user "user0" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    And user "user0" has deleted file "/PARENT/parent.txt"
+    And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+    When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the trashbin API
+    Then the HTTP status code should be "401"
+    And as "user0" the file with original path "/textfile1.txt" should exist in trash
+    And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
 
-    Scenario: User tries to delete trashbin file using invalid password
-      Given user "user0" has been created with default attributes and skeleton files
-      Given user "user1" has been created with default attributes and skeleton files
-      And user "user0" has deleted file "/textfile0.txt"
-      And user "user0" has deleted file "/textfile1.txt"
-      And user "user0" has deleted file "/PARENT/parent.txt"
-      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
-      When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "invalid" and the trashbin API
-      Then the HTTP status code should be "401"
-      And as "user0" the file with original path "/textfile1.txt" should exist in trash
-      And as "user0" the file with original path "/textfile0.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+  Scenario: User tries to delete trashbin file using invalid password
+    Given user "user0" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    And user "user0" has deleted file "/PARENT/parent.txt"
+    And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+    When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "invalid" and the trashbin API
+    Then the HTTP status code should be "401"
+    And as "user0" the file with original path "/textfile1.txt" should exist in trash
+    And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
 
-    Scenario: User tries to delete trashbin file using no password
-      Given user "user0" has been created with default attributes and skeleton files
-      Given user "user1" has been created with default attributes and skeleton files
-      And user "user0" has deleted file "/textfile0.txt"
-      And user "user0" has deleted file "/textfile1.txt"
-      And user "user0" has deleted file "/PARENT/parent.txt"
-      And user "user0" has deleted file "/PARENT/CHILD/child.txt"
-      When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "" and the trashbin API
-      Then the HTTP status code should be "401"
-      And as "user0" the file with original path "/textfile1.txt" should exist in trash
-      And as "user0" the file with original path "/textfile0.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-      And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+  Scenario: User tries to delete trashbin file using no password
+    Given user "user0" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user0" has deleted file "/textfile0.txt"
+    And user "user0" has deleted file "/textfile1.txt"
+    And user "user0" has deleted file "/PARENT/parent.txt"
+    And user "user0" has deleted file "/PARENT/CHILD/child.txt"
+    When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "" and the trashbin API
+    Then the HTTP status code should be "401"
+    And as "user0" the file with original path "/textfile1.txt" should exist in trash
+    And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -171,8 +171,8 @@ Feature: files and folders exist in the trashbin after being deleted
       | new      |
 
   @local_storage
-  @skipOnEncryptionType:user-keys @encryption-issue-42
-  @skip_on_objectstore
+    @skipOnEncryptionType:user-keys @encryption-issue-42
+    @skip_on_objectstore
   Scenario Outline: Deleting a folder into external storage moves it to the trashbin
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
@@ -244,7 +244,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | path          | user    |
       | textfile0.txt | user504 |
       | textfile2.txt | user504 |
-      | textfile3.txt  | user504 |
+      | textfile3.txt | user504 |
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -103,13 +103,13 @@ Feature: Restore deleted files/folders
     And as "user0" file "<restore-path>" should exist
     And as "user0" file "<delete-path>" should not exist
     Examples:
-      | dav-path | delete-path              | restore-path         |
-      | old      | /PARENT/parent.txt       | parent.txt           |
-      | new      | /PARENT/parent.txt       | parent.txt           |
-      | old      | /PARENT/CHILD/child.txt  | child.txt            |
-      | new      | /PARENT/CHILD/child.txt  | child.txt            |
-      | old      | /textfile0.txt           | FOLDER/textfile0.txt |
-      | new      | /textfile0.txt           | FOLDER/textfile0.txt |
+      | dav-path | delete-path             | restore-path         |
+      | old      | /PARENT/parent.txt      | parent.txt           |
+      | new      | /PARENT/parent.txt      | parent.txt           |
+      | old      | /PARENT/CHILD/child.txt | child.txt            |
+      | new      | /PARENT/CHILD/child.txt | child.txt            |
+      | old      | /textfile0.txt          | FOLDER/textfile0.txt |
+      | new      | /textfile0.txt          | FOLDER/textfile0.txt |
 
   @issue-35974
   Scenario Outline: restoring a file to an already existing path overrides the file
@@ -140,9 +140,9 @@ Feature: Restore deleted files/folders
   Scenario Outline: restoring a file to a read-only folder
     Given using <dav-path> DAV path
     And these users have been created with default attributes and skeleton files:
-    | username |
-    | user0    |
-    | user1    |
+      | username |
+      | user0    |
+      | user1    |
     And user "user1" has created folder "shareFolderParent"
     And user "user1" has shared folder "shareFolderParent" with user "user0" with permissions "read"
     And as "user0" folder "/shareFolderParent" should exist
@@ -207,8 +207,8 @@ Feature: Restore deleted files/folders
       | new      |
 
   @local_storage
-  @skipOnEncryptionType:user-keys @encryption-issue-42
-  @skip_on_objectstore
+    @skipOnEncryptionType:user-keys @encryption-issue-42
+    @skip_on_objectstore
   Scenario Outline: Deleting a file into external storage moves it to the trashbin and can be restored
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
@@ -276,7 +276,7 @@ Feature: Restore deleted files/folders
     Then the HTTP status code should be "401"
     And as "user0" the folder with original path "/textfile0.txt" should exist in trash
     And user "user0" should not see the following elements
-      | /textfile0.txt     |
+      | /textfile0.txt |
     Examples:
       | dav-path |
       | old      |
@@ -292,7 +292,7 @@ Feature: Restore deleted files/folders
     Then the HTTP status code should be "401"
     And as "user0" the folder with original path "/textfile0.txt" should exist in trash
     And user "user0" should not see the following elements
-      | /textfile0.txt     |
+      | /textfile0.txt |
     Examples:
       | dav-path |
       | old      |
@@ -308,7 +308,7 @@ Feature: Restore deleted files/folders
     Then the HTTP status code should be "401"
     And as "user0" the folder with original path "/textfile0.txt" should exist in trash
     And user "user0" should not see the following elements
-      | /textfile0.txt     |
+      | /textfile0.txt |
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -3,10 +3,10 @@ Feature: lock should propagate correctly if a share is reshared
 
   Background:
     Given these users have been created with default attributes and skeleton files:
-    | username |
-    | user0    |
-    | user1    |
-    | user2    |
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
 
   Scenario Outline: upload to a share that was locked by owner
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
@@ -15,8 +15,8 @@ Feature: move (rename) file
     And the following headers should match these regular expressions
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
-      | status | /^finished$/       |
-      | fileId | /^[0-9a-z]{20,}$/  |
+      | status | /^finished$/         |
+      | fileId | /^[0-9a-z]{20,}$/    |
       | ETag   | /^"[0-9a-f]{1,32}"$/ |
     And the downloaded content when downloading file "/FOLDER/<destination-file-name>" for user "user0" with range "bytes=0-6" should be "Welcome"
     And user "user0" should not see the following elements
@@ -35,8 +35,8 @@ Feature: move (rename) file
     And the following headers should match these regular expressions
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
-      | status | /^finished$/       |
-      | fileId | /^[0-9a-z]{20,}$/  |
+      | status | /^finished$/         |
+      | fileId | /^[0-9a-z]{20,}$/    |
       | ETag   | /^"[0-9a-f]{1,32}"$/ |
     And the downloaded content when downloading file "/textfile0.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
     And user "user0" should not see the following elements
@@ -48,8 +48,8 @@ Feature: move (rename) file
     And the following headers should match these regular expressions
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
-      | status | /^finished$/       |
-      | fileId | /^[0-9a-z]{20,}$/  |
+      | status | /^finished$/         |
+      | fileId | /^[0-9a-z]{20,}$/    |
       | ETag   | /^"[0-9a-f]{1,32}"$/ |
     And the content of file "/TextFile0.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
     And user "user0" should not see the following elements
@@ -61,8 +61,8 @@ Feature: move (rename) file
     And the following headers should match these regular expressions
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
-      | status | /^finished$/       |
-      | fileId | /^[0-9a-z]{20,}$/  |
+      | status | /^finished$/         |
+      | fileId | /^[0-9a-z]{20,}$/    |
       | ETag   | /^"[0-9a-f]{1,32}"$/ |
     And the content of file "/textfile0.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
     And the content of file "/TextFile0.txt" for user "user0" should be "ownCloud test text file 1" plus end-of-line
@@ -75,8 +75,8 @@ Feature: move (rename) file
     And the following headers should match these regular expressions
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
-      | status | /^finished$/       |
-      | fileId | /^[0-9a-z]{20,}$/  |
+      | status | /^finished$/         |
+      | fileId | /^[0-9a-z]{20,}$/    |
       | ETag   | /^"[0-9a-f]{1,32}"$/ |
     And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
     And the content of file "/PARENT/Parent.txt" for user "user0" should be "ownCloud test text file 1" plus end-of-line
@@ -251,4 +251,4 @@ Feature: move (rename) file
     And the following headers should match these regular expressions
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
-      | status | /^started$/        |
+      | status | /^started$/ |

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -59,11 +59,11 @@ Feature: delete folder
     And user "user1" should be able to delete folder "/Top/ReceivedShares"
     And user "user1" should be able to delete folder "/Top"
     Examples:
-      | dav_version | share_folder        |
-      | old         | /ReceivedShares     |
-      | new         | /ReceivedShares     |
-      | old         | ReceivedShares      |
-      | new         | ReceivedShares      |
+      | dav_version | share_folder    |
+      | old         | /ReceivedShares |
+      | new         | /ReceivedShares |
+      | old         | ReceivedShares  |
+      | new         | ReceivedShares  |
 
   @files_sharing-app-required
   Scenario Outline: delete a folder when there is a default folder for received shares that is a multi-level path

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -34,7 +34,7 @@ Feature: Search
       | /upload😀 😁                  |
       | /upload😀 😁/upload😀 😁.txt  |
     But the search result should not contain these entries:
-      | /a-image.png             |
+      | /a-image.png |
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -10,17 +10,17 @@ Feature: security certificates
     When the administrator invokes occ command "security:certificates"
     Then the command should have been successful
     And the command output table should contain the following text:
-      | table_column         |
-      | goodCertificate.crt  |
+      | table_column        |
+      | goodCertificate.crt |
 
   Scenario: List security certificates when multiple certificates are imported
     Given the administrator has imported security certificate from the path "tests/data/certificates/goodCertificate.crt"
     And the administrator has imported security certificate from the path "tests/data/certificates/badCertificate.crt"
     When the administrator invokes occ command "security:certificates"
     And the command output table should contain the following text:
-    | table_column         |
-    | goodCertificate.crt  |
-    | badCertificate.crt   |
+      | table_column        |
+      | goodCertificate.crt |
+      | badCertificate.crt  |
 
   Scenario: Remove a security certificate
     Given the administrator has imported security certificate from the path "tests/data/certificates/goodCertificate.crt"
@@ -29,8 +29,8 @@ Feature: security certificates
     Then the command should have been successful
     When the administrator invokes occ command "security:certificates"
     And the command output table should contain the following text:
-      | table_column         |
-      | badCertificate.crt   |
+      | table_column       |
+      | badCertificate.crt |
 
   @issue-35364
   Scenario: Remove a security certificate that is not installed

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -10,10 +10,10 @@ Feature: add group
     And the command output should contain the text 'Created group "<group_id>"'
     And group "<group_id>" should exist
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: group names are case-sensitive, multiple groups can exist with different upper and lower case names
     When the administrator creates group "<group_id1>" using the occ command

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -13,10 +13,10 @@ Feature: add users to group
     And the command output should contain the text 'User "brand-new-user" added to group "<group_id>"'
     And user "brand-new-user" should belong to group "<group_id>"
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -58,11 +58,11 @@ Feature: add a user using the using the occ command
     And user "brand-new-user" should exist
     And user "brand-new-user" should be able to access a skeleton file
     Examples:
-      | password                     | comment                     |
-      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
-      | España§àôœ€  | special European and other characters       |
-      | नेपाली                       | Unicode                     |
-      | password with spaces         | password with spaces        |
+      | password                     | comment                               |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
+      | España§àôœ€                  | special European and other characters |
+      | नेपाली                       | Unicode                               |
+      | password with spaces         | password with spaces                  |
 
   Scenario: admin creates a user and specifies an invalid password, containing just space
     Given user "brand-new-user" has been deleted

--- a/tests/acceptance/features/cliProvisioning/deleteGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteGroup.feature
@@ -11,10 +11,10 @@ Feature: delete groups
     And the command output should contain the text 'The specified group was deleted'
     And group "<group_id>" should not exist
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: group names are case-sensitive, the correct group is deleted
     Given group "<group_id1>" has been created
@@ -27,7 +27,7 @@ Feature: delete groups
     But group "<group_id2>" should exist
     And group "<group_id3>" should exist
     Examples:
-      | group_id1            | group_id2            | group_id3 |
+      | group_id1            | group_id2            | group_id3            |
       | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -46,11 +46,11 @@ Feature: edit users
     And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
     Examples:
-      | password                     | comment                     |
-      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
-      | España§àôœ€  | special European and other characters       |
-      | नेपाली                       | Unicode                     |
-      | password with spaces         | password with spaces        |
+      | password                     | comment                               |
+      | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
+      | España§àôœ€                  | special European and other characters |
+      | नेपाली                       | Unicode                               |
+      | password with spaces         | password with spaces                  |
 
   Scenario: admin creates a user and specifies an invalid password, containing just space
     Given user "brand-new-user" has been deleted

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -13,10 +13,10 @@ Feature: remove a user from a group
     And the command output should contain the text 'Member "brand-new-user" removed from group "<group_id>"'
     And user "brand-new-user" should not belong to group "<group_id>"
     Examples:
-      | group_id     | comment                               |
-      | simplegroup  | nothing special here                  |
-      | España§àôœ€  | special European and other characters |
-      | नेपाली       | Unicode group name                    |
+      | group_id    | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली      | Unicode group name                    |
 
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -174,7 +174,7 @@ Feature: add users
       | password                     | comment                     |
       | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
       | España                       | special European characters |
-      | नेपाली                                                  | Unicode                     |
+      | नेपाली                       | Unicode                     |
       | password with spaces         | password with spaces        |
 
   Scenario Outline: admin creates a user without setting password and user sets password containing special characters
@@ -190,7 +190,7 @@ Feature: add users
       | password                     | comment                     |
       | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters          |
       | España                       | special European characters |
-      | नेपाली                                                  | Unicode                     |
+      | नेपाली                       | Unicode                     |
       | password with spaces         | password with spaces        |
 
   Scenario: admin creates a user without setting password and user sets empty spaces as password
@@ -223,7 +223,7 @@ Feature: add users
     Then notifications should be displayed on the webUI with the text
       | Error creating user: A user with that name already exists. |
     Examples:
-      | user_id1          | user_id2       | user_id3       |
-      | Brand-New-User    | brand-new-user | BRAND-NEW-USER |
-      | brand-new-user    | BRAND-NEW-USER | Brand-New-User |
-      | BRAND-NEW-USER    | Brand-New-User | brand-new-user |
+      | user_id1       | user_id2       | user_id3       |
+      | Brand-New-User | brand-new-user | BRAND-NEW-USER |
+      | brand-new-user | BRAND-NEW-USER | Brand-New-User |
+      | BRAND-NEW-USER | Brand-New-User | brand-new-user |

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -240,7 +240,7 @@ Feature: deleting files and folders
     And it should not be possible to delete folder "<top_share_folder_on_ui>" using the webUI
     And as "user1" folder "<share_folder>/ShareThis" should exist
     Examples:
-      | share_folder        | top_share_folder_on_ui |other_folder1 | top_folder2 | other_folder2  |
-      | /ReceivedShares     | ReceivedShares         | Received     | Top         | ReceivedShares |
-      | ReceivedShares      | ReceivedShares         | Received     | Top         | ReceivedShares |
-      | /My/Received/Shares | My                     | M            | Received    | Shares         |
+      | share_folder        | top_share_folder_on_ui | other_folder1 | top_folder2 | other_folder2  |
+      | /ReceivedShares     | ReceivedShares         | Received      | Top         | ReceivedShares |
+      | ReceivedShares      | ReceivedShares         | Received      | Top         | ReceivedShares |
+      | /My/Received/Shares | My                     | M             | Received    | Shares         |

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -130,8 +130,8 @@ Feature: User can open the details panel for any file or folder
     When the user selects the breadcrumb for folder "<grand-parent>"
     Then folder "<parent>" should be listed on the webUI
     Examples:
-      | grand-parent  | parent       | child        | grand-child   |
-      | grand-parent  | parent       | child        | grand-child   |
-      | PARENT        | PARENT       | PARENT       | PARENT        |
-      | Grand parent  | grand child  | grand child  | grand child   |
-      | Folder12      | #fol3der     | FOL DER       | FoLdEr       |
+      | grand-parent | parent      | child       | grand-child |
+      | grand-parent | parent      | child       | grand-child |
+      | PARENT       | PARENT      | PARENT      | PARENT      |
+      | Grand parent | grand child | grand child | grand child |
+      | Folder12     | #fol3der    | FOL DER     | FoLdEr      |

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -52,12 +52,12 @@ Feature: Add group
     Then the group name <groupname> should be listed on the webUI
     And group <groupname> should exist
     Examples:
-      | groupname                    |
-      | "☺"                          |
-      | "☹"                          |
-      | "✍"                          |
-      | "⛷"                           |
-      | "⛹"                           |
+      | groupname |
+      | "☺"       |
+      | "☹"       |
+      | "✍"       |
+      | "⛷"       |
+      | "⛹"       |
 
   Scenario: adding multiple users to a group
     Given these users have been created without skeleton files:

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -32,7 +32,7 @@ Feature: delete users
     Then user "<user_id1>" should not exist
     And user "<user_id2>" should not exist
     Examples:
-      | user_id1          | user_id2       |
-      | Brand-New-User    | brand-new-user |
-      | brand-new-user    | Brand-New-User |
-      | Brand-New-User    | BRAND-NEW-USER |
+      | user_id1       | user_id2       |
+      | Brand-New-User | brand-new-user |
+      | brand-new-user | Brand-New-User |
+      | Brand-New-User | BRAND-NEW-USER |

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -22,13 +22,13 @@ Feature: manage groups
       | 0         |
       | false     |
     Then these groups should be listed on the webUI:
-      |groupname     |
-      |do-not-delete |
-      |do-not-delete2|
+      | groupname      |
+      | do-not-delete  |
+      | do-not-delete2 |
     But these groups should not be listed on the webUI:
-      |groupname|
-      |0        |
-      |false    |
+      | groupname |
+      | 0         |
+      | false     |
     And the administrator reloads the users page
     Then these groups should be listed on the webUI:
       | groupname      |
@@ -65,15 +65,15 @@ Feature: manage groups
       | hash#char |
       | q?mark    |
     Then these groups should be listed on the webUI:
-      |groupname     |
-      |do-not-delete |
-      |do-not-delete2|
+      | groupname      |
+      | do-not-delete  |
+      | do-not-delete2 |
     But these groups should not be listed on the webUI:
-      |groupname     |
-      |a/slash       |
-      |per%cent      |
-      |hash#char     |
-      |q?mark        |
+      | groupname |
+      | a/slash   |
+      | per%cent  |
+      | hash#char |
+      | q?mark    |
     And the administrator reloads the users page
     Then these groups should be listed on the webUI:
       | groupname      |
@@ -113,9 +113,9 @@ Feature: manage groups
       | quotes'     |
       | quotes"     |
     Then these groups should be listed on the webUI:
-      |groupname     |
-      |do-not-delete |
-      |do-not-delete2|
+      | groupname      |
+      | do-not-delete  |
+      | do-not-delete2 |
     But these groups should not be listed on the webUI:
       | groupname   |
       | grp1        |
@@ -196,7 +196,7 @@ Feature: manage groups
     But group "<group_id2>" should exist
     And group "<group_id3>" should exist
     Examples:
-      | group_id1            | group_id2            | group_id3 |
+      | group_id1            | group_id2            | group_id3            |
       | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP |
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -22,4 +22,4 @@ Feature: Renaming files inside a folder with problematic name
       | folder                |
       | 0                     |
       | 'single'quotes        |
-      | strängé नेपाली folder   |
+      | strängé नेपाली folder |

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -16,7 +16,7 @@ Feature: rename folders
     Then folder <to_folder_name> should be listed on the webUI
     Examples:
       | to_folder_name          |
-      | 'सिमप्ले फोल्देर$%#?&@'       |
+      | 'सिमप्ले फोल्देर$%#?&@' |
       | '"quotes1"'             |
       | "'quotes2'"             |
 
@@ -29,7 +29,7 @@ Feature: rename folders
     Then folder <to_name> should be listed on the webUI
     Examples:
       | from_name               | to_name                     |
-      | "strängé नेपाली folder"   | "strängé नेपाली folder-#?2"   |
+      | "strängé नेपाली folder" | "strängé नेपाली folder-#?2" |
       | "'single'quotes"        | "single-quotes"             |
 
   Scenario: Rename a folder using special characters and check its existence after page reload
@@ -66,7 +66,7 @@ Feature: rename folders
     And user "user1" has logged in using the webUI
     When the user renames the following folder using the webUI
       | from-name-parts | to-name-parts         |
-      | a-folder   | First 'single' quotes |
+      | a-folder        | First 'single' quotes |
       |                 | -then "double"        |
     And the user reloads the current page of the webUI
     Then the following folder should be listed on the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -69,11 +69,11 @@ Feature: restrict Sharing
     When the user sets the sharing permissions of group "grp1" for "simple-folder" using the webUI to
       | share | no |
     Then dialog should be displayed on the webUI
-      | title | content               |
-      | Error while sharing |Group sharing is not allowed   |
+      | title               | content                      |
+      | Error while sharing | Group sharing is not allowed |
     When the user reloads the current page of the webUI
     Then the following permissions are seen for "simple-folder" in the sharing dialog for group "grp1"
-      | share  | yes  |
+      | share | yes |
 
   Scenario: Editing create permission of existing share when sharing with groups is forbidden
     Given the user has shared folder "simple-folder" with group "grp1"
@@ -83,11 +83,11 @@ Feature: restrict Sharing
     When the user sets the sharing permissions of group "grp1" for "simple-folder" using the webUI to
       | create | no |
     Then dialog should be displayed on the webUI
-      | title | content               |
-      | Error while sharing |Group sharing is not allowed   |
+      | title               | content                      |
+      | Error while sharing | Group sharing is not allowed |
     When the user reloads the current page of the webUI
     Then the following permissions are seen for "simple-folder" in the sharing dialog for group "grp1"
-      | create  | yes  |
+      | create | yes |
 
   Scenario: Deleting group share when sharing with groups is forbidden
     Given the user has shared folder "simple-folder" with group "grp1"

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -15,7 +15,7 @@ Feature: add users
   Scenario: administrator should be able to see email of a user
     When the administrator enables the setting "Show email address" in the User Management page using the webUI
     Then the administrator should be able to see the email of these users in the User Management page:
-      | username | email        |
+      | username | email             |
       | user1    | user1@example.org |
       | user2    | user2@example.org |
 
@@ -62,18 +62,18 @@ Feature: add users
   Scenario: administrator should be able to see quota of user
     When the administrator enables the setting "Show quota field" in the User Management page using the webUI
     Then the administrator should be able to see the quota of these users in the User Management page:
-      | username |   quota   |
-      | user1    |   Default |
-      | user2    |   Default |
+      | username | quota   |
+      | user1    | Default |
+      | user2    | Default |
 
   Scenario: administrator should be able to see updated quota of user when enabled show quota field
     Given the administrator has changed the quota of user "user1" to "Unlimited"
     And the administrator has changed the quota of user "user2" to "5 GB"
     When the administrator enables the setting "Show quota field" in the User Management page using the webUI
     Then the administrator should be able to see the quota of these users in the User Management page:
-      | username |   quota     |
-      | user1    |   Unlimited |
-      | user2    |   5 GB      |
+      | username | quota     |
+      | user1    | Unlimited |
+      | user2    | 5 GB      |
 
   Scenario: administrator should not be able to see quota of user
     When the administrator disables the setting "Show quota field" in the User Management page using the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -205,6 +205,7 @@ Feature: Sharing files and folders with internal groups
       """
       just letting you know that User Three shared lorem.txt with you.
       """
+
   Scenario: user added to a group has a share that matches the skeleton of added user
     Given user "user1" has uploaded file with content "some content" to "lorem.txt"
     And user "user3" has been added to group "grp1"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -388,10 +388,10 @@ Feature: Sharing files and folders with internal users
     When the user types "<user_id3>" in the share-with-field
     Then a tooltip with the text "No users or groups found for <user_id3>" should be shown near the share-with-field on the webUI
     Examples:
-      | user_id1          | user_id2       | user_id3       |
-      | Brand-New-User    | brand-new-user | BRAND-NEW-USER |
-      | brand-new-user    | BRAND-NEW-USER | Brand-New-User |
-      | BRAND-NEW-USER    | Brand-New-User | brand-new-user |
+      | user_id1       | user_id2       | user_id3       |
+      | Brand-New-User | brand-new-user | BRAND-NEW-USER |
+      | brand-new-user | BRAND-NEW-USER | Brand-New-User |
+      | BRAND-NEW-USER | Brand-New-User | brand-new-user |
 
   Scenario: sharer should be able to share a folder to a user when only share with groups they are member of is enabled
     Given these users have been created with default attributes and without skeleton files:
@@ -432,7 +432,7 @@ Feature: Sharing files and folders with internal users
     And user "user2" has logged in using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
-      | edit   | no |
+      | edit | no |
     And the user re-logs in as "user1" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should not be available on the webUI
@@ -516,7 +516,7 @@ Feature: Sharing files and folders with internal users
     And user "user2" has logged in using the webUI
     When the user shares folder "simple-folder" with user "User One" using the webUI
     And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
-      | share   | no |
+      | share | no |
     And the user re-logs in as "user1" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -25,11 +25,11 @@ Feature: Sharing files and folders with internal groups
     When user "user3" has shared folder "/a-folder" with group "grp1"
     And user "user3" has shared file "/data.zip" with group "grp1"
     Then the user should see 2 notifications on the webUI with these details
-      | title                                        |
-      | "User Three" shared "a-folder" with you      |
-      | "User Three" shared "data.zip" with you    |
+      | title                                   |
+      | "User Three" shared "a-folder" with you |
+      | "User Three" shared "data.zip" with you |
     When the user re-logs in as "user1" using the webUI
     Then the user should see 2 notifications on the webUI with these details
-      | title                                        |
-      | "User Three" shared "a-folder" with you      |
-      | "User Three" shared "data.zip" with you    |
+      | title                                   |
+      | "User Three" shared "a-folder" with you |
+      | "User Three" shared "data.zip" with you |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -20,9 +20,9 @@ Feature: Sharing files and folders with internal users
     And user "user1" has shared folder "/a-folder" with user "user2"
     And user "user1" has shared file "/data.zip" with user "user2"
     Then the user should see 2 notifications on the webUI with these details
-      | title                                      |
+      | title                                 |
       | "User One" shared "a-folder" with you |
-      | "User One" shared "data.zip" with you      |
+      | "User One" shared "data.zip" with you |
 
   @smokeTest
   Scenario: Notification is gone after accepting a share

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -474,19 +474,19 @@ Feature: Share by public link
     #And folder "newfolder" should be listed on the webUI
     And folder "test" should be listed on the webUI
 
-    @issue-35174
-    Scenario: User renames folders with different path in Shared by link page
-      Given user "user1" has created folder "nf1"
-      And user "user1" has created folder "nf1/newfolder"
-      And user "user1" has created folder "test"
-      And user "user1" has created a public link share with settings
-        | path | nf1/newfolder |
-      And user "user1" has created a public link share with settings
-        | path | test |
-      And user "user1" has logged in using the webUI
-      And the user has browsed to the shared-by-link page
-      When the user renames folder "test" to "newfolder" using the webUI
-      Then near folder "test" a tooltip with the text 'newfolder already exists' should be displayed on the webUI
+  @issue-35174
+  Scenario: User renames folders with different path in Shared by link page
+    Given user "user1" has created folder "nf1"
+    And user "user1" has created folder "nf1/newfolder"
+    And user "user1" has created folder "test"
+    And user "user1" has created a public link share with settings
+      | path | nf1/newfolder |
+    And user "user1" has created a public link share with settings
+      | path | test |
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the shared-by-link page
+    When the user renames folder "test" to "newfolder" using the webUI
+    Then near folder "test" a tooltip with the text 'newfolder already exists' should be displayed on the webUI
       #Then the following folder should be listed on the webUI
         #| newfolder |
         #| newfolder |
@@ -582,7 +582,7 @@ Feature: Share by public link
     Then the user should see an error message on the public link popup saying "Expiration date is required"
     And the user gets the info of the last share using the sharing API
     And the fields of the last response should include
-      | expiration | + 5 days   |
+      | expiration | + 5 days |
 
   Scenario: user deletes the expiration date of already existing public link using webUI when expiration date is set but not enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -590,13 +590,13 @@ Feature: Share by public link
     And user "user1" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
-      | expireDate |  + 5 days   |
+      | expireDate | + 5 days    |
       | shareType  | public_link |
     And user "user1" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     And the user gets the info of the last share using the sharing API
     And the fields of the last response should include
-      | expiration   | |
+      | expiration |  |
 
   Scenario: user creates a new public link using webUI without setting expiration date when default expire date is set but not enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -604,10 +604,10 @@ Feature: Share by public link
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "user1" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI with
-      | expiration | |
+      | expiration |  |
     And user "user1" gets the info of the last share using the sharing API
     Then the fields of the last response should include
-      | expiration   | |
+      | expiration |  |
 
   Scenario: user creates a new public link using webUI removing expiration date when default expire date is set and enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -615,7 +615,7 @@ Feature: Share by public link
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "user1" has logged in using the webUI
     When the user tries to create a new public link for file "lorem.txt" using the webUI
-      | expiration | |
+      | expiration |  |
     Then the user should see an error message on the public link popup saying "Expiration date is required"
 
   Scenario: user creates a new public link using webUI when default expire date is set and enforced
@@ -657,7 +657,7 @@ Feature: Share by public link
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
-      | email           | foo@bar.co  |
+      | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
 			user0 shared simple-folder with you
@@ -722,8 +722,8 @@ Feature: Share by public link
       | path | /simple-folder |
       | name | Public Link    |
     And user "user1" has created a public link share with settings
-      | path | /simple-folder/sub-folder        |
-      | name | strängé लिंक नाम (#2 &).नेपाली      |
+      | path | /simple-folder/sub-folder      |
+      | name | strängé लिंक नाम (#2 &).नेपाली |
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -61,17 +61,17 @@ Feature: Creation of tags for the files and folders
       | tag2 | normal |
 
   @files_sharing-app-required
-   Scenario: Add tags on skeleton file before sharing
-     Given these users have been created with skeleton files:
-       | username |
-       | user2    |
-       | user3    |
-     And the user re-logs in as "user2" using the webUI
-     And the user browses directly to display the details of file "lorem.txt" in folder "/"
-     When the user adds a tag "skeleton" to the file using the webUI
-     And the user shares file "lorem.txt" with user "user3" using the webUI
-     Then file "lorem (2).txt" should have the following tags for user "user3"
-       | skeleton | normal |
+  Scenario: Add tags on skeleton file before sharing
+    Given these users have been created with skeleton files:
+      | username |
+      | user2    |
+      | user3    |
+    And the user re-logs in as "user2" using the webUI
+    And the user browses directly to display the details of file "lorem.txt" in folder "/"
+    When the user adds a tag "skeleton" to the file using the webUI
+    And the user shares file "lorem.txt" with user "user3" using the webUI
+    Then file "lorem (2).txt" should have the following tags for user "user3"
+      | skeleton | normal |
 
   @files_sharing-app-required
   Scenario: Check for existence of tags in shared file
@@ -81,5 +81,5 @@ Feature: Creation of tags for the files and folders
     And the user adds a tag "Confidential" to the file using the webUI
     And the user shares file "randomfile.txt" with user "User Two" using the webUI
     Then file "/randomfile.txt" should have the following tags for user "user2"
-      | Confidential   | normal |
+      | Confidential | normal |
 

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -11,7 +11,7 @@ Feature: Deletion of existing tags from files and folders
     And the user has browsed to the login page
     And the user has logged in with username "user1" and password "%alt1%" using the webUI
 
-@skipOnFIREFOX @files_sharing-app-required
+  @skipOnFIREFOX @files_sharing-app-required
   Scenario: Delete a tag in a shared file
     Given user "user2" has been created with default attributes and without skeleton files
     And user "user1" has uploaded file with content "some content" to "/randomfile.txt"
@@ -20,7 +20,7 @@ Feature: Deletion of existing tags from files and folders
     And the user shares file "randomfile.txt" with user "User Two" using the webUI
     And the user re-logs in with username "user2" and password "%alt2%" using the webUI
     Then file "randomfile.txt" should have the following tags for user "user2"
-    | tag1 | normal |
+      | tag1 | normal |
     When the user browses directly to display the details of file "randomfile.txt" in folder ""
     And the user deletes tag with name "tag1" using the webUI
     Then tag "tag1" should not exist for user "user1"

--- a/tests/acceptance/features/webUITags/editTags.feature
+++ b/tests/acceptance/features/webUITags/editTags.feature
@@ -20,7 +20,7 @@ Feature: Edit tags for files and folders
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user edits the tag with name "random" and sets its name to "random-big" using the webUI
     Then file "randomfile.txt" should have the following tags for user "user1"
-      | random-big  | normal |
+      | random-big | normal |
     And tag "random" should not exist for the user
 
   @files_sharing-app-required
@@ -34,7 +34,7 @@ Feature: Edit tags for files and folders
     And the user edits the tag with name "random" and sets its name to "random-big" using the webUI
     And the user edits the tag with name "some-tag" and sets its name to "another-tag" using the webUI
     Then file "randomfile.txt" should have the following tags for user "user1"
-      |  random-big  | normal |
+      | random-big  | normal |
       | another-tag | normal |
     And tag "random" should not exist for the user
     And tag "some-tag" should not exist for the user

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -7,8 +7,8 @@ Feature: Locks
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
     Given these users have been created without skeleton files:
-      |username      |
-      |brand-new-user|
+      | username       |
+      | brand-new-user |
 
   @files_sharing-app-required
   Scenario Outline: deleting a file in a public share of a locked folder


### PR DESCRIPTION
The feature file formats (lineup of scenario tables, indent...) have got "out of standard" over time.
PHPstorm is able to reformat them "to standard", and this is the resulting changes.
There is no functional change.

Now that we have just merged the main feature PRs that had lots of feature file changes, this seems the best time to do this "formatting" PR, when it will cause minimal conflicts to other PRs.