### PR TITLE
Dependency bumps for 10.4 20200109

### DIFF
--- a/changelog/unreleased/36709
+++ b/changelog/unreleased/36709
@@ -1,0 +1,3 @@
+Change: Update league/flysystem (1.0.62 => 1.0.63)
+
+https://github.com/owncloud/core/pull/36709

--- a/changelog/unreleased/36717
+++ b/changelog/unreleased/36717
@@ -1,0 +1,7 @@
+Change: switch to new id3parser
+
+The previous lukasreschke/id3parser library was archived.
+Use the new one published as christophwurst/id3parser
+
+https://github.com/owncloud/core/issues/36717
+https://github.com/owncloud/core/pull/36718

--- a/changelog/unreleased/36722
+++ b/changelog/unreleased/36722
@@ -1,0 +1,3 @@
+Change: Update deepdiver1975/tarstreamer (0.1.1 => 2.0.0)
+
+https://github.com/owncloud/core/pull/36722

--- a/changelog/unreleased/36726
+++ b/changelog/unreleased/36726
@@ -1,0 +1,4 @@
+Change: Update egulias/email-validator (2.1.13 => 2.1.14)
+
+https://github.com/owncloud/core/issues/36726
+https://github.com/owncloud/core/pull/36727

--- a/changelog/unreleased/36727
+++ b/changelog/unreleased/36727
@@ -1,0 +1,7 @@
+Change: Update laminas dependencies
+
+Update laminas/laminas-zendframework-bridge (1.0.0 => 1.0.1)
+Update laminas/laminas-filter (2.9.2 => 2.9.3)
+
+https://github.com/owncloud/core/issues/36726
+https://github.com/owncloud/core/pull/36727

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "interfasys/lognormalizer": "^v1.0",
         "deepdiver1975/tarstreamer": "v0.1.1",
         "patchwork/jsqueeze": "^2.0",
-        "lukasreschke/id3parser": "^0.0.3",
+        "christophwurst/id3parser": "^0.1.1",
         "sabre/dav": "^4.0",
         "sabre/http": "^5.0.5",
         "deepdiver/zipstreamer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "league/flysystem": "^1.0",
         "pear/pear-core-minimal": "^v1.10",
         "interfasys/lognormalizer": "^v1.0",
-        "deepdiver1975/tarstreamer": "v0.1.1",
+        "deepdiver1975/tarstreamer": "v2.0.0",
         "patchwork/jsqueeze": "^2.0",
         "christophwurst/id3parser": "^0.1.1",
         "sabre/dav": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -984,16 +984,16 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.9.2",
+            "version": "2.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "4d8c0c25e40836bd617335e744009c2c950c4ad5"
+                "reference": "52b5cdbef8902280996e687e7352a648a8e22f31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/4d8c0c25e40836bd617335e744009c2c950c4ad5",
-                "reference": "4d8c0c25e40836bd617335e744009c2c950c4ad5",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/52b5cdbef8902280996e687e7352a648a8e22f31",
+                "reference": "52b5cdbef8902280996e687e7352a648a8e22f31",
                 "shasum": ""
             },
             "require": {
@@ -1049,7 +1049,7 @@
                 "filter",
                 "laminas"
             ],
-            "time": "2019-12-31T16:54:29+00:00"
+            "time": "2020-01-07T20:43:53+00:00"
         },
         {
             "name": "laminas/laminas-inputfilter",
@@ -1315,16 +1315,16 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "32d7095e436a31b8d98e485a5c63d70df74915a8"
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/32d7095e436a31b8d98e485a5c63d70df74915a8",
-                "reference": "32d7095e436a31b8d98e485a5c63d70df74915a8",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d",
                 "shasum": ""
             },
             "require": {
@@ -1363,7 +1363,7 @@
                 "laminas",
                 "zf"
             ],
-            "time": "2019-12-31T15:24:03+00:00"
+            "time": "2020-01-07T22:58:31+00:00"
         },
         {
             "name": "league/flysystem",

--- a/composer.lock
+++ b/composer.lock
@@ -621,16 +621,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.13",
+            "version": "2.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "834593d5900615639208417760ba6a17299e2497"
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/834593d5900615639208417760ba6a17299e2497",
-                "reference": "834593d5900615639208417760ba6a17299e2497",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/c4b8d12921999d8a561004371701dbc2e05b5ece",
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece",
                 "shasum": ""
             },
             "require": {
@@ -674,7 +674,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-12-30T08:14:25+00:00"
+            "time": "2020-01-05T14:11:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4b5a22145132ae8ba871d4664adde5f",
+    "content-hash": "473f70a18a378167d5cf8c5d7e1b615c",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -35,6 +35,42 @@
             ],
             "description": "Convenience wrapper around ini_get()",
             "time": "2014-09-15T13:12:35+00:00"
+        },
+        {
+            "name": "christophwurst/id3parser",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ChristophWurst/ID3Parser.git",
+                "reference": "c0e56c336bd6131c199827f928e5a9aec89aa4da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ChristophWurst/ID3Parser/zipball/c0e56c336bd6131c199827f928e5a9aec89aa4da",
+                "reference": "c0e56c336bd6131c199827f928e5a9aec89aa4da",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ID3Parser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "An ID3 parser",
+            "homepage": "https://github.com/ChristophWurst/ID3Parser/",
+            "keywords": [
+                "codecs",
+                "php",
+                "tags"
+            ],
+            "time": "2020-01-07T09:05:03+00:00"
         },
         {
             "name": "composer/semver",
@@ -1412,41 +1448,6 @@
                 "storage"
             ],
             "time": "2020-01-04T16:30:31+00:00"
-        },
-        {
-            "name": "lukasreschke/id3parser",
-            "version": "v0.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/LukasReschke/ID3Parser.git",
-                "reference": "62f4de76d4eaa9ea13c66dacc1f22977dace6638"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/LukasReschke/ID3Parser/zipball/62f4de76d4eaa9ea13c66dacc1f22977dace6638",
-                "reference": "62f4de76d4eaa9ea13c66dacc1f22977dace6638",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ID3Parser\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL"
-            ],
-            "homepage": "https://github.com/LukasReschke/ID3Parser/",
-            "keywords": [
-                "codecs",
-                "php",
-                "tags"
-            ],
-            "time": "2016-09-22T15:10:54+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4222,16 +4222,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.18",
+            "version": "7.5.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fcf6c4bfafaadc07785528b06385cce88935474d"
+                "reference": "4263f76a3fc65385e242ef7357b99f3bed36707e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fcf6c4bfafaadc07785528b06385cce88935474d",
-                "reference": "fcf6c4bfafaadc07785528b06385cce88935474d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4263f76a3fc65385e242ef7357b99f3bed36707e",
+                "reference": "4263f76a3fc65385e242ef7357b99f3bed36707e",
                 "shasum": ""
             },
             "require": {
@@ -4302,7 +4302,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-12-06T05:14:37+00:00"
+            "time": "2020-01-06T16:53:05+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4310,12 +4310,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "5306962d2a35c901a07a98b55248894469d112b6"
+                "reference": "67ac6ea8f4a078c3c9b7aec5d7ae70f098c37389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5306962d2a35c901a07a98b55248894469d112b6",
-                "reference": "5306962d2a35c901a07a98b55248894469d112b6",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/67ac6ea8f4a078c3c9b7aec5d7ae70f098c37389",
+                "reference": "67ac6ea8f4a078c3c9b7aec5d7ae70f098c37389",
                 "shasum": ""
             },
             "conflict": {
@@ -4350,8 +4350,8 @@
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
                 "dompdf/dompdf": ">=0.6,<0.6.2",
-                "drupal/core": ">=7,<8.7.11|>=8.8,<8.8.1",
-                "drupal/drupal": ">=7,<8.7.11|>=8.8,<8.8.1",
+                "drupal/core": ">=7,<7.69|>=8,<8.7.11|>=8.8,<8.8.1",
+                "drupal/drupal": ">=7,<7.69|>=8,<8.7.11|>=8.8,<8.8.1",
                 "endroid/qr-code-bundle": "<3.4.2",
                 "erusev/parsedown": "<1.7.2",
                 "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.4",
@@ -4522,7 +4522,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2020-01-01T17:15:10+00:00"
+            "time": "2020-01-06T19:16:46+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "473f70a18a378167d5cf8c5d7e1b615c",
+    "content-hash": "02e46bfcc081e8ada2af383e82985590",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -233,25 +233,25 @@
         },
         {
             "name": "deepdiver1975/tarstreamer",
-            "version": "0.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/owncloud/TarStreamer.git",
-                "reference": "2d99636ded9c8a8a1ecd8129e7976dcd606106d9"
+                "reference": "ad48505d1ab54a8e94e6b1cc5297bbed72e956de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/owncloud/TarStreamer/zipball/2d99636ded9c8a8a1ecd8129e7976dcd606106d9",
-                "reference": "2d99636ded9c8a8a1ecd8129e7976dcd606106d9",
+                "url": "https://api.github.com/repos/owncloud/TarStreamer/zipball/ad48505d1ab54a8e94e6b1cc5297bbed72e956de",
+                "reference": "ad48505d1ab54a8e94e6b1cc5297bbed72e956de",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.8"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "pear/archive_tar": "~1.4",
-                "pear/pear-core-minimal": "v1.10.0alpha2",
-                "phpunit/phpunit": "^4.8"
+                "pear/pear-core-minimal": "v1.10.10",
+                "phpunit/phpunit": "^7.5"
             },
             "type": "library",
             "autoload": {
@@ -271,7 +271,7 @@
                 "stream",
                 "tar"
             ],
-            "time": "2019-02-11T13:56:51+00:00"
+            "time": "2020-01-08T09:55:35+00:00"
         },
         {
             "name": "dg/composer-cleaner",

--- a/composer.lock
+++ b/composer.lock
@@ -1331,16 +1331,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.62",
+            "version": "1.0.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "14dd5d7dff5fbc29ca9a2a53ff109760e40d91a0"
+                "reference": "8132daec326565036bc8e8d1876f77ec183a7bd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/14dd5d7dff5fbc29ca9a2a53ff109760e40d91a0",
-                "reference": "14dd5d7dff5fbc29ca9a2a53ff109760e40d91a0",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/8132daec326565036bc8e8d1876f77ec183a7bd6",
+                "reference": "8132daec326565036bc8e8d1876f77ec183a7bd6",
                 "shasum": ""
             },
             "require": {
@@ -1411,7 +1411,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2019-12-29T14:46:55+00:00"
+            "time": "2020-01-04T16:30:31+00:00"
         },
         {
             "name": "lukasreschke/id3parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4223,16 +4223,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.19",
+            "version": "7.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4263f76a3fc65385e242ef7357b99f3bed36707e"
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4263f76a3fc65385e242ef7357b99f3bed36707e",
-                "reference": "4263f76a3fc65385e242ef7357b99f3bed36707e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
                 "shasum": ""
             },
             "require": {
@@ -4303,7 +4303,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-06T16:53:05+00:00"
+            "time": "2020-01-08T08:45:45+00:00"
         },
         {
             "name": "roave/security-advisories",


### PR DESCRIPTION
## Description
Add recent dependency updates to `release-10.4.0` branch.
(This is optional - it gets the fix in `deepdiver1975/tarstreamer` into 10.4, if we want it)
(To avoid conflicts, I cherry-picked in order all the commits that touched `composer.lock')
(If this is approved/merged then it will likely end up in 10.4.0RC2)

1) Bump league/flysystem from 1.0.62 to 1.0.63 - PR #36709 
2) switch from lukasreschke/id3parser to christophwurst/id3parser - PR #36718 
3) Bump deepdiver1975/tarstreamer from 0.1.1 to 2.0.0 - PR #36722 
4) Bump egulias/email-validator (2.1.13 => 2.1.14) - PR #36727 
5) Update laminas dependencies - PR #36727 
6) Bump phpunit/phpunit from 7.5.18 to 7.5.19 - PR #36708 
7) Bump phpunit/phpunit from 7.5.19 to 7.5.20 - PR #36723 

Includes changelog entries for (1) to (5). The `phpunit` bumps are development tools only, so do not need changelogs.

## Motivation and Context

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
