### PR TITLE
fix xpath of 'show crud operations button' of secure view sharing

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -55,7 +55,7 @@ class SharingDialog extends OwncloudPage {
 	private $permissionsFieldByUserName = ".//*[@id='shareWithList']//*[@class='has-tooltip username' and .='%s']/../..";
 	private $permissionsFieldByGroupName = ".//*[@id='shareWithList']//*[@class='has-tooltip username' and .='%s (group)']/../..";
 	private $permissionLabelXpath = ".//label[@for='%s']";
-	private $showCrudsXpath = ".//*[@class='action-item toggleShareDetails']";
+	private $showCrudsXpath = ".//span[@class='icon icon-settings-dark']";
 	private $publicLinksShareTabXpath = ".//li[contains(@class,'subtab-publicshare')]";
 	private $publicLinksTabContentXpath = "//div[@id='shareDialogLinkList']";
 	private $noSharingMessageXpath = "//div[@class='noSharingPlaceholder']";


### PR DESCRIPTION
## Description
From core master PR #36628 
In our new webUI ```showCrudsXpath``` that is required in secure view, is changed. This PR adjusts the xpath according to the new changes in webUI.

## Related Issue
- Fixes https://github.com/owncloud/richdocuments/issues/309

## Motivation and Context
cherry-pick this back to `release-10.4.0` so that we can run richdocuments tests against 10.4 tarballs without a problem.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
