### PR TITLE
Dependency bumps 20200109

### DIFF
--- a/changelog/unreleased/36709
+++ b/changelog/unreleased/36709
@@ -1,0 +1,3 @@
+Change: Update league/flysystem (1.0.62 => 1.0.63)
+
+https://github.com/owncloud/core/pull/36709

--- a/changelog/unreleased/36722
+++ b/changelog/unreleased/36722
@@ -1,0 +1,3 @@
+Change: Update deepdiver1975/tarstreamer (0.1.1 => 2.0.0)
+
+https://github.com/owncloud/core/pull/36722

--- a/changelog/unreleased/36726
+++ b/changelog/unreleased/36726
@@ -1,0 +1,4 @@
+Change: Update egulias/email-validator (2.1.13 => 2.1.14)
+
+https://github.com/owncloud/core/issues/36726
+https://github.com/owncloud/core/pull/36727

--- a/changelog/unreleased/36727
+++ b/changelog/unreleased/36727
@@ -1,0 +1,7 @@
+Change: Update laminas dependencies
+
+Update laminas/laminas-zendframework-bridge (1.0.0 => 1.0.1)
+Update laminas/laminas-filter (2.9.2 => 2.9.3)
+
+https://github.com/owncloud/core/issues/36726
+https://github.com/owncloud/core/pull/36727

--- a/composer.lock
+++ b/composer.lock
@@ -984,16 +984,16 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.9.2",
+            "version": "2.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "4d8c0c25e40836bd617335e744009c2c950c4ad5"
+                "reference": "52b5cdbef8902280996e687e7352a648a8e22f31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/4d8c0c25e40836bd617335e744009c2c950c4ad5",
-                "reference": "4d8c0c25e40836bd617335e744009c2c950c4ad5",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/52b5cdbef8902280996e687e7352a648a8e22f31",
+                "reference": "52b5cdbef8902280996e687e7352a648a8e22f31",
                 "shasum": ""
             },
             "require": {
@@ -1049,7 +1049,7 @@
                 "filter",
                 "laminas"
             ],
-            "time": "2019-12-31T16:54:29+00:00"
+            "time": "2020-01-07T20:43:53+00:00"
         },
         {
             "name": "laminas/laminas-inputfilter",
@@ -1315,16 +1315,16 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "32d7095e436a31b8d98e485a5c63d70df74915a8"
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/32d7095e436a31b8d98e485a5c63d70df74915a8",
-                "reference": "32d7095e436a31b8d98e485a5c63d70df74915a8",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d",
                 "shasum": ""
             },
             "require": {
@@ -1363,7 +1363,7 @@
                 "laminas",
                 "zf"
             ],
-            "time": "2019-12-31T15:24:03+00:00"
+            "time": "2020-01-07T22:58:31+00:00"
         },
         {
             "name": "league/flysystem",

--- a/composer.lock
+++ b/composer.lock
@@ -621,16 +621,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.13",
+            "version": "2.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "834593d5900615639208417760ba6a17299e2497"
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/834593d5900615639208417760ba6a17299e2497",
-                "reference": "834593d5900615639208417760ba6a17299e2497",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/c4b8d12921999d8a561004371701dbc2e05b5ece",
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece",
                 "shasum": ""
             },
             "require": {
@@ -674,7 +674,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-12-30T08:14:25+00:00"
+            "time": "2020-01-05T14:11:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
## Description
1) update egulias/email-validator (2.1.13 => 2.1.14)
https://github.com/egulias/EmailValidator/releases/tag/2.1.14

2) update laminas/laminas-zendframework-bridge (1.0.0 => 1.0.1)
https://github.com/laminas/laminas-zendframework-bridge/releases/tag/1.0.1
and laminas/laminas-filter (2.9.2 => 2.9.3)
https://github.com/laminas/laminas-filter/releases/tag/2.9.3

3) Add changelog for league/flysystem 1.0.63 done in PR #36709 by dependabot

4) Add changelog for deepdiver1975/tarstreamer 2.0.0 done in PR #36722 by dependabot

## Related Issue
- Fixes #36726 

## Motivation and Context
Be up-to-date

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
