### PR TITLE
Adjust read-only local storage mount scenario

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -33,8 +33,8 @@ Feature: admin storage settings
   @skipOnOcV10.3
   Scenario: administrator creates a read-only local storage mount
     Given user "user0" has been created with default attributes and without skeleton files
-    And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
     When the administrator creates the local storage mount "local_storage1" using the webUI
     And the administrator uploads file with content "this is a file in local storage" to "/local_storage1/file-in-local-storage.txt" using the WebDAV API
     And the administrator enables read-only for the last created local storage mount using the webUI


### PR DESCRIPTION
## Description
The scenario above this was refactored a bit in recent days so it enables external storage via the API first and then the admin browses to the admin storage settings page before doing the actions to create a local storage.

This scenario "administrator creates a read-only local storage mount" was added for the read-only storage feature. It missed the refactoring. Maybe the now-out-of-order steps will work anyway, but it will be better to be adjusted.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
