### PR TITLE
Add changelog item 36752

### DIFF
--- a/changelog/unreleased/36752
+++ b/changelog/unreleased/36752
@@ -1,0 +1,5 @@
+Change: Update handlebars library to 4.5.3
+
+The @bower_components/showdown library has been updated from 1.9.0 to 1.9.1.
+
+https://github.com/owncloud/core/pull/36752


### PR DESCRIPTION
Change: Update handlebars library to 4.5.3

The @bower_components/showdown library has been updated from 1.9.0 to 1.9.1.

https://github.com/owncloud/core/pull/36752