### PR TITLE
Reformat acceptance test code

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -131,7 +131,7 @@ trait AppConfiguration {
 			$capabilitiesPath
 		);
 
-		return (string)$answeredValue;
+		return (string) $answeredValue;
 	}
 
 	/**
@@ -235,7 +235,7 @@ trait AppConfiguration {
 			}
 		}
 
-		return (string)$answeredValue;
+		return (string) $answeredValue;
 	}
 
 	/**
@@ -638,7 +638,7 @@ trait AppConfiguration {
 		$user = $this->currentUser;
 		$this->currentUser = $this->getAdminUsername();
 		$previousServer = $this->currentServer;
-		foreach (['LOCAL','REMOTE'] as $server) {
+		foreach (['LOCAL', 'REMOTE'] as $server) {
 			if (($server === 'LOCAL') || $this->federatedServerExists()) {
 				$this->usingServer($server);
 				$this->resetAppConfigs();
@@ -716,9 +716,9 @@ trait AppConfiguration {
 	 *
 	 * @param string $server LOCAL|REMOTE
 	 *
-	 * @throws \Exception
-	 *
 	 * @return void
+	 *
+	 * @throws \Exception
 	 *
 	 */
 	private function restoreParameters($server) {

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -442,7 +442,7 @@ trait Auth {
 	 *
 	 * @return void
 	 */
-	public function userRequestsURLWithUsingBasicAuth($user, $url, $method, $password=null, $body=null) {
+	public function userRequestsURLWithUsingBasicAuth($user, $url, $method, $password = null, $body = null) {
 		if ($password === null) {
 			$authString = "$user:" . $this->getPasswordForUser($user);
 		} else {
@@ -465,7 +465,7 @@ trait Auth {
 	 * @return void
 	 */
 	public function userHasRequestedURLWithUsingBasicAuth(
-		$user, $url, $method, $password=null, $body=null
+		$user, $url, $method, $password = null, $body = null
 	) {
 		$this->userRequestsURLWithUsingBasicAuth(
 			$user, $url, $method, $password, $body
@@ -482,7 +482,7 @@ trait Auth {
 	 *
 	 * @return void
 	 */
-	public function administratorRequestsURLWithUsingBasicAuth($url, $method, $password=null) {
+	public function administratorRequestsURLWithUsingBasicAuth($url, $method, $password = null) {
 		$this->userRequestsURLWithUsingBasicAuth(
 			$this->getAdminUsername(), $url, $method, $password
 		);

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -505,7 +505,7 @@ trait BasicStructure {
 
 	/**
 	 * returns the complete DAV path including the base path e.g. owncloud-core/remote.php/dav
-
+	 *
 	 * @return string
 	 */
 	public function getDAVPathIncludingBasePath() {
@@ -596,8 +596,8 @@ trait BasicStructure {
 	/**
 	 * @param string $storageName
 	 *
-	 * @throws Exception
 	 * @return integer
+	 * @throws Exception
 	 */
 	public function getStorageId($storageName) {
 		if (\array_key_exists($storageName, $this->getStorageIds())) {
@@ -753,8 +753,8 @@ trait BasicStructure {
 	/**
 	 * disable CSRF
 	 *
-	 * @throws Exception
 	 * @return string the previous setting of csrf.disabled
+	 * @throws Exception
 	 */
 	public function disableCSRF() {
 		return $this->setCSRFDotDisabled('true');
@@ -763,8 +763,8 @@ trait BasicStructure {
 	/**
 	 * enable CSRF
 	 *
-	 * @throws Exception
 	 * @return string the previous setting of csrf.disabled
+	 * @throws Exception
 	 */
 	public function enableCSRF() {
 		return $this->setCSRFDotDisabled('false');
@@ -775,8 +775,8 @@ trait BasicStructure {
 	 *
 	 * @param string $setting "true", "false" or "" to delete the setting
 	 *
-	 * @throws Exception
 	 * @return string the previous setting of csrf.disabled
+	 * @throws Exception
 	 */
 	public function setCSRFDotDisabled($setting) {
 		$oldCSRFSetting = $this->getSystemConfigValue('csrf.disabled');
@@ -1472,7 +1472,7 @@ trait BasicStructure {
 		if (\array_key_exists($userName, $this->createdUsers)) {
 			return (string) $this->createdUsers[$userName]['displayname'];
 		} elseif (\array_key_exists($userName, $this->createdRemoteUsers)) {
-			return (string)$this->createdRemoteUsers[$userName]['displayname'];
+			return (string) $this->createdRemoteUsers[$userName]['displayname'];
 		} elseif ($userName === 'regularuser') {
 			return 'Regular User';
 		} elseif ($userName === 'user0') {
@@ -1515,7 +1515,7 @@ trait BasicStructure {
 		if (\array_key_exists($userName, $this->createdUsers)) {
 			return (string) $this->createdUsers[$userName]['email'];
 		} elseif (\array_key_exists($userName, $this->createdRemoteUsers)) {
-			return (string)$this->createdRemoteUsers[$userName]['email'];
+			return (string) $this->createdRemoteUsers[$userName]['email'];
 		} elseif ($userName === 'regularuser') {
 			return 'regularuser@example.org';
 		} elseif ($userName === 'user0') {
@@ -1538,6 +1538,7 @@ trait BasicStructure {
 	}
 
 	// TODO do similar for other usernames for e.g. %regularuser% or %test-user-1%
+
 	/**
 	 * @param string $functionalUsername
 	 *
@@ -1684,6 +1685,7 @@ trait BasicStructure {
 		);
 		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
+
 	/**
 	 * @When the administrator deletes file :path in local storage using the testing API
 	 *
@@ -1840,7 +1842,7 @@ trait BasicStructure {
 		);
 
 		$fileContent = HttpRequestHelper::getResponseXml($this->getResponse());
-		$fileContent = (string)$fileContent->data->element->contentUrlEncoded;
+		$fileContent = (string) $fileContent->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($fileContent);
 
 		Assert::assertSame(
@@ -2263,7 +2265,7 @@ trait BasicStructure {
 		$configkeyList = $this->getConfigKeyList($appID);
 		foreach ($configkeyList as $config) {
 			if ($config['configkey'] === $key) {
-				return  true;
+				return true;
 			}
 		}
 		return false;
@@ -2484,7 +2486,7 @@ trait BasicStructure {
 	public function runFunctionOnEveryServer($callback) {
 		$previousServer = $this->getCurrentServer();
 		$result = [];
-		foreach (['LOCAL','REMOTE'] as $server) {
+		foreach (['LOCAL', 'REMOTE'] as $server) {
 			$this->usingServer($server);
 			if (($server === 'LOCAL')
 				|| $this->federatedServerExists()

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -108,11 +108,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function theCalDavHttpStatusCodeShouldBe($code) {
-		if ((int)$code !== $this->response->getStatusCode()) {
+		if ((int) $code !== $this->response->getStatusCode()) {
 			throw new \Exception(
 				\sprintf(
 					'Expected %s got %s',
-					(int)$code,
+					(int) $code,
 					$this->response->getStatusCode()
 				)
 			);

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -155,11 +155,11 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function theCardDavHttpStatusCodeShouldBe($code) {
-		if ((int)$code !== $this->response->getStatusCode()) {
+		if ((int) $code !== $this->response->getStatusCode()) {
 			throw new \Exception(
 				\sprintf(
 					'Expected %s got %s',
-					(int)$code,
+					(int) $code,
 					$this->response->getStatusCode()
 				)
 			);

--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -77,7 +77,7 @@ class CommentsContext implements Context {
 			"uploads"
 		);
 		$this->featureContext->setResponse($response);
-		$responseHeaders =  $response->getHeaders();
+		$responseHeaders = $response->getHeaders();
 		if (isset($responseHeaders['Content-Location'][0])) {
 			$commentUrl = $responseHeaders['Content-Location'][0];
 			$this->lastCommentId = \substr(
@@ -246,7 +246,7 @@ class CommentsContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function userDeletesLastComment($user=null) {
+	public function userDeletesLastComment($user = null) {
 		if ($user === null) {
 			$user = $this->featureContext->getCurrentUser();
 		}
@@ -262,7 +262,7 @@ class CommentsContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function userHasDeletedLastComment($user=null) {
+	public function userHasDeletedLastComment($user = null) {
 		$this->userDeletesLastComment($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe("204");
 	}
@@ -302,7 +302,7 @@ class CommentsContext implements Context {
 	 */
 	public function theResponseShouldContainOnlyComments($number) {
 		$response = $this->featureContext->getResponse();
-		if (\count($response) !== (int)$number) {
+		if (\count($response) !== (int) $number) {
 			throw new \Exception(
 				"Found more comments than $number (" . \count($response) . ")"
 			);

--- a/tests/acceptance/features/bootstrap/CorsContext.php
+++ b/tests/acceptance/features/bootstrap/CorsContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
+
 /**
  * Steps that relate to CORS tests
  */
@@ -34,7 +35,7 @@ class CorsContext implements Context {
 	 * @var FeatureContext
 	 */
 	private $featureContext;
-	
+
 	private $originalAdminCorsDomains = null;
 
 	/**
@@ -66,10 +67,10 @@ class CorsContext implements Context {
 		) {
 			$this->originalAdminCorsDomains = $domainsJson;
 		}
-		
+
 		$domains[] = $domain;
 		$valueString = \json_encode($domains);
-		
+
 		$this->featureContext->runOcc(
 			[
 				'user:setting',

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -124,8 +124,8 @@ class EmailContext implements Context {
 			EmailHelper::deleteAllMessages($this->getLocalMailhogUrl());
 		} catch (Exception $e) {
 			echo __METHOD__ .
-			" could not delete mailhog messages, is mailhog set up?\n" .
-			$e->getMessage();
+				" could not delete mailhog messages, is mailhog set up?\n" .
+				$e->getMessage();
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -119,11 +119,11 @@ class EncryptionContext implements Context {
 
 		$response = $this->featureContext->getResponse();
 		$parsedResponse = HttpRequestHelper::getResponseXml($response);
-		$encodedFileContent = (string)$parsedResponse->data->element->contentUrlEncoded;
+		$encodedFileContent = (string) $parsedResponse->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($encodedFileContent);
 
 		$this->featureContext->userDownloadsFileUsingTheAPI($username, "/$fileName");
-		$fileContentServer = (string)$this->featureContext->getResponse()->getBody();
+		$fileContentServer = (string) $this->featureContext->getResponse()->getBody();
 
 		Assert::assertEquals(
 			$fileContentServer,
@@ -146,7 +146,7 @@ class EncryptionContext implements Context {
 
 		$response = $this->featureContext->getResponse();
 		$parsedResponse = HttpRequestHelper::getResponseXml($this->featureContext->getResponse());
-		$encodedFileContent = (string)$parsedResponse->data->element->contentUrlEncoded;
+		$encodedFileContent = (string) $parsedResponse->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($encodedFileContent);
 
 		Assert::assertStringStartsWith(

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -63,7 +63,7 @@ class FederationContext implements Context {
 			$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
 		);
 	}
-	
+
 	/**
 	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)" using the sharing API with permissions (.*)$/
 	 *
@@ -279,7 +279,7 @@ class FederationContext implements Context {
 		} else {
 			$url = "/apps/files_sharing/api/v1/remote_shares/$share_id";
 		}
-		
+
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, 'DELETE', $url, null, $password
 		);
@@ -293,7 +293,7 @@ class FederationContext implements Context {
 	 * @return void
 	 */
 	public function userRequestsSharedSecretUsingTheFederationApi($user) {
-		$url  = '/apps/federation/api/v1/request-shared-secret';
+		$url = '/apps/federation/api/v1/request-shared-secret';
 		$this->featureContext->asUser($user);
 		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
 			'POST',

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -121,7 +121,7 @@ class FilesVersionsContext implements Context {
 		);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getcontentlength");
 		Assert::assertEquals(
-			$length, (int)$xmlPart[$index]
+			$length, (int) $xmlPart[$index]
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/Ip.php
+++ b/tests/acceptance/features/bootstrap/Ip.php
@@ -45,7 +45,7 @@ trait Ip {
 
 	private $ipv4Url;
 	private $ipv6Url;
-	
+
 	private $guzzleClientHeaders = [];
 
 	/**
@@ -69,7 +69,7 @@ trait Ip {
 	public function getGuzzleClientHeaders() {
 		return $this->guzzleClientHeaders;
 	}
-	
+
 	/**
 	 * @param array $guzzleClientHeaders ['X-Foo' => 'Bar']
 	 *
@@ -89,6 +89,7 @@ trait Ip {
 			$this->guzzleClientHeaders, $guzzleClientHeaders
 		);
 	}
+
 	/**
 	 * @When the client accesses the server from a :networkScope :ipAddressFamily address
 	 *
@@ -122,7 +123,7 @@ trait Ip {
 		} else {
 			$this->baseUrlForSourceIp = $this->featureContext->getBaseUrl();
 		}
-		
+
 		$this->featureContext->setSourceIpAddress($sourceIpAddress);
 	}
 
@@ -139,7 +140,7 @@ trait Ip {
 		$this->addGuzzleClientHeaders(["X-Forwarded-For" => $sourceIpAddress]);
 		$this->featureContext->addGuzzleClientHeaders(["X-Forwarded-For" => $sourceIpAddress]);
 	}
-	
+
 	/**
 	 * @BeforeScenario
 	 *

--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -161,6 +161,8 @@ trait Logging {
 	/**
 	 * wrapper around assertLogFileContainsAtLeastOneEntryMatchingTable()
 	 *
+	 * @Then the log file should contain at least one entry matching each of these lines:
+	 *
 	 * @param TableNode $expectedLogEntries table with headings that correspond
 	 *                                      to the json keys in the log entry
 	 *                                      e.g.
@@ -169,9 +171,6 @@ trait Logging {
 	 * @return void
 	 * @throws \Exception
 	 * @see assertLogFileContainsAtLeastOneEntryMatchingTable()
-	 *
-	 * @Then the log file should contain at least one entry matching each of these lines:
-	 *
 	 */
 	public function logFileShouldContainEntriesMatching(
 		TableNode $expectedLogEntries
@@ -184,14 +183,13 @@ trait Logging {
 	/**
 	 * wrapper around assertLogFileContainsAtLeastOneEntryMatchingTable()
 	 *
+	 * @Then the log file should contain at least one entry matching the regular expressions in each of these lines:
+	 *
 	 * @param TableNode $expectedLogEntries
 	 *
 	 * @return void
 	 * @throws \Exception
 	 * @see assertLogFileContainsAtLeastOneEntryMatchingTable()
-	 *
-	 * @Then the log file should contain at least one entry matching the regular expressions in each of these lines:
-	 *
 	 */
 	public function logFileShouldContainEntriesMatchingRegularExpression(
 		TableNode $expectedLogEntries

--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -72,7 +72,7 @@ trait Logging {
 				if ($comparingMode === 'matching') {
 					$expectedLogEntry[$attribute]
 						= $this->featureContext->substituteInLineCodes(
-							$expectedLogEntry[$attribute], ['preg_quote' => ['/'] ]
+							$expectedLogEntry[$attribute], ['preg_quote' => ['/']]
 						);
 				} else {
 					$expectedLogEntry[$attribute]
@@ -161,10 +161,6 @@ trait Logging {
 	/**
 	 * wrapper around assertLogFileContainsAtLeastOneEntryMatchingTable()
 	 *
-	 * @see assertLogFileContainsAtLeastOneEntryMatchingTable()
-	 *
-	 * @Then the log file should contain at least one entry matching each of these lines:
-	 *
 	 * @param TableNode $expectedLogEntries table with headings that correspond
 	 *                                      to the json keys in the log entry
 	 *                                      e.g.
@@ -172,6 +168,10 @@ trait Logging {
 	 *
 	 * @return void
 	 * @throws \Exception
+	 * @see assertLogFileContainsAtLeastOneEntryMatchingTable()
+	 *
+	 * @Then the log file should contain at least one entry matching each of these lines:
+	 *
 	 */
 	public function logFileShouldContainEntriesMatching(
 		TableNode $expectedLogEntries
@@ -184,14 +184,14 @@ trait Logging {
 	/**
 	 * wrapper around assertLogFileContainsAtLeastOneEntryMatchingTable()
 	 *
-	 * @see assertLogFileContainsAtLeastOneEntryMatchingTable()
-	 *
-	 * @Then the log file should contain at least one entry matching the regular expressions in each of these lines:
-	 *
 	 * @param TableNode $expectedLogEntries
 	 *
 	 * @return void
 	 * @throws \Exception
+	 * @see assertLogFileContainsAtLeastOneEntryMatchingTable()
+	 *
+	 * @Then the log file should contain at least one entry matching the regular expressions in each of these lines:
+	 *
 	 */
 	public function logFileShouldContainEntriesMatchingRegularExpression(
 		TableNode $expectedLogEntries
@@ -224,7 +224,7 @@ trait Logging {
 	 *
 	 * @param boolean $shouldOrNot if true the table entries are expected to match
 	 *                             at least one entry in the log
-	 * 							   if false the table entries are expected not
+	 *                             if false the table entries are expected not
 	 *                             to match any log in the log file
 	 * @param TableNode $expectedLogEntries table with headings that correspond
 	 *                                      to the json keys in the log entry
@@ -275,7 +275,7 @@ trait Logging {
 					if ($regexCompare === true) {
 						$expectedLogEntry[$attribute]
 							= $this->featureContext->substituteInLineCodes(
-								$expectedLogEntry[$attribute], ['preg_quote' => ['/'] ]
+								$expectedLogEntry[$attribute], ['preg_quote' => ['/']]
 							);
 						$matchAttribute = \preg_match(
 							$expectedLogEntry[$attribute], $logEntry[$attribute]

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -214,10 +214,10 @@ class NotificationsCoreContext implements Context {
 			);
 			if ($regex) {
 				$value = $this->featureContext->substituteInLineCodes(
-					$value, ['preg_quote' => ['/'] ]
+					$value, ['preg_quote' => ['/']]
 				);
 				Assert::assertNotFalse(
-					(bool)\preg_match($value, $response['ocs']['data'][$key]),
+					(bool) \preg_match($value, $response['ocs']['data'][$key]),
 					"'$value' does not match '{$response['ocs']['data'][$key]}'"
 				);
 			} else {

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -481,8 +481,8 @@ class OCSContext implements Context {
 	 *
 	 * @param ResponseInterface $response
 	 *
-	 * @throws \Exception
 	 * @return string
+	 * @throws \Exception
 	 */
 	public function getOCSResponseStatusCode($response) {
 		$responseXml = $this->featureContext->getResponseXml($response);
@@ -522,6 +522,7 @@ class OCSContext implements Context {
 			$this->theOCSStatusCodeShouldBe('200', $message);
 		}
 	}
+
 	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -186,11 +186,11 @@ class OccContext implements Context {
 		$exitStatusCode = $this->featureContext->getExitStatusCodeOfOccCommand();
 		if ($exitStatusCode !== 0) {
 			$msg = "The command was not successful, exit code was " .
-				   $exitStatusCode . ".\n" .
-				   "stdOut was: '" .
-				   $this->featureContext->getStdOutOfOccCommand() . "'\n" .
-				   "stdErr was: '" .
-				   $this->featureContext->getStdErrOfOccCommand() . "'\n";
+				$exitStatusCode . ".\n" .
+				"stdOut was: '" .
+				$this->featureContext->getStdOutOfOccCommand() . "'\n" .
+				"stdErr was: '" .
+				$this->featureContext->getStdErrOfOccCommand() . "'\n";
 			if (!empty($exceptions)) {
 				$msg .= ' Exceptions: ' . \implode(', ', $exceptions);
 			}
@@ -212,7 +212,7 @@ class OccContext implements Context {
 	 */
 	public function theCommandFailedWithExitCode($exitCode) {
 		$exitStatusCode = $this->featureContext->getExitStatusCodeOfOccCommand();
-		if ($exitStatusCode !== (int)$exitCode) {
+		if ($exitStatusCode !== (int) $exitCode) {
 			throw new \Exception(
 				"The command was expected to fail with exit code $exitCode but got "
 				. $exitStatusCode
@@ -678,7 +678,7 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand(
-		$key, $value, $type="string"
+		$key, $value, $type = "string"
 	) {
 		$this->invokingTheCommand(
 			"config:system:set --value ${value} --type ${type} ${key}"

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -456,7 +456,7 @@ class OccUsersGroupsContext implements Context {
 		// check if an array is a multi-dimensional array with inner array key 'displayName'
 		if (\array_column($lastOutputUsers, 'displayName')) {
 			foreach ($lastOutputUsers as $key => $value) {
-				$result[$key] =  $value['displayName'];
+				$result[$key] = $value['displayName'];
 			}
 		} else {
 			$result = $lastOutputUsers;

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -419,7 +419,7 @@ trait Provisioning {
 			if (isset($row['password'])) {
 				$body['password'] = $this->getActualPassword($row['password']);
 			} else {
-				$body['password'] =  $this->getPasswordForUser($row['username']);
+				$body['password'] = $this->getPasswordForUser($row['username']);
 			}
 
 			// Add request body to the bodies array. we will use that later to loop through created users.
@@ -2263,7 +2263,7 @@ trait Provisioning {
 		$user, $anotheruser, $group
 	) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$anotheruser/subadmins";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$anotheruser/subadmins";
 		$body = ['groupid' => $group];
 		$this->response = HttpRequestHelper::post(
 			$fullUrl,
@@ -2283,7 +2283,7 @@ trait Provisioning {
 	 */
 	public function theAdministratorGetsAllTheGroupsWhereUserIsSubadminUsingTheProvisioningApi($user) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user/subadmins";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user/subadmins";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
@@ -2331,7 +2331,7 @@ trait Provisioning {
 	 */
 	public function userGetsAllTheSubadminsOfGroupUsingTheProvisioningApi($user, $group) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/cloud/groups/$group/subadmins";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/groups/$group/subadmins";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getActualUsername($user), $this->getUserPassword($user)
 		);
@@ -2366,7 +2366,7 @@ trait Provisioning {
 		$user, $anotheruser, $group
 	) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$anotheruser/subadmins";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$anotheruser/subadmins";
 		$this->response = HttpRequestHelper::delete(
 			$fullUrl,
 			$this->getActualUsername($user),
@@ -2721,7 +2721,7 @@ trait Provisioning {
 	 */
 	public function appShouldBeDisabled($app) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v2.php/cloud/apps?filter=disabled";
+			. "/ocs/v2.php/cloud/apps?filter=disabled";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
@@ -2826,9 +2826,9 @@ trait Provisioning {
 	public function adminSetsUserQuotaToUsingTheProvisioningApi($user, $quota) {
 		$body
 			= [
-				'key' => 'quota',
-				'value' => $quota,
-			];
+			'key' => 'quota',
+			'value' => $quota,
+		];
 
 		$this->response = OcsApiHelper::sendRequest(
 			$this->getBaseUrl(),
@@ -3063,7 +3063,7 @@ trait Provisioning {
 	 */
 	public function disableOrEnableUser($user, $anotheruser, $action) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$anotheruser/$action";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$anotheruser/$action";
 		$this->response = HttpRequestHelper::put(
 			$fullUrl,
 			$this->getActualUsername($user),
@@ -3078,7 +3078,7 @@ trait Provisioning {
 	 */
 	public function getEnabledApps() {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/cloud/apps?filter=enabled";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/apps?filter=enabled";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
@@ -3092,7 +3092,7 @@ trait Provisioning {
 	 */
 	public function getDisabledApps() {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/cloud/apps?filter=disabled";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/apps?filter=disabled";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -53,7 +53,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function downloadPublicFileWithRange($range, $publicWebDAVAPIVersion, $password ="") {
+	public function downloadPublicFileWithRange($range, $publicWebDAVAPIVersion, $password = "") {
 		if ($publicWebDAVAPIVersion === "new") {
 			$path = $this->featureContext->getLastShareData()->data->file_target;
 		} else {
@@ -117,7 +117,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function deleteFileFromPublicShare($fileName, $publicWebDAVAPIVersion, $password = "") {
-		$token = (string)$this->featureContext->getLastShareData()->data->token;
+		$token = (string) $this->featureContext->getLastShareData()->data->token;
 		$davPath = WebDavHelper::getDavPath(
 			$token, 0, "public-files-$publicWebDAVAPIVersion"
 		);
@@ -246,7 +246,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function publicDownloadsTheFileInsideThePublicSharedFolderWithPasswordAndRange(
-		$path, $password, $range, $publicWebDAVAPIVersion="old"
+		$path, $password, $range, $publicWebDAVAPIVersion = "old"
 	) {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
@@ -316,7 +316,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function publiclyUploadingContentWithPassword(
-		$filename, $password = '', $body = 'test', $publicWebDAVAPIVersion="old"
+		$filename, $password = '', $body = 'test', $publicWebDAVAPIVersion = "old"
 	) {
 		$this->publicUploadContent(
 			$filename, $password, $body, false, [], $publicWebDAVAPIVersion
@@ -347,7 +347,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function publiclyUploadingContent(
-		$filename, $body = 'test', $publicWebDAVAPIVersion="old"
+		$filename, $body = 'test', $publicWebDAVAPIVersion = "old"
 	) {
 		$this->publicUploadContent(
 			$filename, '', $body, false, [], $publicWebDAVAPIVersion
@@ -743,7 +743,7 @@ class PublicWebDavContext implements Context {
 		$publicWebDAVAPIVersion = "old"
 	) {
 		$password = $this->featureContext->getActualPassword($password);
-		$token =  $this->featureContext->getLastShareToken();
+		$token = $this->featureContext->getLastShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token, 0, "public-files-$publicWebDAVAPIVersion"
 		);
@@ -779,10 +779,10 @@ class PublicWebDavContext implements Context {
 		$token, $password, $publicWebDAVAPIVersion
 	) {
 		if ($publicWebDAVAPIVersion === "old") {
-			$userName =  $token;
+			$userName = $token;
 		} else {
 			if ($password !== '') {
-				$userName =  'public';
+				$userName = 'public';
 			} else {
 				$userName = null;
 			}

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -46,6 +46,7 @@ class ShareesContext implements Context {
 	 * @var OCSContext
 	 */
 	private $ocsContext;
+
 	/**
 	 * @When /^the user gets the sharees using the sharing API with parameters$/
 	 *

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -200,7 +200,7 @@ trait Sharing {
 
 			if (\array_key_exists('permissions', $fd)) {
 				if (\is_numeric($fd['permissions'])) {
-					$fd['permissions'] = (int)$fd['permissions'];
+					$fd['permissions'] = (int) $fd['permissions'];
 				} else {
 					$fd['permissions'] = $this->splitPermissionsString($fd['permissions']);
 				}
@@ -209,7 +209,7 @@ trait Sharing {
 			}
 			if (\array_key_exists('shareType', $fd)) {
 				if (\is_numeric($fd['shareType'])) {
-					$fd['shareType'] = (int)$fd['shareType'];
+					$fd['shareType'] = (int) $fd['shareType'];
 				}
 			} else {
 				$fd['shareType'] = null;
@@ -566,7 +566,7 @@ trait Sharing {
 			}
 			if (\array_key_exists('permissions', $fd)) {
 				if (\is_numeric($fd['permissions'])) {
-					$fd['permissions'] = (int)$fd['permissions'];
+					$fd['permissions'] = (int) $fd['permissions'];
 				} else {
 					$fd['permissions'] = $this->splitPermissionsString($fd['permissions']);
 					$fd['permissions'] = SharingHelper::getPermissionSum($fd['permissions']);
@@ -689,7 +689,7 @@ trait Sharing {
 			foreach ($data as $element) {
 				if (isset($element->$field)) {
 					$fieldIsSet = true;
-					$value = (string)$element->$field;
+					$value = (string) $element->$field;
 					if ($this->doesFieldValueMatchExpectedContent(
 						$field, $value, $contentExpected, $expectSuccess
 					)
@@ -701,7 +701,7 @@ trait Sharing {
 		} else {
 			$fieldIsSet = isset($data->$field);
 			if ($fieldIsSet) {
-				$value = (string)$data->$field;
+				$value = (string) $data->$field;
 				if ($this->doesFieldValueMatchExpectedContent(
 					$field, $value, $contentExpected, $expectSuccess
 				)
@@ -827,7 +827,7 @@ trait Sharing {
 			foreach ($data as $element) {
 				if ($element->share_with->__toString() === $userOrGroup
 					&& ($permissions === null
-					|| $permissionSum === (int)$element->permissions->__toString())
+					|| $permissionSum === (int) $element->permissions->__toString())
 				) {
 					return true;
 				}
@@ -1213,7 +1213,7 @@ trait Sharing {
 	 */
 	public function getLastShareIdOf($user) {
 		if (isset($this->lastShareData->data[0]->id)) {
-			return (int)$this->lastShareData->data[0]->id;
+			return (int) $this->lastShareData->data[0]->id;
 		}
 
 		$this->getListOfShares($user);
@@ -1298,7 +1298,7 @@ trait Sharing {
 	 */
 	public function userGetsAllSharesSharedWithHimFromFileOrFolderUsingTheProvisioningApi($user, $path) {
 		$url = "/apps/files_sharing/api/"
-		. "v{$this->sharingApiVersion}/shares?shared_with_me=true&path=$path";
+			. "v{$this->sharingApiVersion}/shares?shared_with_me=true&path=$path";
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
@@ -1316,8 +1316,8 @@ trait Sharing {
 	 */
 	public function userGetsAllSharesSharedByHimUsingTheSharingApi($user) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
-		. "v{$this->sharingApiVersion}/shares";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+			. "v{$this->sharingApiVersion}/shares";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $user, $this->getPasswordForUser($user)
 		);
@@ -1342,8 +1342,8 @@ trait Sharing {
 	 */
 	public function userGetsAllTheSharesFromTheFileUsingTheSharingApi($user, $path) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
-		. "v{$this->sharingApiVersion}/shares?path=$path";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+			. "v{$this->sharingApiVersion}/shares?path=$path";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $user, $this->getPasswordForUser($user)
 		);
@@ -1361,8 +1361,8 @@ trait Sharing {
 		$user, $path
 	) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
-		. "v{$this->sharingApiVersion}/shares?reshares=true&path=$path";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+			. "v{$this->sharingApiVersion}/shares?reshares=true&path=$path";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $user, $this->getPasswordForUser($user)
 		);
@@ -1378,8 +1378,8 @@ trait Sharing {
 	 */
 	public function userGetsAllTheSharesInsideTheFolderUsingTheSharingApi($user, $path) {
 		$fullUrl = $this->getBaseUrl()
-		. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
-		. "v{$this->sharingApiVersion}/shares?path=$path&subfiles=true";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
+			. "v{$this->sharingApiVersion}/shares?path=$path&subfiles=true";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $user, $this->getPasswordForUser($user)
 		);
@@ -1410,9 +1410,9 @@ trait Sharing {
 	 * @param string $user
 	 * @param TableNode $body
 	 *
+	 * @return void
 	 * @throws \Exception
 	 *
-	 * @return void
 	 */
 	public function informationOfLastShareShouldInclude(
 		$user, $body
@@ -1673,8 +1673,8 @@ trait Sharing {
 	 * @param string $user
 	 * @param string $fileName
 	 *
-	 * @throws \Exception
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function userRemovesAllSharesFromTheFileNamed($user, $fileName) {
 		$url = $this->getBaseUrl()
@@ -1747,14 +1747,14 @@ trait Sharing {
 				//0 path, 1 permissions, 2 name
 				$nameFound = false;
 				foreach ($dataResponded as $elementResponded) {
-					if ((string)$elementResponded->name[0] === $expectedElementsArray[2]) {
+					if ((string) $elementResponded->name[0] === $expectedElementsArray[2]) {
 						Assert::assertEquals(
 							$expectedElementsArray[0],
-							(string)$elementResponded->path[0]
+							(string) $elementResponded->path[0]
 						);
 						Assert::assertEquals(
 							$expectedElementsArray[1],
-							(string)$elementResponded->permissions[0]
+							(string) $elementResponded->permissions[0]
 						);
 						$nameFound = true;
 						break;
@@ -1778,8 +1778,8 @@ trait Sharing {
 	public function getPublicShareIDByName($user, $path, $name) {
 		$dataResponded = $this->getShares($user, $path);
 		foreach ($dataResponded as $elementResponded) {
-			if ((string)$elementResponded->name[0] === $name) {
-				return (int)$elementResponded->id[0];
+			if ((string) $elementResponded->name[0] === $name) {
+				return (int) $elementResponded->id[0];
 			}
 		}
 		return null;
@@ -1820,8 +1820,8 @@ trait Sharing {
 		$dataResponded = $this->getAllSharesSharedWithUser($user);
 		$shareId = null;
 		foreach ($dataResponded as $shareElement) {
-			if ((string)$shareElement['uid_owner'] === $offeredBy
-				&& (string)$shareElement['path'] === $share
+			if ((string) $shareElement['uid_owner'] === $offeredBy
+				&& (string) $shareElement['path'] === $share
 			) {
 				$shareId = (string) $shareElement['id'];
 				break;
@@ -1834,7 +1834,7 @@ trait Sharing {
 			);
 		}
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}" .
-			   "/shares/pending/$shareId";
+			"/shares/pending/$shareId";
 		if (\substr($action, 0, 7) === "decline") {
 			$httpRequestMethod = "DELETE";
 		} elseif (\substr($action, 0, 6) === "accept") {
@@ -1962,10 +1962,10 @@ trait Sharing {
 	 * @param string $user
 	 * @param string $state pending|accepted|declined|rejected|all
 	 *
-	 * @throws InvalidArgumentException
+	 * @return array of shares that are shared with this user
 	 * @throws Exception
 	 *
-	 * @return array of shares that are shared with this user
+	 * @throws InvalidArgumentException
 	 */
 	private function getAllSharesSharedWithUser($user, $state = "all") {
 		switch ($state) {
@@ -1986,7 +1986,7 @@ trait Sharing {
 		}
 
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" .
-			   "?format=json&shared_with_me=true&state=$stateCode";
+			"?format=json&shared_with_me=true&state=$stateCode";
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, "GET", $url, null
 		);
@@ -2041,7 +2041,7 @@ trait Sharing {
 	 */
 	public function thePublicAccessesThePreviewOfTheSharedFileUsingTheSharingApi($path) {
 		$shareData = $this->getLastShareData();
-		$token = (string)$shareData->data->token;
+		$token = (string) $shareData->data->token;
 		$this->getPublicPreviewOfFile($path, $token);
 	}
 
@@ -2186,28 +2186,28 @@ trait Sharing {
 			[
 				'capabilitiesApp' => 'files_sharing',
 				'capabilitiesParameter' =>
-				'public@@@password@@@enforced_for@@@read_only',
+					'public@@@password@@@enforced_for@@@read_only',
 				'testingApp' => 'core',
 				'testingParameter' =>
-				'shareapi_enforce_links_password_read_only',
+					'shareapi_enforce_links_password_read_only',
 				'testingState' => false
 			],
 			[
 				'capabilitiesApp' => 'files_sharing',
 				'capabilitiesParameter' =>
-				'public@@@password@@@enforced_for@@@read_write',
+					'public@@@password@@@enforced_for@@@read_write',
 				'testingApp' => 'core',
 				'testingParameter' =>
-				'shareapi_enforce_links_password_read_write',
+					'shareapi_enforce_links_password_read_write',
 				'testingState' => false
 			],
 			[
 				'capabilitiesApp' => 'files_sharing',
 				'capabilitiesParameter' =>
-				'public@@@password@@@enforced_for@@@upload_only',
+					'public@@@password@@@enforced_for@@@upload_only',
 				'testingApp' => 'core',
 				'testingParameter' =>
-				'shareapi_enforce_links_password_write_only',
+					'shareapi_enforce_links_password_write_only',
 				'testingState' => false
 			],
 			[

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -468,7 +468,7 @@ class TagsContext implements Context {
 	 * @throws \Exception
 	 */
 	public function tagsShouldExistForUser($count, $user) {
-		if ((int)$count !== \count($this->requestTagsForUser($user))) {
+		if ((int) $count !== \count($this->requestTagsForUser($user))) {
 			throw new \Exception(
 				"Expected $count tags, got "
 				. \count($this->requestTagsForUser($user))
@@ -704,13 +704,13 @@ class TagsContext implements Context {
 			$fileID = $this->featureContext->getFileIdForPath($user, $fileName);
 		}
 		$properties = [
-						'oc:id',
-						'oc:display-name',
-						'oc:user-visible',
-						'oc:user-assignable',
-						'oc:user-editable',
-						'oc:can-assign'
-					  ];
+			'oc:id',
+			'oc:display-name',
+			'oc:user-visible',
+			'oc:user-assignable',
+			'oc:user-editable',
+			'oc:can-assign'
+		];
 		$appPath = '/systemtags-relations/files/';
 		$fullPath = $appPath . $fileID;
 		$response = WebDavHelper::propfind(
@@ -925,7 +925,7 @@ class TagsContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function fileHasNoTagsForUser($fileName, $adminOrUser=null, $user=null) {
+	public function fileHasNoTagsForUser($fileName, $adminOrUser = null, $user = null) {
 		if ($user === null) {
 			if ($adminOrUser === 'administrator') {
 				$user = $this->featureContext->getAdminUsername();

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -84,6 +84,7 @@ class TrashbinContext implements Context {
 			204, $response->getStatusCode()
 		);
 	}
+
 	/**
 	 * Get files list from the response from trashbin api
 	 *
@@ -101,7 +102,7 @@ class TrashbinContext implements Context {
 				$successPropStat = \array_filter(
 					$propStats, static function (SimpleXMLElement $propStat) {
 						$status = $propStat->xpath('./d:status');
-						return (string)$status[0] === 'HTTP/1.1 200 OK';
+						return (string) $status[0] === 'HTTP/1.1 200 OK';
 					}
 				);
 				if (isset($successPropStat[0])) {
@@ -117,16 +118,17 @@ class TrashbinContext implements Context {
 				}
 
 				return [
-					'href' => (string)$href,
-					'name' => isset($name[0]) ? (string)$name[0] : null,
-					'mtime' => isset($mtime[0]) ? (string)$mtime[0] : null,
-					'original-location' => isset($originalLocation[0]) ? (string)$originalLocation[0] : null
+					'href' => (string) $href,
+					'name' => isset($name[0]) ? (string) $name[0] : null,
+					'mtime' => isset($mtime[0]) ? (string) $mtime[0] : null,
+					'original-location' => isset($originalLocation[0]) ? (string) $originalLocation[0] : null
 				];
 			}, $xmlElements
 		);
 
 		return $files;
 	}
+
 	/**
 	 * List trashbin folder
 	 *
@@ -162,7 +164,7 @@ class TrashbinContext implements Context {
 		$files = \array_filter(
 			$files, static function ($element) use ($user, $path) {
 				$path = \ltrim($path, '/');
-				if ($path !==  '') {
+				if ($path !== '') {
 					$path .= '/';
 				}
 				return ($element['href'] !== "/remote.php/dav/trash-bin/$user/$path");
@@ -368,7 +370,7 @@ class TrashbinContext implements Context {
 	 *
 	 * @return int the number of items that were matched and requested for delete
 	 */
-	public function tryToDeleteFileFromTrashbin($user, $originalPath, $asUser=null, $password=null) {
+	public function tryToDeleteFileFromTrashbin($user, $originalPath, $asUser = null, $password = null) {
 		$asUser = $asUser ?? $user;
 		$listing = $this->listTrashbinFolder($user, null);
 		$originalPath = \trim($originalPath, '/');

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -338,7 +338,7 @@ trait WebDav {
 		}
 
 		if ($password === null) {
-			$password  = $this->getPasswordForUser($user);
+			$password = $this->getPasswordForUser($user);
 		}
 		return WebDavHelper::makeDavRequest(
 			$this->getBaseUrl(),
@@ -431,7 +431,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function setHttpTimeout($timeout) {
-		$this->httpRequestTimeout = (int)$timeout;
+		$this->httpRequestTimeout = (int) $timeout;
 	}
 
 	/**
@@ -440,8 +440,8 @@ trait WebDav {
 	 * @param string $method
 	 * @param int $seconds
 	 *
-	 * @throws Exception
 	 * @return void
+	 * @throws Exception
 	 */
 	public function slowdownDavRequests($method, $seconds) {
 		if ($this->oldDavSlowdownSetting === null) {
@@ -702,7 +702,7 @@ trait WebDav {
 	 */
 	public function sizeOfDownloadedFileShouldBe($size) {
 		Assert::assertEquals(
-			$size, \strlen((string)$this->response->getBody())
+			$size, \strlen((string) $this->response->getBody())
 		);
 	}
 
@@ -715,7 +715,7 @@ trait WebDav {
 	 */
 	public function downloadedContentShouldEndWith($content) {
 		Assert::assertEquals(
-			$content, \substr((string)$this->response->getBody(), -\strlen($content))
+			$content, \substr((string) $this->response->getBody(), -\strlen($content))
 		);
 	}
 
@@ -728,7 +728,7 @@ trait WebDav {
 	 */
 	public function downloadedContentShouldBe($content) {
 		Assert::assertEquals(
-			$content, (string)$this->response->getBody()
+			$content, (string) $this->response->getBody()
 		);
 	}
 
@@ -1084,10 +1084,10 @@ trait WebDav {
 				$expectedKey, $result, "response does not have expected key '$expectedKey'"
 			);
 			$expectedValue = $this->substituteInLineCodes(
-				$row[1], ['preg_quote' => ['/'] ]
+				$row[1], ['preg_quote' => ['/']]
 			);
 			Assert::assertNotFalse(
-				(bool)\preg_match($expectedValue, $result[$expectedKey]),
+				(bool) \preg_match($expectedValue, $result[$expectedKey]),
 				"'$expectedValue' does not match '$result[$expectedKey]'"
 			);
 		}
@@ -1206,9 +1206,9 @@ trait WebDav {
 	 * @param string $shouldOrNot
 	 * @param TableNode $elements
 	 *
+	 * @return void
 	 * @throws InvalidArgumentException
 	 *
-	 * @return void
 	 */
 	public function userShouldSeeTheElements($user, $shouldOrNot, $elements) {
 		$should = ($shouldOrNot !== "not");
@@ -1222,9 +1222,9 @@ trait WebDav {
 	 * @param TableNode $elements
 	 * @param boolean $expectedToBeListed
 	 *
+	 * @return void
 	 * @throws InvalidArgumentException
 	 *
-	 * @return void
 	 */
 	public function checkElementList(
 		$user, $elements, $expectedToBeListed = true
@@ -1372,7 +1372,7 @@ trait WebDav {
 		$user,
 		$source,
 		$destination,
-		$headers=[],
+		$headers = [],
 		$noOfChunks = 0
 	) {
 		$chunkingVersion = $this->chunkingToUse;
@@ -1455,7 +1455,7 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
-	 * @param int  $noOfChunks
+	 * @param int $noOfChunks
 	 * @param string $chunkingVersion old|v1|new|v2 null for autodetect
 	 *
 	 * @return void
@@ -2629,12 +2629,12 @@ trait WebDav {
 			$headerName = $header[0];
 			$expectedHeaderValue = $header[1];
 			$expectedHeaderValue = $this->substituteInLineCodes(
-				$expectedHeaderValue, ['preg_quote' => ['/'] ]
+				$expectedHeaderValue, ['preg_quote' => ['/']]
 			);
 
 			$returnedHeader = $this->response->getHeader($headerName);
 			Assert::assertNotFalse(
-				(bool)\preg_match($expectedHeaderValue, $returnedHeader),
+				(bool) \preg_match($expectedHeaderValue, $returnedHeader),
 				"'$expectedHeaderValue' does not match '$returnedHeader'"
 			);
 		}
@@ -2792,7 +2792,7 @@ trait WebDav {
 		if ($multistatusResults === null) {
 			$multistatusResults = [];
 		}
-		Assert::assertEquals((int)$numFiles, \count($multistatusResults));
+		Assert::assertEquals((int) $numFiles, \count($multistatusResults));
 	}
 
 	/**
@@ -2836,7 +2836,7 @@ trait WebDav {
 		$fullWebDavPath = \trim(
 			\parse_url($this->response->getEffectiveUrl(), PHP_URL_PATH),
 			"/"
-		) . "/" ;
+		) . "/";
 
 		$multistatusResults = $this->responseXml["value"];
 		$results = [];

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -100,7 +100,7 @@ class WebDavLockingContext implements Context {
 		$responseXml->registerXPathNamespace('d', 'DAV:');
 		$xmlPart = $responseXml->xpath("//d:locktoken/d:href");
 		if (isset($xmlPart[0])) {
-			$this->tokenOfLastLock[$user][$file] = (string)$xmlPart[0];
+			$this->tokenOfLastLock[$user][$file] = (string) $xmlPart[0];
 		} else {
 			if ($expectToSucceed === true) {
 				Assert::fail("could not find lock token");
@@ -133,6 +133,7 @@ class WebDavLockingContext implements Context {
 	public function userHasLockedFile($user, $file, TableNode $properties) {
 		$this->lockFile($user, $file, $properties, false, true);
 	}
+
 	/**
 	 * @Given the public has locked the last public shared file/folder setting following properties
 	 *
@@ -142,7 +143,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicHasLockedLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			(string)$this->featureContext->getLastShareData()->data->token,
+			(string) $this->featureContext->getLastShareData()->data->token,
 			"/", $properties, true
 		);
 	}
@@ -156,7 +157,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicLocksLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			(string)$this->featureContext->getLastShareData()->data->token,
+			(string) $this->featureContext->getLastShareData()->data->token,
 			"/", $properties, true, false
 		);
 	}
@@ -173,7 +174,7 @@ class WebDavLockingContext implements Context {
 		$file, TableNode $properties
 	) {
 		$this->lockFile(
-			(string)$this->featureContext->getLastShareData()->data->token,
+			(string) $this->featureContext->getLastShareData()->data->token,
 			$file, $properties, true
 		);
 	}
@@ -191,7 +192,7 @@ class WebDavLockingContext implements Context {
 		$file, $publicWebDAVAPIVersion, TableNode $properties
 	) {
 		$this->lockFile(
-			(string)$this->featureContext->getLastShareData()->data->token,
+			(string) $this->featureContext->getLastShareData()->data->token,
 			$file, $properties, true, false
 		);
 	}
@@ -239,7 +240,7 @@ class WebDavLockingContext implements Context {
 	public function unlockItemWithLastPublicLockOfOtherItemUsingWebDavAPI(
 		$user, $itemToUnlock, $itemToUseLockOf
 	) {
-		$lockOwner = (string)$this->featureContext->getLastShareData()->data->token;
+		$lockOwner = (string) $this->featureContext->getLastShareData()->data->token;
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user, $itemToUnlock, $lockOwner, $itemToUseLockOf
 		);
@@ -290,7 +291,7 @@ class WebDavLockingContext implements Context {
 	public function unlockItemAsPublicWithLastLockOfUserAndItemUsingWebDavAPI(
 		$itemToUnlock, $lockOwner, $itemToUseLockOf
 	) {
-		$user = (string)$this->featureContext->getLastShareData()->data->token;
+		$user = (string) $this->featureContext->getLastShareData()->data->token;
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user, $itemToUnlock, $lockOwner, $itemToUseLockOf, true
 		);
@@ -304,7 +305,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 */
 	public function unlockItemAsPublicUsingWebDavAPI($itemToUnlock) {
-		$user = (string)$this->featureContext->getLastShareData()->data->token;
+		$user = (string) $this->featureContext->getLastShareData()->data->token;
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user, $itemToUnlock, $user, $itemToUnlock, true
 		);
@@ -417,11 +418,12 @@ class WebDavLockingContext implements Context {
 	public function publicUploadFileSendingLockTokenOfPublic(
 		$filename, $content, $itemToUseLockOf, $publicWebDAVAPIVersion
 	) {
-		$lockOwner = (string)$this->featureContext->getLastShareData()->data->token;
+		$lockOwner = (string) $this->featureContext->getLastShareData()->data->token;
 		$this->publicUploadFileSendingLockTokenOfUser(
 			$filename, $content, $itemToUseLockOf, $lockOwner, $publicWebDAVAPIVersion
 		);
 	}
+
 	/**
 	 * @Then :count locks should be reported for file/folder :file of user :user by the WebDAV API
 	 *
@@ -447,7 +449,7 @@ class WebDavLockingContext implements Context {
 		$responseXml->registerXPathNamespace('d', 'DAV:');
 		$xmlPart = $responseXml->xpath("//d:response//d:lockdiscovery/d:activelock");
 		Assert::assertCount(
-			(int)$count, $xmlPart,
+			(int) $count, $xmlPart,
 			"expected $count lock(s) for '$file' but found " . \count($xmlPart)
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -135,7 +135,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 */
 	public function publicGetsThePropertiesOfFolder($path, TableNode $propertiesTable) {
-		$user = (string)$this->featureContext->getLastShareData()->data->token;
+		$user = (string) $this->featureContext->getLastShareData()->data->token;
 		$properties = null;
 		if ($propertiesTable instanceof TableNode) {
 			foreach ($propertiesTable->getRows() as $row) {
@@ -331,7 +331,7 @@ class WebDavPropertiesContext implements Context {
 		);
 		$value = $xmlPart[0]->__toString();
 		$pattern = $this->featureContext->substituteInLineCodes(
-			$pattern, ['preg_quote' => ['/'] ]
+			$pattern, ['preg_quote' => ['/']]
 		);
 		Assert::assertRegExp(
 			$pattern, $value,

--- a/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
@@ -33,13 +33,13 @@ require_once 'bootstrap.php';
  */
 class WebUIAdminAppsSettingsContext extends RawMinkContext implements Context {
 	private $adminAppsSettingsPage;
-	
+
 	/**
 	 *
 	 * @var WebUIGeneralContext
 	 */
 	private $webUIGeneralContext;
-	
+
 	/**
 	 * WebUIAdminAdminSettingsContext constructor.
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -37,7 +37,7 @@ require_once 'bootstrap.php';
  */
 class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context {
 	private $adminGeneralSettingsPage;
-	
+
 	/**
 	 *
 	 * @var WebUIGeneralContext
@@ -52,7 +52,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 
 	private $appParameterValues = null;
 	private $logLevelValue = null;
-	
+
 	/**
 	 * WebUIAdminAdminSettingsContext constructor.
 	 *
@@ -182,7 +182,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 
 		if ($this->appParameterValues === null || $this->logLevelValue) {
 			// Get app config values
-			$appConfigs =  AppConfigHelper::getAppConfigs(
+			$appConfigs = AppConfigHelper::getAppConfigs(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getAdminUsername(),
 				$this->featureContext->getAdminPassword(),
@@ -219,7 +219,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	 * @return void
 	 */
 	public function theVersionStringOfTheOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
-		$actualVersion =  $this->adminGeneralSettingsPage->getOwncloudVersionString();
+		$actualVersion = $this->adminGeneralSettingsPage->getOwncloudVersionString();
 		$expectedVersion = SetupHelper::runOcc(['-V'])['stdOut'];
 		Assert::assertStringEndsWith($actualVersion, \trim($expectedVersion));
 	}

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -35,7 +35,7 @@ require_once 'bootstrap.php';
  */
 class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context {
 	private $adminStorageSettingsPage;
-	
+
 	/**
 	 *
 	 * @var WebUIGeneralContext

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -785,7 +785,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 					break;
 				} elseif ($response->getStatusCode() === 423) {
 					$message = "INFORMATION: file '" . $file['name'] .
-					"' is locked";
+						"' is locked";
 					\error_log($message);
 				} else {
 					throw new \Exception(
@@ -929,9 +929,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			if ($currentNotificationsCount > $previousNotificationsCount) {
 				$message
 					= "Upload overwriting $name" .
-					  " and got $currentNotificationsCount" .
-					  " notifications including " .
-					  \end($notifications) . "\n";
+					" and got $currentNotificationsCount" .
+					" notifications including " .
+					\end($notifications) . "\n";
 				echo $message;
 				\error_log($message);
 				$previousNotificationsCount = $currentNotificationsCount;
@@ -1918,9 +1918,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @see WebDavAssert::assertContentOfRemoteAndLocalFileIsSame
-	 * uses the current user to download the remote file
-	 *
 	 * @param string $remoteFile
 	 * @param string $localFile
 	 * @param bool $shouldBeSame (default true) if true then check that the file contents are the same
@@ -1929,6 +1926,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 * @throws \Exception
+	 * @see WebDavAssert::assertContentOfRemoteAndLocalFileIsSame
+	 * uses the current user to download the remote file
+	 *
 	 */
 	private function assertContentOfRemoteAndLocalFileIsSame(
 		$remoteFile, $localFile, $shouldBeSame = true, $checkOnRemoteServer = false
@@ -1951,9 +1951,6 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @see WebDavAssert::assertContentOfDAVFileAndSkeletonFileOnSUT
-	 * uses the current user to download the remote file
-	 *
 	 * @param string $remoteFile
 	 * @param string $fileInSkeletonFolder
 	 * @param bool $shouldBeSame (default true) if true then check that the file contents are the same
@@ -1962,6 +1959,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 * @throws \Exception
+	 * @see WebDavAssert::assertContentOfDAVFileAndSkeletonFileOnSUT
+	 * uses the current user to download the remote file
+	 *
 	 */
 	private function assertContentOfDAVFileAndSkeletonFileOnSUT(
 		$remoteFile,
@@ -2069,8 +2069,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $action_label
 	 *
-	 * @throws \Exception
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function theUserClicksTheFileActionOnTheWebui($action_label) {
 		switch ($action_label) {

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -575,8 +575,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @param int $size if not int given it will be cast to int
 	 * @param string $name
 	 *
-	 * @throws InvalidArgumentException
 	 * @return void
+	 * @throws InvalidArgumentException
 	 */
 	public function aFileWithSizeAndNameHasBeenCreatedLocally($size, $name) {
 		$fullPath = \getenv("FILES_FOR_UPLOAD") . $name;
@@ -585,7 +585,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				__METHOD__ . " could not create '$fullPath' file exists"
 			);
 		}
-		UploadHelper::createFileSpecificSize($fullPath, (int)$size);
+		UploadHelper::createFileSpecificSize($fullPath, (int) $size);
 		$this->createdFiles[] = $fullPath;
 	}
 
@@ -695,7 +695,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$result = SetupHelper::runOcc(
 				["user:sync", "OCA\User_LDAP\User_Proxy", "-m remove"]
 			);
-			if ((int)$result['code'] !== 0) {
+			if ((int) $result['code'] !== 0) {
 				throw new Exception(
 					"could not sync users with LDAP. stdOut:\n" .
 					"{$result['stdOut']}\n" .

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -68,7 +68,7 @@ class WebUIHelpAndTipsContext extends RawMinkContext implements Context {
 	protected function generateHelpLinks($to) {
 		$version = $this->featureContext->getSystemConfigValue('version');
 		$version = \explode(".", $version);
-		$version = (string)$version[0] . "." . (string)$version[1];
+		$version = (string) $version[0] . "." . (string) $version[1];
 		return "https://doc.owncloud.org/server/$version/go.php?to=$to";
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -36,7 +36,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	private $loginPage;
 	private $filesPage;
 	private $expectedPage;
-	
+
 	/**
 	 *
 	 * @var FeatureContext

--- a/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
@@ -48,7 +48,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 	) {
 		$this->owncloudPage = $owncloudPage;
 	}
-	
+
 	/**
 	 *
 	 * @Then /^the user should see (\d+) notification(?:s|) on the webUI with these details$/
@@ -101,10 +101,10 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $firstOrLast first|last
 	 *
-	 * @throws InvalidArgumentException
+	 * @return void
 	 * @throws \Exception
 	 *
-	 * @return void
+	 * @throws InvalidArgumentException
 	 */
 	public function userFollowsLink($firstOrLast) {
 		$notificationsDialog = $this->openNotificationsDialog($this->getSession());

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -53,7 +53,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 * @param PersonalGeneralSettingsPage $personalGeneralSettingsPage
 	 */
 	public function __construct(
-		PersonalGeneralSettingsPage$personalGeneralSettingsPage
+		PersonalGeneralSettingsPage $personalGeneralSettingsPage
 	) {
 		$this->personalGeneralSettingsPage = $personalGeneralSettingsPage;
 	}
@@ -123,7 +123,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 			$oldPassword, $newPassword, $this->getSession()
 		);
 	}
-	
+
 	/**
 	 * @When the user changes the password to :newPassword entering the wrong current password :wrongPassword using the webUI
 	 * @Given the user has changed the password to :newPassword entering the wrong current password :wrongPassword using the webUI

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -178,9 +178,9 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param int $maxRetries
 	 * @param bool $quiet
 	 *
+	 * @return void
 	 * @throws \Exception
 	 *
-	 * @return void
 	 */
 	public function theUserSharesWithUserWithoutClosingDialog(
 		$folder, $remote, $name, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
@@ -196,9 +196,9 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param int $maxRetries
 	 * @param bool $quiet
 	 *
-	 * @throws \Exception
-	 *
 	 * @return void
+	 *
+	 * @throws \Exception
 	 *
 	 */
 	public function theUserSharesWithGroupWithoutClosingDialog(
@@ -294,9 +294,9 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param int $maxRetries
 	 * @param bool $quiet
 	 *
+	 * @return void
 	 * @throws \Exception
 	 *
-	 * @return void
 	 */
 	public function theUserSharesUsingWebUIWithoutClosingDialog(
 		$folder, $userOrGroup, $remote, $name, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false

--- a/tests/acceptance/features/bootstrap/WebUIUserContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUserContext.php
@@ -32,7 +32,7 @@ require_once 'bootstrap.php';
  * Context for steps associated with the user logged in to the WebUI
  */
 class WebUIUserContext extends RawMinkContext implements Context {
-	
+
 	/**
 	 *
 	 * @var OwncloudPage
@@ -47,7 +47,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	public function __construct(OwncloudPage $owncloudPage) {
 		$this->owncloudPage = $owncloudPage;
 	}
-	
+
 	/**
 	 * @Then :displayname should be shown as the name of the current user on the WebUI
 	 *
@@ -62,7 +62,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 			"displayed username should be '$displayname' but it is '$actualUserName'"
 		);
 	}
-	
+
 	/**
 	 * @Then /^the display name should (not|)\s?be visible on the WebUI$/
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -132,7 +132,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAdminCreatesAUserUsingTheWebUI(
-		$attemptTo, $username, $password, $email=null, TableNode $groupsTable=null
+		$attemptTo, $username, $password, $email = null, TableNode $groupsTable = null
 	) {
 		$password = $this->featureContext->getActualPassword($password);
 		if ($groupsTable !== null) {
@@ -195,7 +195,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAdminCreatesAUserUsingWithoutAPasswordTheWebUI(
-		$attemptTo, $username, $email, TableNode $groupsTable=null
+		$attemptTo, $username, $email, TableNode $groupsTable = null
 	) {
 		$this->theAdminCreatesAUserUsingTheWebUI(
 			$attemptTo, $username, null, $email, $groupsTable

--- a/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
@@ -117,7 +117,7 @@ class WebUIWebDavLockingContext extends RawMinkContext implements Context {
 			"'$file' should not be marked as locked, but it is"
 		);
 	}
-	
+
 	/**
 	 * @Then /^(?:file|folder) "([^"]*)" should (not|)\s?be marked as locked by user "([^"]*)" in the locks tab of the details panel on the webUI$/
 	 *

--- a/tests/acceptance/features/lib/AdminAppsSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminAppsSettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Gherkin\Node\TableNode;
@@ -128,21 +129,21 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 	public function checkRequiredAuthentication($requiredState) {
 		$checkbox = $this->find("xpath", $this->authRequiredCheckboxXpath);
 		$checkCheckbox = $this->findById($this->authRequiredCheckboxId);
-		
+
 		$this->assertElementNotNull(
 			$checkbox,
 			__METHOD__ .
 			" xpath $this->authRequiredCheckboxXpath " .
 			"could not find label for checkbox"
 		);
-		
+
 		$this->assertElementNotNull(
 			$checkCheckbox,
 			__METHOD__ .
 			" id $this->authRequiredCheckboxId " .
 			"could not find checkbox"
 		);
-		
+
 		if ($requiredState == 'true') {
 			if (!$checkCheckbox->isChecked()) {
 				$checkbox->click();

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Element\NodeElement;
@@ -94,6 +95,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $enforceExpirationDateUserShareCheckboxId = 'shareapiEnforceExpireDateUserShare';
 	protected $enforceExpirationDateGroupShareCheckboxXpath = '//span[@id="setDefaultExpireDateGroupShare"]//label[contains(text(),"expiration date")]';
 	protected $enforceExpirationDateGroupShareCheckboxId = 'shareapiEnforceExpireDateGroupShare';
+
 	/**
 	 * toggle the Share API
 	 *
@@ -456,8 +458,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement|NULL
+	 * @throws ElementNotFoundException
 	 */
 	private function findUserShareExpirationField() {
 		$expirationDateField = $this->find("xpath", $this->userShareExpirationDateFieldXpath);
@@ -471,8 +473,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement|NULL
+	 * @throws ElementNotFoundException
 	 */
 	private function findGroupShareExpirationField() {
 		$expirationDateField = $this->find("xpath", $this->groupShareExpirationDateFieldXpath);

--- a/tests/acceptance/features/lib/AdminStorageSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminStorageSettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/FavoritesPage.php
+++ b/tests/acceptance/features/lib/FavoritesPage.php
@@ -30,7 +30,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
  * Favorites page.
  */
 class FavoritesPage extends FilesPageBasic {
-	
+
 	/**
 	 *
 	 * @var string $path
@@ -41,28 +41,28 @@ class FavoritesPage extends FilesPageBasic {
 	protected $fileListXpath = ".//div[@id='app-content-favorites']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-favorites']//div[@id='emptycontent']";
 	protected $filePathInRowXpath = "//*[@data-tags='_\$!<Favorite>!\$_']";
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileListXpath() {
 		return $this->fileListXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNamesXpath() {
 		return $this->fileNamesXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNameMatchXpath() {
 		return $this->fileNameMatchXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
@@ -73,9 +73,9 @@ class FavoritesPage extends FilesPageBasic {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return string
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return string
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -81,9 +81,9 @@ class FilesPage extends FilesPageBasic {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return void
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return void
 	 */
 	protected function getFilePathInRowXpath() {
 		throw new \Exception("not implemented in FilesPage");
@@ -92,7 +92,7 @@ class FilesPage extends FilesPageBasic {
 	/**
 	 * @param Session $session
 	 * @param Factory $factory
-	 * @param array   $parameters
+	 * @param array $parameters
 	 */
 	public function __construct(
 		Session $session, Factory $factory, array $parameters = []
@@ -116,8 +116,8 @@ class FilesPage extends FilesPageBasic {
 	 * @param string $name
 	 * @param int $timeoutMsec
 	 *
-	 * @throws ElementNotFoundException|\Exception
 	 * @return string name of the created file
+	 * @throws ElementNotFoundException|\Exception
 	 */
 	public function createFolder(
 		Session $session, $name = null,
@@ -147,8 +147,8 @@ class FilesPage extends FilesPageBasic {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getCreateFolderTooltip() {
 		$newFolderTooltip = $this->find("xpath", $this->newFolderTooltipXpath);
@@ -175,8 +175,8 @@ class FilesPage extends FilesPageBasic {
 	/**
 	 * gets a sharing dialog object
 	 *
-	 * @throws ElementNotFoundException
 	 * @return SharingDialog
+	 * @throws ElementNotFoundException
 	 */
 	public function getSharingDialog() {
 		return $this->getPage("FilesPageElement\\SharingDialog");
@@ -200,9 +200,9 @@ class FilesPage extends FilesPageBasic {
 	 * closes an open details dialog
 	 * the details dialog contains the comments, sharing, versions etc tabs
 	 *
+	 * @return void
 	 * @throws ElementNotFoundException
 	 * if no sharing dialog is open
-	 * @return void
 	 */
 	public function closeDetailsDialog() {
 		$this->getDetailsDialog()->closeDetailsDialog();
@@ -344,6 +344,7 @@ class FilesPage extends FilesPageBasic {
 
 		return $this;
 	}
+
 	/**
 	 * Browse to Home Page by clicking on home icon.
 	 *
@@ -393,8 +394,8 @@ class FilesPage extends FilesPageBasic {
 	/**
 	 * waits till the upload progressbar is not visible anymore
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function waitForUploadProgressbarToFinish() {
 		$this->filesPageCRUDFunctions->waitForUploadProgressbarToFinish();

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -360,8 +360,8 @@ abstract class FilesPageBasic extends OwncloudPage {
 	/**
 	 * gets a details dialog object
 	 *
-	 * @throws ElementNotFoundException
 	 * @return DetailsDialog
+	 * @throws ElementNotFoundException
 	 */
 	public function getDetailsDialog() {
 		$detailsDialogElement = $this->find("xpath", $this->detailsDialogXpath);
@@ -383,8 +383,8 @@ abstract class FilesPageBasic extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findSelectAllFilesBtn() {
 		$selectedAllFilesBtn = $this->find(
@@ -424,8 +424,8 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 *
 	 * @param int $number
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findFileActionsMenuBtnByNo($number) {
 		$xpathLocator = \sprintf($this->fileActionMenuBtnXpathByNo, $number);
@@ -606,8 +606,8 @@ abstract class FilesPageBasic extends OwncloudPage {
 	}
 
 	/**
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function enableShowHiddenFilesSettings() {
 		$appSettingsButton = $this->find('xpath', $this->appSettingsXpath);

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -122,21 +122,21 @@ class FilesPageCRUD extends FilesPageBasic {
 	protected function getFileListXpath() {
 		return $this->fileListXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNamesXpath() {
 		return $this->fileNamesXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
 	protected function getFileNameMatchXpath() {
 		return $this->fileNameMatchXpath;
 	}
-	
+
 	/**
 	 * @return string
 	 */
@@ -168,9 +168,9 @@ class FilesPageCRUD extends FilesPageBasic {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return void
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return void
 	 */
 	protected function getFilePathInRowXpath() {
 		throw new \Exception("not implemented");
@@ -195,7 +195,7 @@ class FilesPageCRUD extends FilesPageBasic {
 		if (\is_array($toFileName)) {
 			$toFileName = \implode($toFileName);
 		}
-		
+
 		for ($counter = 0; $counter < $maxRetries; $counter++) {
 			try {
 				$fileRow = $this->findFileRowByName($fromFileName, $session);
@@ -216,7 +216,7 @@ class FilesPageCRUD extends FilesPageBasic {
 			echo $message;
 			\error_log($message);
 		}
-		
+
 		$this->waitTillFileRowsAreReady($session);
 	}
 
@@ -235,10 +235,10 @@ class FilesPageCRUD extends FilesPageBasic {
 	) {
 		$toMoveFileRow = $this->findFileRowByName($name, $session);
 		$destinationFileRow = $this->findFileRowByName($destination, $session);
-		
+
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
-		
+
 		for ($retryCounter = 0; $retryCounter < $maxRetries; $retryCounter++) {
 			$toMoveFileRow->findFileLink()->dragTo(
 				$destinationFileRow->findFileLink()
@@ -266,7 +266,7 @@ class FilesPageCRUD extends FilesPageBasic {
 	 */
 	public function findNewFileFolderButton() {
 		$newButtonElement = $this->find("xpath", $this->newFileFolderButtonXpath);
-		
+
 		$this->assertElementNotNull(
 			$newButtonElement,
 			__METHOD__ .
@@ -284,8 +284,8 @@ class FilesPageCRUD extends FilesPageBasic {
 	 * @param string $name
 	 * @param int $timeoutMsec
 	 *
-	 * @throws ElementNotFoundException|\Exception
 	 * @return string name of the created file
+	 * @throws ElementNotFoundException|\Exception
 	 */
 	public function createFolder(
 		Session $session, $name = null,
@@ -296,16 +296,16 @@ class FilesPageCRUD extends FilesPageBasic {
 		}
 		$newButtonElement = $this->findNewFileFolderButton();
 		$newButtonElement->click();
-		
+
 		$newFolderButtonElement = $this->find("xpath", $this->newFolderButtonXpath);
-		
+
 		$this->assertElementNotNull(
 			$newFolderButtonElement,
 			__METHOD__ .
 			" xpath $this->newFolderButtonXpath " .
 			"could not find new folder button"
 		);
-		
+
 		try {
 			$newFolderButtonElement->click();
 		} catch (NoSuchElement $e) {
@@ -320,7 +320,7 @@ class FilesPageCRUD extends FilesPageBasic {
 				. "\n-------------------------\n"
 			);
 		}
-		
+
 		try {
 			$this->fillField($this->newFolderNameInputLabel, $name . Key::ENTER);
 		} catch (NoSuchElement $e) {
@@ -337,7 +337,7 @@ class FilesPageCRUD extends FilesPageBasic {
 		$timeoutMsec = (int) $timeoutMsec;
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeoutMsec / 1000);
-		
+
 		while ($currentTime <= $end) {
 			$newFolderButton = $this->find("xpath", $this->newFolderButtonXpath);
 			if ($newFolderButton === null || !$newFolderButton->isVisible()) {
@@ -356,7 +356,7 @@ class FilesPageCRUD extends FilesPageBasic {
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
-		
+
 		if ($currentTime > $end) {
 			throw new \Exception("could not create folder");
 		}
@@ -380,7 +380,7 @@ class FilesPageCRUD extends FilesPageBasic {
 	) {
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
-		
+
 		for ($counter = 0; $counter < $maxRetries; $counter++) {
 			$row = $this->findFileRowByName($name, $session);
 			try {
@@ -424,8 +424,8 @@ class FilesPageCRUD extends FilesPageBasic {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findDeleteAllSelectedFilesBtn() {
 		$deleteAllSelectedBtn = $this->find(
@@ -475,8 +475,8 @@ class FilesPageCRUD extends FilesPageBasic {
 	/**
 	 * waits till the upload progressbar is not visible anymore
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function waitForUploadProgressbarToFinish() {
 		$uploadProgressbar = $this->find(

--- a/tests/acceptance/features/lib/FilesPageElement/ConflictDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/ConflictDialog.php
@@ -33,14 +33,14 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 class ConflictDialog extends OCDialog {
 	private $keepNewFilesCheckXpath = "//label[@for='checkbox-allnewfiles']";
 	private $keepExistingFilesCheckXpath = "//label[@for='checkbox-allexistingfiles']";
-	
+
 	/**
 	 * takes the xpath and selects the option with that xpath
 	 *
 	 * @param string $xpath
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	private function keepFiles($xpath) {
 		$checkBox = $this->dialogElement->find("xpath", $xpath);
@@ -54,16 +54,16 @@ class ConflictDialog extends OCDialog {
 	}
 
 	/**
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function keepExistingFiles() {
 		$this->keepFiles($this->keepExistingFilesCheckXpath);
 	}
 
 	/**
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function keepNewFiles() {
 		$this->keepFiles($this->keepNewFilesCheckXpath);

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -60,8 +60,8 @@ class DetailsDialog extends OwncloudPage {
 	private $tagEditButtonInTagXpath = "//span[@class='systemtags-actions']//a[contains(@class, 'rename')]";
 	private $tagDeleteButtonInTagXpath = "//form[@class='systemtags-rename-form']//a";
 	private $tagsDropDownResultXpath = "//div[contains(@class, 'systemtags-select2-dropdown')]" .
-										"//ul[@class='select2-results']" .
-										"//span[@class='label']";
+	"//ul[@class='select2-results']" .
+	"//span[@class='label']";
 	private $tagEditInputXpath = "//input[@id='view9-rename-input']";
 
 	private $commentXpath = "//ul[@class='comments']//div[@class='message' and contains(., '%s')]";
@@ -121,8 +121,8 @@ class DetailsDialog extends OwncloudPage {
 	 *
 	 * @param string $tabName e.g. comments, sharing, versions
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	private function findDetailsTab($tabName) {
 		$tab = $this->detailsDialogElement->findById(
@@ -199,8 +199,8 @@ class DetailsDialog extends OwncloudPage {
 	 *
 	 * @param string $tabName e.g. comments, sharing, versions
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function changeDetailsTab($tabName) {
 		$tabId = $this->getDetailsTabId($tabName);
@@ -364,8 +364,8 @@ class DetailsDialog extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement of the whole container holding the thumbnail
+	 * @throws ElementNotFoundException
 	 */
 	public function findThumbnailContainer() {
 		$thumbnailContainer = $this->detailsDialogElement->find(
@@ -382,8 +382,8 @@ class DetailsDialog extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findThumbnail() {
 		$thumbnailContainer = $this->findThumbnailContainer();
@@ -578,8 +578,8 @@ class DetailsDialog extends OwncloudPage {
 	/**
 	 * closes the details dialog panel
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function closeDetailsDialog() {
 		$detailsDialogCloseButton = $this->detailsDialogElement->find(

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -88,8 +88,8 @@ class FileActionsMenu extends OwncloudPage {
 	 * @param string $xpathToWaitFor wait for this element to appear before returning
 	 * @param int $timeout_msec
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function rename(
 		$xpathToWaitFor = null, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
@@ -155,6 +155,7 @@ class FileActionsMenu extends OwncloudPage {
 		$detailsBtn->focus();
 		$detailsBtn->click();
 	}
+
 	/**
 	 * clicks the decline share button
 	 *

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -140,8 +140,8 @@ class FileRow extends OwncloudPage {
 	/**
 	 * finds and clicks the file actions button
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function clickFileActionButton() {
 		$this->findFileActionButton()->click();
@@ -152,8 +152,8 @@ class FileRow extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 *
-	 * @throws ElementNotFoundException
 	 * @return FileActionsMenu
+	 * @throws ElementNotFoundException
 	 */
 	public function openFileActionsMenu(Session $session) {
 		$this->clickFileActionButton();
@@ -177,8 +177,8 @@ class FileRow extends OwncloudPage {
 	/**
 	 * finds and returns the share button element
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findSharingButton() {
 		$shareBtn = $this->rowElement->find("xpath", $this->shareBtnXpath);
@@ -196,8 +196,8 @@ class FileRow extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 *
-	 * @throws ElementNotFoundException
 	 * @return SharingDialog
+	 * @throws ElementNotFoundException
 	 */
 	public function openSharingDialog(Session $session) {
 		$this->findSharingButton()->click();
@@ -216,8 +216,8 @@ class FileRow extends OwncloudPage {
 	/**
 	 * opens the lock dialog that list all locks of the given file row
 	 *
-	 * @throws ElementNotFoundException
 	 * @return LockDialog
+	 * @throws ElementNotFoundException
 	 */
 	public function openLockDialog() {
 		$element = $this->rowElement->find("xpath", $this->lockStateXpath);
@@ -262,8 +262,8 @@ class FileRow extends OwncloudPage {
 	/**
 	 * finds the input field to rename the file/folder
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findRenameInputField() {
 		$inputField = $this->rowElement->find(
@@ -310,8 +310,8 @@ class FileRow extends OwncloudPage {
 	/**
 	 * finds and returns the tooltip element
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findTooltipElement() {
 		$element = $this->rowElement->find("xpath", $this->fileTooltipXpath);
@@ -338,8 +338,8 @@ class FileRow extends OwncloudPage {
 	 *
 	 * @param string $xpath xpath related to the fileRow element
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getFilePath($xpath) {
 		$filePathElement = $this->rowElement->find("xpath", $xpath);
@@ -354,8 +354,8 @@ class FileRow extends OwncloudPage {
 	/**
 	 * finds and returns the thumbnail of the file
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findThumbnail() {
 		$thumbnail = $this->rowElement->find("xpath", $this->thumbnailXpath);
@@ -381,8 +381,8 @@ class FileRow extends OwncloudPage {
 	/**
 	 * find and return the link to the file/folder
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findFileLink() {
 		$linkElement = $this->rowElement->find("xpath", $this->fileLinkXpath);
@@ -473,9 +473,9 @@ class FileRow extends OwncloudPage {
 	/**
 	 * returns the lock state
 	 *
+	 * @return bool
 	 * @throws ElementNotFoundException
 	 *
-	 * @return bool
 	 */
 	public function getLockState() {
 		$element = $this->rowElement->find("xpath", $this->lockStateXpath);
@@ -488,9 +488,9 @@ class FileRow extends OwncloudPage {
 	/**
 	 * returns the share state (only works on the "Shared with you" page)
 	 *
+	 * @return string
 	 * @throws ElementNotFoundException
 	 *
-	 * @return string
 	 */
 	public function getShareState() {
 		$element = $this->rowElement->find("xpath", $this->shareStateXpath);
@@ -504,9 +504,9 @@ class FileRow extends OwncloudPage {
 
 	/**
 	 *
+	 * @return string
 	 * @throws ElementNotFoundException
 	 *
-	 * @return string
 	 */
 	public function getSharer() {
 		$element = $this->rowElement->find("xpath", $this->sharerXpath);
@@ -517,6 +517,7 @@ class FileRow extends OwncloudPage {
 		);
 		return \trim($element->getText());
 	}
+
 	/**
 	 *
 	 * @param Session $session
@@ -560,8 +561,8 @@ class FileRow extends OwncloudPage {
 	 * returns the element that contains the highlighted content of the file
 	 * when using elastic search
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function getHighlightsElement() {
 		$element = $this->rowElement->find("xpath", $this->highlightsXpath);

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
@@ -82,9 +82,9 @@ class LockEntry extends OwncloudPage {
 	/**
 	 * gets the user that has locked the resource
 	 *
+	 * @return string
 	 * @throws \Exception
 	 *
-	 * @return string
 	 */
 	public function getLockingUser() {
 		$lockDescriptionElement = $this->lockElement->find(

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -79,8 +79,8 @@ class SharingDialog extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement|NULL
+	 * @throws ElementNotFoundException
 	 */
 	private function findShareWithField() {
 		$shareWithField = $this->find("xpath", $this->shareWithFieldXpath);
@@ -156,8 +156,8 @@ class SharingDialog extends OwncloudPage {
 	 * @param string $user
 	 * @param string $type
 	 *
-	 * @throws \Exception
 	 * @return string
+	 * @throws \Exception
 	 */
 	public function getExpirationDateFor($user, $type = 'user') {
 		$field = $this->getExpirationFieldFor($user, $type);
@@ -342,8 +342,8 @@ class SharingDialog extends OwncloudPage {
 	 * @param int $maxRetries
 	 * @param boolean $quiet
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function shareWithUserOrGroup(
 		$nameToType, $nameToMatch, Session $session, $maxRetries = 5, $quiet = false
@@ -391,8 +391,8 @@ class SharingDialog extends OwncloudPage {
 	 * @param int $maxRetries
 	 * @param boolean $quiet
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function shareWithUser(
 		$name, Session $session, $maxRetries = 5, $quiet = false
@@ -410,8 +410,8 @@ class SharingDialog extends OwncloudPage {
 	 * @param int $maxRetries
 	 * @param boolean $quiet
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function shareWithRemoteUser(
 		$name, Session $session, $maxRetries = 5, $quiet = false
@@ -429,8 +429,8 @@ class SharingDialog extends OwncloudPage {
 	 * @param int $maxRetries
 	 * @param boolean $quiet
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function shareWithGroup(
 		$name, Session $session, $maxRetries = 5, $quiet = false
@@ -448,8 +448,8 @@ class SharingDialog extends OwncloudPage {
 	 * @param array $permissions [['permission' => 'yes|no']]
 	 * @param Session $session
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function setSharingPermissions(
 		$userOrGroup,
@@ -477,8 +477,8 @@ class SharingDialog extends OwncloudPage {
 		$this->assertElementNotNull(
 			$showCrudsBtn,
 			__METHOD__
-				. " xpath $this->showCrudsXpath could not find show-cruds button for user "
-				. $shareReceiverName
+			. " xpath $this->showCrudsXpath could not find show-cruds button for user "
+			. $shareReceiverName
 		);
 		$showCrudsBtn->click();
 		foreach ($permissions as $permission => $value) {
@@ -541,8 +541,8 @@ class SharingDialog extends OwncloudPage {
 	 * @param array $permissions [['permission' => 'yes|no']]
 	 * @param Session $session
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function checkSharingPermissions(
 		$userOrGroup,
@@ -590,8 +590,8 @@ class SharingDialog extends OwncloudPage {
 	/**
 	 * gets the text of the tooltip associated with the "share-with" input
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getShareWithTooltip() {
 		$shareWithField = $this->findShareWithField();
@@ -611,8 +611,8 @@ class SharingDialog extends OwncloudPage {
 	 * gets the Element with the information about who has shared the current
 	 * file/folder. This Element will contain the Avatar and some text.
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findSharerInformationItem() {
 		$sharerInformation = $this->find("xpath", $this->sharerInformationXpath);
@@ -629,8 +629,8 @@ class SharingDialog extends OwncloudPage {
 	 * gets the group that the file/folder was shared with
 	 * and the user that shared it
 	 *
-	 * @throws \Exception
 	 * @return array ["sharedWithGroup" => string, "sharer" => string]
+	 * @throws \Exception
 	 */
 	public function getSharedWithGroupAndSharerName() {
 		if ($this->sharedWithGroupAndSharerName === null) {
@@ -662,8 +662,8 @@ class SharingDialog extends OwncloudPage {
 	/**
 	 * gets the display name of the user that has shared the current file/folder
 	 *
-	 * @throws \Exception
 	 * @return string
+	 * @throws \Exception
 	 */
 	public function getSharerName() {
 		return $this->getSharedWithGroupAndSharerName()["sharer"];
@@ -672,8 +672,8 @@ class SharingDialog extends OwncloudPage {
 	/**
 	 * @param Session $session
 	 *
-	 * @throws ElementNotFoundException
 	 * @return PublicLinkTab
+	 * @throws ElementNotFoundException
 	 */
 	public function openPublicShareTab(Session $session) {
 		$publicLinksShareTab = $this->find("xpath", $this->publicLinksShareTabXpath);
@@ -766,9 +766,9 @@ class SharingDialog extends OwncloudPage {
 	 * @param Session $session
 	 * @param string $entryName
 	 *
+	 * @return void
 	 * @throws \Exception
 	 *
-	 * @return void
 	 */
 	public function checkThatNameIsNotInPublicLinkList(Session $session, $entryName) {
 		$publicLinkTitles = $this->findAll("xpath", $this->publicLinkTitleXpath);
@@ -815,9 +815,9 @@ class SharingDialog extends OwncloudPage {
 	 * @param Session $session
 	 * @param integer $count
 	 *
+	 * @return void
 	 * @throws \Exception
 	 *
-	 * @return void
 	 */
 	public function checkPublicLinkCount(Session $session, $count) {
 		$publicLinkTitles = $this->findAll("xpath", $this->publicLinkTitleXpath);
@@ -900,7 +900,7 @@ class SharingDialog extends OwncloudPage {
 		);
 		return $item;
 	}
-	
+
 	/**
 	 * waits for the dialog to appear
 	 *

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -50,7 +50,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	private $permissionLabelXpath = [
 		'read' => ".//label[contains(@for, 'sharingDialogAllowPublicRead')]",
 		'read-write' => ".//label[contains(@for, 'sharingDialogAllowPublicReadWrite')]",
-		'upload-write-without-modify' =>  ".//label[contains(@for, 'sharingDialogAllowpublicUploadWrite')]",
+		'upload-write-without-modify' => ".//label[contains(@for, 'sharingDialogAllowpublicUploadWrite')]",
 		'upload' => ".//label[contains(@for, 'sharingDialogAllowPublicUpload')]"
 	];
 	private $popupCloseButton = "//a[@class='oc-dialog-close']";
@@ -74,8 +74,8 @@ class EditPublicLinkPopup extends OwncloudPage {
 	/**
 	 * finds and returns the NodeElement of the name input field
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	private function findNameInput() {
 		$nameInput = $this->popupElement->find("xpath", $this->nameInputXpath);

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -60,8 +60,8 @@ class PublicLinkTab extends OwncloudPage {
 	 *
 	 * @param NodeElement $publicLinkTab
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function setElement(NodeElement $publicLinkTab) {
 		$this->publicLinkTabElement = $publicLinkTab;
@@ -261,8 +261,8 @@ class PublicLinkTab extends OwncloudPage {
 	 *
 	 * @param string $name
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getLinkUrl($name) {
 		$linkEntry = $this->findLinkEntryByName($name);
@@ -329,8 +329,8 @@ class PublicLinkTab extends OwncloudPage {
 	 *
 	 * @param string $name
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	private function findLinkEntryByName($name) {
 		$xpathString = $this->quotedText($name);

--- a/tests/acceptance/features/lib/GeneralErrorPage.php
+++ b/tests/acceptance/features/lib/GeneralErrorPage.php
@@ -33,8 +33,8 @@ class GeneralErrorPage extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getErrorMessage() {
 		$errorMessageElement = $this->find("xpath", $this->errorMessageXpath);

--- a/tests/acceptance/features/lib/GeneralExceptionPage.php
+++ b/tests/acceptance/features/lib/GeneralExceptionPage.php
@@ -34,8 +34,8 @@ class GeneralExceptionPage extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getExceptionMessage() {
 		$exceptionMessageElement = $this->find("xpath", $this->exceptionMessageXpath);
@@ -49,8 +49,8 @@ class GeneralExceptionPage extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getExceptionTitle() {
 		$exceptionTitleElement = $this->find("xpath", $this->exceptionTitleXpath);

--- a/tests/acceptance/features/lib/HelpAndTipsPage.php
+++ b/tests/acceptance/features/lib/HelpAndTipsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Element\NodeElement;

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -54,8 +54,8 @@ class LoginPage extends OwncloudPage {
 	 * @param string $password
 	 * @param string $target
 	 *
-	 * @throws ElementNotFoundException
 	 * @return Page
+	 * @throws ElementNotFoundException
 	 */
 	public function loginAs($username, $password, $target = 'FilesPage') {
 		$this->fillField($this->userInputId, $username);
@@ -110,9 +110,9 @@ class LoginPage extends OwncloudPage {
 
 	/**
 	 *
+	 * @return Page
 	 * @throws ElementNotFoundException
 	 *
-	 * @return Page
 	 */
 	private function lostPasswordField() {
 		$lostPasswordField = $this->findById($this->lostPasswordId);
@@ -126,9 +126,9 @@ class LoginPage extends OwncloudPage {
 
 	/**
 	 *
+	 * @return NodeElement
 	 * @throws ElementNotFoundException
 	 *
-	 * @return NodeElement
 	 */
 	private function getSetPasswordErrorMessageField() {
 		$setPasswordErrorMessageField = $this->findById($this->setPasswordErrorMessageId);
@@ -142,9 +142,9 @@ class LoginPage extends OwncloudPage {
 
 	/**
 	 *
+	 * @return NodeElement
 	 * @throws ElementNotFoundException
 	 *
-	 * @return NodeElement
 	 */
 	private function getLostPasswordResetErrorMessageField() {
 		$lostPasswordResetErrorMessageField = $this->find(
@@ -252,6 +252,6 @@ class LoginPage extends OwncloudPage {
 			"could not find link"
 		);
 
-		return($legalUrlLink->getAttribute("href"));
+		return ($legalUrlLink->getAttribute("href"));
 	}
 }

--- a/tests/acceptance/features/lib/Notification.php
+++ b/tests/acceptance/features/lib/Notification.php
@@ -30,16 +30,16 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
  * PageObject for a single notification
  */
 class Notification extends OwncloudPage {
-	
+
 	/**
 	 *
 	 * @var NodeElement
 	 */
 	private $notificationElement;
-	
+
 	private $buttonByTextXpath = "//button[text()='%s']";
 	private $notificationLinkXpath = "//a[@class='notification-link']";
-	
+
 	/**
 	 * sets the NodeElement for the current notification
 	 * a little bit like __construct() but as we access this "sub-page-object"
@@ -59,9 +59,9 @@ class Notification extends OwncloudPage {
 	 * @param Session $session
 	 * @param int $timeout_msec
 	 *
+	 * @return void
 	 * @throws ElementNotFoundException
 	 *
-	 * @return void
 	 */
 	public function followLink(
 		Session $session, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC

--- a/tests/acceptance/features/lib/NotificationsAppDialog.php
+++ b/tests/acceptance/features/lib/NotificationsAppDialog.php
@@ -32,7 +32,7 @@ class NotificationsAppDialog extends OwncloudPage {
 	private $notificationTitleXpath = "//h3[@class='notification-title']";
 	private $notificationLinkXpath = "//a[@class='notification-link']";
 	private $notificationMessageXpath = "//p[@class='notification-message']";
-	
+
 	/**
 	 *
 	 * @return array with notifications details title,link,message

--- a/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
+++ b/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
@@ -32,11 +32,11 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
  */
 class NotificationsEnabledOwncloudPage extends OwncloudPage {
 	private $notificationsButtonXpath = "//div[contains(@class,'notifications-button')]";
-	
+
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	private function findNotificationsButton() {
 		$button = $this->waitTillElementIsNotNull($this->notificationsButtonXpath);

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -179,8 +179,8 @@ class OwncloudPage extends Page {
 	/**
 	 * Get the text of the first notification
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getNotificationText() {
 		$notificationElement = $this->findById($this->notificationId);
@@ -196,8 +196,8 @@ class OwncloudPage extends Page {
 	/**
 	 * Get the text of any notifications
 	 *
-	 * @throws ElementNotFoundException
 	 * @return array
+	 * @throws ElementNotFoundException
 	 */
 	public function getNotifications() {
 		$notificationsText = [];
@@ -216,8 +216,8 @@ class OwncloudPage extends Page {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getPageTitle() {
 		$title = $this->find('xpath', $this->titleXpath);
@@ -253,8 +253,8 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 *
-	 * @throws ElementNotFoundException
 	 * @return Page
+	 * @throws ElementNotFoundException
 	 */
 	public function openSettingsMenu(Session $session) {
 		$userNameDisplayElement = $this->findById($this->userNameDisplayId);
@@ -278,8 +278,8 @@ class OwncloudPage extends Page {
 	/**
 	 * finds the element that contains the displayname of the current user
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	protected function findUserDisplayNameElement() {
 		$displayNameElement = $this->findById($this->userNameDisplayId);
@@ -295,8 +295,8 @@ class OwncloudPage extends Page {
 	/**
 	 * returns the displayname (Full Name or username) of the current user
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getMyDisplayname() {
 		return $this->getTrimmedText($this->findUserDisplayNameElement());
@@ -312,8 +312,8 @@ class OwncloudPage extends Page {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	protected function findAvatarElement() {
 		$avatarElement = $this->find("xpath", $this->avatarImgXpath);
@@ -344,8 +344,8 @@ class OwncloudPage extends Page {
 	 * @param Session $session
 	 * @param string $searchTerm
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function search($session, $searchTerm) {
 		$searchbox = $this->findById($this->searchBoxId);
@@ -575,9 +575,9 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 *
-	 * @see resetSumStartedAjaxRequests()
-	 * @see getSumStartedAjaxRequests()
 	 * @return void
+	 * @see getSumStartedAjaxRequests()
+	 * @see resetSumStartedAjaxRequests()
 	 */
 	public function initAjaxCounters(
 		Session $session
@@ -620,8 +620,8 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 *
-	 * @see initAjaxCounters()
 	 * @return void
+	 * @see initAjaxCounters()
 	 */
 	public function resetSumStartedAjaxRequests(Session $session) {
 		$this->assertSumStartedAjaxRequestsIsDefined($session);
@@ -633,8 +633,8 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 *
-	 * @see initAjaxCounters()
 	 * @return int
+	 * @see initAjaxCounters()
 	 */
 	public function getSumStartedAjaxRequests(Session $session) {
 		$this->assertSumStartedAjaxRequestsIsDefined($session);
@@ -645,9 +645,9 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 *
-	 * @see initAjaxCounters()
-	 * @throws \Exception
 	 * @return void
+	 * @throws \Exception
+	 * @see initAjaxCounters()
 	 */
 	private function assertSumStartedAjaxRequestsIsDefined(Session $session) {
 		$sumStartedAjaxRequestsIsUndefined = $session->evaluateScript(
@@ -731,7 +731,7 @@ class OwncloudPage extends Page {
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end && $result !== 0) {
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
-			$result = (int)$session->evaluateScript("jQuery.scrolling");
+			$result = (int) $session->evaluateScript("jQuery.scrolling");
 			$currentTime = \microtime(true);
 		}
 		if ($currentTime > $end) {
@@ -755,8 +755,8 @@ class OwncloudPage extends Page {
 	 * @param string $value
 	 * @param Session $session
 	 *
-	 * @throws \Exception
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function fillFieldAndKeepFocus(NodeElement $element, $value, $session) {
 		$driver = $session->getDriver();
@@ -795,8 +795,8 @@ class OwncloudPage extends Page {
 	 *
 	 * @param NodeElement $element
 	 *
-	 * @throws \Exception
 	 * @return string text of the element with any whitespace trimmed
+	 * @throws \Exception
 	 */
 	public function getTrimmedText(NodeElement $element) {
 		return \trim($element->getText());
@@ -836,8 +836,8 @@ class OwncloudPage extends Page {
 	 * @param NodeElement $element
 	 * @param string $message
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function assertElementNotNull($element, $message) {
 		if ($element === null) {

--- a/tests/acceptance/features/lib/OwncloudPageElement/OCDialog.php
+++ b/tests/acceptance/features/lib/OwncloudPageElement/OCDialog.php
@@ -70,10 +70,11 @@ class OCDialog extends OwncloudPage {
 	public function getOwnElement() {
 		return $this->dialogElement;
 	}
+
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getTitle() {
 		$title = $this->dialogElement->find("xpath", $this->titleClassXpath);
@@ -88,8 +89,8 @@ class OCDialog extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string
+	 * @throws ElementNotFoundException
 	 */
 	public function getMessage() {
 		$contentElement = $this->dialogElement->find(
@@ -111,8 +112,8 @@ class OCDialog extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function accept(Session $session) {
 		$primaryButton = $this->dialogElement->find(

--- a/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
@@ -39,6 +39,7 @@ class PersonalEncryptionSettingsPage extends OwncloudPage {
 
 	private $userEnableRecoveryCheckboxId = 'userEnableRecoveryCheckbox';
 	private $userEnableRecoveryCheckboxXpath = '//label[@for="userEnableRecoveryCheckbox"]';
+
 	/**
 	 * Enable password recovery
 	 *

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Session;
@@ -150,19 +151,19 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 
 	/**
 	 *
+	 * @return string
 	 * @throws ElementNotFoundException
 	 *
-	 * @return string
 	 */
 	public function getWrongPasswordMessageText() {
 		$errorMessage = $this->findById($this->passwordErrorMessageID);
-		
+
 		$this->assertElementNotNull(
 			$errorMessage,
 			__METHOD__ .
 			" could not find element with id $this->passwordErrorMessageID"
 		);
-		
+
 		return $this->getTrimmedText($errorMessage);
 	}
 

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Session;
@@ -53,8 +54,8 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	 *
 	 * @param string $appName
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function createNewAppPassword($appName) {
 		$this->fillField($this->appPasswordNameInputId, $appName);
@@ -97,8 +98,8 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	 *
 	 * @param string $appName
 	 *
-	 * @throws \Exception
 	 * @return NodeElement
+	 * @throws \Exception
 	 */
 	public function getLinkedAppByName($appName) {
 		$appTrs = $this->findAll("xpath", $this->linkedAppsTrXpath);

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Session;
@@ -47,6 +48,7 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 		= '//label[@for="allow_share_dialog_user_enumeration_input"]';
 	protected $allowFindingYouViaAutocompleteCheckboxXpathCheckboxId
 		= 'allow_share_dialog_user_enumeration_input';
+
 	/**
 	 *
 	 * @param Session $session
@@ -94,6 +96,7 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 			$this->allowFindingYouViaAutocompleteCheckboxXpathCheckboxId
 		);
 	}
+
 	/**
 	 * there is no reliable loading indicator on the personal sharing settings page,
 	 * so just wait for files_sharing personal panel div to be there and all Ajax calls to finish

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -87,10 +87,10 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return void
+	 * @throws \Exception
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @throws \Exception
-	 * @return void
 	 */
 	protected function getFilePathInRowXpath() {
 		throw new \Exception("not implemented in PublicLinkFilesPage");
@@ -99,7 +99,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	/**
 	 * @param Session $session
 	 * @param Factory $factory
-	 * @param array   $parameters
+	 * @param array $parameters
 	 */
 	public function __construct(
 		Session $session, Factory $factory, array $parameters = []
@@ -120,8 +120,8 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 *
 	 * @param string $server
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function addToServer($server) {
 		$addToYourOcBtn = $this->findById($this->addToYourOcBtnId);
@@ -155,8 +155,8 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @param string $name
 	 * @param int $timeoutMsec
 	 *
-	 * @throws ElementNotFoundException|\Exception
 	 * @return string name of the created file
+	 * @throws ElementNotFoundException|\Exception
 	 */
 	public function createFolder(
 		Session $session, $name = null,
@@ -272,6 +272,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 		$url3 = $directLink->getAttribute("value");
 		return [$url1, $url2, $url3];
 	}
+
 	/**
 	 * enter public link password
 	 *
@@ -480,8 +481,8 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	/**
 	 * waits till the upload progressbar is not visible anymore
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function waitForUploadProgressbarToFinish() {
 		$this->filesPageCRUDFunctions->waitForUploadProgressbarToFinish();

--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -77,9 +77,9 @@ class SharedByLinkPage extends FilesPageCRUD {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return void
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return void
 	 */
 	protected function getFilePathInRowXpath() {
 		throw new \Exception("not implemented in SharedByLinkPage");
@@ -88,7 +88,7 @@ class SharedByLinkPage extends FilesPageCRUD {
 	/**
 	 * @param Session $session
 	 * @param Factory $factory
-	 * @param array   $parameters
+	 * @param array $parameters
 	 */
 	public function __construct(
 		Session $session, Factory $factory, array $parameters = []

--- a/tests/acceptance/features/lib/SharedWithOthersPage.php
+++ b/tests/acceptance/features/lib/SharedWithOthersPage.php
@@ -48,6 +48,7 @@ class SharedWithOthersPage extends FilesPageBasic {
 	 * @var FilesPageCRUD $filesPageCRUDFunctions
 	 */
 	protected $filesPageCRUDFunctions;
+
 	/**
 	 * @return string
 	 */
@@ -79,9 +80,9 @@ class SharedWithOthersPage extends FilesPageBasic {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return string
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return string
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;
@@ -90,7 +91,7 @@ class SharedWithOthersPage extends FilesPageBasic {
 	/**
 	 * @param Session $session
 	 * @param Factory $factory
-	 * @param array   $parameters
+	 * @param array $parameters
 	 */
 	public function __construct(
 		Session $session, Factory $factory, array $parameters = []

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -70,9 +70,9 @@ class SharedWithYouPage extends FilesPageBasic {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return void
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return void
 	 */
 	protected function getFilePathInRowXpath() {
 		throw new \Exception("not implemented in SharedWithYouPage");

--- a/tests/acceptance/features/lib/SharingSettingsPage.php
+++ b/tests/acceptance/features/lib/SharingSettingsPage.php
@@ -20,6 +20,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace Page;
 
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/TagsPage.php
+++ b/tests/acceptance/features/lib/TagsPage.php
@@ -86,7 +86,7 @@ class TagsPage extends FilesPageBasic {
 	/**
 	 * @param Session $session
 	 * @param Factory $factory
-	 * @param array   $parameters
+	 * @param array $parameters
 	 */
 	public function __construct(
 		Session $session, Factory $factory, array $parameters = []

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -51,6 +51,7 @@ class TrashbinPage extends FilesPageBasic {
 	 * @var FilesPageCRUD $filesPageCRUDFunctions
 	 */
 	protected $filesPageCRUDFunctions;
+
 	/**
 	 * @return string
 	 */
@@ -82,9 +83,9 @@ class TrashbinPage extends FilesPageBasic {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @return string
 	 * @see \Page\FilesPageBasic::getFilePathInRowXpath()
 	 *
-	 * @return string
 	 */
 	protected function getFilePathInRowXpath() {
 		return $this->filePathInRowXpath;
@@ -93,7 +94,7 @@ class TrashbinPage extends FilesPageBasic {
 	/**
 	 * @param Session $session
 	 * @param Factory $factory
-	 * @param array   $parameters
+	 * @param array $parameters
 	 */
 	public function __construct(
 		Session $session, Factory $factory, array $parameters = []
@@ -110,8 +111,8 @@ class TrashbinPage extends FilesPageBasic {
 	}
 
 	/**
-	 * @throws ElementNotFoundException
 	 * @return NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function findRestoreAllSelectedFilesBtn() {
 		$restoreAllSelectedBtn = $this->find(

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -66,8 +66,8 @@ class GroupList extends OwncloudPage {
 	 *
 	 * @param string $name
 	 *
-	 * @throws ElementNotFoundException
 	 * @return \Behat\Mink\Element\NodeElement
+	 * @throws ElementNotFoundException
 	 */
 	public function selectGroup($name) {
 		$name = $this->quotedText($name);
@@ -92,8 +92,8 @@ class GroupList extends OwncloudPage {
 	 * @param string $name
 	 * @param bool $confirm
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function deleteGroup($name, $confirm) {
 		$groupLi = $this->selectGroup($name);
@@ -126,10 +126,10 @@ class GroupList extends OwncloudPage {
 
 	/**
 	 *
-	 * @param string  $groupName
+	 * @param string $groupName
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function addGroup($groupName) {
 		$addLink = $this->find("xpath", $this->addGroupXpath);

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -125,8 +125,8 @@ class UsersPage extends OwncloudPage {
 	/**
 	 * @param string $username
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string text describing the quota
+	 * @throws ElementNotFoundException
 	 */
 	public function getQuotaOfUser($username) {
 		$userTr = $this->findUserInTable($username);
@@ -157,8 +157,8 @@ class UsersPage extends OwncloudPage {
 	/**
 	 * @param string $username
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string email of user
+	 * @throws ElementNotFoundException
 	 */
 	public function getEmailOfUser($username) {
 		$userTr = $this->findUserInTable($username);
@@ -234,8 +234,8 @@ class UsersPage extends OwncloudPage {
 	/**
 	 * @param string $username
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string storage location of user
+	 * @throws ElementNotFoundException
 	 */
 	public function getStorageLocationOfUser($username) {
 		$userTr = $this->findUserInTable($username);
@@ -265,8 +265,8 @@ class UsersPage extends OwncloudPage {
 	/**
 	 * @param string $username
 	 *
-	 * @throws ElementNotFoundException
 	 * @return string last login of a user
+	 * @throws ElementNotFoundException
 	 */
 	public function getLastLoginOfUser($username) {
 		$userTr = $this->findUserInTable($username);
@@ -296,8 +296,8 @@ class UsersPage extends OwncloudPage {
 	/**
 	 * Open the settings menu
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function openAppSettingsMenu() {
 		$settingsBtn = $this->find("xpath", $this->settingsBtnXpath);
@@ -325,8 +325,8 @@ class UsersPage extends OwncloudPage {
 	 * @param string $setting the human readable setting string
 	 * @param boolean $value
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function setSetting($setting, $value = true) {
 		$settingContent = $this->findById($this->settingContentId);
@@ -391,8 +391,8 @@ class UsersPage extends OwncloudPage {
 	 * @param string $email
 	 * @param string[] $groups
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function createUser(
 		Session $session, $username, $password, $email = null, $groups = null
@@ -494,8 +494,8 @@ class UsersPage extends OwncloudPage {
 	 * @param Session $session
 	 * @param boolean $valid is the set quota expected to be valid
 	 *
-	 * @throws ElementNotFoundException
 	 * @return void
+	 * @throws ElementNotFoundException
 	 */
 	public function setQuotaOfUserTo(
 		$username, $quota, Session $session, $valid = true
@@ -566,8 +566,8 @@ class UsersPage extends OwncloudPage {
 
 	/**
 	 *
-	 * @throws ElementNotFoundException
 	 * @return GroupList
+	 * @throws ElementNotFoundException
 	 */
 	private function getGroupListElement() {
 		$groupListElement = $this->findById($this->groupListId);
@@ -790,7 +790,7 @@ class UsersPage extends OwncloudPage {
 	 * @return void
 	 * @throws ElementNotFoundException
 	 */
-	public function addOrRemoveUserToGroup(Session $session, $user, $group, $add=true) {
+	public function addOrRemoveUserToGroup(Session $session, $user, $group, $add = true) {
 		$userTr = $this->findUserInTable($user);
 		$groupsField = $userTr->find('xpath', $this->groupsFieldXpath);
 		$userGroupsInput = $groupsField->find("xpath", $this->userGroupsInputXpath);


### PR DESCRIPTION
This PR applies "Reformat code" in PHPstorm to the acceptance test bootstrap and lib folders.
It standardizes spacing, indenting, ordering of things in PHpdoc and...

Now to look through and see if it did anything really weird...

(this is a good chance to do this while there are not many core PRs open with acceptance test code changes)