### PR TITLE
OCS api request header improvement

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1929,9 +1929,9 @@ def createShare(phpVersion):
 		'pull': 'always',
 		'commands': [
 			'curl -k -s -u user1:123456 -X MKCOL "https://server/remote.php/webdav/new_folder"',
-			'curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data "path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin"',
+			'curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" -H "OCS-APIREQUEST: true" --data "path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin"',
 			'echo -n "PUBLIC_TOKEN=" > .env',
-			'curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data "path=/new_folder&shareType=3&permissions=15&name=new_folder" | grep token | cut -d">" -f2 | cut -d"<" -f1 >> .env',
+			'curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" -H "OCS-APIREQUEST: true" --data "path=/new_folder&shareType=3&permissions=15&name=new_folder" | grep token | cut -d">" -f2 | cut -d"<" -f1 >> .env',
 		]
 	}]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -802,9 +802,9 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - curl -k -s -u user1:123456 -X MKCOL "https://server/remote.php/webdav/new_folder"
-  - curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data "path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin"
+  - "curl -k -s -u user1:123456 \"https://server/ocs/v2.php/apps/files_sharing/api/v1/shares\" -H \"OCS-APIREQUEST: true\" --data \"path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin\""
   - echo -n "PUBLIC_TOKEN=" > .env
-  - curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data "path=/new_folder&shareType=3&permissions=15&name=new_folder" | grep token | cut -d">" -f2 | cut -d"<" -f1 >> .env
+  - "curl -k -s -u user1:123456 \"https://server/ocs/v2.php/apps/files_sharing/api/v1/shares\" -H \"OCS-APIREQUEST: true\" --data \"path=/new_folder&shareType=3&permissions=15&name=new_folder\" | grep token | cut -d\">\" -f2 | cut -d\"<\" -f1 >> .env"
 
 - name: owncloud-log-server
   pull: always

