### PR TITLE
[Tests-only] Expand create local storage test scenarios

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -151,6 +151,31 @@ class OccContext implements Context {
 
 	/**
 	 * @param string $mountPoint
+	 * @param boolean $setting
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function setExtStorageReadOnlyUsingTheOccCommand($mountPoint, $setting = true) {
+		$command = "files_external:option";
+
+		$mountId = $this->featureContext->getStorageId($mountPoint);
+
+		$key = "read_only";
+
+		if ($setting) {
+			$value = "1";
+		} else {
+			$value = "0";
+		}
+
+		$this->invokingTheCommand(
+			"$command $mountId $key $value"
+		);
+	}
+
+	/**
+	 * @param string $mountPoint
 	 * @param string $setting "never" (switch it off) otherwise "Once every direct access"
 	 *
 	 * @return void
@@ -159,11 +184,7 @@ class OccContext implements Context {
 	public function setExtStorageCheckChangesUsingTheOccCommand($mountPoint, $setting) {
 		$command = "files_external:option";
 
-		// get the first mount id created in before scenario
 		$mountId = $this->featureContext->getStorageId($mountPoint);
-
-		// $mountId should have been set. If not, @local_storage BeforeScenario never ran
-		\assert($mountId !== null);
 
 		$key = "filesystem_check_changes";
 
@@ -788,6 +809,31 @@ class OccContext implements Context {
 	 */
 	public function theAdministratorHasChangedTheBackgroundJobsModeTo($mode) {
 		$this->changeBackgroundJobsModeUsingTheOccCommand($mode);
+	}
+
+	/**
+	 * @When the administrator sets the external storage :mountPoint to read-only using the occ command
+	 *
+	 * @param string $mountPoint
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminSetsTheExtStorageToReadOnly($mountPoint) {
+		$this->setExtStorageReadOnlyUsingTheOccCommand($mountPoint);
+	}
+
+	/**
+	 * @Given the administrator has set the external storage :mountPoint to read-only
+	 *
+	 * @param string $mountPoint
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminHasSetTheExtStorageToReadOnly($mountPoint) {
+		$this->setExtStorageReadOnlyUsingTheOccCommand($mountPoint);
+		$this->theCommandShouldHaveBeenSuccessful();
 	}
 
 	/**

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
@@ -15,25 +15,14 @@ Feature: create local storage from the command line
     And user "user1" has been added to group "grp1"
     And the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    And the administrator has uploaded file with content "this is a file to delete in local storage2" to "/local_storage2/file-to-delete2.txt"
+    And the administrator has uploaded file with content "this is a file to rename in local storage2" to "/local_storage2/file-to-rename2.txt"
     When the administrator adds group "grp1" as the applicable group for local storage mount "local_storage2" using the occ command
     Then as "user1" folder "/local_storage2" should exist
+    And user "user1" should be able to delete file "/local_storage2/file-to-delete2.txt"
+    And user "user1" should be able to rename file "/local_storage2/file-to-rename2.txt" to "/local_storage2/another-name2.txt"
+    And user "user1" should be able to upload file "filesForUpload/textfile.txt" to "/local_storage2/textfile2.txt"
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user1" should be "this is a file in local storage2"
-    And as "user0" folder "/local_storage2" should not exist
-
-  Scenario: create local storage for a specific group and user
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | user2    |
-    And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
-    When the administrator adds group "grp1" as the applicable group for local storage mount "local_storage2" using the occ command
-    And the administrator adds user "user2" as the applicable user for local storage mount "local_storage2" using the occ command
-    Then as "user1" folder "/local_storage2" should exist
-    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user1" should be "this is a file in local storage2"
-    And as "user2" folder "/local_storage2" should exist
-    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user2" should be "this is a file in local storage2"
     But as "user0" folder "/local_storage2" should not exist
 
   Scenario: removing the only group from applicable group of local storage leaves the storage available to everyone
@@ -65,3 +54,17 @@ Feature: create local storage from the command line
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user2" should be "this is a file in local storage2"
     And as "user0" folder "/local_storage2" should not exist
     And as "user1" folder "/local_storage2" should not exist
+
+  Scenario: another user can create a folder matching a local storage name that is for a specific group
+    Given group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    And the administrator has added group "grp1" as the applicable group for local storage mount "local_storage2"
+    When user "user0" creates folder "local_storage2" using the WebDAV API
+    And user "user0" uploads file with content "this is a file of user0" to "/local_storage2/file-in-local-storage2.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user0" should be "this is a file of user0"
+    And as "user1" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user1" should be "this is a file in local storage2"

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
@@ -15,12 +15,22 @@ Feature: create local storage from the command line
     And the administrator has created the local storage mount "local_storage3"
     And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
     And the administrator has uploaded file with content "this is a file in local storage3" to "/local_storage3/file-in-local-storage3.txt"
+    And the administrator has uploaded file with content "this is a file to delete in local storage2" to "/local_storage2/file-to-delete2.txt"
+    And the administrator has uploaded file with content "this is a file to delete in local storage3" to "/local_storage3/file-to-delete3.txt"
+    And the administrator has uploaded file with content "this is a file to rename in local storage2" to "/local_storage2/file-to-rename2.txt"
+    And the administrator has uploaded file with content "this is a file to rename in local storage3" to "/local_storage3/file-to-rename3.txt"
     When the administrator adds user "user0" as the applicable user for local storage mount "local_storage2" using the occ command
     And the administrator adds user "user1" as the applicable user for local storage mount "local_storage3" using the occ command
     Then as "user0" folder "/local_storage2" should exist
+    And user "user0" should be able to delete file "/local_storage2/file-to-delete2.txt"
+    And user "user0" should be able to rename file "/local_storage2/file-to-rename2.txt" to "/local_storage2/another-name2.txt"
+    And user "user0" should be able to upload file "filesForUpload/textfile.txt" to "/local_storage2/textfile2.txt"
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user0" should be "this is a file in local storage2"
     But as "user0" folder "/local_storage3" should not exist
     And as "user1" folder "/local_storage3" should exist
+    And user "user1" should be able to delete file "/local_storage3/file-to-delete3.txt"
+    And user "user1" should be able to rename file "/local_storage3/file-to-rename3.txt" to "/local_storage3/another-name3.txt"
+    And user "user1" should be able to upload file "filesForUpload/textfile.txt" to "/local_storage3/textfile3.txt"
     And the content of file "/local_storage3/file-in-local-storage3.txt" for user "user1" should be "this is a file in local storage3"
     But as "user1" folder "/local_storage2" should not exist
 
@@ -30,13 +40,21 @@ Feature: create local storage from the command line
       | user2    |
     And the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    And the administrator has uploaded file with content "this is a file to delete in local storage2" to "/local_storage2/file-to-delete2.txt"
+    And the administrator has uploaded file with content "this is a file to rename in local storage2" to "/local_storage2/file-to-rename2.txt"
     When the administrator adds user "user0" as the applicable user for local storage mount "local_storage2" using the occ command
     And the administrator adds user "user1" as the applicable user for local storage mount "local_storage2" using the occ command
     Then as "user0" folder "/local_storage2" should exist
+    And user "user0" should be able to delete file "/local_storage2/file-to-delete2.txt"
+    And user "user0" should be able to rename file "/local_storage2/file-to-rename2.txt" to "/local_storage2/another-name2.txt"
+    And user "user0" should be able to upload file "filesForUpload/textfile.txt" to "/local_storage2/textfile2.txt"
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user0" should be "this is a file in local storage2"
-    Then as "user1" folder "/local_storage2" should exist
+    And as "user1" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user1" should be "this is a file in local storage2"
-    But as "user2" folder "/local_storage2" should not exist
+    And the content of file "/local_storage2/another-name2.txt" for user "user1" should be "this is a file to rename in local storage2"
+    And as "user1" file "/local_storage2/textfile2.txt" should exist
+    But as "user1" file "/local_storage2/file-to-delete2.txt" should not exist
+    And as "user2" folder "/local_storage2" should not exist
 
   Scenario: removing the only user from applicable users of local storage leaves the storage available to everyone
     And the administrator has created the local storage mount "local_storage2"
@@ -56,4 +74,16 @@ Feature: create local storage from the command line
     When the administrator removes user "user0" from the applicable user for local storage mount "local_storage2" using the occ command
     Then as "user0" folder "/local_storage2" should not exist
     But as "user1" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user1" should be "this is a file in local storage2"
+
+  Scenario: another user can create a folder matching a local storage name that is for another specific user
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    And the administrator has added user "user1" as the applicable user for local storage mount "local_storage2"
+    When user "user0" creates folder "local_storage2" using the WebDAV API
+    And user "user0" uploads file with content "this is a file of user0" to "/local_storage2/file-in-local-storage2.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user0" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user0" should be "this is a file of user0"
+    And as "user1" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user1" should be "this is a file in local storage2"

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
@@ -13,19 +13,11 @@ Feature: create local storage from the command line
   Scenario: create local storage that is available to all users
     When the administrator creates the local storage mount "local_storage2" using the occ command
     And the administrator uploads file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt" using the WebDAV API
-    And the administrator uploads file with content "this is a file to delete in local storage" to "/local_storage2/file-to-delete.txt" using the WebDAV API
-    And the administrator uploads file with content "this is a file to rename in local storage" to "/local_storage2/file-to-rename.txt" using the WebDAV API
     Then the command should have been successful
     And as "user0" folder "/local_storage2" should exist
     And as "user1" folder "/local_storage2" should exist
-    And user "user0" should be able to delete file "/local_storage2/file-to-delete.txt"
-    And user "user0" should be able to rename file "/local_storage2/file-to-rename.txt" to "/local_storage2/another-name.txt"
-    And user "user0" should be able to upload file "filesForUpload/textfile.txt" to "/local_storage2/textfile.txt"
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
-    And the content of file "/local_storage2/another-name.txt" for user "user1" should be "this is a file to rename in local storage"
-    And as "user1" file "/local_storage2/textfile.txt" should exist
-    And as "user1" file "/local_storage2/file-to-delete.txt" should not exist
 
   Scenario: user cannot rename a local storage
     Given the administrator has created the local storage mount "local_storage2"
@@ -59,6 +51,30 @@ Feature: create local storage from the command line
     Then the HTTP status code should be "409"
     And as "user0" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
+
+  Scenario: user can delete from local storage that is available to all users
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    When user "user1" deletes file "/local_storage2/file-in-local-storage2.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "user1" folder "/local_storage2" should exist
+    But as "user1" file "/local_storage2/file-in-local-storage2.txt" should not exist
+
+  Scenario: user can rename in local storage that is available to all users
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    When user "user1" moves file "local_storage2/file-in-local-storage2.txt" to "local_storage2/another-name.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user1" folder "/local_storage2" should exist
+    And as "user1" file "/local_storage2/another-name.txt" should exist
+    But as "user1" file "/local_storage2/file-in-local-storage2.txt" should not exist
+
+  Scenario: user can upload to local storage that is available to all users
+    Given the administrator has created the local storage mount "local_storage2"
+    When user "user1" uploads file with content "this is a file called local_storage2" to "/local_storage2/file-in-local-storage2.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user1" folder "/local_storage2" should exist
+    And as "user1" file "/local_storage2/file-in-local-storage2.txt" should exist
 
   @issue-36713
   Scenario: create local storage that already exists

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
@@ -1,8 +1,8 @@
 @cli @skipOnLDAP @local_storage
-Feature: create local storage from the command line
+Feature: create read-only local storage from the command line
   As an admin
-  I want to create local storage from the command line
-  So that local folders on my server can be made visible to users of ownCloud
+  I want to create read-only local storage from the command line
+  So that local folders on my server can be made visible but read-only to users of ownCloud
 
   Background:
     Given these users have been created with default attributes and without skeleton files:
@@ -10,144 +10,15 @@ Feature: create local storage from the command line
       | user0    |
       | user1    |
 
-  Scenario: create local storage that is available to all users
-    When the administrator creates the local storage mount "local_storage2" using the occ command
-    And the administrator uploads file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt" using the WebDAV API
+  Scenario: create read-only local storage that is available to all users
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    When the administrator sets the external storage "local_storage2" to read-only using the occ command
     Then the command should have been successful
     And as "user0" folder "/local_storage2" should exist
     And as "user1" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
-
-  Scenario: user cannot rename a local storage
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
-    When user "user0" moves folder "local_storage2" to "another_name" using the WebDAV API
-    Then the HTTP status code should be "403"
-    And as "user0" folder "/local_storage2" should exist
-    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-    And as "user0" folder "/another_name" should not exist
-
-  Scenario: user cannot delete a local storage
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
-    When user "user0" deletes folder "local_storage2" using the WebDAV API
-    Then the HTTP status code should be "403"
-    And as "user0" folder "/local_storage2" should exist
-    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-
-  Scenario: user cannot create a folder that matches a local storage
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
-    When user "user0" creates folder "local_storage2" using the WebDAV API
-    Then the HTTP status code should be "405"
-    And as "user0" folder "/local_storage2" should exist
-    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-
-  Scenario: user cannot upload a file that matches a local storage folder name
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
-    When user "user0" uploads file with content "this is a file called local_storage2" to "/local_storage2" using the WebDAV API
-    Then the HTTP status code should be "409"
-    And as "user0" folder "/local_storage2" should exist
-    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-
-  Scenario: user can delete from local storage that is available to all users
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
-    When user "user1" deletes file "/local_storage2/file-in-local-storage2.txt" using the WebDAV API
-    Then the HTTP status code should be "204"
-    And as "user1" folder "/local_storage2" should exist
-    But as "user1" file "/local_storage2/file-in-local-storage2.txt" should not exist
-
-  Scenario: user can rename in local storage that is available to all users
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
-    When user "user1" moves file "local_storage2/file-in-local-storage2.txt" to "local_storage2/another-name.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And as "user1" folder "/local_storage2" should exist
-    And as "user1" file "/local_storage2/another-name.txt" should exist
-    But as "user1" file "/local_storage2/file-in-local-storage2.txt" should not exist
-
-  Scenario: user can upload to local storage that is available to all users
-    Given the administrator has created the local storage mount "local_storage2"
-    When user "user1" uploads file with content "this is a file called local_storage2" to "/local_storage2/file-in-local-storage2.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And as "user1" folder "/local_storage2" should exist
-    And as "user1" file "/local_storage2/file-in-local-storage2.txt" should exist
-
-  @issue-36713
-  Scenario: create local storage that already exists
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
-    When the administrator creates the local storage mount "local_storage2" using the occ command
-    #Then the command should have failed with exit code 1
-    Then the command should have been successful
-    And as "user0" folder "/local_storage2" should exist
-    And as "user1" folder "/local_storage2" should exist
-    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-    And the content of file "/local_storage2/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
-
-  @issue-36719
-  Scenario: create local storage that matches an existing folder of a user
-    Given user "user0" has created folder "reference"
-    And user "user0" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
-    And user "user0" has created folder "other"
-    And user "user0" has uploaded file with content "this is another file of user0" to "/other/other-file.txt"
-    When the administrator creates the local storage mount "reference" using the occ command
-    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
-    Then the command should have been successful
-    And as "user0" folder "/reference" should exist
-    And as "user1" folder "/reference" should exist
-    And the content of file "/reference/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-    And the content of file "/reference/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
-    And the content of file "/other/other-file.txt" for user "user0" should be "this is another file of user0"
-    # Some other behaviour is to be defined here. See discussion in the issue.
-    # How can user0 get access to their own previous folder with file?
-    But as "user0" file "/reference/reference-file.txt" should not exist
-
-  @issue-36719
-  Scenario: create local storage that matches an existing shared folder of a user
-    Given user "user0" has created folder "reference"
-    And user "user0" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
-    And user "user0" has shared folder "reference" with user "user1"
-    And user "user0" has created folder "other"
-    And user "user0" has uploaded file with content "this is another file of user0" to "/other/other-file.txt"
-    And user "user0" has shared folder "other" with user "user1"
-    When the administrator creates the local storage mount "reference" using the occ command
-    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
-    Then the command should have been successful
-    And as "user0" folder "/reference" should exist
-    And as "user1" folder "/reference" should exist
-    And the content of file "/reference/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-    And the content of file "/reference/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
-    And the content of file "/other/other-file.txt" for user "user0" should be "this is another file of user0"
-    And the content of file "/other/other-file.txt" for user "user1" should be "this is another file of user0"
-    # Some other behaviour is to be defined here. See discussion in the issue.
-    # How can user0 and user1 get access to their previous shared folder with file?
-    But as "user0" file "/reference/reference-file.txt" should not exist
-    And as "user1" file "/reference/reference-file.txt" should not exist
-
-  @issue-36719
-  Scenario: create local storage that matches an existing shared folder, and the sharee has renamed the received folder
-    Given user "user0" has created folder "reference"
-    And user "user0" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
-    And user "user0" has shared folder "reference" with user "user1"
-    And user "user0" has created folder "other"
-    And user "user0" has uploaded file with content "this is another file of user0" to "/other/other-file.txt"
-    And user "user0" has shared folder "other" with user "user1"
-    And user "user1" has moved folder "reference" to "reference1"
-    When the administrator creates the local storage mount "reference" using the occ command
-    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
-    Then the command should have been successful
-    And as "user0" folder "/reference" should exist
-    And as "user1" folder "/reference" should exist
-    And the content of file "/reference/file-in-local-storage.txt" for user "user0" should be "this is a file in local storage"
-    And the content of file "/reference/file-in-local-storage.txt" for user "user1" should be "this is a file in local storage"
-    And the content of file "/other/other-file.txt" for user "user0" should be "this is another file of user0"
-    And the content of file "/other/other-file.txt" for user "user1" should be "this is another file of user0"
-    # user1 receives "/reference" from user0 and has renamed it to "/reference1"
-    # it would be helpful if they could still see "/reference1" as well as the local storage called "/reference"
-    And as "user1" file "/reference1/reference-file.txt" should not exist
-    #And as "user1" file "/reference1/reference-file.txt" should exist
-    #And the content of file "/reference1/reference-file.txt" for user "user1" should be "this is a reference file"
+    And user "user0" should not be able to delete file "/local_storage2/file-in-local-storage.txt"
+    And user "user0" should not be able to rename file "/local_storage2/file-in-local-storage.txt" to "/local_storage2/another-name.txt"
+    And user "user0" should not be able to upload file "filesForUpload/textfile.txt" to "/local_storage2/textfile.txt"


### PR DESCRIPTION
## Description
1a) check that users can upload/rename/delete in "default" local storage
1b) check that users who do not receive the local storage can create a folder with that name
2) add new scenario that sets a local storage read-only with the occ command

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
