### PR TITLE
Fix ini_set error spamming the log

### DIFF
--- a/changelog/unreleased/36749
+++ b/changelog/unreleased/36749
@@ -1,0 +1,3 @@
+Change: Fix ini_set error spamming the log
+
+https://github.com/owncloud/core/pull/36749

--- a/lib/base.php
+++ b/lib/base.php
@@ -632,10 +632,6 @@ class OC {
 		// set back user
 		\OC::$server->getSession()->set('user_id', $uid);
 
-		//try to set the session lifetime
-		$sessionLifeTime = self::getSessionLifeTime();
-		@\ini_set('session.gc_maxlifetime', (string)$sessionLifeTime);
-
 		$systemConfig = \OC::$server->getSystemConfig();
 
 		// User and Groups

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -169,8 +169,19 @@ class Internal extends Session {
 			if ($this->getServerProtocol() === 'https') {
 				\ini_set('session.cookie_secure', true);
 			}
+
+			//try to set the session lifetime
+			$sessionLifeTime = self::getSessionLifeTime();
+			@\ini_set('session.gc_maxlifetime', (string)$sessionLifeTime);
 		}
 		\session_start();
+	}
+
+	/**
+	 * @return string
+	 */
+	private static function getSessionLifeTime() {
+		return \OC::$server->getConfig()->getSystemValue('session_lifetime', 60 * 20);
 	}
 
 	private function getServerProtocol() {


### PR DESCRIPTION
## Description
The log will be spammed with entries in case ini_set is called after the session was created.
We fixed a similar case back in 2018


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