--- a/changelog/10.4.0_2020-01-10/36762
+++ b/changelog/10.4.0_2020-01-10/36762
@@ -1,0 +1,6 @@
+Change: Validate OCS API Request Header in OCSController
+
+Any OCS request has to send the header OCS-APIREQUEST to comply to the specification.
+This is now properly validated on OCSController based implementations.
+
+https://github.com/owncloud/core/pull/36762

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -113,11 +113,11 @@ class SecurityMiddleware extends Middleware {
 	 * This runs all the security checks before a method call. The
 	 * security checks are determined by inspecting the controller method
 	 * annotations
-	 * @param string $controller the controllername or string
+	 * @param Controller $controller the controller
 	 * @param string $methodName the name of the method
 	 * @throws SecurityException when a security check fails
 	 */
-	public function beforeController($controller, $methodName) {
+	public function beforeController($controller, $methodName) : void {
 
 		// this will set the current navigation entry of the app, use this only
 		// for normal HTML requests and not for AJAX requests
@@ -142,6 +142,13 @@ class SecurityMiddleware extends Middleware {
 		if (!$this->reflector->hasAnnotation('NoCSRFRequired')) {
 			if (!$this->request->passesCSRFCheck()) {
 				throw new CrossSiteRequestForgeryException();
+			}
+		}
+
+		// OCS_APIREQUEST header check
+		if ($controller instanceof OCSController) {
+			if ($this->request->getHeader('OCS-APIREQUEST') === null) {
+				throw new NotLoggedInException();
 			}
 		}
 

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -51,6 +51,7 @@ class OcsApiHelper {
 			$fullUrl .= '/';
 		}
 		$fullUrl .= "ocs/v{$ocsApiVersion}.php" . $path;
+		$headers['OCS-APIREQUEST'] = true;
 
 		return HttpRequestHelper::sendRequest($fullUrl, $method, $user, $password, $headers, $body);
 	}

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -148,8 +148,9 @@ class SharingHelper {
 		if ($expireDate !== null) {
 			$fd['expireDate'] = $expireDate;
 		}
+		$headers = ['OCS-APIREQUEST' => 'true'];
 
-		return HttpRequestHelper::post($fullUrl, $user, $password, null, $fd);
+		return HttpRequestHelper::post($fullUrl, $user, $password, $headers, $fd);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -722,9 +722,10 @@ trait Sharing {
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$date = \date('Y-m-d', \strtotime("+3 days"));
 		$body = ['expireDate' => $date];
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::put(
 			$fullUrl, $this->currentUser,
-			$this->getPasswordForUser($this->currentUser), null, $body
+			$this->getPasswordForUser($this->currentUser), $headers, $body
 		);
 	}
 
@@ -806,8 +807,9 @@ trait Sharing {
 			}
 		}
 
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::put(
-			$fullUrl, $user, $this->getPasswordForUser($user), null, $fd
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers, $fd
 		);
 	}
 
@@ -1121,8 +1123,9 @@ trait Sharing {
 
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?path=$filepath";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user1, $this->getPasswordForUser($user1)
+			$fullUrl, $user1, $this->getPasswordForUser($user1), $headers
 		);
 		if ($getShareData && $this->isUserOrGroupInSharedData($user2, $permissions)) {
 			return;
@@ -1133,7 +1136,7 @@ trait Sharing {
 		}
 		if ($getShareData) {
 			$this->response = HttpRequestHelper::get(
-				$fullUrl, $user1, $this->getPasswordForUser($user1)
+				$fullUrl, $user1, $this->getPasswordForUser($user1), $headers
 			);
 		}
 	}
@@ -1291,8 +1294,9 @@ trait Sharing {
 	) {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?path=$filepath";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers
 		);
 		if ($getShareData && $this->isUserOrGroupInSharedData($group, $permissions)) {
 			return;
@@ -1303,7 +1307,7 @@ trait Sharing {
 		}
 		if ($getShareData) {
 			$this->response = HttpRequestHelper::get(
-				$fullUrl, $user, $this->getPasswordForUser($user)
+				$fullUrl, $user, $this->getPasswordForUser($user), $headers
 			);
 		}
 	}
@@ -1530,8 +1534,9 @@ trait Sharing {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
 			. "v{$this->sharingApiVersion}/shares";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers
 		);
 		return $this->response;
 	}
@@ -1613,8 +1618,9 @@ trait Sharing {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
 			. "v{$this->sharingApiVersion}/shares";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers
 		);
 	}
 
@@ -1639,8 +1645,9 @@ trait Sharing {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
 			. "v{$this->sharingApiVersion}/shares?path=$path";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers
 		);
 	}
 
@@ -1658,8 +1665,9 @@ trait Sharing {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
 			. "v{$this->sharingApiVersion}/shares?reshares=true&path=$path";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers
 		);
 	}
 
@@ -1675,8 +1683,9 @@ trait Sharing {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/"
 			. "v{$this->sharingApiVersion}/shares?path=$path&subfiles=true";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers
 		);
 	}
 
@@ -1974,7 +1983,7 @@ trait Sharing {
 		$url = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?format=json";
 
-		$headers = ['Content-Type' => 'application/json'];
+		$headers = ['Content-Type' => 'application/json', 'OCS-APIREQUEST' => 'true'];
 		$res = HttpRequestHelper::get(
 			$url, $user, $this->getPasswordForUser($user), $headers
 		);
@@ -2047,8 +2056,9 @@ trait Sharing {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$fullUrl = "$fullUrl?path=$path";
+		$headers = ['OCS-APIREQUEST' => 'true'];
 		$this->response = HttpRequestHelper::get(
-			$fullUrl, $user, $this->getPasswordForUser($user)
+			$fullUrl, $user, $this->getPasswordForUser($user), $headers
 		);
 		return $this->getResponseXml()->data->element;
 	}

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\OCSController;
 use OCP\ISession;
 use OCP\AppFramework\Controller;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 use OCP\AppFramework\Http\Response;
 use OCP\IConfig;
@@ -54,23 +55,23 @@ class SecurityMiddlewareTest extends TestCase {
 
 	/** @var SecurityMiddleware */
 	private $middleware;
-	/** @var Controller | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var Controller | MockObject */
 	private $controller;
 	private $secException;
 	private $secAjaxException;
-	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IRequest | MockObject */
 	private $request;
-	/** @var ControllerMethodReflector | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var ControllerMethodReflector | MockObject */
 	private $reader;
-	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var ILogger | MockObject */
 	private $logger;
-	/** @var INavigationManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var INavigationManager | MockObject */
 	private $navigationManager;
-	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IURLGenerator | MockObject */
 	private $urlGenerator;
-	/** @var ContentSecurityPolicyManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var ContentSecurityPolicyManager | MockObject */
 	private $contentSecurityPolicyManager;
-	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserSession | MockObject */
 	private $session;
 
 	protected function setUp(): void {
@@ -110,9 +111,9 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @param bool $isAdminUser
 	 * @return SecurityMiddleware
 	 */
-	private function getMiddleware($isLoggedIn, $isAdminUser) {
+	private function getMiddleware($isLoggedIn, $isAdminUser): SecurityMiddleware {
 		$this->session = $this->createMock(IUserSession::class);
-		$this->session->expects($this->any())->method('isLoggedIn')->willReturn($isLoggedIn);
+		$this->session->method('isLoggedIn')->willReturn($isLoggedIn);
 		return new SecurityMiddleware(
 			$this->request,
 			$this->reader,
@@ -132,7 +133,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testSetNavigationEntry() {
+	public function testSetNavigationEntry(): void {
 		$this->navigationManager->expects($this->once())
 			->method('setActiveEntry')
 			->with($this->equalTo('files'));
@@ -147,7 +148,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @param $status
 	 * @throws \ReflectionException
 	 */
-	private function ajaxExceptionStatus($method, $test, $status) {
+	private function ajaxExceptionStatus($method, $test, $status): void {
 		$isLoggedIn = false;
 		$isAdminUser = false;
 
@@ -175,7 +176,7 @@ class SecurityMiddlewareTest extends TestCase {
 	/**
 	 * @throws \ReflectionException
 	 */
-	public function testAjaxStatusLoggedInCheck() {
+	public function testAjaxStatusLoggedInCheck(): void {
 		$this->ajaxExceptionStatus(
 			__FUNCTION__,
 			'isLoggedIn',
@@ -187,7 +188,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @NoCSRFRequired
 	 * @throws \ReflectionException
 	 */
-	public function testAjaxNotAdminCheck() {
+	public function testAjaxNotAdminCheck(): void {
 		$this->ajaxExceptionStatus(
 			__FUNCTION__,
 			'isAdminUser',
@@ -199,7 +200,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @PublicPage
 	 * @throws \ReflectionException
 	 */
-	public function testAjaxStatusCSRFCheck() {
+	public function testAjaxStatusCSRFCheck(): void {
 		$this->ajaxExceptionStatus(
 			__FUNCTION__,
 			'passesCSRFCheck',
@@ -215,7 +216,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws \ReflectionException
 	 * @throws \ReflectionException
 	 */
-	public function testAjaxStatusAllGood() {
+	public function testAjaxStatusAllGood(): void {
 		$this->ajaxExceptionStatus(
 			__FUNCTION__,
 			'isLoggedIn',
@@ -244,10 +245,10 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testNoChecks() {
+	public function testNoChecks(): void {
 		$this->request->expects($this->never())
 				->method('passesCSRFCheck')
-				->will($this->returnValue(false));
+				->willReturn(false);
 
 		$sec = $this->getMiddleware(false, false);
 
@@ -262,7 +263,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	private function securityCheck($method, $expects, $shouldFail=false) {
+	private function securityCheck($method, $expects, $shouldFail=false): void {
 		// admin check requires login
 		if ($expects === 'isAdminUser') {
 			$isLoggedIn = true;
@@ -289,12 +290,12 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testCsrfCheck() {
-		$this->expectException(\OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryException::class);
+	public function testCsrfCheck(): void {
+		$this->expectException(CrossSiteRequestForgeryException::class);
 
 		$this->request->expects($this->once())
 			->method('passesCSRFCheck')
-			->will($this->returnValue(false));
+			->willReturn(false);
 
 		$this->reader->reflect(__CLASS__, __FUNCTION__);
 		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
@@ -306,10 +307,10 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testNoCsrfCheck() {
+	public function testNoCsrfCheck(): void {
 		$this->request->expects($this->never())
 			->method('passesCSRFCheck')
-			->will($this->returnValue(false));
+			->willReturn(false);
 
 		$this->reader->reflect(__CLASS__, __FUNCTION__);
 		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
@@ -320,10 +321,10 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testFailCsrfCheck() {
+	public function testFailCsrfCheck(): void {
 		$this->request->expects($this->once())
 			->method('passesCSRFCheck')
-			->will($this->returnValue(true));
+			->willReturn(true);
 
 		$this->reader->reflect(__CLASS__, __FUNCTION__);
 		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
@@ -335,7 +336,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testLoggedInCheck() {
+	public function testLoggedInCheck(): void {
 		$this->securityCheck(__FUNCTION__, 'isLoggedIn');
 	}
 
@@ -345,7 +346,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testFailLoggedInCheck() {
+	public function testFailLoggedInCheck(): void {
 		$this->securityCheck(__FUNCTION__, 'isLoggedIn', true);
 	}
 
@@ -354,7 +355,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testIsAdminCheck() {
+	public function testIsAdminCheck(): void {
 		$this->securityCheck(__FUNCTION__, 'isAdminUser');
 	}
 
@@ -363,14 +364,14 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @throws SecurityException
 	 * @throws \ReflectionException
 	 */
-	public function testFailIsAdminCheck() {
+	public function testFailIsAdminCheck(): void {
 		$this->securityCheck(__FUNCTION__, 'isAdminUser', true);
 	}
 
 	/**
 	 * @throws \Exception
 	 */
-	public function testAfterExceptionNotCaughtThrowsItAgain() {
+	public function testAfterExceptionNotCaughtThrowsItAgain(): void {
 		$ex = new \Exception();
 		$this->expectException(\Exception::class);
 		$this->middleware->afterException($this->controller, 'test', $ex);
@@ -379,7 +380,7 @@ class SecurityMiddlewareTest extends TestCase {
 	/**
 	 * @throws \Exception
 	 */
-	public function testAfterExceptionReturnsRedirectForNotLoggedInUser() {
+	public function testAfterExceptionReturnsRedirectForNotLoggedInUser(): void {
 		$this->request = new Request(
 				[
 						'server' =>
@@ -401,7 +402,7 @@ class SecurityMiddlewareTest extends TestCase {
 						'redirect_url' => 'owncloud%2Findex.php%2Fapps%2Fspecialapp',
 					]
 				)
-				->will($this->returnValue('http://localhost/index.php/login?redirect_url=owncloud%2Findex.php%2Fapps%2Fspecialapp'));
+				->willReturn('http://localhost/index.php/login?redirect_url=owncloud%2Findex.php%2Fapps%2Fspecialapp');
 		$this->logger
 				->expects($this->once())
 				->method('debug')
@@ -419,7 +420,7 @@ class SecurityMiddlewareTest extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function exceptionProvider() {
+	public function exceptionProvider(): array {
 		return [
 			[
 				new AppNotEnabledException(),
@@ -438,7 +439,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 * @param SecurityException $exception
 	 * @throws \Exception
 	 */
-	public function testAfterExceptionReturnsTemplateResponse(SecurityException $exception) {
+	public function testAfterExceptionReturnsTemplateResponse(SecurityException $exception): void {
 		$this->request = new Request(
 				[
 						'server' =>
@@ -473,7 +474,7 @@ class SecurityMiddlewareTest extends TestCase {
 	 *
 	 * @throws \Exception
 	 */
-	public function testAfterExceptionReturnsLoginPageForAnyContentType() {
+	public function testAfterExceptionReturnsLoginPageForAnyContentType(): void {
 		$this->request = new Request(
 			[
 				'server' =>
@@ -487,10 +488,6 @@ class SecurityMiddlewareTest extends TestCase {
 		);
 
 		$exception = new NotLoggedInException();
-		$sessionMock = $this->getMockBuilder(ISession::class)
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->controller = $this->getMockBuilder(LoginController::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -514,7 +511,7 @@ class SecurityMiddlewareTest extends TestCase {
 	/**
 	 * @throws \Exception
 	 */
-	public function testAfterExceptionReturnsLoginPageForCsrfErrorOnLogin() {
+	public function testAfterExceptionReturnsLoginPageForCsrfErrorOnLogin(): void {
 		$this->request = new Request(
 			[
 				'server' =>
@@ -551,7 +548,7 @@ class SecurityMiddlewareTest extends TestCase {
 			->method('getSession')
 			->willReturn($sessionMock);
 
-		$response = $this->middleware->afterException(
+		$this->middleware->afterException(
 			$this->controller,
 			'tryLogin',
 			$exception
@@ -561,14 +558,14 @@ class SecurityMiddlewareTest extends TestCase {
 	/**
 	 * @throws \Exception
 	 */
-	public function testAfterAjaxExceptionReturnsJSONError() {
+	public function testAfterAjaxExceptionReturnsJSONError(): void {
 		$response = $this->middleware->afterException($this->controller, 'test',
 				$this->secAjaxException);
 
 		$this->assertInstanceOf(JSONResponse::class, $response);
 	}
 
-	public function testAfterExceptionForNonAdminAccess() {
+	public function testAfterExceptionForNonAdminAccess(): void {
 		$nonAdminException = new NotAdminException();
 		$expectedResponse = $this->createMock(Response::class);
 		$controller = $this->createMock(OCSController::class);
@@ -579,8 +576,37 @@ class SecurityMiddlewareTest extends TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testAfterController() {
-		/** @var Response | \PHPUnit\Framework\MockObject\MockObject $response */
+	/**
+	 * @NoCSRFRequired
+	 */
+	public function testBeforeOCSController(): void {
+		$this->expectException(NotLoggedInException::class);
+		$controller = $this->createMock(OCSController::class);
+		$controller->expects($this->never())->method('buildResponse');
+
+		// this header needs to be verified
+		$this->request->expects(self::once())->method('getHeader')->with('OCS-APIREQUEST');
+
+		$this->reader->reflect(__CLASS__, __FUNCTION__);
+		$this->middleware->beforeController($controller, 'test');
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 */
+	public function testBeforeOCSControllerWithHeader(): void {
+		$controller = $this->createMock(OCSController::class);
+		$controller->expects($this->never())->method('buildResponse');
+
+		// this header needs to be verified
+		$this->request->expects(self::once())->method('getHeader')->with('OCS-APIREQUEST')->willReturn(true);
+
+		$this->reader->reflect(__CLASS__, __FUNCTION__);
+		$this->middleware->beforeController($controller, 'test');
+	}
+
+	public function testAfterController(): void {
+		/** @var Response | MockObject $response */
 		$response = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->getMock();
 		$defaultPolicy = new ContentSecurityPolicy();
 		$defaultPolicy->addAllowedImageDomain('defaultpolicy');


### PR DESCRIPTION
OCS api request header needs to be checked before the controller method is executed

## Related
Follow up of #36734 
## Description
OCS requests need to transmit the header OCS-APIREQUEST

## Motivation and Context
This got lost while migrating from the legacy OCS implementation to OCSControllers

## How Has This Been Tested?
- send an OCS request (e.g. create share) with session cookie but no OCS_APIREQUEST header -> get a 401
- with the header the request will be processed properly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

