### PR TITLE
[Tests-only] Add functions to create/delete/manage ldap users and groups

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -5,6 +5,12 @@ default:
     apiMain:
       paths:
         - '%paths.base%/../features/apiMain'
+      context: &common_ldap_suite_context
+        parameters:
+          ldapAdminPassword: admin
+          ldapUsersOU: TestUsers
+          ldapGroupsOU: TestGroups
+          ldapInitialUserFilePath: /../../config/ldap-users.ldif
       contexts:
         - FeatureContext: &common_feature_context_params
             baseUrl:  http://localhost:8080
@@ -24,6 +30,7 @@ default:
     apiAuth:
       paths:
         - '%paths.base%/../features/apiAuth'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - CorsContext:
@@ -32,6 +39,7 @@ default:
     apiAuthOcs:
       paths:
         - '%paths.base%/../features/apiAuthOcs'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - AuthContext:
@@ -39,6 +47,7 @@ default:
     apiAuthWebDav:
       paths:
         - '%paths.base%/../features/apiAuthWebDav'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
@@ -51,6 +60,7 @@ default:
     apiCapabilities:
       paths:
         - '%paths.base%/../features/apiCapabilities'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
@@ -60,6 +70,7 @@ default:
     apiComments:
       paths:
         - '%paths.base%/../features/apiComments'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - CommentsContext:
@@ -68,6 +79,7 @@ default:
     apiFavorites:
       paths:
         - '%paths.base%/../features/apiFavorites'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - FavoritesContext:
@@ -76,6 +88,7 @@ default:
     apiFederation:
       paths:
         - '%paths.base%/../features/apiFederation'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - FederationContext:
@@ -85,6 +98,7 @@ default:
     apiProvisioning-v1:
       paths:
         - '%paths.base%/../features/apiProvisioning-v1'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -94,6 +108,7 @@ default:
     apiProvisioning-v2:
       paths:
         - '%paths.base%/../features/apiProvisioning-v2'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -103,6 +118,7 @@ default:
     apiProvisioningGroups-v1:
       paths:
         - '%paths.base%/../features/apiProvisioningGroups-v1'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -111,6 +127,7 @@ default:
     apiProvisioningGroups-v2:
       paths:
         - '%paths.base%/../features/apiProvisioningGroups-v2'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -119,6 +136,7 @@ default:
     apiShareCreateSpecial:
       paths:
         - '%paths.base%/../features/apiShareCreateSpecial'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -129,6 +147,7 @@ default:
     apiSharees:
       paths:
         - '%paths.base%/../features/apiSharees'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - ShareesContext:
@@ -137,6 +156,7 @@ default:
     apiShareManagement:
       paths:
         - '%paths.base%/../features/apiShareManagement'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -148,6 +168,7 @@ default:
     apiShareManagementBasic:
       paths:
         - '%paths.base%/../features/apiShareManagementBasic'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -159,6 +180,7 @@ default:
     apiShareOperations:
       paths:
         - '%paths.base%/../features/apiShareOperations'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -169,6 +191,7 @@ default:
     apiSharePublicLink1:
       paths:
         - '%paths.base%/../features/apiSharePublicLink1'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -180,6 +203,7 @@ default:
     apiSharePublicLink2:
       paths:
         - '%paths.base%/../features/apiSharePublicLink2'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -191,6 +215,7 @@ default:
     apiShareReshare1:
       paths:
         - '%paths.base%/../features/apiShareReshare1'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -201,6 +226,7 @@ default:
     apiShareReshare2:
       paths:
         - '%paths.base%/../features/apiShareReshare2'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -212,6 +238,7 @@ default:
     apiShareUpdate:
       paths:
         - '%paths.base%/../features/apiShareUpdate'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -223,6 +250,7 @@ default:
     apiSharingNotifications:
       paths:
         - '%paths.base%/../features/apiSharingNotifications'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
@@ -231,6 +259,7 @@ default:
     apiTags:
       paths:
         - '%paths.base%/../features/apiTags'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - TagsContext:
@@ -238,6 +267,7 @@ default:
     apiTrashbin:
       paths:
         - '%paths.base%/../features/apiTrashbin'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -247,6 +277,7 @@ default:
     apiVersions:
       paths:
         - '%paths.base%/../features/apiVersions'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - ChecksumContext:
@@ -256,6 +287,7 @@ default:
     apiWebdavLocks:
       paths:
         - '%paths.base%/../features/apiWebdavLocks'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -266,6 +298,7 @@ default:
     apiWebdavLocks2:
       paths:
         - '%paths.base%/../features/apiWebdavLocks2'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -276,6 +309,7 @@ default:
     apiWebdavMove:
       paths:
         - '%paths.base%/../features/apiWebdavMove'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
@@ -285,6 +319,7 @@ default:
     apiWebdavOperations:
       paths:
         - '%paths.base%/../features/apiWebdavOperations'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
@@ -296,6 +331,7 @@ default:
     apiWebdavProperties:
       paths:
         - '%paths.base%/../features/apiWebdavProperties'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
@@ -305,6 +341,7 @@ default:
     apiWebdavUpload:
       paths:
         - '%paths.base%/../features/apiWebdavUpload'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
@@ -314,6 +351,7 @@ default:
     cliAppManagement:
       paths:
         - '%paths.base%/../features/cliAppManagement'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -322,6 +360,7 @@ default:
     cliBackground:
       paths:
         - '%paths.base%/../features/cliBackground'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -329,6 +368,7 @@ default:
     cliLocalStorage:
       paths:
         - '%paths.base%/../features/cliLocalStorage'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -337,6 +377,7 @@ default:
     cliMain:
       paths:
         - '%paths.base%/../features/cliMain'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -349,6 +390,7 @@ default:
     cliProvisioning:
       paths:
         - '%paths.base%/../features/cliProvisioning'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
@@ -359,6 +401,7 @@ default:
     cliTrashbin:
       paths:
         - '%paths.base%/../features/cliTrashbin'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -367,6 +410,7 @@ default:
     webUIAdminSettings:
       paths:
         - '%paths.base%/../features/webUIAdminSettings'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
@@ -384,6 +428,7 @@ default:
     webUIComments:
       paths:
         - '%paths.base%/../features/webUIComments'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -394,6 +439,7 @@ default:
     webUICreateDelete:
       paths:
         - '%paths.base%/../features/webUICreateDelete'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -406,6 +452,7 @@ default:
     webUIFavorites:
       paths:
         - '%paths.base%/../features/webUIFavorites'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -415,6 +462,7 @@ default:
     webUIFiles:
       paths:
         - '%paths.base%/../features/webUIFiles'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - TagsContext:
@@ -429,6 +477,7 @@ default:
     webUILogin:
       paths:
         - '%paths.base%/../features/webUILogin'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
@@ -440,6 +489,7 @@ default:
     webUIMoveFilesFolders:
       paths:
         - '%paths.base%/../features/webUIMoveFilesFolders'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -452,6 +502,7 @@ default:
     webUIPersonalSettings:
       paths:
         - '%paths.base%/../features/webUIPersonalSettings'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
