### PR TITLE
Skip on oc v10.3 20191223 for 10.4

### DIFF
--- a/tests/acceptance/features/apiMain/userSync.feature
+++ b/tests/acceptance/features/apiMain/userSync.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnOcV10.3
 Feature: Users sync
 
   Background:

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -16,6 +16,7 @@ Feature: add user
     And user "brand-new-user" should exist
     And user "brand-new-user" should be able to access a skeleton file
 
+  @skipOnOcV10.3
   Scenario Outline: admin creates a user with special characters in the username
     Given user "<username>" has been deleted
     When the administrator sends a user creation request for user "<username>" password "%alt1%" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -15,6 +15,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
+  @skipOnOcV10.3
   Scenario Outline: Delete a user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -15,6 +15,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "user1" should be disabled
 
+  @skipOnOcV10.3
   Scenario Outline: admin disables an user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -15,6 +15,7 @@ Feature: edit users
     And the OCS status code should be "100"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
+  @skipOnOcV10.3
   Scenario Outline: the administrator can edit a user email of an user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -16,6 +16,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "user1" should be enabled
 
+  @skipOnOcV10.3
   Scenario Outline: admin enables an user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -18,6 +18,7 @@ Feature: get user
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
 
+  @skipOnOcV10.3
   Scenario Outline: admin gets an existing user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | displayname   | email   |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -16,6 +16,7 @@ Feature: add user
     And user "brand-new-user" should exist
     And user "brand-new-user" should be able to access a skeleton file
 
+  @skipOnOcV10.3
   Scenario Outline: admin creates a user with special characters in the username
     Given user "<username>" has been deleted
     When the administrator sends a user creation request for user "<username>" password "%alt1%" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -15,6 +15,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
+  @skipOnOcV10.3
   Scenario Outline: Delete a user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -15,6 +15,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "user1" should be disabled
 
+  @skipOnOcV10.3
   Scenario Outline: admin disables an user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -15,6 +15,7 @@ Feature: edit users
     And the OCS status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
+  @skipOnOcV10.3
   Scenario Outline: the administrator can edit a user email of an user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -16,6 +16,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "user1" should be enabled
 
+  @skipOnOcV10.3
   Scenario Outline: admin enables an user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | email   |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -18,6 +18,7 @@ Feature: get user
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
 
+  @skipOnOcV10.3
   Scenario Outline: admin gets an existing user with special characters in the username
     Given these users have been created with skeleton files:
       | username   | displayname   | email   |

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -14,12 +14,14 @@ Feature: add users
     And user "guiusr1" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
+  @skipOnOcV10.3
   Scenario: use the webUI to create a user with special valid characters
     When the administrator creates a user with the name "@-+_.'" and the password "%regular%" using the webUI
     And the administrator logs out of the webUI
     And user "@-+_.'" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
+  @skipOnOcV10.3
   Scenario: use the webUI to create a user with special invalid characters
     When the administrator attempts to create these users then the notifications should be as listed
       | user | password    | notification                                                                                                    |
@@ -55,7 +57,7 @@ Feature: add users
       Access it:
       """
 
-  @smokeTest @skipOnOcV10.0 @skipOnOcV10.1
+  @smokeTest @skipOnOcV10.0 @skipOnOcV10.1 @skipOnOcV10.2 @skipOnOcV10.3
   Scenario Outline: user sets his own password after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
@@ -73,6 +75,7 @@ Feature: add users
       | guiusr1  | simple user-name      |
       | a@-+_.'b | complicated user-name |
 
+  @skipOnOcV10.3
   Scenario Outline: user sets his own password but retypes it wrongly after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -20,7 +20,7 @@ Feature: restrict resharing
     And user "user2" has logged in using the webUI
 
   @skipOnMICROSOFTEDGE @skipOnFIREFOX @TestAlsoOnExternalUserBackend @files_sharing-app-required
-  @smokeTest
+  @smokeTest @skipOnOcV10.3
   Scenario: share a folder with another internal user and prohibit resharing
     Given the setting "Allow resharing" in the section "Sharing" has been enabled
     And the user has browsed to the files page

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -61,6 +61,7 @@ Feature: restrict Sharing
     And the user re-logs in as "user1" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: Editing share permission of existing share when sharing with groups is forbidden
     Given the user has shared folder "simple-folder" with group "grp1"
     And the setting "Allow sharing with groups" in the section "Sharing" has been disabled
@@ -75,6 +76,7 @@ Feature: restrict Sharing
     Then the following permissions are seen for "simple-folder" in the sharing dialog for group "grp1"
       | share | yes |
 
+  @skipOnOcV10.3
   Scenario: Editing create permission of existing share when sharing with groups is forbidden
     Given the user has shared folder "simple-folder" with group "grp1"
     And the setting "Allow sharing with groups" in the section "Sharing" has been disabled

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -124,7 +124,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then user "user1" should not see the following elements
       | /lorem%20(2).txt |
 
-  @skipOnMICROSOFTEDGE
+  @skipOnMICROSOFTEDGE @skipOnOcV10.3
   Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
     And the user sets the sharing permissions of user "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
@@ -287,6 +287,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
+  @skipOnOcV10.3
   Scenario: test resharing folder and set it as readonly by owner
     Given using server "LOCAL"
     And user "user2" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -91,7 +91,7 @@ Feature: Sharing files and folders with internal users
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
-  @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
+  @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend @skipOnOcV10.3
   Scenario: share a folder with another internal user and prohibit deleting
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -421,6 +421,7 @@ Feature: Sharing files and folders with internal users
     And the user shares file "lorem.txt" with user "User Two" using the webUI
     Then as "user2" file "/lorem.txt" should exist
 
+  @skipOnOcV10.3
   Scenario: Create share with share permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -446,6 +447,7 @@ Feature: Sharing files and folders with internal users
     When the user shares file "lorem.txt" with user "User Three" using the webUI
     Then as "user3" file "lorem.txt" should exist
 
+  @skipOnOcV10.3
   Scenario: Create share with share and create permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -466,6 +468,7 @@ Feature: Sharing files and folders with internal users
     Then as "user1" file "simple-folder/textfile.txt" should exist
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
 
+  @skipOnOcV10.3
   Scenario: Create share with share and change permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -486,6 +489,7 @@ Feature: Sharing files and folders with internal users
     Then as "user1" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: Create share with share and delete permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -506,6 +510,7 @@ Feature: Sharing files and folders with internal users
     Then as "user1" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: Create share with edit and without share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -543,6 +548,7 @@ Feature: Sharing files and folders with internal users
     Then the content of "lorem.txt" should be the same as the original "lorem.txt"
 #   And the content of file "lorem.txt" for user "user1" should be "edited original content"
 
+  @skipOnOcV10.3
   Scenario: Create share when admin disables delete in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -568,6 +574,7 @@ Feature: Sharing files and folders with internal users
     When the user shares file "lorem.txt" with user "User Three" using the webUI
     Then as "user3" file "lorem.txt" should exist
 
+  @skipOnOcV10.3
   Scenario: Create share when admin disables change in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -593,6 +600,7 @@ Feature: Sharing files and folders with internal users
     Then as "user3" file "lorem.txt" should exist
     And the option to delete file "lorem.txt" should be available on the webUI
 
+  @skipOnOcV10.3
   Scenario: Create share when admin disables create and share in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -617,6 +625,7 @@ Feature: Sharing files and folders with internal users
     And the option to rename file "lorem.txt" should be available on the webUI
     And it should be possible to delete file "lorem.txt" using the webUI
 
+  @skipOnOcV10.3
   Scenario: Create share when admin disables delete in share permissions but then user enables the permission
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -637,6 +646,7 @@ Feature: Sharing files and folders with internal users
     And it should not be possible to share file "lorem.txt" using the webUI
     And the option to delete file "lorem.txt" should be available on the webUI
 
+  @skipOnOcV10.3
   Scenario: Create share when admin disables multiple default share permissions but then user enables a disabled permission
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
## Description
cherry-pick of PR #36624 - correctly skip scenarios if testing against old core 10.3

## Related Issue
https://github.com/owncloud/files_primary_s3/issues/293
https://github.com/owncloud/files_primary_s3/issues/294

## Motivation and Context
Get these skip tage correct in the 10.4 release branch also, so that if we are running some app CI against `release-10.4.0` branch, that we do not get problems with drone pipelines that also run against `latest` 10.3

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
