### PR TITLE
Delete unused Given steps in TagsContext

### DIFF
--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -1038,22 +1038,6 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has deleted the tag with name :name
-	 *
-	 * @param string $user
-	 * @param string $name
-	 *
-	 * @return void
-	 */
-	public function userHasDeletedTag($user, $name) {
-		$this->deleteTag(
-			$user,
-			$name
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
-	}
-
-	/**
 	 * @param string $name
 	 *
 	 * @return void
@@ -1076,18 +1060,6 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Given the user has deleted the tag with name :name
-	 *
-	 * @param string $name
-	 *
-	 * @return void
-	 */
-	public function theUserHasDeletedTagWithName($name) {
-		$this->deleteTagAsCurrentUser($name);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
-	}
-
-	/**
 	 * @param string $name
 	 *
 	 * @return void
@@ -1107,18 +1079,6 @@ class TagsContext implements Context {
 	 */
 	public function theAdministratorDeletesTagWithName($name) {
 		$this->deleteTagAsAdmin($name);
-	}
-
-	/**
-	 * @Given the administrator has deleted the tag with name :name
-	 *
-	 * @param string $name
-	 *
-	 * @return void
-	 */
-	public function theAdministratorHasDeletedTagWithName($name) {
-		$this->deleteTagAsAdmin($name);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**
@@ -1583,24 +1543,6 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has removed tag :tagName from file :fileName
-	 *
-	 * @param string $user
-	 * @param string $tagName
-	 * @param string $fileName
-	 *
-	 * @return void
-	 */
-	public function userHasRemovedTagFromFile($user, $tagName, $fileName) {
-		$this->removeTagFromFile(
-			$user,
-			$tagName,
-			$fileName
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
-	}
-
-	/**
 	 * @param string $user
 	 * @param string $tagName
 	 * @param string $fileName
@@ -1641,28 +1583,6 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has removed tag :tagName from file :fileName shared by :shareUser
-	 *
-	 * @param string $user
-	 * @param string $tagName
-	 * @param string $fileName
-	 * @param string $shareUser
-	 *
-	 * @return void
-	 */
-	public function userHasRemovedTagFromFileSharedBy(
-		$user, $tagName, $fileName, $shareUser
-	) {
-		$this->removeTagFromFileSharedByUser(
-			$user,
-			$tagName,
-			$fileName,
-			$shareUser
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
-	}
-
-	/**
 	 * @param string $tagName
 	 * @param string $fileName
 	 * @param string $shareUser
@@ -1686,25 +1606,6 @@ class TagsContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorRemovesTheTagFromFileSharedByUsingTheWebdavApi(
-		$tagName, $fileName, $shareUser
-	) {
-		$this->removeTagFromFileSharedByUserAsAdminUsingWebDavApi(
-			$tagName,
-			$fileName,
-			$shareUser
-		);
-	}
-
-	/**
-	 * Given the administrator has removed tag :tagName from file :fileName shared by :shareUser
-	 *
-	 * @param string $tagName
-	 * @param string $fileName
-	 * @param string $shareUser
-	 *
-	 * @return void
-	 */
-	public function theAdministratorHasRemovedTheTagFromFileSharedByUsingTheWebdavApi(
 		$tagName, $fileName, $shareUser
 	) {
 		$this->removeTagFromFileSharedByUserAsAdminUsingWebDavApi(


### PR DESCRIPTION
## Description
A `Given` step in `TagsContext` had no `@` at the beginning. The step is not used.
Actually none of the`Given` steps that delete tags are used. And they are not likely to ever be used - the system starts with no tags defined, no there is no reason to be removing a tag in a `Given`

Delete these unused steps. Deleted code is tested code.

## Related Issue
PR #36666 


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
