### PR TITLE
Dependency bumps 20191231

### DIFF
--- a/changelog/unreleased/36659
+++ b/changelog/unreleased/36659
@@ -1,0 +1,3 @@
+Change: Update league/flysystem (1.0.61 => 1.0.62)
+
+https://github.com/owncloud/core/pull/36659

--- a/changelog/unreleased/36660
+++ b/changelog/unreleased/36660
@@ -1,0 +1,3 @@
+Change: Update zendframework/zend-validator (2.12.2 => 2.13.0)
+
+https://github.com/owncloud/core/pull/36660

--- a/changelog/unreleased/36661-1
+++ b/changelog/unreleased/36661-1
@@ -1,0 +1,3 @@
+Change: Update egulias/email-validator (2.1.11 => 2.1.13)
+
+https://github.com/owncloud/core/pull/36661

--- a/changelog/unreleased/36661-2
+++ b/changelog/unreleased/36661-2
@@ -1,0 +1,3 @@
+Change: Update phpdocumentor/reflection-docblock (4.3.2 => 4.3.4)
+
+https://github.com/owncloud/core/pull/36661

--- a/changelog/unreleased/36661-3
+++ b/changelog/unreleased/36661-3
@@ -1,0 +1,3 @@
+Change: Update phpspec/prophecy (1.10.0 => 1.10.1)
+
+https://github.com/owncloud/core/pull/36661

--- a/composer.lock
+++ b/composer.lock
@@ -3736,16 +3736,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.2",
+            "version": "4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
                 "shasum": ""
             },
             "require": {
@@ -3757,6 +3757,7 @@
             "require-dev": {
                 "doctrine/instantiator": "^1.0.5",
                 "mockery/mockery": "^1.0",
+                "phpdocumentor/type-resolver": "0.4.*",
                 "phpunit/phpunit": "^6.4"
             },
             "type": "library",
@@ -3783,7 +3784,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-09-12T14:27:41+00:00"
+            "time": "2019-12-28T18:55:12+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",

--- a/composer.lock
+++ b/composer.lock
@@ -585,27 +585,26 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.11",
+            "version": "2.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "92dd169c32f6f55ba570c309d83f5209cefb5e23"
+                "reference": "834593d5900615639208417760ba6a17299e2497"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/92dd169c32f6f55ba570c309d83f5209cefb5e23",
-                "reference": "92dd169c32f6f55ba570c309d83f5209cefb5e23",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/834593d5900615639208417760ba6a17299e2497",
+                "reference": "834593d5900615639208417760ba6a17299e2497",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "^1.0.1",
-                "php": ">= 5.5"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "dominicsayers/isemail": "dev-master",
-                "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
-                "satooshi/php-coveralls": "^1.0.1",
-                "symfony/phpunit-bridge": "^4.4@dev"
+                "dominicsayers/isemail": "^3.0.7",
+                "phpunit/phpunit": "^4.8.36|^7.5.15",
+                "satooshi/php-coveralls": "^1.0.1"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -639,7 +638,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-08-13T17:33:27+00:00"
+            "time": "2019-12-30T08:14:25+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -3835,16 +3835,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682"
+                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
-                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
+                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
                 "shasum": ""
             },
             "require": {
@@ -3894,7 +3894,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-12-17T16:54:23+00:00"
+            "time": "2019-12-22T21:05:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
## Description
1) egulias/email-validator (2.1.11 => 2.1.13) https://github.com/egulias/EmailValidator/releases/tag/2.1.13 https://github.com/egulias/EmailValidator/releases/tag/2.1.12
2) phpdocumentor/reflection-docblock (4.3.2 => 4.3.4) https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/4.3.4 https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/4.3.3
3) phpspec/prophecy (1.10.0 => 1.10.1) https://github.com/phpspec/prophecy/releases/tag/1.10.1
4) add changelogs for PRs #36659 and #36660 that dependabot made last night

## Motivation and Context
Be up-to-date with dependencies that the bot did not find.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
