### PR TITLE
Do not dispatch event for non existing shares

### DIFF
--- a/apps/federatedfilesharing/tests/External/ManagerTest.php
+++ b/apps/federatedfilesharing/tests/External/ManagerTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Tests\External;
+
+use Doctrine\DBAL\Driver\Statement;
+use OC\Files\Cache\Cache;
+use OC\Files\Mount\Manager as MountManager;
+use OC\Files\Storage\Storage;
+use OCA\Files_Sharing\External\Manager;
+use OCA\FederatedFileSharing\Tests\TestCase;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IDBConnection;
+use OCP\Notification\IManager;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ManagerTest extends TestCase {
+	/** @var Manager */
+	private $manager;
+
+	/** @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject */
+	private $connection;
+
+	/** @var MountManager | \PHPUnit\Framework\MockObject\MockObject */
+	private $mountManager;
+
+	/** @var IStorageFactory | \PHPUnit\Framework\MockObject\MockObject */
+	private $storageFactory;
+
+	/** @var IManager | \PHPUnit\Framework\MockObject\MockObject */
+	private $notificationManager;
+
+	/** @var EventDispatcherInterface | \PHPUnit\Framework\MockObject\MockObject */
+	private $eventDispatcher;
+
+	private $uid = 'john doe';
+
+	protected function setUp():void {
+		$this->connection = $this->createMock(IDBConnection::class);
+		$this->mountManager = $this->createMock(MountManager::class);
+		$this->storageFactory = $this->createMock(IStorageFactory::class);
+		$this->notificationManager = $this->createMock(IManager::class);
+		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->manager = new Manager(
+			$this->connection,
+			$this->mountManager,
+			$this->storageFactory,
+			$this->notificationManager,
+			$this->eventDispatcher,
+			$this->uid
+		);
+	}
+
+	public function testRemoveShareForNonExistingShareDispatchNoEvents() {
+		$this->eventDispatcher->expects($this->never())
+			->method('dispatch');
+
+		$statement = $this->createMock(Statement::class);
+		$statement->method('execute')->willReturnOnConsecutiveCalls(true, false);
+		$statement->method('fetch')->willReturn(false);
+		$this->connection->method('prepare')->willReturn($statement);
+
+		$cache = $this->createMock(Cache::class);
+		$cache->method('getId')->willReturn(99);
+
+		$storage = $this->createMock(Storage::class);
+		$storage->method('getCache')->willReturn($cache);
+
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->method('getStorage')->willReturn($storage);
+
+		$this->mountManager->method('find')
+			->willReturn($mountPoint);
+
+		$this->manager->removeShare('/neverhood');
+	}
+}

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -354,10 +354,12 @@ class Manager {
 
 		if ($result) {
 			$share = $getShare->fetch();
-			$this->eventDispatcher->dispatch(
-				DeclineShare::class,
-				new DeclineShare($share)
-			);
+			if ($share !== false) {
+				$this->eventDispatcher->dispatch(
+					DeclineShare::class,
+					new DeclineShare($share)
+				);
+			}
 		}
 		$getShare->closeCursor();
 

--- a/changelog/unreleased/36759
+++ b/changelog/unreleased/36759
@@ -1,0 +1,6 @@
+Bugfix: Do not dispatch DeclineShare event for non-existing shares
+
+DeclineShare event was dispatched even when the share had been not found in oc_share_external table.
+It caused sending unshare notification to the empty hostname.
+
+https://github.com/owncloud/core/pull/36759

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -57,7 +57,9 @@ trait UserTrait {
 		foreach ($this->users as $user) {
 			$user->delete();
 		}
-		\OC::$server->getUserManager()
-			->reset($this->previousUserManagerInternals[0], $this->previousUserManagerInternals[1], $this->previousUserManagerInternals[2]);
+		if ($this->previousUserManagerInternals !== null) {
+			\OC::$server->getUserManager()
+				->reset($this->previousUserManagerInternals[0], $this->previousUserManagerInternals[1], $this->previousUserManagerInternals[2]);
+		}
 	}
 }


### PR DESCRIPTION
## Description
`fetch` returns `false` when the share does not exist
we don't need to dispatch the Decline event on `false`

## Motivation and Context
it causes sending a decline request to an empty remote server:
`federatedfilesharing/lib/AppInfo/Application.php(268): OCA\FederatedFileSharing\Notifications->sendDeclineShare(NULL, NULL, NULL)`

## How Has This Been Tested?
An unit test. 
The way of reproduction IRL is unclear.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
