### PR TITLE
Adjusted combined given-when steps in PublicWebDav context

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -272,9 +272,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename using the :publicWebDAVAPIVersion WebDAV API
-	 * @Given the public has uploaded file :filename
-	 *
 	 * @param string $source target file name
 	 * @param string $publicWebDAVAPIVersion
 	 *
@@ -289,10 +286,62 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @When the public uploads file :filename using the :publicWebDAVAPIVersion WebDAV API
+	 *
+	 * @param string $source target file name
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicUploadsFileUsingTheWebDAVApi($source, $publicWebDAVAPIVersion) {
+		$this->publiclyUploadingFile(
+			$source,
+			$publicWebDAVAPIVersion
+		);
+	}
+
+	/**
+	 * @Given the public has uploaded file :filename
+	 *
+	 * @param string $source target file name
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicHasUploadedFileUsingTheWebDAVApi($source, $publicWebDAVAPIVersion) {
+		$this->publiclyUploadingFile(
+			$source,
+			$publicWebDAVAPIVersion
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
 	 * This only works with the old API, autorename is not supported in the new API
 	 * auto renaming is handled on files drop folders implicitly
 	 *
+	 * @param string $filename target file name
+	 * @param string $body content to upload
+	 *
+	 * @return void
+	 */
+	public function publiclyUploadingContentAutoRename($filename, $body = 'test') {
+		$this->publicUploadContent($filename, '', $body, true);
+	}
+
+	/**
 	 * @When the public uploads file :filename with content :body with autorename mode using the old public WebDAV API
+	 *
+	 * @param string $filename target file name
+	 * @param string $body content to upload
+	 *
+	 * @return void
+	 */
+	public function thePublicUploadsFileWithContentWithAutoRenameMode($filename, $body = 'test') {
+		$this->publiclyUploadingContentAutoRename($filename, $body);
+	}
+
+	/**
 	 * @Given the public has uploaded file :filename with content :body with autorename mode
 	 *
 	 * @param string $filename target file name
@@ -300,14 +349,12 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function publiclyUploadingContentAutorename($filename, $body = 'test') {
-		$this->publicUploadContent($filename, '', $body, true);
+	public function thePublicHasUploadedFileWithContentWithAutoRenameMode($filename, $body = 'test') {
+		$this->publiclyUploadingContentAutoRename($filename, $body);
+		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**
-	 * @When /^the public uploads file "([^"]*)" with password "([^"]*)" and content "([^"]*)" using the (old|new) public WebDAV API$/
-	 * @Given the public has uploaded file :filename" with password :password and content :body
-	 *
 	 * @param string $filename target file name
 	 * @param string $password
 	 * @param string $body content to upload
@@ -324,9 +371,49 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public overwrites file :filename with content :body using the old WebDAV API
-	 * @Given the public has overwritten file :filename with content :body
+	 * @When /^the public uploads file "([^"]*)" with password "([^"]*)" and content "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
+	 * @param string $filename target file name
+	 * @param string $password
+	 * @param string $body content to upload
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicUploadsFileWithPasswordAndContentUsingPublicWebDAVApi(
+		$filename, $password = '', $body = 'test', $publicWebDAVAPIVersion = "old"
+	) {
+		$this->publiclyUploadingContentWithPassword(
+			$filename,
+			$password,
+			$body,
+			$publicWebDAVAPIVersion
+		);
+	}
+
+	/**
+	 * @Given the public has uploaded file :filename" with password :password and content :body
+	 *
+	 * @param string $filename target file name
+	 * @param string $password
+	 * @param string $body content to upload
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicHasUploadedFileWithPasswordAndContentUsingPublicWebDAVApi(
+		$filename, $password = '', $body = 'test', $publicWebDAVAPIVersion = "old"
+	) {
+		$this->publiclyUploadingContentWithPassword(
+			$filename,
+			$password,
+			$body,
+			$publicWebDAVAPIVersion
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 *
@@ -337,9 +424,37 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public uploads file "([^"]*)" with content "([^"]*)" using the (old|new) public WebDAV API$/
-	 * @Given the public has uploaded file :filename with content :body
+	 * @When the public overwrites file :filename with content :body using the old WebDAV API
 	 *
+	 * @param string $filename target file name
+	 * @param string $body content to upload
+	 *
+	 * @return void
+	 */
+	public function thePublicOverwritesFileWithContentUsingOldWebDavApi($filename, $body = 'test') {
+		$this->publiclyOverwritingContent(
+			$filename,
+			$body
+		);
+	}
+
+	/**
+	 * @Given the public has overwritten file :filename with content :body
+	 *
+	 * @param string $filename target file name
+	 * @param string $body content to upload
+	 *
+	 * @return void
+	 */
+	public function thePublicHasOverwrittenFileWithContentUsingOldWebDavApi($filename, $body = 'test') {
+		$this->publiclyOverwritingContent(
+			$filename,
+			$body
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @param string $publicWebDAVAPIVersion
@@ -352,6 +467,45 @@ class PublicWebDavContext implements Context {
 		$this->publicUploadContent(
 			$filename, '', $body, false, [], $publicWebDAVAPIVersion
 		);
+	}
+
+	/**
+	 * @When /^the public uploads file "([^"]*)" with content "([^"]*)" using the (old|new) public WebDAV API$/
+	 *
+	 * @param string $filename target file name
+	 * @param string $body content to upload
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicUploadsFileWithCOntentUsingThePublicWebDavApi(
+		$filename, $body = 'test', $publicWebDAVAPIVersion = "old"
+	) {
+		$this->publiclyUploadingContent(
+			$filename,
+			$body,
+			$publicWebDAVAPIVersion
+		);
+	}
+
+	/**
+	 * @Given the public has uploaded file :filename with content :body
+	 *
+	 * @param string $filename target file name
+	 * @param string $body content to upload
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicHasUploadedFileWithCOntentUsingThePublicWebDavApi(
+		$filename, $body = 'test', $publicWebDAVAPIVersion = "old"
+	) {
+		$this->publiclyUploadingContent(
+			$filename,
+			$body,
+			$publicWebDAVAPIVersion
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**


### PR DESCRIPTION
## Description
Combined `given-when` steps splitted into seperate functions and `check-success` assertion added on **Given** steps.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/635

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- :robot:

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes