### PR TITLE
Remove part files when upload is cancelled for all public links

### DIFF
--- a/changelog/unreleased/36761
+++ b/changelog/unreleased/36761
@@ -1,0 +1,8 @@
+Bugfix: Remove part files when upload is cancelled for all public links
+
+Remove part files when the upload is cancelled for the public links.
+Prior to this change, it was noticed that for `Upload Only` and
+`Download / View / Upload` the part files were not cleaned up. With this
+change it does clean up.
+
+https://github.com/owncloud/core/pull/36761

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -104,7 +104,7 @@ class PermissionsMask extends Wrapper {
 	}
 
 	public function unlink($path) {
-		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::unlink($path);
+		return ($this->isPartFile($path) || $this->checkMask(Constants::PERMISSION_DELETE)) && parent::unlink($path);
 	}
 
 	public function file_put_contents($path, $data) {

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -75,6 +75,14 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($storage->file_exists('foo'));
 	}
 
+	public function testUnlinkPartFiles() {
+		$file = 'foo.txt.part';
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_DELETE);
+		$storage->touch($file);
+		$this->assertTrue($storage->unlink($file));
+		$this->assertFalse($storage->file_exists($file));
+	}
+
 	public function testPutContentsNewFileNoUpdate() {
 		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE);
 		$this->assertTrue($storage->file_put_contents('foo', 'bar'));


### PR DESCRIPTION
Remove the part files when upload is cancelled for
the public links.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When user tries to upload files to public links with `Upload Only` or `Download / View / Upload` and cancels when the files are uploaded:
Then it is noticed that the part files are not cleaned up properly.
So this change would help to clean up the part files even though the upload is cancelled for the public links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes enterprise ticket 3637

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change set helps to clean up the part files when the uplaod is cancelled for the public links.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested and verified manually for the public links
   - `Upload Only`
   - `Download / View / Upload`


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
