### PR TITLE
[Tests-only] Add local storage acceptance tests to demonstrate issue 36719

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -19,6 +19,39 @@ Feature: create local storage from the command line
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
 
+  Scenario: user cannot rename a local storage
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    When user "user0" moves folder "local_storage2" to "another_name" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And as "user0" folder "/another_name" should not exist
+
+  Scenario: user cannot delete a local storage
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    When user "user0" deletes folder "local_storage2" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user0" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+
+  Scenario: user cannot create a folder that matches a local storage
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    When user "user0" creates folder "local_storage2" using the WebDAV API
+    Then the HTTP status code should be "405"
+    And as "user0" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+
+  Scenario: user cannot upload a file that matches a local storage folder name
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    When user "user0" uploads file with content "this is a file called local_storage2" to "/local_storage2" using the WebDAV API
+    Then the HTTP status code should be "409"
+    And as "user0" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+
   @issue-36713
   Scenario: create local storage that already exists
     Given the administrator has created the local storage mount "local_storage2"

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -30,3 +30,67 @@ Feature: create local storage from the command line
     And as "user1" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
+
+  @issue-36719
+  Scenario: create local storage that matches an existing folder of a user
+    Given user "user0" has created folder "reference"
+    And user "user0" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
+    And user "user0" has created folder "other"
+    And user "user0" has uploaded file with content "this is another file of user0" to "/other/other-file.txt"
+    When the administrator creates the local storage mount "reference" using the occ command
+    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
+    Then the command should have been successful
+    And as "user0" folder "/reference" should exist
+    And as "user1" folder "/reference" should exist
+    And the content of file "/reference/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And the content of file "/reference/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
+    And the content of file "/other/other-file.txt" for user "user0" should be "this is another file of user0"
+    # Some other behaviour is to be defined here. See discussion in the issue.
+    # How can user0 get access to their own previous folder with file?
+    But as "user0" file "/reference/reference-file.txt" should not exist
+
+  @issue-36719
+  Scenario: create local storage that matches an existing shared folder of a user
+    Given user "user0" has created folder "reference"
+    And user "user0" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
+    And user "user0" has shared folder "reference" with user "user1"
+    And user "user0" has created folder "other"
+    And user "user0" has uploaded file with content "this is another file of user0" to "/other/other-file.txt"
+    And user "user0" has shared folder "other" with user "user1"
+    When the administrator creates the local storage mount "reference" using the occ command
+    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
+    Then the command should have been successful
+    And as "user0" folder "/reference" should exist
+    And as "user1" folder "/reference" should exist
+    And the content of file "/reference/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And the content of file "/reference/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
+    And the content of file "/other/other-file.txt" for user "user0" should be "this is another file of user0"
+    And the content of file "/other/other-file.txt" for user "user1" should be "this is another file of user0"
+    # Some other behaviour is to be defined here. See discussion in the issue.
+    # How can user0 and user1 get access to their previous shared folder with file?
+    But as "user0" file "/reference/reference-file.txt" should not exist
+    And as "user1" file "/reference/reference-file.txt" should not exist
+
+  @issue-36719
+  Scenario: create local storage that matches an existing shared folder, and the sharee has renamed the received folder
+    Given user "user0" has created folder "reference"
+    And user "user0" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
+    And user "user0" has shared folder "reference" with user "user1"
+    And user "user0" has created folder "other"
+    And user "user0" has uploaded file with content "this is another file of user0" to "/other/other-file.txt"
+    And user "user0" has shared folder "other" with user "user1"
+    And user "user1" has moved folder "reference" to "reference1"
+    When the administrator creates the local storage mount "reference" using the occ command
+    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
+    Then the command should have been successful
+    And as "user0" folder "/reference" should exist
+    And as "user1" folder "/reference" should exist
+    And the content of file "/reference/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+    And the content of file "/reference/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
+    And the content of file "/other/other-file.txt" for user "user0" should be "this is another file of user0"
+    And the content of file "/other/other-file.txt" for user "user1" should be "this is another file of user0"
+    # user1 receives "/reference" from user0 and has renamed it to "/reference1"
+    # it would be helpful if they could still see "/reference1" as well as the local storage called "/reference"
+    And as "user1" file "/reference1/reference-file.txt" should not exist
+    #And as "user1" file "/reference1/reference-file.txt" should exist
+    #And the content of file "/reference1/reference-file.txt" for user "user1" should be "this is a reference file"


### PR DESCRIPTION
## Description
Add some CLI+API test scenarios to demonstrate the basic problem when the admin creates a new local storage and the name of the local storage matches the existing name of a folder and/or share.

Note: the issue also mentions that this can lock up the UI. I don't really want to write a UI test that locks up the UI! When the issue is being fixed, someone can also add some basic UI test scenario(s) to demonstrate good/fixed behaviour.

## Related Issue
- Tests for issue #36719 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