@@ -467,6 +518,7 @@ default:
     webUIRenameFiles:
       paths:
         - '%paths.base%/../features/webUIRenameFiles'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -479,6 +531,7 @@ default:
     webUIRenameFolders:
       paths:
         - '%paths.base%/../features/webUIRenameFolders'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -489,6 +542,7 @@ default:
     webUIRestrictSharing:
       paths:
         - '%paths.base%/../features/webUIRestrictSharing'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -499,6 +553,7 @@ default:
     webUISharingAcceptShares:
       paths:
         - '%paths.base%/../features/webUISharingAcceptShares'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -513,6 +568,7 @@ default:
     webUISharingAutocompletion:
       paths:
         - '%paths.base%/../features/webUISharingAutocompletion'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - AppConfigurationContext:
@@ -526,6 +582,7 @@ default:
     webUISharingExternal:
       paths:
         - '%paths.base%/../features/webUISharingExternal'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - AppConfigurationContext:
@@ -543,6 +600,7 @@ default:
     webUISharingInternalGroups:
       paths:
         - '%paths.base%/../features/webUISharingInternalGroups'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -556,6 +614,7 @@ default:
     webUISharingInternalUsers:
       paths:
         - '%paths.base%/../features/webUISharingInternalUsers'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -570,6 +629,7 @@ default:
     webUISharingNotifications:
       paths:
         - '%paths.base%/../features/webUISharingNotifications'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
@@ -582,6 +642,7 @@ default:
     webUISharingPublic:
       paths:
         - '%paths.base%/../features/webUISharingPublic'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - AppConfigurationContext:
@@ -596,6 +657,7 @@ default:
     webUITags:
       paths:
         - '%paths.base%/../features/webUITags'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - TagsContext:
@@ -608,6 +670,7 @@ default:
     webUITrashbin:
       paths:
         - '%paths.base%/../features/webUITrashbin'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
@@ -619,6 +682,7 @@ default:
     webUIUpload:
       paths:
         - '%paths.base%/../features/webUIUpload'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIFilesContext:
@@ -632,6 +696,7 @@ default:
     webUIAddUsers:
       paths:
         - '%paths.base%/../features/webUIAddUsers'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
@@ -647,6 +712,7 @@ default:
     webUIManageQuota:
       paths:
         - '%paths.base%/../features/webUIManageQuota'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebDavPropertiesContext:
@@ -659,6 +725,7 @@ default:
     webUIManageUsersGroups:
       paths:
         - '%paths.base%/../features/webUIManageUsersGroups'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
@@ -674,6 +741,7 @@ default:
     webUISettingsMenu:
       paths:
         - '%paths.base%/../features/webUISettingsMenu'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebDavPropertiesContext:
@@ -687,6 +755,7 @@ default:
     webUIWebdavLocks:
       paths:
         - '%paths.base%/../features/webUIWebdavLocks'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebDavLockingContext:
@@ -701,6 +770,7 @@ default:
     webUIWebdavLockProtection:
       paths:
         - '%paths.base%/../features/webUIWebdavLockProtection'
+      context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebDavLockingContext:

--- a/tests/acceptance/config/ldap-users.ldif
+++ b/tests/acceptance/config/ldap-users.ldif
@@ -1,0 +1,9 @@
+dn: ou=TestUsers,dc=owncloud,dc=com
+objectclass: top
+objectclass: organizationalUnit
+ou: TestUsers
+
+dn: ou=TestGroups,dc=owncloud,dc=com
+objectclass: top
+objectclass: organizationalUnit
+ou: TestGroups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
@@ -7,7 +7,7 @@ Feature: get groups
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @skipOnLdap @issue-ldap-500
   Scenario: admin gets all the groups
     Given group "0" has been created
     And group "new-group" has been created
@@ -19,6 +19,7 @@ Feature: get groups
       | new-group |
       | 0         |
 
+  @skipOnLdap @issue-ldap-499
   Scenario: admin gets all the groups, including groups with mixed case
     Given group "new-group" has been created
     And group "New-Group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -7,7 +7,7 @@ Feature: get groups
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @skipOnLdap @issue-ldap-500
   Scenario: admin gets all the groups
     Given group "0" has been created
     And group "new-group" has been created
@@ -19,6 +19,7 @@ Feature: get groups
       | new-group |
       | 0         |
 
+  @skipOnLdap @issue-ldap-499
   Scenario: admin gets all the groups, including groups with mixed case
     Given group "new-group" has been created
     And group "New-Group" has been created

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -56,7 +56,6 @@ Feature: Display notifications when receiving a share
 
 	# This scenario documents behavior discussed in core issue 31870
 	# An old share keeps its old auto-accept behavior, even after auto-accept has been disabled.
-  @skipOnLDAP
   Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
     Given user "user0" has shared folder "/PARENT" with group "grp1"
     When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
@@ -68,7 +67,6 @@ Feature: Display notifications when receiving a share
 
 	# This scenario documents behavior discussed in core issue 31870
 	# As users are added to an existing group, they are not sent notifications about group shares.
-  @skipOnLDAP
   Scenario: share to group sends notifications to existing members, but not to new members, for a share created after auto-accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -95,7 +93,6 @@ Feature: Display notifications when receiving a share
 	# This scenario documents behavior discussed in core issue 31870
 	# Similar to the previous scenario, a new user added to the group does not get a notification,
 	# even though the group, when originally created, had notifications on.
-  @skipOnLDAP
   Scenario: share to group sends notifications to existing members, but not to new members, for an old share created before auto-accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "user0" has shared folder "/PARENT" with group "grp1"
@@ -120,7 +117,6 @@ Feature: Display notifications when receiving a share
       | object_type | /^local_share$/                              |
     And user "user3" should have 0 notifications
 
-  @skipOnLDAP
   Scenario: share to group does not send notifications to existing and new members for a share created after auto-accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -136,7 +132,6 @@ Feature: Display notifications when receiving a share
     And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
     Then user "user1" should have 0 notifications
 
-  @skipOnLDAP
   Scenario: discard notification if target user is not member of the group anymore
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -144,10 +139,9 @@ Feature: Display notifications when receiving a share
     Then user "user1" should have 0 notifications
     Then user "user2" should have 1 notification
 
-  @skipOnLDAP
   Scenario: discard notification if group is deleted
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
-    And the administrator deletes group "grp1" using the provisioning API
+    And the administrator deletes group "grp1" from the default user backend
     Then user "user1" should have 0 notifications
     Then user "user2" should have 0 notifications

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -34,6 +34,7 @@ use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\UploadHelper;
+use Zend\Ldap\Ldap;
 
 require_once 'bootstrap.php';
 
@@ -252,6 +253,85 @@ class FeatureContext extends BehatVariablesContext {
 	 * @var string stderr of last command
 	 */
 	private $lastStdErr;
+	/*
+	 * @var Ldap
+	 */
+	private $ldap;
+	private $ldapBaseDN;
+	private $ldapHost;
+	private $ldapPort;
+	private $ldapAdminUser;
+	private $ldapAdminPassword;
+	private $ldapUsersOU;
+	private $ldapGroupsOU;
+	/**
+	 * @var array
+	 */
+	private $toDeleteDNs = [];
+	private $ldapCreatedUsers = [];
+	private $ldapCreatedGroups = [];
+	private $toDeleteLdapConfigs = [];
+	private $oldLdapConfig = [];
+
+	/**
+	 * @return Ldap
+	 */
+	public function getLdap() {
+		return $this->ldap;
+	}
+
+	/**
+	 * @param string $configId
+	 *
+	 * @return void
+	 */
+	public function setToDeleteLdapConfigs($configId) {
+		$this->toDeleteLdapConfigs = $configId;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getToDeleteLdapConfigs() {
+		return $this->toDeleteLdapConfigs;
+	}
+
+	/**
+	 * @param string $setValue
+	 *
+	 * @return void
+	 */
+	public function setToDeleteDNs($setValue) {
+		$this->toDeleteDNs = $setValue;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLdapBaseDN() {
+		return $this->ldapBaseDN;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLdapUsersOU() {
+		return $this->ldapUsersOU;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLdapGroupsOU() {
+		return $this->ldapGroupsOU;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isTestingWithLdap() {
+		return (\getenv("TEST_EXTERNAL_USER_BACKENDS") === "true");
+	}
 
 	/**
 	 * BasicStructure constructor.
@@ -2536,6 +2616,11 @@ class FeatureContext extends BehatVariablesContext {
 			$this->getBaseUrl(),
 			$this->getOcPath()
 		);
+
+		if ($this->isTestingWithLdap()) {
+			$suiteParameters = SetupHelper::getSuiteParameters($scope);
+			$this->connectToLdap($suiteParameters);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -523,6 +523,7 @@ class OccUsersGroupsContext implements Context {
 	 * @param TableNode $useridTable
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theUsersReturnedByTheOccCommandShouldBe(TableNode $useridTable) {
 		$this->featureContext->verifyTableNodeColumns($useridTable, ['uid', 'display name']);

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -27,6 +27,8 @@ use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
 use TestHelpers\HttpRequestHelper;
+use Zend\Ldap\Exception\LdapException;
+use Zend\Ldap\Ldap;
 
 /**
  * Functions for provisioning of users and groups
@@ -289,10 +291,7 @@ trait Provisioning {
 	 */
 	public function userHasBeenCreatedWithDefaultAttributes($user) {
 		$this->createUser($user);
-
-		if (\getenv("TEST_EXTERNAL_USER_BACKENDS") !== "true") {
-			$this->userShouldExist($user);
-		}
+		$this->userShouldExist($user);
 	}
 
 	/**
@@ -301,6 +300,7 @@ trait Provisioning {
 	 * @param string $user
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles($user) {
 		$baseUrl = $this->getBaseUrl();
@@ -324,6 +324,7 @@ trait Provisioning {
 	 * @param TableNode $table
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theseUsersHaveBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles(TableNode $table) {
 		$baseUrl = $this->getBaseUrl();
@@ -348,6 +349,7 @@ trait Provisioning {
 	 * @param TableNode $table
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theseUsersHaveBeenCreatedWithoutSkeletonFiles(TableNode $table) {
 		$baseUrl = $this->getBaseUrl();
@@ -364,10 +366,416 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^these users have been created with ?(default attributes and|) skeleton files ?(but not initialized|):$/
-	 * @When /^the administrator creates these users with ?(default attributes and|) skeleton files ?(but not initialized|):$/
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function importLdifFile($path) {
+		$ldifData = \file_get_contents($path);
+		$this->importLdifData($ldifData);
+	}
+
+	/**
+	 * imports an ldif string
+	 *
+	 * @param string $ldifData
+	 *
+	 * @return void
+	 */
+	public function importLdifData($ldifData) {
+		$items = Zend\Ldap\Ldif\Encoder::decode($ldifData);
+		if (isset($items['dn'])) {
+			//only one item in the ldif data
+			$this->ldap->add($items['dn'], $items);
+		} else {
+			foreach ($items as $item) {
+				$this->ldap->add($item['dn'], $item);
+			}
+		}
+	}
+
+	/**
+	 * @param $suiteParameters
+	 *
+	 * @return void
+	 * @throws \Exception
+	 * @throws \LdapException
+	 */
+	public function connectToLdap($suiteParameters) {
+		$occResult = SetupHelper::runOcc(
+			['ldap:show-config', 'LDAPTestId', '--output=json']
+		);
+		Assert::assertSame(
+			'0', $occResult['code'],
+			"could not read current LDAP config. stdOut: " .
+			$occResult['stdOut'] .
+			" stdErr: " . $occResult['stdErr']
+		);
+
+		$ldapConfig = \json_decode(
+			$occResult['stdOut'], true
+		);
+		Assert::assertNotNull(
+			$ldapConfig,
+			"could not json decode current LDAP config. stdOut: " . $occResult['stdOut']
+		);
+
+		$this->ldapBaseDN = (string)$ldapConfig['ldapBase'][0];
+		$this->ldapHost = (string)$ldapConfig['ldapHost'];
+		$this->ldapPort = (string)$ldapConfig['ldapPort'];
+		$this->ldapAdminUser = (string)$ldapConfig['ldapAgentName'];
+
+		$this->ldapAdminPassword = (string)$suiteParameters['ldapAdminPassword'];
+		$this->ldapUsersOU = (string)$suiteParameters['ldapUsersOU'];
+		$this->ldapGroupsOU = (string)$suiteParameters['ldapGroupsOU'];
+
+		$options = [
+			'host' => $this->ldapHost,
+			'port' => $this->ldapPort,
+			'password' => $this->ldapAdminPassword,
+			'bindRequiresDn' => true,
+			'baseDn' => $this->ldapBaseDN,
+			'username' => $this->ldapAdminUser
+		];
+		$this->ldap = new Ldap($options);
+		$this->ldap->bind();
+
+		$this->importLdifFile(
+			__DIR__ . (string)$suiteParameters['ldapInitialUserFilePath']
+		);
+		$this->theLdapUsersHaveBeenResynced();
+	}
+
+	/**
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theLdapUsersHaveBeenReSynced() {
+		$occResult = SetupHelper::runOcc(
+			['user:sync', 'OCA\User_LDAP\User_Proxy', '-m', 'remove']
+		);
+		if ($occResult['code'] !== "0") {
+			throw new \Exception("could not sync LDAP users " . $occResult['stdErr']);
+		}
+	}
+
+	/**
+	 * prepares suitable nested array with user-attributes for multiple users to be created
+	 *
+	 * @param boolean $setDefaultAttributes
+	 * @param array $table
+	 *
+	 * @return array
+	 */
+	public function buildUsersAttributesArray($setDefaultAttributes, $table) {
+		$usersAttributes = [];
+		foreach ($table as $row) {
+			$userAttribute['userid'] = $this->getActualUsername($row['username']);
+			if (isset($row['displayname'])) {
+				$userAttribute['displayName'] = $row['displayname'];
+			} elseif ($setDefaultAttributes) {
+				$userAttribute['displayName'] = $this->getDisplayNameForUser($userAttribute['userid']);
+				if ($userAttribute['displayName'] === null) {
+					$userAttribute['displayName'] = $this->getDisplayNameForUser('regularuser');
+				}
+			} else {
+				$userAttribute['displayName'] = null;
+			}
+
+			if (isset($row['email'])) {
+				$userAttribute['email'] = $row['email'];
+			} elseif ($setDefaultAttributes) {
+				$userAttribute['email'] = $this->getEmailAddressForUser($userAttribute['userid']);
+				if ($userAttribute['email'] === null) {
+					$userAttribute['email'] = $row['username'] . '@owncloud.org';
+				}
+			} else {
+				$userAttribute['email'] = null;
+			}
+
+			if (isset($row['password'])) {
+				$userAttribute['password'] = $this->getActualPassword($row['password']);
+			} else {
+				$userAttribute['password'] = $this->getPasswordForUser($row['username']);
+			}
+			// Add request body to the bodies array. we will use that later to loop through created users.
+			\array_push($usersAttributes, $userAttribute);
+		}
+		return $usersAttributes;
+	}
+
+	/**
+	 * creates a user in the ldap server
+	 * the created user is added to `createdUsersList`
+	 * ldap users are re-synced after creating a new user
+	 *
+	 * @param array $setting
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function createLdapUser($setting) {
+		$ou = "TestUsers";
+		$newDN = 'uid=' . $setting["userid"] . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		$uidNumber = \count($this->ldapCreatedUsers) + 1;
+		$entry = [];
+		$entry['cn'] = $setting["userid"];
+		$entry['sn'] = $setting["userid"];
+		$entry['homeDirectory'] = '/home/openldap/' . $setting["userid"];
+		$entry['objectclass'][] = 'posixAccount';
+		$entry['objectclass'][] = 'inetOrgPerson';
+		$entry['userPassword'] = $setting["password"];
+		if (isset($setting["displayName"])) {
+			$entry['displayName'] = $setting["displayName"];
+		}
+		if (isset($setting["email"])) {
+			$entry['mail'] = $setting["email"];
+		}
+		$entry['gidNumber'] = 5000;
+		$entry['uidNumber'] = $uidNumber;
+		$this->ldap->add($newDN, $entry);
+		\array_push($this->ldapCreatedUsers, $setting["userid"]);
+		$this->theLdapUsersHaveBeenReSynced();
+	}
+
+	/**
+	 * @param string $group group name
+	 *
+	 * @return void
+	 * @throws Exception
+	 * @throws LdapException
+	 */
+	public function createLdapGroup($group) {
+		$ou = "TestGroups";
+		$newDN = 'cn=' . $group . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		$entry = [];
+		$entry['cn'] = $group;
+		$entry['objectclass'][] = 'posixGroup';
+		$entry['objectclass'][] = 'top';
+		$entry['gidNumber'] = 5000;
+		$this->ldap->add($newDN, $entry);
+		\array_push($this->ldapCreatedGroups, $group);
+		$this->theLdapUsersHaveBeenReSynced();
+	}
+
+	/**
+	 *
+	 * @param string $configId
+	 * @param string $configKey
+	 * @param string $configValue
+	 *
+	 * @throws \Exception
+	 * @return void
+	 */
+	public function setLdapSetting($configId, $configKey, $configValue) {
+		if ($configValue === "") {
+			$configValue = "''";
+		}
+		$substitutions = [
+			[
+				"code" => "%ldap_host_without_scheme%",
+				"function" => [
+					$this,
+					"getLdapHostWithoutScheme"
+				],
+				"parameter" => []
+			],
+			[
+				"code" => "%ldap_host%",
+				"function" => [
+					$this,
+					"getLdapHost"
+				],
+				"parameter" => []
+			],
+			[
+				"code" => "%ldap_port%",
+				"function" => [
+					$this,
+					"getLdapPort"
+				],
+				"parameter" => []
+			]
+		];
+		$configValue = $this->substituteInLineCodes(
+			$configValue, [], $substitutions
+		);
+		$occResult = SetupHelper::runOcc(
+			['ldap:set-config', $configId, $configKey, $configValue]
+		);
+		if ($occResult['code'] !== "0") {
+			throw new \Exception(
+				"could not set LDAP setting " . $occResult['stdErr']
+			);
+		}
+	}
+
+	/**
+	 * deletes LDAP users|groups created during test
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function deleteLdapUsersAndGroups() {
+		//delete created ldap users
+		$this->ldap->delete(
+			"ou=" . $this->ldapUsersOU . "," . $this->ldapBaseDN, true
+		);
+		//delete all created ldap groups
+		$this->ldap->delete(
+			"ou=" . $this->ldapGroupsOU . "," . $this->ldapBaseDN, true
+		);
+		foreach ($this->ldapCreatedUsers as $user) {
+			$this->rememberThatUserIsNotExpectedToExist($user);
+		}
+		foreach ($this->ldapCreatedGroups as $group) {
+			$this->rememberThatGroupIsNotExpectedToExist($group);
+		}
+		$this->theLdapUsersHaveBeenResynced();
+	}
+
+	/**
+	 * Sets back old settings
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function resetOldLdapConfig() {
+		$toDeleteLdapConfig = $this->getToDeleteLdapConfigs();
+		foreach ($toDeleteLdapConfig as $configId) {
+			SetupHelper::runOcc(['ldap:delete-config', $configId]);
+		}
+		foreach ($this->oldLdapConfig as $configId => $settings) {
+			foreach ($settings as $configKey => $configValue) {
+				$this->setLdapSetting($configId, $configKey, $configValue);
+			}
+		}
+	}
+
+	/**
+	 * @AfterScenario
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function afterScenario() {
+		if ($this->isTestingWithLdap()) {
+			$this->deleteLdapUsersAndGroups();
+			$this->resetOldLdapConfig();
+		}
+	}
+
+	/**
 	 * This function will allow us to send user creation requests in parallel.
-	 * This will be faster in comparision to waiting for each request to complete before sending another request.
+	 * This will be faster in comparison to waiting for each request to complete before sending another request.
+	 *
+	 * @param boolean $initialize
+	 * @param array $usersAttributes
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function usersHaveBeenCreated($initialize, $usersAttributes) {
+		$requests = [];
+		$client = new Client();
+
+		foreach ($usersAttributes as $userAttributes) {
+			if ($this->isTestingWithLdap()) {
+				$this->createLdapUser($userAttributes);
+			} else {
+				// Create a OCS request for creating the user. The request is not sent to the server yet.
+				$request = OcsApiHelper::createOcsRequest(
+					$this->getBaseUrl(),
+					$this->getAdminUsername(),
+					$this->getAdminPassword(),
+					'POST',
+					"/cloud/users",
+					$userAttributes,
+					$client
+				);
+				// Add the request to the $requests array so that they can be sent in parallel.
+				\array_push($requests, $request);
+			}
+		}
+
+		if (!$this->isTestingWithLdap()) {
+			$results = HttpRequestHelper::sendBatchRequest($requests, $client);
+			// Retrieve all failures.
+			foreach ($results->getFailures() as $e) {
+				$failedUser = $e->getRequest()->getBody()->getFields()['userid'];
+				$message = $this->getResponseXml($e->getResponse())->xpath("/ocs/meta/message");
+				if ($message && (string)$message[0] === "User already exists") {
+					Assert::fail(
+						"Could not create user '$failedUser' as it already exists. " .
+						"Please delete the user to run tests again."
+					);
+				}
+				throw new Exception(
+					"could not create user. "
+					. $e->getResponse()->getStatusCode() . " " . $e->getResponse()->getBody()
+				);
+			}
+		}
+
+		// Create requests for setting displayname and email for the newly created users.
+		// These values cannot be set while creating the user, so we have to edit the newly created user to set these values.
+		$users = [];
+		$editData = [];
+		foreach ($usersAttributes as $userAttributes) {
+			\array_push($users, $userAttributes['userid']);
+			$this->addUserToCreatedUsersList($userAttributes['userid'], $userAttributes['password'], $userAttributes['displayName'], $userAttributes['email']);
+			if (isset($userAttributes['displayName'])) {
+				\array_push($editData, ['user' => $userAttributes['userid'], 'key' => 'displayname', 'value' => $userAttributes['displayName']]);
+			}
+			if (isset($userAttributes['email'])) {
+				\array_push($editData, ['user' => $userAttributes['userid'], 'key' => 'email', 'value' => $userAttributes['email']]);
+			}
+		}
+		// Edit the users in parallel to make the process faster.
+		if (\count($editData) > 0) {
+			UserHelper::editUserBatch(
+				$this->getBaseUrl(),
+				$editData,
+				$this->getAdminUsername(),
+				$this->getAdminPassword()
+			);
+		}
+
+		// If the users need to be initialized then initialize them in parallel.
+		if ($initialize) {
+			$this->initializeUserBatch($users);
+		}
+	}
+
+	/**
+	 * @When /^the administrator creates these users with ?(default attributes and|) skeleton files ?(but not initialized|):$/
+	 *
+	 * expects a table of users with the heading
+	 * "|username|password|displayname|email|"
+	 * password, displayname & email are optional
+	 *
+	 * @param string $setDefaultAttributes
+	 * @param string $doNotInitialize
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theAdministratorCreatesTheseUsers($setDefaultAttributes, $doNotInitialize, TableNode $table) {
+		$this->verifyTableNodeColumns($table, ['username'], ['displayname', 'email', 'password']);
+		$table = $table->getColumnsHash();
+		$setDefaultAttributes = $setDefaultAttributes !== "";
+		$initialize = $doNotInitialize === "";
+		$usersAttributes = $this->buildUsersAttributesArray($setDefaultAttributes, $table);
+		$this->usersHaveBeenCreated(
+			$initialize,
+			$usersAttributes
+		);
+	}
+
+	/**
+	 * @Given /^these users have been created with ?(default attributes and|) skeleton files ?(but not initialized|):$/
 	 *
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
@@ -385,114 +793,13 @@ trait Provisioning {
 		$table = $table->getColumnsHash();
 		$setDefaultAttributes = $setDefaultAttributes !== "";
 		$initialize = $doNotInitialize === "";
-		// We add all the request bodies in an array.
-		$bodies = [];
-		// We add all the request objects in an array so that we can send all the requests in parallel.
-		$requests = [];
-		$client = new Client();
-
-		if (\getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
-			$users = [];
-			echo "creating LDAP users is not implemented, so assume they exist\n";
-			foreach ($table as $user) {
-				\array_push($users, $user["username"]);
-			}
-			$this->initializeUserBatch($users);
-			return;
-		}
-
-		foreach ($table as $row) {
-			$body['userid'] = $this->getActualUsername($row['username']);
-
-			if (isset($row['displayname'])) {
-				$body['displayName'] = $row['displayname'];
-			} elseif ($setDefaultAttributes) {
-				$body['displayName'] = $this->getDisplayNameForUser($body['userid']);
-				if ($body['displayName'] === null) {
-					$body['displayName'] = $this->getDisplayNameForUser('regularuser');
-				}
-			} else {
-				$body['displayName'] = null;
-			}
-
-			if (isset($row['email'])) {
-				$body['email'] = $row['email'];
-			} elseif ($setDefaultAttributes) {
-				$body['email'] = $this->getEmailAddressForUser($body['userid']);
-				if ($body['email'] === null) {
-					$body['email'] = $row['username'] . '@owncloud.org';
-				}
-			} else {
-				$body['email'] = null;
-			}
-
-			if (isset($row['password'])) {
-				$body['password'] = $this->getActualPassword($row['password']);
-			} else {
-				$body['password'] = $this->getPasswordForUser($row['username']);
-			}
-
-			// Add request body to the bodies array. we will use that later to loop through created users.
-			\array_push($bodies, $body);
-
-			// Create a OCS request for creating the user. The request is not sent to the server yet.
-			$request = OcsApiHelper::createOcsRequest(
-				$this->getBaseUrl(),
-				$this->getAdminUsername(),
-				$this->getAdminPassword(),
-				'POST',
-				"/cloud/users",
-				$body,
-				$client
-			);
-			// Add the request to the $requests array so that they can be sent in parallel.
-			\array_push($requests, $request);
-		}
-
-		$results = HttpRequestHelper::sendBatchRequest($requests, $client);
-		// Retrieve all failures.
-		foreach ($results->getFailures() as $e) {
-			$failedUser = $e->getRequest()->getBody()->getFields()['userid'];
-			$message = $this->getResponseXml($e->getResponse())->xpath("/ocs/meta/message");
-			if ($message && (string) $message[0] === "User already exists") {
-				Assert::fail(
-					"Could not create user '$failedUser' as it already exists. " .
-					"Please delete the user to run tests again."
-				);
-			}
-			throw new Exception(
-				"could not create user. "
-				. $e->getResponse()->getStatusCode() . " " . $e->getResponse()->getBody()
-			);
-		}
-
-		// Create requests for setting displayname and email for the newly created users.
-		// These values cannot be set while creating the user, so we have to edit the newly created user to set these values.
-		$users = [];
-		$editData = [];
-		foreach ($bodies as $user) {
-			\array_push($users, $user['userid']);
-			$this->addUserToCreatedUsersList($user['userid'], $user['password'], $user['displayName'], $user['email']);
-			if (isset($user['displayName'])) {
-				\array_push($editData, ['user' => $user['userid'], 'key' => 'displayname', 'value' => $user['displayName']]);
-			}
-			if (isset($user['email'])) {
-				\array_push($editData, ['user' => $user['userid'], 'key' => 'email', 'value' => $user['email']]);
-			}
-		}
-		// Edit the users in parallel to make the process faster.
-		if (\count($editData) > 0) {
-			UserHelper::editUserBatch(
-				$this->getBaseUrl(),
-				$editData,
-				$this->getAdminUsername(),
-				$this->getAdminPassword()
-			);
-		}
-
-		// If the users need to be initialized then initialize them in parallel.
-		if ($initialize) {
-			$this->initializeUserBatch($users);
+		$usersAttributes = $this->buildUsersAttributesArray($setDefaultAttributes, $table);
+		$this->usersHaveBeenCreated(
+			$initialize,
+			$usersAttributes
+		);
+		foreach ($usersAttributes as $expectedUser) {
+			$this->userShouldExist($expectedUser["userid"]);
 		}
 	}
 
@@ -837,7 +1144,6 @@ trait Provisioning {
 	 * @see https://github.com/owncloud/core/pull/33040
 	 *
 	 * @When /^the administrator changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
-	 * @Given /^the administrator has changed the display name of user "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $displayname
@@ -853,6 +1159,36 @@ trait Provisioning {
 		);
 	}
 
+	/**
+	 * @Given /^the administrator has changed the display name of user "([^"]*)" to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $displayname
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminHasChangedTheDisplayNameOfUser(
+		$user, $displayname
+	) {
+		if ($this->isTestingWithLdap()) {
+			$this->editLdapUserDisplayName(
+				$user, $displayname
+			);
+		} else {
+			$this->adminChangesTheDisplayNameOfUserUsingKey(
+				$user, 'displayname', $displayname
+			);
+		}
+		$response = UserHelper::getUser(
+			$this->getBaseUrl(),
+			$user,
+			$this->getAdminUsername(),
+			$this->getAdminPassword()
+		);
+		$this->setResponse($response);
+		$this->theDisplayNameReturnedByTheApiShouldBe($displayname);
+	}
 	/**
 	 * As the administrator, edit the "display name" of a user by sending the key "display" to the API end point.
 	 *
@@ -1125,6 +1461,7 @@ trait Provisioning {
 	 * @param string $group
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function groupShouldExist($group) {
 		Assert::assertTrue(
@@ -1139,6 +1476,7 @@ trait Provisioning {
 	 * @param string $group
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function groupShouldNotExist($group) {
 		Assert::assertFalse(
@@ -1182,7 +1520,11 @@ trait Provisioning {
 	 */
 	public function userHasBeenDeleted($user) {
 		if ($this->userExists($user)) {
-			$this->deleteTheUserUsingTheProvisioningApi($user);
+			if ($this->isTestingWithLdap() && \in_array($user, $this->ldapCreatedUsers)) {
+				$this->deleteLdapUser($user);
+			} else {
+				$this->deleteTheUserUsingTheProvisioningApi($user);
+			}
 		}
 		$this->userShouldNotExist($user);
 	}
@@ -1474,7 +1816,7 @@ trait Provisioning {
 			}
 		}
 
-		if ($method === null && \getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
+		if ($method === null && $this->isTestingWithLdap()) {
 			//guess yourself
 			$method = "ldap";
 		} elseif ($method === null) {
@@ -1519,7 +1861,22 @@ trait Provisioning {
 				}
 				break;
 			case "ldap":
-				echo "creating LDAP users is not implemented, so assume they exist\n";
+				$settings = [];
+				$setting["userid"] = $user;
+				$setting["displayName"] = $displayName;
+				$setting["password"] = $password;
+				$setting["email"] = $email;
+				\array_push($settings, $setting);
+				try {
+					$this->usersHaveBeenCreated(
+						$initialize,
+						$settings
+					);
+				} catch (LdapException $exception) {
+					throw new Exception(
+						"cannot create a LDAP user with provided data. Error: {$exception}"
+					);
+				}
 				break;
 			default:
 				throw new InvalidArgumentException(
@@ -1607,6 +1964,18 @@ trait Provisioning {
 		Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
+	}
+
+	/**
+	 * @param string $group
+	 *
+	 * @return array
+	 */
+	public function getUsersOfLdapGroup($group) {
+		$ou = $this->getLdapGroupsOU();
+		$entry = 'cn=' . $group . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		$ldapResponse = $this->ldap->getEntry($entry);
+		return $ldapResponse["memberuid"];
 	}
 
 	/**
@@ -1766,7 +2135,7 @@ trait Provisioning {
 	 */
 	public function addUserToGroup($user, $group, $method = null, $checkResult = false) {
 		$user = $this->getActualUsername($user);
-		if ($method === null && \getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
+		if ($method === null && $this->isTestingWithLdap()) {
 			//guess yourself
 			$method = "ldap";
 		} elseif ($method === null) {
@@ -1799,8 +2168,16 @@ trait Provisioning {
 				}
 				break;
 			case "ldap":
-				echo "adding users to groups in LDAP is not implemented, " .
-					"so assume user is in group\n";
+				try {
+					$this->addUserToLdapGroup(
+						$user,
+						$group
+					);
+				} catch (LdapException $exception) {
+					throw new Exception(
+						"User " . $user . " cannot be added to " . $group . " . Error: {$exception}"
+					);
+				};
 				break;
 			default:
 				throw new InvalidArgumentException(
@@ -1885,9 +2262,7 @@ trait Provisioning {
 	 */
 	public function groupHasBeenCreated($group) {
 		$this->createTheGroup($group);
-		if (\getenv("TEST_EXTERNAL_USER_BACKENDS") !== "true") {
-			$this->groupShouldExist($group);
-		}
+		$this->groupShouldExist($group);
 	}
 
 	/**
@@ -1900,7 +2275,6 @@ trait Provisioning {
 	 */
 	public function groupHasBeenCreatedOnDatabaseBackend($group) {
 		$this->adminCreatesGroupUsingTheProvisioningApi($group);
-		$this->groupShouldExist($group);
 	}
 
 	/**
@@ -1977,7 +2351,7 @@ trait Provisioning {
 	 */
 	private function createTheGroup($group, $method = null) {
 		//guess yourself
-		if ($method === null && \getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
+		if ($method === null && $this->isTestingWithLdap()) {
 			$method = "ldap";
 		} elseif ($method === null) {
 			$method = "api";
@@ -2013,7 +2387,13 @@ trait Provisioning {
 				}
 				break;
 			case "ldap":
-				echo "creating LDAP groups is not implemented, so assume they exist\n";
+				try {
+					$this->createLdapGroup($group);
+				} catch (LdapException $e) {
+					throw new Exception(
+						"could not create group. Error: {$e}"
+					);
+				}
 				break;
 			default:
 				throw new InvalidArgumentException(
@@ -2022,6 +2402,147 @@ trait Provisioning {
 		}
 
 		$this->addGroupToCreatedGroupsList($group, true, $groupCanBeDeleted);
+	}
+
+	/**
+	 * @param string $attribute
+	 * @param string $entry
+	 * @param string $value
+	 * @param bool $append
+	 *
+	 * @return void
+	 */
+	public function setTheLdapAttributeOfTheEntryTo(
+		$attribute, $entry, $value, $append=false
+	) {
+		$ldapEntry = $this->ldap->getEntry($entry . "," . $this->ldapBaseDN);
+		Zend\Ldap\Attribute::setAttribute($ldapEntry, $attribute, $value, $append);
+		$this->ldap->update($entry . "," . $this->ldapBaseDN, $ldapEntry);
+		$this->theLdapUsersHaveBeenReSynced();
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $group
+	 * @param string|null $ou
+	 *
+	 * @return void
+	 */
+	public function addUserToLdapGroup($user, $group, $ou = null) {
+		if ($ou === null) {
+			$ou = $this->getLdapGroupsOU();
+		}
+		$this->setTheLdapAttributeOfTheEntryTo(
+			"memberUid",
+			"cn=$group,ou=$ou",
+			$user,
+			true
+		);
+	}
+	
+	/**
+	 * @param string $value
+	 * @param string $attribute
+	 * @param string $entry
+	 *
+	 * @return void
+	 */
+	public function deleteValueFromLdapAttribute($value, $attribute, $entry) {
+		$this->ldap->deleteAttributes(
+			$entry . "," . $this->ldapBaseDN, [$attribute => [$value]]
+		);
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $group
+	 * @param null $ou
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function removeUserFromLdapGroup($user, $group, $ou = null) {
+		if ($ou === null) {
+			$ou = $this->getLdapGroupsOU();
+		}
+		$this->deleteValueFromLdapAttribute(
+			$user, "memberUid", "cn=$group,ou=$ou"
+		);
+		$this->theLdapUsersHaveBeenReSynced();
+	}
+
+	/**
+	 * @param string $entry
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function deleteTheLdapEntry($entry) {
+		$this->ldap->delete($entry . "," . $this->ldapBaseDN);
+		$this->theLdapUsersHaveBeenReSynced();
+	}
+
+	/**
+	 * @param string $group
+	 * @param null $ou
+	 *
+	 * @return void
+	 * @throws LdapException
+	 * @throws Exception
+	 */
+	public function deleteLdapGroup($group, $ou = null) {
+		if ($ou === null) {
+			$ou = $this->getLdapGroupsOU();
+		}
+		$this->deleteTheLdapEntry("cn=$group,ou=$ou");
+		$this->theLdapUsersHaveBeenReSynced();
+		$key = \array_search($group, $this->ldapCreatedGroups);
+		if ($key !== false) {
+			unset($this->ldapCreatedGroups[$key]);
+		}
+		$this->rememberThatGroupIsNotExpectedToExist($group);
+	}
+
+	/**
+	 * @param string $username
+	 * @param null $ou
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function deleteLdapUser($username, $ou = null) {
+		if (!\in_array($username, $this->ldapCreatedUsers)) {
+			throw new Error(
+				"User " . $username . " was not created using Ldap and does not exist as an Ldap User"
+			);
+		}
+		if ($ou === null) {
+			$ou = $this->getLdapUsersOU();
+		}
+		$entry = "uid=$username,ou=$ou";
+		$this->deleteTheLdapEntry($entry);
+		$key = \array_search($username, $this->ldapCreatedUsers);
+		if ($key !== false) {
+			unset($this->ldapCreatedUsers[$key]);
+		}
+		$this->rememberThatUserIsNotExpectedToExist($username);
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $displayName
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function editLdapUserDisplayName($user, $displayName) {
+		$entry = "uid=" . $user . ",ou=" . $this->getLdapUsersOU();
+		$this->setTheLdapAttributeOfTheEntryTo(
+			'displayname',
+			$entry,
+			$displayName
+		);
+		$this->theLdapUsersHaveBeenReSynced();
 	}
 
 	/**
@@ -2106,6 +2627,23 @@ trait Provisioning {
 	}
 
 	/**
+	 * @param string $group group name
+	 *
+	 * @return void
+	 * @throws Exception
+	 * @throws LdapException
+	 */
+	public function deleteGroup($group) {
+		if ($this->groupExists($group)) {
+			if ($this->isTestingWithLdap() && \in_array($group, $this->ldapCreatedGroups)) {
+				$this->deleteLdapGroup($group);
+			} else {
+				$this->deleteTheGroupUsingTheProvisioningApi($group);
+			}
+		}
+	}
+
+	/**
 	 * @Given /^group "([^"]*)" has been deleted$/
 	 *
 	 * @param string $group
@@ -2113,11 +2651,21 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function groupHasBeenDeletedUsingTheProvisioningApi($group) {
-		if ($this->groupExists($group)) {
-			$this->deleteTheGroupUsingTheProvisioningApi($group);
-		}
+	public function groupHasBeenDeleted($group) {
+		$this->deleteGroup($group);
 		$this->groupShouldNotExist($group);
+	}
+
+	/**
+	 * @When /^the administrator deletes group "([^"]*)" from the default user backend$/
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function adminDeletesGroup($group) {
+		$this->deleteGroup($group);
 	}
 
 	/**
@@ -2172,6 +2720,7 @@ trait Provisioning {
 	 * @param string $group
 	 *
 	 * @return bool
+	 * @throws Exception
 	 */
 	public function groupExists($group) {
 		$group = \rawurlencode($group);
@@ -2186,18 +2735,51 @@ trait Provisioning {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function removeUserFromGroupAsAdminUsingTheProvisioningApi($user, $group) {
+		$this->userRemovesUserFromGroupUsingTheProvisioningApi(
+			$this->getAdminUsername(), $user, $group
+		);
+	}
+
+	/**
 	 * @When the administrator removes user :user from group :group using the provisioning API
+	 *
+	 * @param string $user
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminRemovesUserFromGroupUsingTheProvisioningApi($user, $group) {
+		$this->removeUserFromGroupAsAdminUsingTheProvisioningApi(
+			$user, $group
+		);
+	}
+
+	/**
 	 * @Given user :user has been removed from group :group
 	 *
 	 * @param string $user
 	 * @param string $group
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	public function adminRemovesUserFromGroupUsingTheProvisioningApi($user, $group) {
-		$this->userRemovesUserFromGroupUsingTheProvisioningApi(
-			$this->getAdminUsername(), $user, $group
-		);
+	public function adminHasRemovedUserFromGroup($user, $group) {
+		if ($this->isTestingWithLdap() && \in_array($group, $this->ldapCreatedGroups)) {
+			$this->removeUserFromLdapGroup($user, $group);
+		} else {
+			$this->removeUserFromGroupAsAdminUsingTheProvisioningApi(
+				$user, $group
+			);
+		}
+		$this->userShouldNotBelongToGroup($user, $group);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -672,7 +672,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		);
 
 		//TODO make it smarter to be able also to work with other backends
-		if (\getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
+		if ($this->featureContext->isTestingWithLdap()) {
 			$result = SetupHelper::runOcc(
 				["user:sync", "OCA\User_LDAP\User_Proxy", "-m remove"]
 			);

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -1,9 +1,10 @@
-@cli @skipOnLDAP
+@cli
 Feature: get group
   As an admin
   I want to be able to get group details
   So that I can know which users are in a group
 
+  @skipOnLDAP
   Scenario: admin gets users in the group
     Given these users have been created with skeleton files:
       | username       |
@@ -38,6 +39,7 @@ Feature: get group
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group not-a-group does not exist'
 
+  @skipOnLDAP @issue-499
   Scenario Outline: admin tries to get users in a group but using wrong case of the group name
     Given group "<group_id1>" has been created
     When the administrator gets the users in group "<group_id2>" in JSON format using the occ command

--- a/tests/acceptance/features/cliProvisioning/getGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroups.feature
@@ -4,6 +4,7 @@ Feature: get groups
   I want to be able to get a list of groups
   So that I can see all the groups in my ownCloud
 
+  @issue-user_ldap-500
   Scenario: admin gets all the groups
     Given group "0" has been created
     And group "new-group" has been created
@@ -17,6 +18,7 @@ Feature: get groups
       | new-group |
       | 0         |
 
+  @issue-user_ldap-499
   Scenario: admin gets all the groups, including groups with mixed case
     Given group "new-group" has been created
     And group "New-Group" has been created

--- a/tests/acceptance/features/cliProvisioning/getUserGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getUserGroups.feature
@@ -4,6 +4,7 @@ Feature: get user groups
   I want to be able to get group membership information
   So that I can manage group membership
 
+  @issue-ldap-500
   Scenario: admin gets groups of an user
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -30,7 +30,6 @@ Feature: Autocompletion of share-with names
       | users-finance |
       | other         |
 
-  @skipOnLDAP @user_ldap-issue-175
   @smokeTest
   Scenario: autocompletion of regular existing users
     Given user "regularuser" has logged in using the webUI
@@ -41,7 +40,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   @smokeTest
   Scenario: autocompletion of regular existing groups
     Given user "regularuser" has logged in using the webUI
@@ -52,7 +50,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "other" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion for a pattern that does not match any user or group
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
@@ -61,7 +58,6 @@ Feature: Autocompletion of share-with names
     Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
 
-  @skipOnLDAP
   Scenario: autocomplete short user/display names when completely typed
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
     And user "regularuser" has logged in using the webUI
@@ -74,7 +70,6 @@ Feature: Autocompletion of share-with names
     Then only user "Use" should be listed in the autocomplete list on the webUI
     And user "User Two" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocomplete short group names when completely typed
     Given the administrator has set the minimum characters for sharing autocomplete to "3"
     And these groups have been created:
@@ -87,7 +82,6 @@ Feature: Autocompletion of share-with names
     Then only group "fi" should be listed in the autocomplete list on the webUI
     And user "finance1" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
@@ -96,7 +90,6 @@ Feature: Autocompletion of share-with names
     Then a tooltip with the text "No users or groups found for u. Please enter at least 2 characters for suggestions" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion when minimum characters is increased and not enough characters are typed
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
     And user "regularuser" has logged in using the webUI
@@ -106,7 +99,6 @@ Feature: Autocompletion of share-with names
     Then a tooltip with the text "No users or groups found for use. Please enter at least 4 characters for suggestions" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion when increasing the minimum characters for sharing autocomplete
     Given the administrator has set the minimum characters for sharing autocomplete to "3"
     And user "regularuser" has logged in using the webUI
@@ -117,7 +109,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
     Given user "regularuser" has shared folder "simple-folder" with user "user1"
     And user "regularuser" has logged in using the webUI
@@ -128,7 +119,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP @user_ldap-issue-175
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
     Given user "regularuser" has shared file "data.zip" with user "usergrp"
     And user "regularuser" has logged in using the webUI
@@ -139,7 +129,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
     Given user "regularuser" has shared folder "simple-folder" with group "finance1"
     And user "regularuser" has logged in using the webUI
@@ -150,7 +139,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
     Given user "regularuser" has shared file "data.zip" with group "finance1"
     And user "regularuser" has logged in using the webUI
@@ -161,7 +149,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing users contains the pattern somewhere in the middle
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -171,7 +158,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing users contain the pattern at the end
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
@@ -181,7 +167,6 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "User One" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the username of existing user contains the pattern somewhere in the middle
     Given user "ivan" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
@@ -190,7 +175,6 @@ Feature: Autocompletion of share-with names
     When the user types "iv" in the share-with-field
     Then all users and groups that contain the string "iv" in their name should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing group contains the pattern somewhere in the middle
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -199,7 +183,6 @@ Feature: Autocompletion of share-with names
     Then all users and groups that contain the string "finance" in their name should be listed in the autocomplete list on the webUI
     But group "other" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the username of the existing user contains the pattern somewhere in the end
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username     | displayname |
@@ -210,7 +193,6 @@ Feature: Autocompletion of share-with names
     When the user types "user3" in the share-with-field
     Then all users and groups that contain the string "user3" in their name should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing group contains the pattern at the end
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -221,7 +203,6 @@ Feature: Autocompletion of share-with names
     And group "finance3" should not be listed in the autocomplete list on the webUI
     And group "users-finance" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere in the middle
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -229,7 +210,6 @@ Feature: Autocompletion of share-with names
     When the user types "finn" in the share-with-field
     Then only user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere at the end
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -237,7 +217,6 @@ Feature: Autocompletion of share-with names
     When the user types "group" in the share-with-field
     Then only user "User Group" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -245,7 +224,6 @@ Feature: Autocompletion of share-with names
     When the user types "u2" in the share-with-field
     Then only user "User Two" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -253,7 +231,6 @@ Feature: Autocompletion of share-with names
     When the user types "net" in the share-with-field
     Then only user "User Group" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
@@ -261,7 +238,6 @@ Feature: Autocompletion of share-with names
     When the user types "de" in the share-with-field
     Then only user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing group contains the pattern somewhere in the middle but group medial search is disabled
     Given these groups have been created:
       | groupname |
@@ -276,7 +252,6 @@ Feature: Autocompletion of share-with names
     And group "finance2" should not be listed in the autocomplete list on the webUI
     And group "users-finance" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing group contains the pattern somewhere in the end but group medial search is disabled
     Given these groups have been created:
       | groupname         |
@@ -290,7 +265,6 @@ Feature: Autocompletion of share-with names
     Then all users and groups that contain the string "customers-finance" in their name should be listed in the autocomplete list on the webUI
     And group "ncell-customers" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the middle but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname |
@@ -302,7 +276,6 @@ Feature: Autocompletion of share-with names
     When the user types "iv" in the share-with-field
     Then only user "Ivan" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username     | displayname |
@@ -314,7 +287,6 @@ Feature: Autocompletion of share-with names
     When the user types "user3" in the share-with-field
     Then only user "User Three" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere in the middle but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname   |
@@ -326,7 +298,6 @@ Feature: Autocompletion of share-with names
     When the user types "finn" in the share-with-field
     Then only user "finnance typo" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the display name of existing user contains the pattern somewhere in the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname |
@@ -338,7 +309,6 @@ Feature: Autocompletion of share-with names
     When the user types "group" in the share-with-field
     Then only user "Group User" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email              |
@@ -350,7 +320,6 @@ Feature: Autocompletion of share-with names
     When the user types "u2" in the share-with-field
     Then only user "User Two" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email         |
@@ -362,7 +331,6 @@ Feature: Autocompletion of share-with names
     When the user types "net" in the share-with-field
     Then only user "User2" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email        |
@@ -374,7 +342,6 @@ Feature: Autocompletion of share-with names
     When the user types "de" in the share-with-field
     Then only user "User2" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: allow user to disable autocomplete in sharing dialog
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
@@ -385,7 +352,6 @@ Feature: Autocompletion of share-with names
     And the user types "reg" in the share-with-field
     Then user "Regular User" should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: user disables autocomplete in sharing dialog but the sharer types full username
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
@@ -396,7 +362,6 @@ Feature: Autocompletion of share-with names
     And the user types "regularuser" in the share-with-field
     Then user "Regular User" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: user disables autocomplete in sharing dialog but the sharer types full display name
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
@@ -407,7 +372,6 @@ Feature: Autocompletion of share-with names
     And the user types "Regular User" in the share-with-field
     Then user "Regular User" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: allow user to enable autocomplete in sharing dialog
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
@@ -419,7 +383,6 @@ Feature: Autocompletion of share-with names
     Then user "Regular User" should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: autocompletion of a pattern when admin disables username autocompletion in share dialog
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     And user "regularuser" has logged in using the webUI
@@ -429,14 +392,12 @@ Feature: Autocompletion of share-with names
     Then a tooltip with the text "No users or groups found for user" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
 
-  @skipOnLDAP
   Scenario: admin disables share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     And user "regularuser" has logged in using the webUI
     When the user browses to the personal sharing settings page
     Then allow finding you via autocomplete checkbox should not be displayed on the personal sharing settings page
 
-  @skipOnLDAP
   Scenario: admin disables share dialog user enumeration and types full user name of user in sharing dialog
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     And user "regularuser" has logged in using the webUI
@@ -445,7 +406,6 @@ Feature: Autocompletion of share-with names
     When the user types "user1" in the share-with-field
     Then user "User One" should be listed in the autocomplete list on the webUI
 
-  @skipOnLDAP
   Scenario: admin disables share dialog user enumeration and types full display name of user in sharing dialog
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     And user "regularuser" has logged in using the webUI
@@ -453,8 +413,7 @@ Feature: Autocompletion of share-with names
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "User One" in the share-with-field
     Then user "User One" should be listed in the autocomplete list on the webUI
-
-  @skipOnLDAP
+    
   Scenario: autocompletion of pattern when user disables and then enables autocompletion in sharing dialog
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the personal sharing settings page

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -10,6 +10,7 @@
         "symfony/translation": "^3.4",
         "sabre/xml": "^2.1",
         "guzzlehttp/guzzle": "^5.3",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^7.5",
+        "zendframework/zend-ldap": "^2.10"
     }
 }


### PR DESCRIPTION
## Description
Previously, user creation were skipped and pre-created users were used when running ldap tests.
Function to create user in ldap server are added.

## How Has This Been Tested?
- CI
- manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
