### PR TITLE
Add local storage scenario for issue 36713

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -600,12 +600,13 @@ trait BasicStructure {
 	 * @throws Exception
 	 */
 	public function getStorageId($storageName) {
-		if (\array_key_exists($storageName, $this->getStorageIds())) {
-			return $this->getStorageIds()[$storageName];
-		}
-		throw new \Exception(
+		$storageIds = $this->getStorageIds();
+		$storageId = \array_search($storageName, $storageIds);
+		Assert::assertNotFalse(
+			$storageId,
 			"Could not find storageId with storage name $storageName"
 		);
+		return $storageId;
 	}
 
 	/**
@@ -615,7 +616,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function addStorageId($storageName, $storageId) {
-		$this->storageIds[$storageName] = $storageId;
+		$this->storageIds[$storageId] = $storageName;
 	}
 
 	/**
@@ -2436,12 +2437,12 @@ trait BasicStructure {
 	 */
 	public function removeLocalStorageAfter() {
 		if ($this->getStorageIds() !== null) {
-			foreach ($this->getStorageIds() as $key => $value) {
+			foreach ($this->getStorageIds() as $storageId => $storageName) {
 				SetupHelper::runOcc(
 					[
 						'files_external:delete',
 						'-y',
-						$value
+						$storageId
 					]
 				);
 			}

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1027,8 +1027,7 @@ class OccContext implements Context {
 			\count($storageIds),
 			"addRemoveAsApplicableUserLastLocalMount no local mounts exist"
 		);
-		\end($storageIds);
-		$lastMountName = \key($storageIds);
+		$lastMountName = \end($storageIds);
 		$this->addRemoveUserOrGroupToOrFromMount(
 			$action, $userOrGroup, $userOrGroupName, $lastMountName
 		);

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -115,8 +115,9 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 			$dirLocation
 		);
 		$storageIds = $this->featureContext->getStorageIds();
-		$lastMount = \end($storageIds);
-		$this->featureContext->addStorageId($mount, $lastMount + 1);
+		\end($storageIds);
+		$lastMountId = \key($storageIds);
+		$this->featureContext->addStorageId($mount, $lastMountId + 1);
 	}
 
 	/**
@@ -201,7 +202,7 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	 * @return void
 	 */
 	public function theLastCreatedLocalStorageMountShouldOrNotBeListedOnTheWebui($shouldOrNot) {
-		$mountNameList = \array_keys($this->featureContext->getStorageIds());
+		$mountNameList = $this->featureContext->getStorageIds();
 		$lastCreatedMountName = \end($mountNameList);
 		$result = $this->adminStorageSettingsPage->checkIfLastCreatedMountIsPresent(
 			$lastCreatedMountName

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -18,3 +18,15 @@ Feature: create local storage from the command line
     And as "user1" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
+
+  @issue-36713
+  Scenario: create local storage that already exists
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    When the administrator creates the local storage mount "local_storage2" using the occ command
+    #Then the command should have failed with exit code 1
+    Then the command should have been successful
+    And as "user0" folder "/local_storage2" should exist
+    And as "user1" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"


### PR DESCRIPTION
## Description
1) Refactor `addStorageId` so that it stores the data with storage Id as the key and name as the value. This allows us to remember multiple different storage Ids that have the same name. Then the test code correctly cleans them all up at the end of a scenario.

2) Add a scenario `create local storage that already exists` that demonstrates the problem - the same local storage can be added twice.

## Related Issue
#36713 

## Motivation and Context
Have a scenario that demonstrates the problem.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
