### PR TITLE
Adjusted given steps in WebUISharing context

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -73,6 +73,15 @@ trait Sharing {
 		'attributes', 'permissions', 'share_with', 'share_with_displayname', 'share_with_additional_info'
 	];
 
+	private $createdPublicLinks = [];
+
+	/**
+	 * @return array
+	 */
+	public function getCreatedPublicLinks() {
+		return $this->createdPublicLinks;
+	}
+
 	/**
 	 * @return SimpleXMLElement
 	 */
@@ -837,6 +846,16 @@ trait Sharing {
 	}
 
 	/**
+	 * @param string $name
+	 * @param string $url
+	 *
+	 * @return void
+	 */
+	public function addToListOfCreatedPublicLinks($name, $url) {
+		$this->createdPublicLinks[] = ["name" => $name, "url" => $url];
+	}
+
+	/**
 	 * @param string $user
 	 * @param string $path
 	 * @param string $shareType
@@ -880,6 +899,11 @@ trait Sharing {
 			$this->sharingApiVersion
 		);
 		$this->lastShareData = $this->getResponseXml();
+		if ($shareType === 'public_link') {
+			$linkName = (string) $this->lastShareData->data[0]->name;
+			$linkUrl = (string) $this->lastShareData->data[0]->url;
+			$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+		}
 		$this->localLastShareTime = \microtime(true);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -975,6 +975,29 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then following elements should be listed as uploaded items on the webUI:
+	 *
+	 * @param TableNode $table list of expected uploaded elements to be visible on the webUI
+	 * 						   the heading of the table is required to be "uploaded-elements"
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theFollowingElementsShouldBeListedAsUploadedFilesOnTheWebUI($table) {
+		$this->featureContext->verifyTableNodeColumns($table, ["uploaded-elements"]);
+		$expectedElements = [];
+		foreach ($table as $row) {
+			\array_push($expectedElements, $row["uploaded-elements"]);
+		}
+		$pageObject = $this->getCurrentPageObject();
+		$currentUploadedElements = $pageObject->getCompletelyUploadedElements();
+		Assert::assertEqualsCanonicalizing(
+			$currentUploadedElements,
+			$expectedElements
+		);
+	}
+
+	/**
 	 * @When /^the user chooses to keep the (new|existing) files in the upload dialog$/
 	 *
 	 * @param string $choice

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -975,7 +975,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then following elements should be listed as uploaded items on the webUI:
+	 * @Then the following elements should be listed as uploaded items on the webUI:
 	 *
 	 * @param TableNode $table list of expected uploaded elements to be visible on the webUI
 	 * 						   the heading of the table is required to be "uploaded-elements"

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -97,7 +97,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @var WebUIFilesContext
 	 */
 	private $webUIFilesContext;
-	private $createdPublicLinks = [];
 
 	private $oldMinCharactersForAutocomplete = null;
 	private $oldFedSharingFallbackSetting = null;
