### PR TITLE
Adjusted combined given-when in WebUIAdminStorageSettings context

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -978,6 +978,43 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has enabled the external storage
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function enableExternalStorageUsingOccAsAdmin() {
+		SetupHelper::runOcc(
+			[
+				'config:app:set',
+				'core',
+				'enable_external_storage',
+				'--value=yes'
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$response = SetupHelper::runOcc(
+			[
+				'config:app:get',
+				'core',
+				'enable_external_storage',
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$status = \trim($response['stdOut']);
+		Assert::assertEquals(
+			'yes',
+			$status
+		);
+	}
+
+	/**
 	 * This will run after EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -84,43 +84,6 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Given the administrator has enabled the external storage
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theAdministratorHasEnabledTheExternalStorageUsingTheWebui() {
-		SetupHelper::runOcc(
-			[
-				'config:app:set',
-				'core',
-				'enable_external_storage',
-				'--value=yes'
-			],
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getOcPath()
-		);
-		$response = SetupHelper::runOcc(
-			[
-				'config:app:get',
-				'core',
-				'enable_external_storage',
-			],
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getOcPath()
-		);
-		$status = \trim($response['stdOut']);
-		Assert::assertEquals(
-			'yes',
-			$status
-		);
-	}
-
-	/**
 	 * @When the administrator disables the external storage using the webUI
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -74,13 +74,49 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 
 	/**
 	 * @When the administrator enables the external storage using the webUI
-	 * @Given the administrator has enabled the external storage
 	 *
 	 * @return void
 	 */
 	public function theAdministratorEnablesTheExternalStorageUsingTheWebui() {
 		$this->adminStorageSettingsPage->enableExternalStorage(
 			$this->getSession()
+		);
+	}
+
+	/**
+	 * @Given the administrator has enabled the external storage
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasEnabledTheExternalStorageUsingTheWebui() {
+		SetupHelper::runOcc(
+			[
+				'config:app:set',
+				'core',
+				'enable_external_storage',
+				'--value=yes'
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$response = SetupHelper::runOcc(
+			[
+				'config:app:get',
+				'core',
+				'enable_external_storage',
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$status = \trim($response['stdOut']);
+		Assert::assertEquals(
+			'yes',
+			$status
 		);
 	}
 

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -16,8 +16,8 @@ Feature: admin storage settings
 
   Scenario: administrator creates a local storage mount
     Given user "user0" has been created with default attributes and without skeleton files
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     When the administrator creates the local storage mount "local_storage1" using the webUI
     And the administrator uploads file with content "this is a file in local storage" to "/local_storage1/file-in-local-storage.txt" using the WebDAV API
     And the user re-logs in as "user0" using the webUI
@@ -52,8 +52,8 @@ Feature: admin storage settings
       | username |
       | user0    |
       | user1    |
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     When the administrator creates the local storage mount "local_storage1" using the webUI
     And the administrator adds user "user0" as the applicable user for the last local storage mount using the webUI
     And the administrator creates the local storage mount "local_storage2" using the webUI
@@ -71,8 +71,8 @@ Feature: admin storage settings
       | username |
       | user0    |
       | user1    |
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
     And the administrator has added user "user0" as the applicable user for the last local storage mount from the admin storage settings page
     When the administrator removes user "user0" from the applicable user for the last local storage mount using the webUI
@@ -88,8 +88,8 @@ Feature: admin storage settings
       | user1    |
     And group "newgroup" has been created
     And user "user0" has been added to group "newgroup"
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
     When the administrator adds group "newgroup" as the applicable group for the last local storage mount using the webUI
     And the user re-logs in as "user0" using the webUI
@@ -104,8 +104,8 @@ Feature: admin storage settings
       | user1    |
     And group "newgroup" has been created
     And user "user0" has been added to group "newgroup"
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
     And the administrator has added group "newgroup" as the applicable group for the last local storage mount from the admin storage settings page
     When the administrator removes group "newgroup" from the applicable group for the last local storage mount using the webUI
@@ -116,8 +116,8 @@ Feature: admin storage settings
 
   Scenario: administrator deletes local storage mount
     Given user "user0" has been created with default attributes and skeleton files
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
     When the administrator deletes the last created local storage mount using the webUI
     And the user re-logs in as "user0" using the webUI
@@ -125,8 +125,8 @@ Feature: admin storage settings
 
   Scenario: local storage mount is deleted when the last user applicable to it is deleted
     Given user "user0" has been created with default attributes and skeleton files
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
     And the administrator has added user "user0" as the applicable user for the last local storage mount from the admin storage settings page
     And user "user0" has been deleted
@@ -137,8 +137,8 @@ Feature: admin storage settings
     Given user "user0" has been created with default attributes and skeleton files
     And group "newgroup" has been created
     And user "user0" has been added to group "newgroup"
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
     And the administrator has added group "newgroup" as the applicable group for the last local storage mount from the admin storage settings page
     And group "newgroup" has been deleted
@@ -152,8 +152,8 @@ Feature: admin storage settings
       | username |
       | user0    |
       | user1    |
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
     And the administrator has added user "user0" as the applicable user for the last local storage mount from the admin storage settings page
     And the administrator has added user "user1" as the applicable user for the last local storage mount from the admin storage settings page


### PR DESCRIPTION
## Description
Combined `given-when` steps splitted into seperate functions and `check-success` assertion added on **Given** steps.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/635

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- :robot:

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes