### PR TITLE
Add cliLocalStorage test suite with first createLocalStorage.feature

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -127,6 +127,7 @@ config = {
 		'cli': {
 			'suites': [
 				'cliBackground',
+				'cliLocalStorage',
 				'cliMain',
 				'cliProvisioning',
 				'cliTrashbin',

--- a/.drone.yml
+++ b/.drone.yml
@@ -8855,6 +8855,158 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: cliLocalStorage-mariadb10.2-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: mariadb
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - git clone https://github.com/owncloud/testing.git /drone/src/apps/testing
+  - cd /drone/src/apps/testing
+  - composer install
+  - cd /drone/src
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /drone/saved-settings.sh
+  - . /drone/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliLocalStorage
+    MAILHOG_HOST: email
+    TESTING_REMOTE_SYSTEM: true
+    TEST_SERVER_URL: https://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_CONFIG_TEMPLATE: ssl
+    APACHE_SSL_CERT: /drone/server.crt
+    APACHE_SSL_CERT_CN: server
+    APACHE_SSL_KEY: /drone/server.key
+    APACHE_WEBROOT: /drone/src
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- changelog
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: cliMain-mariadb10.2-php7.1
 
 platform:
@@ -15512,6 +15664,7 @@ depends_on:
 - apiFederation-master-mariadb10.2-php7.1
 - apiFederation-10.2.1-mariadb10.2-php7.1
 - cliBackground-mariadb10.2-php7.1
+- cliLocalStorage-mariadb10.2-php7.1
 - cliMain-mariadb10.2-php7.1
 - cliProvisioning-mariadb10.2-php7.1
 - cliTrashbin-mariadb10.2-php7.1

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -765,7 +765,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 	 *
 	 * @param string $mount (name of local storage mount)
 	 *
-	 * @return integer
+	 * @return string[] associated array with "code", "stdOut", "stdErr", "storageId"
 	 */
 	public static function createLocalStorageMount($mount) {
 		$mountPath = TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/$mount";
@@ -788,7 +788,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		);
 		// stdOut should have a string like "Storage created with id 65"
 		$storageIdWords = \explode(" ", \trim($result['stdOut']));
-		$storageId = (int)$storageIdWords[4];
-		return $storageId;
+		$result['storageId'] = (int)$storageIdWords[4];
+		return $result;
 	}
 }

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -307,6 +307,13 @@ default:
         - FeatureContext: *common_feature_context_params
         - OccContext:
 
+    cliLocalStorage:
+      paths:
+        - '%paths.base%/../features/cliLocalStorage'
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+
     cliMain:
       paths:
         - '%paths.base%/../features/cliMain'

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -2401,7 +2401,8 @@ trait BasicStructure {
 			$this->getOcPath()
 		);
 		$storageName = "local_storage";
-		$storageId = SetupHelper::createLocalStorageMount($storageName);
+		$result = SetupHelper::createLocalStorageMount($storageName);
+		$storageId = $result['storageId'];
 		$this->addStorageId($storageName, $storageId);
 		SetupHelper::runOcc(
 			[

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -20,6 +20,7 @@
  */
 
 use TestHelpers\SetupHelper;
+use PHPUnit\Framework\Assert;
 
 /**
  * Command line functions
@@ -37,6 +38,23 @@ trait CommandLine {
 	 * @var string stderr of last command
 	 */
 	private $lastStdErr;
+
+	/**
+	 * remember the result of the last occ command
+	 *
+	 * @param string[] $result associated array with "code", "stdOut", "stdErr"
+
+	 * @return void
+	 */
+	public function setResultOfOccCommand($result) {
+		Assert::assertIsArray($result);
+		Assert::assertArrayHasKey('code', $result);
+		Assert::assertArrayHasKey('stdOut', $result);
+		Assert::assertArrayHasKey('stdErr', $result);
+		$this->lastCode = (int) $result['code'];
+		$this->lastStdOut = $result['stdOut'];
+		$this->lastStdErr = $result['stdErr'];
+	}
 
 	/**
 	 * get the exit status of the last occ command

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -242,7 +242,9 @@ class OccContext implements Context {
 	 * @return void
 	 */
 	public function createLocalStorageMountUsingTheOccCommand($mount) {
-		$storageId = SetupHelper::createLocalStorageMount($mount);
+		$result = SetupHelper::createLocalStorageMount($mount);
+		$storageId = $result['storageId'];
+		$this->featureContext->setResultOfOccCommand($result);
 		$this->featureContext->addStorageId($mount, $storageId);
 	}
 

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -1,0 +1,20 @@
+@cli @skipOnLDAP @local_storage
+Feature: create local storage from the command line
+  As an admin
+  I want to create local storage from the command line
+  So that local folders on my server can be made visible to users of ownCloud
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+
+  Scenario: create local storage that is available to all users
+    When the administrator creates the local storage mount "local_storage2" using the occ command
+    And the administrator uploads file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt" using the WebDAV API
+    Then the command should have been successful
+    And as "user0" folder "/local_storage2" should exist
+    And as "user1" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"


### PR DESCRIPTION
## Description
1) create a new acceptance test suite `cliLocalStorage`
2) Give it a first feature with 1 scenario that creates a local storage

## Issue
Part of #36704 

## Motivation and Context
I was looking at a bug in `occ files_external:list` command.
To make a test scenario that demonstrates the bug, I first need acceptance test steps that let me create local storages and set options using the occ command.

(we currently have tests that create and change options for local storage via the webUI settings page, and we have some tests that create multiple local storages in `cliMain/files.feature` - I will move the relevant scenarios across to `cliLocalStorage` in the next PR)

## How Has This Been Tested?
Local run of new test scenario

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
