### PR TITLE
Adjusted combined given-when steps in Trashbin context

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -579,14 +579,27 @@ class TrashbinContext implements Context {
 
 	/**
 	 * @When /^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" using the trashbin API$/
+	 *
+	 * @param string $user
+	 * @param string $originalPath
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function elementInTrashIsRestored($user, $originalPath) {
+		$this->restoreElement($user, $originalPath);
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has restored the (?:file|folder|entry) with original path "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $originalPath
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	public function elementInTrashIsRestored($user, $originalPath) {
+	public function elementInTrashHasBeenRestored($user, $originalPath) {
 		$this->restoreElement($user, $originalPath);
 		Assert::assertFalse(
 			$this->isInTrash($user, $originalPath),


### PR DESCRIPTION
## Description
Combined `given-when` steps splitted into seperate functions and `check-success` assertion added on **Given** steps.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/635

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- :robot:

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes