### PR TITLE
Tests for blacklisted_files and excluded_directories config options

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1276,7 +1276,7 @@ $CONFIG = [
   ],
 
 /**
- * Define excluded files
+ * Define excluded directories
  * Exclude specific directory names and disallow scanning, creating and renaming
  * using these names. Case insensitive.
  * Excluded directory names are queried at any path part like at the beginning,

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -261,6 +261,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
+        - OccContext:
         - WebDavPropertiesContext:
 
     apiWebdavOperations:
@@ -456,6 +457,7 @@ default:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - OccContext:
 
     webUIRestrictSharing:
       paths:

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -114,6 +114,20 @@ Feature: capabilities
       | capability    | path_to_element     | value |
       | files_sharing | default_permissions | 7     |
 
+  Scenario: .htaccess is reported as a blacklisted file by default
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability | path_to_element                | value     |
+      | files      | blacklisted_files@@@element[0] | .htaccess |
+
+  Scenario: multiple files can be reported as blacklisted
+    When the administrator updates system config key "blacklisted_files" with value '["test.txt",".htaccess"]' and type "json" using the occ command
+    And the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability | path_to_element                | value     |
+      | files      | blacklisted_files@@@element[0] | test.txt  |
+      | files      | blacklisted_files@@@element[1] | .htaccess |
+
   @skipOnOcV10.3
   Scenario: user expire date can be enabled
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -237,6 +237,26 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+  Scenario Outline: rename a file to an excluded directory name
+    Given using <dav_version> DAV path
+    When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
+    And user "user0" moves file "/welcome.txt" to "/.github" using the WebDAV API
+    Then the HTTP status code should be "403"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: rename a file to an excluded directory name inside a parent directory
+    Given using <dav_version> DAV path
+    When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
+    And user "user0" moves file "/welcome.txt" to "/FOLDER/.github" using the WebDAV API
+    Then the HTTP status code should be "403"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   Scenario Outline: Checking file id after a move
     Given using <dav_version> DAV path
     And user "user0" has stored id of file "/textfile0.txt"

--- a/tests/acceptance/features/apiWebdavMove/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFile.feature
@@ -218,9 +218,19 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  Scenario Outline: rename a file into a banned filename
+  Scenario Outline: rename a file to a filename that is banned by default
     Given using <dav_version> DAV path
     When user "user0" moves file "/welcome.txt" to "/.htaccess" using the WebDAV API
+    Then the HTTP status code should be "403"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: rename a file to a banned filename
+    Given using <dav_version> DAV path
+    When the administrator updates system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json" using the occ command
+    And user "user0" moves file "/welcome.txt" to "/blacklisted-file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
@@ -137,8 +137,15 @@ Feature: move (rename) file
     And user "user0" should see the following elements
       | /welcome.txt |
 
-  Scenario: rename a file into a banned filename
+  Scenario: rename a file to a filename that is banned by default
     When user "user0" moves file "/welcome.txt" asynchronously to "/.htaccess" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And user "user0" should see the following elements
+      | /welcome.txt |
+
+  Scenario: rename a file to a banned filename
+    When the administrator updates system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json" using the occ command
+    And user "user0" moves file "/welcome.txt" asynchronously to "/blacklisted-file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "user0" should see the following elements
       | /welcome.txt |

--- a/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFileAsync.feature
@@ -150,6 +150,20 @@ Feature: move (rename) file
     And user "user0" should see the following elements
       | /welcome.txt |
 
+  Scenario: rename a file to an excluded directory name
+    When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
+    And user "user0" moves file "/welcome.txt" asynchronously to "/.github" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And user "user0" should see the following elements
+      | /welcome.txt |
+
+  Scenario: rename a file to an excluded directory name inside a parent directory
+    When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
+    And user "user0" moves file "/welcome.txt" asynchronously to "/FOLDER/.github" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And user "user0" should see the following elements
+      | /welcome.txt |
+
   Scenario: Renaming a file to a path with extension .part should not be possible
     When user "user0" moves file "/welcome.txt" asynchronously to "/welcome.part" using the WebDAV API
     Then the HTTP status code should be "400"

--- a/tests/acceptance/features/apiWebdavMove/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFolder.feature
@@ -44,10 +44,23 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
-  Scenario Outline: Renaming a folder into a banned name
+  Scenario Outline: Rename a folder to a name that is banned by default
     Given using <dav_version> DAV path
     And user "user0" has created folder "/testshare"
     When user "user0" moves folder "/testshare" to "/.htaccess" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And user "user0" should see the following elements
+      | /testshare/ |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: Rename a folder to a banned name
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "/testshare"
+    When the administrator updates system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json" using the occ command
+    And user "user0" moves folder "/testshare" to "/blacklisted-file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "user0" should see the following elements
       | /testshare/ |

--- a/tests/acceptance/features/apiWebdavMove/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove/moveFolder.feature
@@ -69,6 +69,32 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
+  Scenario Outline: Rename a folder to an excluded directory name
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "/testshare"
+    When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
+    And user "user0" moves folder "/testshare" to "/.github" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And user "user0" should see the following elements
+      | /testshare/ |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: Rename a folder to an excluded directory name inside a parent directory
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "/testshare"
+    When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
+    And user "user0" moves folder "/testshare" to "/FOLDER/.github" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And user "user0" should see the following elements
+      | /testshare/ |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   Scenario Outline: Move a folder into a not existing one
     Given using <dav_version> DAV path
     And user "user0" has created folder "/testshare"

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -666,8 +666,8 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has added system config key :key with value :value
-	 * @Given the administrator has added system config key :key with value :value and type :type
+	 * @Given the administrator has added/updated system config key :key with value :value
+	 * @Given the administrator has added/updated system config key :key with value :value and type :type
 	 * @When the administrator adds/updates system config key :key with value :value using the occ command
 	 * @When the administrator adds/updates system config key :key with value :value and type :type using the occ command
 	 *

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -114,6 +114,28 @@ Feature: rename files
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 
+  Scenario: Rename a file to an excluded folder name
+    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
+    And user "user1" has logged in using the webUI
+    When the user renames file "randomfile.txt" to one of these names using the webUI
+      | .github |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "randomfile.txt" |
+    And file "randomfile.txt" should be listed on the webUI
+
+  Scenario: Rename a file to an excluded folder name inside a parent folder
+    Given user "user1" has created folder "top-folder"
+    And user "user1" has uploaded file with content "some content" to "/top-folder/randomfile.txt"
+    And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "top-folder" using the webUI
+    When the user renames file "randomfile.txt" to one of these names using the webUI
+      | .github |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "randomfile.txt" |
+    And file "randomfile.txt" should be listed on the webUI
+
   Scenario: Rename the last file in a folder
     Given user "user1" has uploaded file with content "some content" to "/firstfile.txt"
     And user "user1" has uploaded file with content "more content" to "/zzzz-must-be-last-file-in-folder.txt"

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -100,12 +100,15 @@ Feature: rename files
 
   Scenario: Rename a file using forbidden characters
     Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    And the administrator has updated system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json"
     And user "user1" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
-      | lorem\txt |
-      | \\.txt    |
-      | .htaccess |
+      | lorem\txt            |
+      | \\.txt               |
+      | .htaccess            |
+      | blacklisted-file.txt |
     Then notifications should be displayed on the webUI with the text
+      | Could not rename "randomfile.txt" |
       | Could not rename "randomfile.txt" |
       | Could not rename "randomfile.txt" |
       | Could not rename "randomfile.txt" |

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -82,12 +82,15 @@ Feature: rename folders
 
   Scenario: Rename a folder using forbidden characters
     Given user "user1" has created folder "a-folder"
+    And the administrator has updated system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json"
     And user "user1" has logged in using the webUI
     When the user renames folder "a-folder" to one of these names using the webUI
-      | simple\folder   |
-      | \\simple-folder |
-      | .htaccess       |
+      | simple\folder        |
+      | \\simple-folder      |
+      | .htaccess            |
+      | blacklisted-file.txt |
     Then notifications should be displayed on the webUI with the text
+      | Could not rename "a-folder" |
       | Could not rename "a-folder" |
       | Could not rename "a-folder" |
       | Could not rename "a-folder" |

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -96,6 +96,28 @@ Feature: rename folders
       | Could not rename "a-folder" |
     And folder "a-folder" should be listed on the webUI
 
+  Scenario: Rename a folder to an excluded folder name
+    Given user "user1" has created folder "a-folder"
+    And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
+    And user "user1" has logged in using the webUI
+    When the user renames folder "a-folder" to one of these names using the webUI
+      | .github |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "a-folder" |
+    And folder "a-folder" should be listed on the webUI
+
+  Scenario: Rename a folder to an excluded folder name inside a parent folder
+    Given user "user1" has created folder "top-folder"
+    And user "user1" has created folder "top-folder/a-folder"
+    And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "top-folder" using the webUI
+    When the user renames folder "a-folder" to one of these names using the webUI
+      | .github            |
+    Then notifications should be displayed on the webUI with the text
+      | Could not rename "a-folder" |
+    And folder "a-folder" should be listed on the webUI
+
   Scenario: Rename a folder putting a name of a file which already exists
     Given user "user1" has created folder "a-folder"
     And user "user1" has uploaded file with content "some content" to "/randomfile.txt"


### PR DESCRIPTION
## Description
- Add acceptance test coverage for setting blacklisted_files config option
- Add acceptance test coverage for setting excluded_directories config option

## Related Issue
Preparation for PR #36360 

## Motivation and Context
The blacklisted_files and excluded_directories config options have little or no coverage in the existing acceptance tests. Extra options are proposed to be added in the linked PR, so first have known-good acceptance test coverage of the existing options.

## How Has This Been Tested?
Local runs of new/changed acceptance test scenarios

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
