### PR TITLE
Refactor runOcc calls to save occ command results

### DIFF
--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -5,13 +5,15 @@ Feature: AppManagement
     Given app "multidirtest" with version "1.0.2" has been put in dir "apps"
     And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
     When the administrator gets the path for app "multidirtest" using the occ command
-    Then the path to "multidirtest" should be "apps"
+    Then the command should have been successful
+    And the path to "multidirtest" should be "apps"
 
   Scenario: Two apps_path exist by default. The second one is more recent
     Given app "multidirtest" with version "1.0.2" has been put in dir "apps"
     And app "multidirtest" with version "1.0.10" has been put in dir "apps-external"
     When the administrator gets the path for app "multidirtest" using the occ command
-    Then the path to "multidirtest" should be "apps-external"
+    Then the command should have been successful
+    And the path to "multidirtest" should be "apps-external"
 
   Scenario: Three app instances, including apps-external, exist. The first one is more recent
     Given these apps' path has been configured additionally with following attributes:
@@ -21,7 +23,8 @@ Feature: AppManagement
     And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
     And app "multidirtest" with version "1.0.0" has been put in dir "apps-custom"
     When the administrator gets the path for app "multidirtest" using the occ command
-    Then the path to "multidirtest" should be "apps"
+    Then the command should have been successful
+    And the path to "multidirtest" should be "apps"
 
   Scenario: Three app instances, including apps-external, exist. The second one is more recent
     Given these apps' path has been configured additionally with following attributes:
@@ -31,7 +34,8 @@ Feature: AppManagement
     And app "multidirtest" with version "1.0.10" has been put in dir "apps-external"
     And app "multidirtest" with version "1.0.0" has been put in dir "apps-custom"
     When the administrator gets the path for app "multidirtest" using the occ command
-    Then the path to "multidirtest" should be "apps-external"
+    Then the command should have been successful
+    And the path to "multidirtest" should be "apps-external"
 
   Scenario: Three app instances, including apps-external, exist. The third one is more recent
     Given these apps' path has been configured additionally with following attributes:
@@ -41,7 +45,8 @@ Feature: AppManagement
     And app "multidirtest" with version "1.0.1" has been put in dir "apps-external"
     And app "multidirtest" with version "1.0.10" has been put in dir "apps-custom"
     When the administrator gets the path for app "multidirtest" using the occ command
-    Then the path to "multidirtest" should be "apps-custom"
+    Then the command should have been successful
+    And the path to "multidirtest" should be "apps-custom"
 
   Scenario: Update of patch version of an app
     Given these apps' path has been configured additionally with following attributes:

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -169,17 +169,18 @@ class AppManagementContext implements Context {
 	 * @return void
 	 */
 	public function adminGetsPathForApp($appId) {
-		$occStatus = SetupHelper::runOcc(
+		$this->featureContext->runOcc(
 			['app:getpath', $appId, '--no-ansi']
 		);
-		$this->cmdOutput = $occStatus['stdOut'];
+		$this->cmdOutput = $this->featureContext->getStdOutOfOccCommand();
 		// check that the command seems to have executed OK, for both When and Given
 		// step forms. There is no point continuing the scenario if the command itself
 		// has reported an error.
+		$statusCode = $this->featureContext->getExitStatusCodeOfOccCommand();
 		Assert::assertEquals(
 			"0",
-			$occStatus['code'],
-			"app:getpath returned error code " . $occStatus['code']
+			$statusCode,
+			"app:getpath returned error code " . $statusCode
 		);
 	}
 
@@ -187,9 +188,10 @@ class AppManagementContext implements Context {
 	 * @When the administrator lists the apps using the occ command
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function adminListsTheApps() {
-		$occStatus = $this->featureContext->runOcc(
+		$this->featureContext->runOcc(
 			['app:list', '--no-ansi']
 		);
 	}
@@ -198,9 +200,10 @@ class AppManagementContext implements Context {
 	 * @When the administrator lists the enabled apps using the occ command
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function adminListsTheEnabledApps() {
-		$occStatus = $this->featureContext->runOcc(
+		$this->featureContext->runOcc(
 			['app:list', '--enabled', '--no-ansi']
 		);
 	}


### PR DESCRIPTION
## Description
Some code was directly calling `SetupHelper::runOcc` - those calls do not save the exit status, stdout and stderr from the occ command.

When that happens in a "real" step, then you cannot sensibly do `Then the command should have been successful` as the next sttep in the scenario.

Fix those to call `featureContext->runOcc` which saves the occ command result.

Directly calling `SetupHelper::runOcc` is OK in before/after scenario methods, in `Given` steps (checks for success are embedded in given steps), and `Then` steps (we do not want to overwrite the "most recent" occ command result if we have to do an occ command in a `Then` step to check something)

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
