### PR TITLE
Add extra error checks to OwncloudPage open

### DIFF
--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -844,8 +844,12 @@ class OwncloudPage extends Page {
 			$expected = \parse_url($this->getUrl($urlParameters));
 			$actual = \parse_url($this->getDriver()->getCurrentUrl());
 			foreach (['scheme', 'host', 'path'] as $part) {
-				if (\array_key_exists($part, $expected) && $expected[$part] !== $actual[$part]) {
-					throw $e;
+				if (\array_key_exists($part, $expected)) {
+					if (!\array_key_exists($part, $actual)
+						|| ($expected[$part] !== $actual[$part])
+					) {
+						throw $e;
+					}
 				}
 			}
 


### PR DESCRIPTION
## Description
If the actual scheme, host or path of the URL does not exist then OwncloudPage open() error checking can fail like in https://drone.owncloud.com/owncloud/activity/1004/16/10
```
Notice: Undefined index: scheme in /var/www/owncloud/testrunner/tests/acceptance/features/lib/OwncloudPage.php line 847
```

Add some more checks so that it will not fail like that, but will throw the exception.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