@@ -138,19 +137,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 *
-	 * @param string $name
-	 * @param string $url
-	 *
-	 * @return void
-	 */
-	private function addToListOfCreatedPublicLinks($name, $url) {
-		$this->createdPublicLinks[] = ["name" => $name, "url" => $url];
-	}
-
-	/**
 	 * @When /^the user shares (?:file|folder) "([^"]*)" with (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
-	 * @Given /^the user has shared (?:file|folder) "([^"]*)" with (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
 	 *
 	 * @param string $folder
 	 * @param string $remote
@@ -230,6 +217,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $receiver
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function expirationFieldEmptyForUser($type, $receiver) {
 		Assert::assertEquals($this->sharingDialog->getExpirationDateFor($receiver, $type), "");
@@ -259,7 +247,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $receiver
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function expirationDateShouldBe($days, $type, $receiver) {
 		if (\strtotime($days) !== false) {
@@ -330,7 +318,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user shares file/folder :folder with group :group using the webUI
-	 * @Given the user has shared file/folder :folder with group :group using the webUI
 	 *
 	 * @param string $folder
 	 * @param string $group
@@ -441,7 +428,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the user has renamed the public link name from :oldName to :newName
 	 * @When the user renames the public link name from :oldName to :newName
 	 *
 	 * @param string $oldName
@@ -457,7 +443,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($newName);
-		$this->addToListOfCreatedPublicLinks($newName, $linkUrl);
+		$this->featureContext->addToListOfCreatedPublicLinks($newName, $linkUrl);
 	}
 
 	/**
@@ -495,7 +481,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the user has changed the password of the public link named :name to :newPassword
 	 * @When the user changes the password of the public link named :name to :newPassword
 	 *
 	 * @param string $name
@@ -510,11 +495,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($name);
-		$this->addToListOfCreatedPublicLinks($name, $linkUrl);
+		$this->featureContext->addToListOfCreatedPublicLinks($name, $linkUrl);
 	}
 
 	/**
-	 * @Given the user has changed the permission of the public link named :name to :newPermission
 	 * @When the user changes the permission of the public link named :name to :newPermission
 	 *
 	 * @param string $name
@@ -529,7 +513,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($name);
-		$this->addToListOfCreatedPublicLinks($name, $linkUrl);
+		$this->featureContext->addToListOfCreatedPublicLinks($name, $linkUrl);
 	}
 
 	/**
@@ -540,6 +524,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $date
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function theUserChangeTheExpirationOfThePublicLinkNamedForTo($linkName, $name, $date) {
 		$session = $this->getSession();
@@ -574,6 +559,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param TableNode $emails
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function theUserAddsTheFollowingEmailAddressesUsingTheWebUI(TableNode $emails) {
 		$this->featureContext->verifyTableNodeColumns($emails, ['email']);
@@ -588,6 +574,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param TableNode $emails
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function theUserRemovesTheFollowingEmailAddressesUsingTheWebui(TableNode $emails) {
 		$this->featureContext->verifyTableNodeColumns($emails, ['email']);
@@ -608,14 +595,13 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->publicSharingPopup->waitForAjaxCallsToStartAndFinish($this->getSession());
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($linkName);
-		$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl);
 
 		$this->featureContext->resetLastShareData();
 	}
 
 	/**
 	 * @When the user creates a new public link for file/folder :name using the webUI
-	 * @Given the user has created a new public link for file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 *
@@ -646,7 +632,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	) {
 		$linkName = $this->createPublicShareLink($name, $settings);
 		$linkUrl = $this->publicShareTab->getLinkUrl($linkName);
-		$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl);
 	}
 
 	/**
@@ -876,7 +862,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function thePublicAccessesTheLastCreatedPublicLinkUsingTheWebUI() {
-		$lastCreatedLink = \end($this->createdPublicLinks);
+		$createdPublicLinks = $this->featureContext->getCreatedPublicLinks();
+		$lastCreatedLink = \end($createdPublicLinks);
 		$path = \str_replace(
 			$this->featureContext->getBaseUrl(),
 			"",
@@ -914,13 +901,13 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^the user (declines|accepts) share "([^"]*)" offered by user "([^"]*)" using the webUI$/
-	 * @Given /^the user has (declined|accepted) share "([^"]*)" offered by user "([^"]*)" using the webUI$/
 	 *
 	 * @param string $action
 	 * @param string $share
 	 * @param string $offeredBy
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function userReactsToShareOfferedByUsingWebUI(
 		$action, $share, $offeredBy
@@ -956,9 +943,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $password
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function thePublicAccessesPublicLinkWithPasswordUsingTheWebui($password) {
-		$createdPublicLinks = $this->createdPublicLinks;
+		$createdPublicLinks = $this->featureContext->getCreatedPublicLinks();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$this->publicLinkFilesPage->openPublicShareAuthenticateUrl($createdPublicLinks, $baseUrl);
 		$this->publicLinkFilesPage->enterPublicLinkPassword($password);
@@ -974,7 +962,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function thePublicTriesToAccessPublicLinkWithWrongPasswordUsingTheWebui($wrongPassword) {
-		$createdPublicLinks = $this->createdPublicLinks;
+		$createdPublicLinks = $this->featureContext->getCreatedPublicLinks();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$this->publicLinkFilesPage->openPublicShareAuthenticateUrl($createdPublicLinks, $baseUrl);
 		$this->publicLinkFilesPage->enterPublicLinkPassword($wrongPassword);
@@ -1072,8 +1060,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function thePublicShouldNotGetAccessToPublicShareFile() {
 		$warningMessage = $this->publicLinkFilesPage->getWarningMessage();
 		Assert::assertEquals('The password is wrong. Try again.', $warningMessage);
-
-		$lastCreatedLink = \end($this->createdPublicLinks);
+		$createdPublicLinks = $this->featureContext->getCreatedPublicLinks();
+		$lastCreatedLink = \end($createdPublicLinks);
 		$lastSharePath = $lastCreatedLink['url'] . '/authenticate';
 		$currentPath = $this->getSession()->getCurrentUrl();
 		Assert::assertEquals($lastSharePath, $currentPath);
@@ -1525,7 +1513,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function thePublicShouldSeeAnErrorMessageWhileAccessingLastCreatedPublicLinkUsingTheWebui($errorMsg) {
-		$lastCreatedLink = \end($this->createdPublicLinks);
+		$createdPublicLinks = $this->featureContext->getCreatedPublicLinks();
+		$lastCreatedLink = \end($createdPublicLinks);
 		$path = \str_replace(
 			$this->featureContext->getBaseUrl(),
 			"",
@@ -1548,6 +1537,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 *                                 exactly the way they are written in the UI
 	 *
 	 * @return string
+	 * @throws \Exception
 	 */
 	public function createPublicShareLink($name, $settings = null) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
@@ -1677,13 +1667,15 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $address
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function theEmailAddressShouldHaveReceivedAnEmailContainingSharedPublicLink($address) {
 		$content = EmailHelper::getBodyOfLastEmail(
 			EmailHelper::getLocalMailhogUrl(),
 			$address
 		);
-		$lastCreatedPublicLink = \end($this->createdPublicLinks);
+		$createdPublicLinks = $this->featureContext->getCreatedPublicLinks();
+		$lastCreatedPublicLink = \end($createdPublicLinks);
 		Assert::assertContains($lastCreatedPublicLink["url"], $content);
 	}
 

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -49,6 +49,8 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	protected $passwordSubmitButtonId = 'password-submit';
 	protected $warningMessageCss = '.warning';
 	protected $deleteAllSelectedBtnXpath = "//a[@class='delete-selected']";
+	protected $uploadedElementsCss = '.public-upload-view--completed';
+	protected $uploadedElementsXpath = "//div[@class='public-upload-view--completed']//li";
 
 	/**
 	 *
@@ -486,5 +488,26 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 */
 	public function waitForUploadProgressbarToFinish() {
 		$this->filesPageCRUDFunctions->waitForUploadProgressbarToFinish();
+	}
+
+	/**
+	 * returns list of completely uploaded elements
+	 *
+	 * @return array
+	 */
+	public function getCompletelyUploadedElements() {
+		$uploadedElementsContainer = $this->find("css", $this->uploadedElementsCss);
+		$this->assertElementNotNull(
+			$uploadedElementsContainer,
+			__METHOD__ .
+			" CSS $this->uploadedElementsCss " .
+			"is found NULL"
+		);
+		$elements = $this->findAll("xpath", $this->uploadedElementsXpath);
+		$uploadedElements = [];
+		foreach ($elements as $element) {
+			\array_push($uploadedElements, $element->getText());
+		}
+		return $uploadedElements;
 	}
 }

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -38,9 +38,9 @@ Feature: create folders
   @files_sharing-app-required
   Scenario: Create a folder in a public share
     Given user "user1" has created folder "/simple-empty-folder"
-    And the user has reloaded the current page of the webUI
-    And the user has created a new public link for folder "simple-empty-folder" using the webUI with
-      | permission | read-write |
+    And user "user1" has created a public link share with settings
+      | path        | /simple-empty-folder |
+      | permissions | read,create          |
     And the public accesses the last created public link using the webUI
     When the user creates a folder with the name "top-folder" using the webUI
     And the user opens folder "top-folder" using the webUI

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -159,8 +159,8 @@ Feature: deleting files and folders
   @files_sharing-app-required
   Scenario: delete a file on a public share
     Given user "user1" has created a public link share with settings
-      | path        | /simple-folder  |
-      | permissions | read,update,create,delete     |
+      | path        | /simple-folder            |
+      | permissions | read,update,create,delete |
     And the public accesses the last created public link using the webUI
     When the user deletes the following elements using the webUI
       | name                                  |
@@ -176,8 +176,8 @@ Feature: deleting files and folders
   @skipOnFIREFOX @files_sharing-app-required
   Scenario: delete a file on a public share with problematic characters
     Given user "user1" has created a public link share with settings
-      | path        | /simple-folder  |
-      | permissions | read,change     |
+      | path        | /simple-folder |
+      | permissions | read,change    |
     And the public accesses the last created public link using the webUI
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |
@@ -208,8 +208,8 @@ Feature: deleting files and folders
   @skipOnEncryption @encryption-issue-74 @files_sharing-app-required
   Scenario: Delete multiple files at once on a public share
     Given user "user1" has created a public link share with settings
-      | path        | /simple-folder  |
-      | permissions | read,update,create,delete     |
+      | path        | /simple-folder            |
+      | permissions | read,update,create,delete |
     And the public accesses the last created public link using the webUI
     When the user batch deletes these files using the webUI
       | name                |

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -119,8 +119,8 @@ Feature: deleting files and folders
   @files_sharing-app-required
   Scenario: delete files from shared with others page
     Given user "user2" has been created with default attributes and without skeleton files
-    Given the user has shared file "lorem.txt" with user "User Two" using the webUI
-    And the user has shared folder "simple-folder" with user "User Two" using the webUI
+    And the user has shared file "lorem.txt" with user "user2"
+    And the user has shared folder "simple-folder" with user "user2"
     And the user has browsed to the shared-with-others page
     When the user deletes file "lorem.txt" using the webUI
     And the user deletes folder "simple-folder" using the webUI
@@ -134,7 +134,7 @@ Feature: deleting files and folders
 
   @public_link_share-feature-required @files_sharing-app-required
   Scenario: delete files from shared by link page
-    Given the user has created a new public link for file "lorem.txt" using the webUI
+    Given the user has created a public link share of file "lorem.txt"
     And the user has browsed to the shared-by-link page
     Then file "lorem.txt" should be listed on the webUI
     When the user deletes file "lorem.txt" using the webUI
@@ -158,8 +158,9 @@ Feature: deleting files and folders
 
   @files_sharing-app-required
   Scenario: delete a file on a public share
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
+    Given user "user1" has created a public link share with settings
+      | path        | /simple-folder  |
+      | permissions | read,update,create,delete     |
     And the public accesses the last created public link using the webUI
     When the user deletes the following elements using the webUI
       | name                                  |
@@ -174,8 +175,9 @@ Feature: deleting files and folders
 
   @skipOnFIREFOX @files_sharing-app-required
   Scenario: delete a file on a public share with problematic characters
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
+    Given user "user1" has created a public link share with settings
+      | path        | /simple-folder  |
+      | permissions | read,change     |
     And the public accesses the last created public link using the webUI
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |
@@ -205,8 +207,9 @@ Feature: deleting files and folders
 
   @skipOnEncryption @encryption-issue-74 @files_sharing-app-required
   Scenario: Delete multiple files at once on a public share
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
+    Given user "user1" has created a public link share with settings
+      | path        | /simple-folder  |
+      | permissions | read,update,create,delete     |
     And the public accesses the last created public link using the webUI
     When the user batch deletes these files using the webUI
       | name                |

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -44,8 +44,8 @@ Feature: User can open the details panel for any file or folder
   @comments-app-required @public_link_share-feature-required @files_sharing-app-required
   Scenario: user shares a file through public link and then the details dialog should work in a Shared by link page
     Given user "user1" has created folder "a-folder"
+    And user "user1" has created a public link share of folder "a-folder" with read permissions
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "a-folder" using the webUI
     When the user browses to the shared-by-link page
     Then folder "a-folder" should be listed on the webUI
     When the user opens the file action menu of folder "a-folder" on the webUI
@@ -61,8 +61,8 @@ Feature: User can open the details panel for any file or folder
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
     Given user "user2" has been created with default attributes and without skeleton files
     And user "user1" has created folder "a-folder"
+    And user "user1" has shared folder "a-folder" with user "user2"
     And user "user1" has logged in using the webUI
-    And the user has shared folder "a-folder" with user "User Two" using the webUI
     When the user browses to the shared-with-others page
     Then folder "a-folder" should be listed on the webUI
     When the user opens the file action menu of folder "a-folder" on the webUI
@@ -78,9 +78,8 @@ Feature: User can open the details panel for any file or folder
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
     Given user "user2" has been created with default attributes and skeleton files
     And user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
-    And the user has shared folder "a-folder" with user "User Two" using the webUI
-    And the user re-logs in as "user2" using the webUI
+    And user "user1" has shared folder "a-folder" with user "user2"
+    And user "user2" has logged in using the webUI
     When the user browses to the shared-with-you page
     Then folder "a-folder" should be listed on the webUI
     When the user opens the file action menu of folder "a-folder" on the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -82,10 +82,11 @@ Feature: move files
 
   @files_sharing-app-required
   Scenario: move files on a public share
-    Given the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
-    And the public accesses the last created public link using the webUI
-    And the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
+    And user "user1" has created a public link share with settings
+      | path        | /simple-folder  |
+      | permissions | read,create,change |
+    And the public has accessed the last created public link using the webUI
+    When the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
     Then file "data.zip" should not be listed on the webUI
     When the user reloads the current page of the webUI
     Then file "data.zip" should not be listed on the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -83,7 +83,7 @@ Feature: move files
   @files_sharing-app-required
   Scenario: move files on a public share
     And user "user1" has created a public link share with settings
-      | path        | /simple-folder  |
+      | path        | /simple-folder     |
       | permissions | read,create,change |
     And the public has accessed the last created public link using the webUI
     When the user moves file "data.zip" into folder "simple-empty-folder" using the webUI

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -119,9 +119,9 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-    Given user "regularuser" has logged in using the webUI
+    Given user "regularuser" has shared folder "simple-folder" with user "user1"
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has shared folder "simple-folder" with user "User One" using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
@@ -130,9 +130,9 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
-    Given user "regularuser" has logged in using the webUI
+    Given user "regularuser" has shared file "data.zip" with user "usergrp"
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has shared file "data.zip" with user "User Grp" using the webUI
     And the user has opened the share dialog for file "data.zip"
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
@@ -141,9 +141,9 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
-    Given user "regularuser" has logged in using the webUI
+    Given user "regularuser" has shared folder "simple-folder" with group "finance1"
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user shares folder "simple-folder" with group "finance1" using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
@@ -152,9 +152,9 @@ Feature: Autocompletion of share-with names
 
   @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
-    Given user "regularuser" has logged in using the webUI
+    Given user "regularuser" has shared file "data.zip" with group "finance1"
+    And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
-    And the user shares file "data.zip" with group "finance1" using the webUI
     And the user has opened the share dialog for file "data.zip"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -12,10 +12,9 @@ Feature: Sharing files and folders with internal users
       | username |
       | user1    |
       | user2    |
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user shares file "testimage.jpg" with user "User One" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And user "user2" has shared folder "simple-folder" with user "user1"
+    And user "user2" has shared file "testimage.jpg" with user "user1"
+    When user "user1" logs in using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
     And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
     And file "testimage (2).jpg" should be listed on the webUI
@@ -109,12 +108,11 @@ Feature: Sharing files and folders with internal users
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has moved folder "simple-folder" to "new-simple-folder"
     And user "user2" has moved file "lorem.txt" to "ipsum.txt"
-    And user "user2" has logged in using the webUI
-    And the user has shared file "ipsum.txt" with user "User One" using the webUI
-    And the user has shared folder "new-simple-folder" with user "User One" using the webUI
-    When the user re-logs in as "user1" using the webUI
+    And user "user2" has moved file "simple-folder" to "new-simple-folder"
+    And user "user2" has shared file "ipsum.txt" with user "user1"
+    And user "user2" has shared file "new-simple-folder" with user "user1"
+    When user "user1" logs in using the webUI
     And the user browses to the shared-with-you page
     Then file "ipsum.txt" should be listed on the webUI
     And folder "new-simple-folder" should be listed on the webUI
@@ -122,9 +120,9 @@ Feature: Sharing files and folders with internal users
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has shared file "lorem.txt" with user "user1"
+    And user "user2" has shared file "simple-folder" with user "user1"
     And user "user2" has logged in using the webUI
-    And the user has shared file "lorem.txt" with user "User One" using the webUI
-    And the user has shared folder "simple-folder" with user "User One" using the webUI
     When the user browses to the shared-with-others page
     Then file "lorem.txt" should be listed on the webUI
     And folder "simple-folder" should be listed on the webUI
@@ -132,8 +130,8 @@ Feature: Sharing files and folders with internal users
   Scenario: share two file with same name but different paths
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has shared file "lorem.txt" with user "user1"
     And user "user2" has logged in using the webUI
-    And the user has shared file "lorem.txt" with user "User One" using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user shares file "lorem.txt" with user "User One" using the webUI
     And the user browses to the shared-with-others page

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -256,10 +256,13 @@ Feature: Share by public link
   Scenario: user edits a public link and does not save the changes
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | email    | foo1234@bar.co |
+    And user "user1" has created a public link share with settings
+      | path     | /simple-folder |
+      | name     |  Public link   |
       | password | pass123        |
+    And user "user1" has logged in using the webUI
+    And the user has opened the share dialog for folder "simple-folder"
+    And the user has opened the public link share tab
     When the user opens the edit public link share popup for the link named "Public link"
     And the user enters the password "qwertyui" on the edit public link share popup for the link
     And the user does not save any changes in the edit public link share popup
@@ -269,8 +272,11 @@ Feature: Share by public link
   Scenario: user edits a name of an already existing public link
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has created a public link share with settings
+      | path     | /simple-folder |
+      | name     |  Public link   |
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI
+    And the user has opened the share dialog for folder "simple-folder"
     And the user has opened the public link share tab
     When the user renames the public link name from "Public link" to "simple-folder Share"
     And the public accesses the last created public link using the webUI
@@ -279,27 +285,34 @@ Feature: Share by public link
   Scenario: user shares a file through public link and then it appears in a Shared by link page
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And user "user1" has created folder "/simple-folder"
+    And user "user1" has created a public link share of file "/simple-folder"
     And user "user1" has logged in using the webUI
-    And the user has reloaded the current page of the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI
     When the user browses to the shared-by-link page
     Then folder "simple-folder" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has created a public link share with settings
+      | path     | /simple-folder |
+      | name     | Public link    |
+      | password | pass123        |
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | password | pass123 |
+    And the user has opened the share dialog for folder "simple-folder"
+    And the user has opened the public link share tab
     When the user changes the password of the public link named "Public link" to "pass1234"
     And the public accesses the last created public link with password "pass1234" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link and tries to access with old password
     Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created a public link share with settings
+      | path     | /simple-folder |
+      | name     | Public link    |
+      | password | pass123        |
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | password | pass123 |
+    And the user opens the share dialog for folder "simple-folder"
+    And the user has opened the public link share tab
     When the user changes the password of the public link named "Public link" to "pass1234"
     And the public tries to access the last created public link with wrong password "pass123" using the webUI
     Then the public should not get access to the publicly shared file
@@ -307,9 +320,13 @@ Feature: Share by public link
   Scenario: user edits the permission of an already existing public link from read-write to read
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has created a public link share with settings
+      | path        | /simple-folder |
+      | name        | Public link    |
+      | permissions | read,create    |
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
+    And the user opens the share dialog for folder "simple-folder"
+    And the user has opened the public link share tab
     When the user changes the permission of the public link named "Public link" to "read"
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -319,9 +336,13 @@ Feature: Share by public link
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has created folder "/simple-folder/simple-empty-folder"
     And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user1" has created a public link share with settings
+      | path        | /simple-folder |
+      | name        | Public link    |
+      | permissions | read           |
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read |
+    And the user opens the share dialog for folder "simple-folder"
+    And the user has opened the public link share tab
     When the user changes the permission of the public link named "Public link" to "read-write"
     And the public accesses the last created public link using the webUI
     And the user deletes the following elements using the webUI
@@ -373,54 +394,63 @@ Feature: Share by public link
 
   Scenario: user removes the public link of a file
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has created a public link share of file "/lorem.txt"
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for file "lorem.txt" using the webUI
     When the user removes the public link of file "lorem.txt" using the webUI
     Then the public should see an error message "File not found" while accessing last created public link using the webUI
 
   Scenario: user cancel removes operation for the public link of a file
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user1" has created a public link share of file "/lorem.txt"
     And user "user1" has logged in using the webUI
-    And the user has created a new public link for file "lorem.txt" using the webUI
     When the user tries to remove the public link of file "lorem.txt" but later cancels the remove dialog using webUI
     And the public accesses the last created public link using the webUI
     Then the content of the file shared by the last public link should be the same as "lorem.txt"
 
   Scenario: user creates a multiple public link of a file and delete the first link
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt |
       | name | first-link |
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt  |
       | name | second-link |
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt |
       | name | third-link |
+    And user "user1" has logged in using the webUI
     When the user removes the public link at position 1 of file "lorem.txt" using the webUI
     Then the public link with name "first-link" should not be in the public links list
     And the number of public links should be 2
 
   Scenario: user creates a multiple public link of a file and delete the second link
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt |
       | name | first-link |
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt  |
       | name | second-link |
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt |
       | name | third-link |
+    And user "user1" has logged in using the webUI
     When the user removes the public link at position 2 of file "lorem.txt" using the webUI
     Then the public link with name "second-link" should not be in the public links list
     And the number of public links should be 2
 
   Scenario: user creates a multiple public link of a file and delete the third link
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt |
       | name | first-link |
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt  |
       | name | second-link |
-    And the user has created a new public link for file "lorem.txt" using the webUI with
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt |
       | name | third-link |
+    And user "user1" has logged in using the webUI
     When the user removes the public link at position 3 of file "lorem.txt" using the webUI
     Then the public link with name "third-link" should not be in the public links list
     And the number of public links should be 2
@@ -440,8 +470,8 @@ Feature: Share by public link
     And user "user1" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
-    And the public accesses the last created public link using the webUI
-    When the user uploads file "lorem.txt" 5 times using webUI
+    When the public accesses the last created public link using the webUI
+    And the user uploads file "lorem.txt" 5 times using webUI
     Then notifications should be displayed on the webUI with the text
       | The file lorem.txt already exists |
       | The file lorem.txt already exists |
@@ -519,8 +549,8 @@ Feature: Share by public link
     And user "user1" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
-    And the public accesses the last created public link using the webUI
-    When the user uploads file "lorem.txt" using the webUI
+    When the public accesses the last created public link using the webUI
+    And the user uploads file "lorem.txt" using the webUI
     Then a notification should be displayed on the webUI with the text "The file lorem.txt already exists"
     And file "lorem.txt" should be listed on the webUI
     And file "lorem (2).txt" should not be listed on the webUI
@@ -531,8 +561,8 @@ Feature: Share by public link
     And user "user1" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
-    And the public accesses the last created public link using the webUI
-    When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
+    When the public accesses the last created public link using the webUI
+    And the user uploads file "lorem.txt" keeping both new and existing files using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem (2).txt" should be listed on the webUI
 
@@ -543,7 +573,7 @@ Feature: Share by public link
     And user "user1" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
-    And the public accesses the last created public link using the webUI
+    When the public accesses the last created public link using the webUI
     Then it should be possible to delete file "lorem.txt" using the webUI
     When the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
@@ -559,7 +589,7 @@ Feature: Share by public link
     And user "user1" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
-    And the public accesses the last created public link using the webUI
+    When the public accesses the last created public link using the webUI
     Then the option to delete file "lorem.txt" should not be available on the webUI
     When the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
@@ -634,7 +664,7 @@ Feature: Share by public link
     And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
-    And the public accesses the last created public link using the webUI
+    When the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
     When the public downloads file "lorem.txt" using the webUI
     Then the downloaded content should be "original content"
@@ -644,7 +674,7 @@ Feature: Share by public link
     And user "user1" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
     And the user logs out of the webUI
-    And the public accesses the last created public link using the webUI
+    When the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "original content"
     And all the links to download the public share should be the same
 

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -258,7 +258,7 @@ Feature: Share by public link
     And user "user1" has created folder "/simple-folder"
     And user "user1" has created a public link share with settings
       | path     | /simple-folder |
-      | name     |  Public link   |
+      | name     | Public link    |
       | password | pass123        |
     And user "user1" has logged in using the webUI
     And the user has opened the share dialog for folder "simple-folder"
@@ -273,8 +273,8 @@ Feature: Share by public link
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "user1" has created a public link share with settings
-      | path     | /simple-folder |
-      | name     |  Public link   |
+      | path | /simple-folder |
+      | name | Public link    |
     And user "user1" has logged in using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     And the user has opened the public link share tab

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -109,31 +109,40 @@ Feature: File Upload
   @files_sharing-app-required
   Scenario: upload a file into a public share
     Given user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
-    And the public accesses the last created public link using the webUI
+    And user "user1" has created a public link share with settings
+      | path        | /simple-folder |
+      | permissions | read,create    |
+    When the public accesses the last created public link using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
+    When user "user1" logs in using the webUI
     And the content of "simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @files_sharing-app-required
   Scenario: upload overwriting a file into a public share
     Given user "user1" has created folder "/simple-folder"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
-    And the public accesses the last created public link using the webUI
+    And user "user1" has created a public link share with settings
+      | path        | /simple-folder     |
+      | permissions | read,update,create |
+    When the public accesses the last created public link using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then file "lorem.txt" should be listed on the webUI
+    When user "user1" logs in using the webUI
     And the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"
 
   @files_sharing-app-required
   Scenario: upload a file into files_drop share
     Given user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | upload |
-    And the public accesses the last created public link using the webUI
-    Then the user uploads file "lorem.txt" using the webUI
+    And user "user1" has created a public link share with settings
+      | path        | /simple-folder  |
+      | permissions | uploadwriteonly |
+    When the public accesses the last created public link using the webUI
+    And the user uploads file "lorem.txt" using the webUI
+    And the user uploads file "lorem-big.txt" using the webUI
+    Then following elements should be listed as uploaded items on the webUI:
+      | uploaded-elements |
+      | lorem.txt         |
+      | lorem-big.txt     |
+    And as "user1" file "/simple-folder/lorem.txt" should exist
+    And as "user1" file "/simple-folder/lorem-big.txt" should exist

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -140,7 +140,7 @@ Feature: File Upload
     When the public accesses the last created public link using the webUI
     And the user uploads file "lorem.txt" using the webUI
     And the user uploads file "lorem-big.txt" using the webUI
-    Then following elements should be listed as uploaded items on the webUI:
+    Then the following elements should be listed as uploaded items on the webUI:
       | uploaded-elements |
       | lorem.txt         |
       | lorem-big.txt     |

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -17,7 +17,7 @@ Feature: Locks
     And user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has created a public link share with settings
-      | path        | /simple-folder  |
+      | path        | /simple-folder            |
       | permissions | read,update,create,delete |
     When the public accesses the last created public link using the webUI
     And the user deletes folder "lorem.txt" using the webUI

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -16,9 +16,9 @@ Feature: Locks
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "brand-new-user" has locked folder "simple-folder" setting following properties
       | lockscope | <lockscope> |
-    And user "brand-new-user" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
+    And user "brand-new-user" has created a public link share with settings
+      | path        | /simple-folder  |
+      | permissions | read,update,create,delete |
     When the public accesses the last created public link using the webUI
     And the user deletes folder "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text


### PR DESCRIPTION
## Description
Given steps are not preferred to be done using webUI. Combined given-when steps in WebUISharing context are separated and given steps implemented using webUI are replaced by ones using sharing API.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/635
- Part of https://github.com/owncloud/QA/issues/637

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- CI

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
