### PR TITLE
refactor thenTheHTTPStatusCodeShouldBe

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -981,28 +981,45 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Then /^the HTTP status code should be "([^"]*)"$/
+	 * Check that the status code in the saved response is the expected status
+	 * code, or one of the expected status codes.
 	 *
-	 * @param int|int[]|string|string[] $statusCode
+	 * @param int|int[]|string|string[] $expectedStatusCode
 	 * @param string $message
 	 *
 	 * @return void
 	 */
-	public function theHTTPStatusCodeShouldBe($statusCode, $message = "") {
-		if ($message === "") {
-			$message = "HTTP status code is not the expected value";
-		}
+	public function theHTTPStatusCodeShouldBe($expectedStatusCode, $message = "") {
+		$actualStatusCode = $this->response->getStatusCode();
+		if (\is_array($expectedStatusCode)) {
+			if ($message === "") {
+				$message = "HTTP status code $actualStatusCode is not one of the expected values";
+			}
 
-		if (\is_array($statusCode)) {
 			Assert::assertContains(
-				$this->response->getStatusCode(), $statusCode,
+				$actualStatusCode, $expectedStatusCode,
 				$message
 			);
 		} else {
+			if ($message === "") {
+				$message = "HTTP status code $actualStatusCode is not the expected value $expectedStatusCode";
+			}
+
 			Assert::assertEquals(
-				$statusCode, $this->response->getStatusCode(), $message
+				$expectedStatusCode, $actualStatusCode, $message
 			);
 		}
+	}
+
+	/**
+	 * @Then /^the HTTP status code should be "([^"]*)"$/
+	 *
+	 * @param int|string $statusCode
+	 *
+	 * @return void
+	 */
+	public function thenTheHTTPStatusCodeShouldBe($statusCode) {
+		$this->theHTTPStatusCodeShouldBe($statusCode, "");
 	}
 
 	/**


### PR DESCRIPTION
## Description
The acceptance test step function `theHTTPStatusCodeShouldBe` had become used in its normal role as a Gherkin step definition, but also could be called with an array of valid status codes. That meant that the PHPdoc for the `statusCode` parameter was "overloaded" with stuff that is not generated by the Gherkin step text.

This PR refactors so that `theHTTPStatusCodeShouldBe` is a separate convenience function which takes the same parameters it currently does (so all callers will still work). The Gherkin step is now a function called `thenTheHTTPStatusCodeShouldBe`. That takes just a single status code from the Gherkin step text.

This is a similar style of refactoring to what we are doing with `Given` steps... I noticed this when doing some other code where I was calling `theHTTPStatusCodeShouldBe`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
