### PR TITLE
Skip new read-only storage test on 10.3

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -30,6 +30,7 @@ Feature: admin storage settings
     And user "user0" should be able to delete file "/local_storage1/another-name.txt"
     And folder "local_storage1" should be listed on the webUI
 
+  @skipOnOcV10.3
   Scenario: administrator creates a read-only local storage mount
     Given user "user0" has been created with default attributes and without skeleton files
     And the administrator has browsed to the admin storage settings page


### PR DESCRIPTION
PR #36397 added the read-only storage feature for 10.4. 
The test scenario needs to be skipped when run on 10.3