### PR TITLE
Added scenario for folder creation with stranges names using webUI

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1218,6 +1218,27 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user opens folder with the following name using the webUI
+	 *
+	 * @param TableNode $namePartsTable table of parts of the file name
+	 *                                  table headings: must be: |name-parts |
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUserOpensFolderWithFollowingNamePartsUsingTheWebUI($namePartsTable) {
+		$fileName = '';
+		foreach ($namePartsTable as $namePartsRow) {
+			$fileName .= $namePartsRow['name-parts'];
+		}
+		$this->theUserOpensTheFileOrFolderUsingTheWebUI(
+			null,
+			'folder',
+			$fileName
+		);
+	}
+
+	/**
 	 * @When /^the user opens (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) (expecting to fail|)\s?using the webUI$/
 	 * @Given /^the user has opened (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) (expecting to fail|)\s?using the webUI$/
 	 *

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -825,10 +825,7 @@ class OwncloudPage extends Page {
 			return '"' . $text . '"';
 		} else {
 			// The text contains both single and double quotes.
-			// With current xpath v1 there is no way to encode that.
-			throw new \InvalidArgumentException(
-				"mixing both single and double quotes is unsupported - '$text'"
-			);
+			return "concat('" . \str_replace("'", "',\"'\",'", $text) . "')";
 		}
 	}
 

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -49,3 +49,25 @@ Feature: create folders
     Then folder "sub-folder" should be listed on the webUI
     When the user reloads the current page of the webUI
     Then folder "sub-folder" should be listed on the webUI
+
+  Scenario: Create folder with name including both double and single quotes
+    When the user creates a folder with the following name using the webUI
+      | name-parts         |
+      | 'single'quotes     |
+      | with"double"quotes |
+    Then the following folder should be listed on the webUI
+      | name-parts         |
+      | 'single'quotes     |
+      | with"double"quotes |
+    When the user opens folder with the following name using the webUI
+      | name-parts         |
+      | 'single'quotes     |
+      | with"double"quotes |
+    And the user creates a folder with the following name using the webUI
+      | name-parts         |
+      | another'single'    |
+      | with"double"quotes |
+    Then the following folder should be listed on the webUI
+      | name-parts         |
+      | another'single'    |
+      | with"double"quotes |


### PR DESCRIPTION
## Description
From #36690 it was noticed that webUI scenario for creating folder with name including both double and single quotes was not written!
- WebUI scenarios are added 
- never implemented steps are used form webUIFilesContext

## Related Issue
- Created by PR #36690

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manually
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
