### PR TITLE
Adjusted combined given-when steps in WebUIAdminSharingSettings context

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1593,6 +1593,87 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has added group :group to the exclude group from sharing list
+	 *
+	 * @param string $groups
+	 * multiple groups can be passed as comma separated string
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasAddedGroupToTheExcludeGroupFromSharingList($groups) {
+		$groups = \explode(',', \trim($groups));
+		$groups = \array_map('trim', $groups); //removing whitespaces around group names
+		$groups = '"' . \implode('","', $groups) . '"';
+		SetupHelper::runOcc(
+			[
+				'config:app:set',
+				'core',
+				'shareapi_exclude_groups_list',
+				"--value='[$groups]'"
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$response = SetupHelper::runOcc(
+			[
+				'config:app:get',
+				'core',
+				'shareapi_exclude_groups_list'
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$excludedGroupsFromResponse = (\trim($response['stdOut']));
+		$excludedGroupsFromResponse = \trim($excludedGroupsFromResponse, '[]');
+		Assert::assertEquals(
+			$groups,
+			$excludedGroupsFromResponse
+		);
+	}
+
+	/**
+	 * @Given the administrator has enabled exclude groups from sharing
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasEnabledExcludeGroupsFromSharingUsingTheWebui() {
+		SetupHelper::runOcc(
+			[
+				"config:app:set",
+				"core",
+				"shareapi_exclude_groups",
+				"--value=yes"
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$response = SetupHelper::runOcc(
+			[
+				"config:app:get",
+				"core",
+				"shareapi_exclude_groups"
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$status = \trim($response['stdOut']);
+		Assert::assertEquals(
+			"yes",
+			$status
+		);
+	}
+
+	/**
 	 * This will run after EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -305,7 +305,6 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 
 	/**
 	 * @When the administrator enables exclude groups from sharing using the webUI
-	 * @Given the administrator has enabled exclude groups from sharing from the admin sharing settings page
 	 *
 	 * @return void
 	 */
@@ -394,7 +393,6 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 
 	/**
 	 * @When the administrator adds group :group to the exclude group from sharing list using the webUI
-	 * @Given the administrator has added group :group to the exclude group from sharing list from the admin sharing settings page
 	 *
 	 * @param string $group
 	 *

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -177,9 +177,9 @@ Feature: Sharing files and folders with internal users
       | user4    |
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And the administrator has browsed to the admin sharing settings page
     And user "user3" has shared file "/testimage.jpg" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
     Then user "user1" should not be able to share file "/testimage (2).jpg" with user "User Four" using the sharing API
 
@@ -192,10 +192,10 @@ Feature: Sharing files and folders with internal users
       | user4    |
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And the administrator has browsed to the admin sharing settings page
     And user "user3" has created folder "/common"
     And user "user3" has shared folder "/common" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
     Then user "user1" should not be able to share folder "/common" with user "User Four" using the sharing API
 
@@ -208,11 +208,11 @@ Feature: Sharing files and folders with internal users
     And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And the administrator has browsed to the admin sharing settings page
     And user "user3" has created folder "/common"
     And user "user3" has moved file "/testimage.jpg" to "/common/testimage.jpg"
     And user "user3" has shared folder "/common" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
     Then user "user1" should not be able to share file "/common/testimage.jpg" with user "User Four" using the sharing API
 
@@ -223,11 +223,11 @@ Feature: Sharing files and folders with internal users
       | user2    |
       | user3    |
       | user4    |
-    And the administrator has browsed to the admin sharing settings page
     And user "user3" has created folder "/common"
     And user "user3" has created folder "/common/inside-common"
     And user "user3" has shared folder "/common" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
     Then user "user1" should not be able to share folder "/common/inside-common" with user "User Four" using the sharing API
 
@@ -235,8 +235,8 @@ Feature: Sharing files and folders with internal users
     Given group "grp1" has been created
     And user "user1" has been created with default attributes and skeleton files
     And user "user1" has been added to group "grp1"
+    And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
     And the user re-logs in as "user1" using the webUI
     And the user opens the sharing tab from the file action menu of file "testimage.jpg" using the webUI
@@ -252,8 +252,8 @@ Feature: Sharing files and folders with internal users
     And user "user1" has been added to group "grp1"
     And user "user3" has been created with default attributes and without skeleton files
     And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
     And the user re-logs in as "user1" using the webUI
     And the user browses to the shared-with-you page


### PR DESCRIPTION
## Description
Combined `given-when` steps splitted into seperate functions and `check-success` assertion added on **Given** steps.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/635

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- :robot:

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes