### PR TITLE
Acceptance tests: Run fed tests without logging in to webUI on Remote server

### DIFF
--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -22,9 +22,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test the single steps of sharing a folder to a remote server
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
+    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     And the user shares folder "simple-empty-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     And using server "REMOTE"
     Then as "user1" folder "/simple-folder (2)" should exist
     And as "user1" file "/simple-folder (2)/lorem.txt" should exist
@@ -126,10 +126,11 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skipOnMICROSOFTEDGE @skipOnOcV10.3
   Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And the user sets the sharing permissions of user "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
-      | delete | no |
-    And user "user1" re-logs in to "%remote_server%" using the webUI
+    Given using server "REMOTE"
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    When the user updates the last share using the sharing API with
+      | permissions | read |
+    And the user re-logs in as "user1" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
@@ -147,7 +148,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
@@ -158,16 +158,14 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
+    And using server "REMOTE"
+    Then as "user1" file "simple-folder/lorem.txt" should exist
+    And the content of "simple-folder/lorem.txt" on the remote server for user "user1" should be the same as the local "lorem.txt"
 
   Scenario: upload a new file in a received share - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
@@ -178,16 +176,14 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "new-lorem.txt" should be listed on the webUI
-    And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
+    And using server "REMOTE"
+    Then as "user1" file "simple-folder/new-lorem.txt" should exist
+    And the content of "simple-folder/new-lorem.txt" on the remote server for user "user1" should be the same as the local "new-lorem.txt"
 
   Scenario: rename a file in a received share - local server shares - remote server receives
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" moves file "/simple-folder (2)/lorem.txt" to "/simple-folder (2)/renamed file.txt" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then file "renamed file.txt" should be listed on the webUI
     But file "lorem.txt" should not be listed on the webUI
@@ -198,20 +194,18 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
     And the user renames file "lorem.txt" to "renamed file.txt" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "renamed file.txt" should be listed on the webUI
+    And using server "REMOTE"
+    Then as "user1" file "simple-folder/renamed file.txt" should exist
     And the content of file "simple-folder/renamed file.txt" for user "user1" on server "REMOTE" should be "I am lorem.txt inside simple-folder"
-    But file "lorem.txt" should not be listed on the webUI
+    But as "user1" file "simple-folder/lorem.txt" should not exist
 
   Scenario: delete a file in a received share - local server shares - remote server receives
     Given user "user1" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
     When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then file "data.zip" should not be listed on the webUI
 
@@ -222,9 +216,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user deletes file "data.zip" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "data.zip" should not be listed on the webUI
+    And using server "REMOTE"
+    Then as "user1" file "simple-folder/data.zip" should not exist
 
   Scenario: receive same name federation share from two users
     Given using server "REMOTE"
@@ -262,10 +255,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user2" has been created with default attributes and without skeleton files
     And user "user2" has created folder "simple-folder"
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
-    And user "user2" re-logs in to "%local_server%" using the webUI
+    And the user re-logs in as "user2" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then as "user2" folder "/simple-folder (2)" should exist
     And as "user2" file "/simple-folder (2)/lorem.txt" should exist
@@ -275,12 +267,11 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user2" has been created with default attributes and without skeleton files
     And user "user2" has created folder "simple-folder"
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
     And the user updates the last share using the sharing API with
       | permissions | read |
-    And user "user2" re-logs in to "%local_server%" using the webUI
+    And the user re-logs in as "user2" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then as "user2" folder "/simple-folder (2)" should exist
     And as "user2" file "/simple-folder (2)/lorem.txt" should exist
@@ -293,14 +284,13 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user2" has been created with default attributes and without skeleton files
     And user "user2" has created folder "simple-folder"
     When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
-    And user "user1" re-logs in to "%local_server%" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user opens the share dialog for folder "simple-folder"
     And the user sets the sharing permissions of user "user2@%local_server% (federated)" for "simple-folder" using the webUI to
       | edit | no |
-    And user "user2" re-logs in to "%local_server%" using the webUI
+    And the user re-logs in as "user2" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then as "user2" folder "/simple-folder (2)" should exist
     And as "user2" file "/simple-folder (2)/lorem.txt" should exist
@@ -312,9 +302,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI
     And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    #  And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     And using server "REMOTE"
+    Then user "user1" should not have any received shares
     # Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
     Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should not exist
 
@@ -324,45 +314,45 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    When the user opens folder "simple-empty-folder" using the webUI
-    Then file "textfile.txt" should be listed on the webUI
-    And folder "finalfolder" should be listed on the webUI
+    And using server "REMOTE"
+    Then as "user1" file "simple-folder (2)/lorem.txt" should exist
+    And as "user1" file "simple-folder (2)/simple-empty-folder/textfile.txt" should exist
+    And as "user1" folder "simple-folder (2)/simple-empty-folder/finalfolder" should exist
 
   Scenario: sharee uploads a file inside a folder of a folder
     Given user "user1" has created folder "simple-folder/simple-empty-folder"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
-    And the user uploads file "lorem.txt" using the webUI
-    And using server "LOCAL"
+    And using server "REMOTE"
+    When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/simple-empty-folder/lorem.txt" using the WebDAV API
+    Then as "user1" file "simple-folder (2)/simple-empty-folder/lorem.txt" should exist
+    When using server "LOCAL"
     Then as "user1" file "simple-folder/simple-empty-folder/lorem.txt" should exist
 
   @skipOnFIREFOX
   Scenario: rename a file in a folder inside a shared folder
-    Given user "user1" has created folder "simple-folder/simple-empty-folder"
+    Given using server "REMOTE"
+    And user "user1" has created folder "simple-folder/simple-empty-folder"
     And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    And user "user1" re-logs in to "%remote_server%" using the webUI
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    When the user re-logs in as "user1" using the webUI
+    And the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
-    When the user renames file "textfile.txt" to "new-lorem.txt" using the webUI
-    And using server "LOCAL"
+    And the user renames file "textfile.txt" to "new-lorem.txt" using the webUI
+    And using server "REMOTE"
     Then as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
     But as "user1" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
 
   Scenario: delete a file in a folder inside a shared folder
-    Given user "user1" has created folder "simple-folder/simple-empty-folder"
+    Given using server "REMOTE"
+    And user "user1" has created folder "simple-folder/simple-empty-folder"
     And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    And user "user1" re-logs in to "%remote_server%" using the webUI
+    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    When the user re-logs in as "user1" using the webUI
+    And the user accepts the offered remote shares using the webUI
     And the user opens folder "/simple-folder (2)/simple-empty-folder" using the webUI
-    When the user deletes file "textfile.txt" using the webUI
-    And using server "LOCAL"
+    And the user deletes file "textfile.txt" using the webUI
+    And using server "REMOTE"
     Then as "user1" file "/simple-folder/simple-empty-folder/textfile.txt" should not exist
 
   Scenario: delete shared folder and create a folder for federation sharing with same name
@@ -372,8 +362,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" has created folder "simple-folder"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
     When user "user1" from server "REMOTE" accepts the last pending share using the sharing API
-    Then using server "REMOTE"
-    And as "user1" folder "simple-folder" should exist
+    And using server "REMOTE"
+    Then as "user1" folder "simple-folder" should exist
     And as "user1" folder "simple-folder (3)" should exist
 
   @skipOnOcV10.3


### PR DESCRIPTION
## Description
Refactor Federation acceptance tests such that there is no need for logging in to the webUI on the fed server.
See #36607  for more details.

## Related Issue
- Fixes #36607

## How Has This Been Tested?
:robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
