### PR TITLE
Adjust expiration logic for shares to account for share attributes registered with apps

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -39,6 +39,58 @@
 	margin-right: 0;
 }
 
+#shareWithList {
+	list-style-type: none;
+	padding        : 0 0 16px;
+}
+
+#shareWithList li {
+	padding-top   : 5px;
+	padding-bottom: 5px;
+	font-weight   : bold;
+	white-space   : normal;
+}
+
+#shareWithList .unshare img {
+	vertical-align: text-bottom;
+	/* properly align icons */
+}
+
+#shareWithList label input[type=checkbox] {
+	margin-left: 0;
+	position   : relative;
+}
+
+#shareWithList .username {
+	padding-right : 8px;
+	white-space   : nowrap;
+	text-overflow : ellipsis;
+	max-width     : 254px;
+	display       : inline-block;
+	overflow      : hidden;
+	vertical-align: middle;
+}
+
+#shareWithList li label {
+	margin-right: 8px;
+}
+
+#shareWithList .expiration {
+	max-width: 190px;
+	text-align: left;
+	margin: 0 0 0 5px;
+}
+
+#shareWithList .removeExpiration {
+	text-indent: -9999px;
+	border: 0 none;
+	transform: translate(calc(-100% - 5px), -1px);
+	background-color: #F8F8F8;
+	background-position: center;
+	background-repeat: no-repeat;
+	background-image: url('../../../core/img/actions/close.svg');
+}
+
 #shareDialogLinkList .link-shares + #shareTreeUserGroupList {
 	margin-top: -20px;
 }
@@ -97,15 +149,6 @@
 .shareTabView .icon {
 	display        : inline-block;
 	background-size: 16px 16px;
-}
-
-.shareTabView .action-item {
-	display: inherit;
-	opacity: .5;
-}
-
-.shareTabView .action-item + .action-item {
-	margin-left: 5px;
 }
 
 .shareTabView .privacyWarningMessage {
@@ -316,94 +359,4 @@
 	color: red;
     padding: 4px;
     display: block;
-}
-
-/* ---------------------------------------------------- ShareWithList --- */
-
-.shareWithList {
-	list-style-type : none;
-	padding         : 0 0 16px;
-}
-
-[class^='shareWithList__item'] {
-	display         : flex;
-	justify-content : space-between;
-	flex-wrap       : wrap;
-	padding-top     : 10px;
-	padding-bottom  : 10px;
-	font-weight     : bold;
-}
-
-.shareWithList__item--detailed {
-	background-color: #f8f8f8;
-	margin-left: -15px;
-	margin-right: -15px;
-	padding: 10px 15px;
-}
-
-.shareWithList__item--detailed + .shareWithList__item--detailed {
-	border-top: 1px solid #eee
-}
-
-[class^='shareWithList__container'] {
-	display     : flex;
-	align-items : center;
-}
-
-.shareWithList__container--left {
-	justify-content: flex-start;
-}
-
-.shareWithList__container--right {
-	justify-content: flex-end;
-}
-
-.shareWithList__item label input[type=checkbox] {
-	margin-left: 0;
-	position   : relative;
-}
-
-.shareWithList__item .username {
-	padding-right : 8px;
-	white-space   : nowrap;
-	text-overflow : ellipsis;
-	max-width     : 254px;
-	display       : inline-block;
-	overflow      : hidden;
-	vertical-align: middle;
-}
-
-.shareWithList__item label {
-	margin-right: 8px;
-}
-
-.shareWithList__item .expiration {
-	max-width: 190px;
-	text-align: left;
-	margin: 0 0 0 5px;
-}
-
-.shareWithList__item .removeExpiration {
-	text-indent: -9999px;
-	border: 0 none;
-	transform: translate(calc(-100% - 5px), -1px);
-	background-color: #F8F8F8;
-	background-position: center;
-	background-repeat: no-repeat;
-	background-image: url('../../../core/img/actions/close.svg');
-}
-
-.shareWithList__item .toggleShareDetails {
-	display: inherit;
-    opacity: 0.5;
-}
-
-.shareWithList__details {
-	width: 100%;
-	background-color: #f8f8f8;
-}
-
-.shareWithList__details-group:first-of-type,
-.shareWithList__details-group + .shareWithList__details-group {
-	margin-top: 10px;
 }

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -354,7 +354,7 @@
 	font-size: 1px;
 }
 
-.shareDialogExpirationView .error-message,
+.shareDialogLinkExpirationView .error-message,
 .linkPass .error-message {
 	color: red;
     padding: 4px;

--- a/changelog/unreleased/36573
+++ b/changelog/unreleased/36573
@@ -11,3 +11,4 @@ be enabled on the admin sharing settings page. They can be set independently for
 user and group shares.
 
 https://github.com/owncloud/core/pull/36573
+https://github.com/owncloud/core/pull/36766

--- a/changelog/unreleased/36813
+++ b/changelog/unreleased/36813
@@ -1,0 +1,8 @@
+Bugfix: Sharing with a user and group of the same name on the webUI
+
+When sharing with both a user and a group that have the same name it was not
+possible to adjust the sharing permissions of the 2nd share on the webUI.
+This problem has been corrected.
+
+https://github.com/owncloud/core/issues/36813
+https://github.com/owncloud/core/pull/36766

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -22,7 +22,6 @@
 		left: 20px;
 	}
 }
-
 .shareTabView .unshare.icon-loading-small {
 	margin-top: 1px;
 }
@@ -95,6 +94,13 @@
 	padding: 8px;
 }
 
+#shareWithList li {
+	padding-top: 10px;
+	padding-bottom: 10px;
+	font-weight: bold;
+	line-height: 21px;
+	white-space: normal;
+}
 #shareWithList .shareOption {
 	white-space: nowrap;
 	display: inline-block;
@@ -133,6 +139,37 @@
 .shareTabView input[type="checkbox"] {
 	margin: 0 3px 0 8px;
 	vertical-align: middle;
+}
+a.showCruds {
+	display: inline;
+	opacity: 0.5;
+}
+
+a.unshare {
+	display: inline;
+	float: right;
+	opacity: 0.5;
+	padding: 10px;
+	margin-top: -5px;
+	margin-right: -10px;
+}
+
+a.time {
+	display: inline;
+	float: right;
+	opacity: 0.5;
+	padding: 10px;
+	margin-top: -5px;
+	margin-right: -10px;
+}
+
+a.toggleShareDetails {
+	display: inline;
+	float: right;
+	opacity: 0.5;
+	padding: 10px;
+	margin-top: -5px;
+	margin-right: -10px;
 }
 
 #link {
@@ -176,6 +213,9 @@
 
 a.showCruds:hover,
 a.unshare:hover {
+	opacity: 1;
+}
+a.toggleShareDetails:hover {
 	opacity: 1;
 }
 #defaultExpireMessage,

--- a/core/js/core.json
+++ b/core/js/core.json
@@ -33,7 +33,7 @@
 		"sharescollection.js",
 		"shareitemmodel.js",
 		"sharedialogview.js",
-		"sharedialogexpirationview.js",
+		"sharedialoglinkexpirationview.js",
 		"sharedialoglinkshareview.js",
 		"sharedialoglinklistview.js",
 		"sharedialogmailview.js",

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -104,14 +104,14 @@
 		 * @returns {boolean}
 		 */
 		isDefaultExpireDateUserEnabled: function() {
-			return this.get('isDefaultExpireDateUserEnabled')
+			return this.get('isDefaultExpireDateUserEnabled');
 		},
 
 		/**
 		 * @returns {boolean}
 		 */
 		isDefaultExpireDateUserEnforced: function() {
-			return this.get('isDefaultExpireDateUserEnforced')
+			return this.get('isDefaultExpireDateUserEnforced');
 		},
 
 		/**
@@ -119,13 +119,13 @@
 		 */
 		getDefaultExpireDateUser: function(format) {
 			format = format || false;
-			defaultExpireDateUser = parseInt(this.get('defaultExpireDateUser'), 10)
+			var defaultExpireDateUser = parseInt(this.get('defaultExpireDateUser'), 10);
 
 			if (format) {
-				return moment().add(defaultExpireDateUser, 'days').format(format)
+				return moment().add(defaultExpireDateUser, 'days').format(format);
 			}
 
-			return defaultExpireDateUser
+			return defaultExpireDateUser;
 		},
 
 		/**

--- a/core/js/sharedialoglinkexpirationview.js
+++ b/core/js/sharedialoglinkexpirationview.js
@@ -28,7 +28,7 @@
 		;
 
 	/**
-	 * @class OCA.Share.ShareDialogExpirationView
+	 * @class OCA.Share.ShareDialogLinkExpirationView
 	 * @member {OC.Share.ShareItemModel} model
 	 * @member {jQuery} $el
 	 * @memberof OCA.Sharing
@@ -37,9 +37,9 @@
 	 * Represents the expiration part in the GUI of the share dialogue
 	 *
 	 */
-	var ShareDialogExpirationView = OC.Backbone.View.extend({
+	var ShareDialogLinkExpirationView = OC.Backbone.View.extend({
 		/** @type {string} **/
-		id: 'shareDialogExpirationView',
+		id: 'shareDialogLinkExpirationView',
 
 		/** @type {OC.Share.ShareConfigModel} **/
 		configModel: undefined,
@@ -47,7 +47,7 @@
 		/** @type {Function} **/
 		_template: undefined,
 
-		className: 'shareDialogExpirationView',
+		className: 'shareDialogLinkExpirationView',
 
 		events: {
 			'change .expirationCheckbox': '_onToggleExpiration',
@@ -104,13 +104,11 @@
 
 			this.$el.html(this.template({
 				cid: this.cid,
-				setExpirationLabel: t('core', 'Set expiration date'),
 				expirationLabel: t('core', 'Expiration'),
 				expirationDatePlaceholder: t('core', 'Choose an expiration date'),
 				defaultExpireMessage: defaultExpireMessage,
 				isExpirationSet: isExpirationSet,
 				isExpirationEnforced: isExpirationEnforced,
-				disableCheckbox: isExpirationEnforced && isExpirationSet,
 				expirationValue: expiration
 			}));
 
@@ -176,6 +174,6 @@
 
 	});
 
-	OC.Share.ShareDialogExpirationView = ShareDialogExpirationView;
+	OC.Share.ShareDialogLinkExpirationView = ShareDialogLinkExpirationView;
 
 })();

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -89,7 +89,7 @@
 				throw 'missing OC.Share.ShareItemModel';
 			}
 
-			this.expirationView = new OC.Share.ShareDialogExpirationView({
+			this.expirationView = new OC.Share.ShareDialogLinkExpirationView({
 				model: this.model,
 				itemModel: this.itemModel
 			});

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -16,90 +16,84 @@
 	var TEMPLATE =
 		'<ul id="shareWithList" class="shareWithList">' +
 		'	{{#each sharees}}' +
-		'	<li class="shareWithList__item" data-share-id="{{shareId}}" data-share-type="{{shareType}}" data-share-with="{{shareWith}}">' +
-		'		<div class="shareWithList__container--left">' +
-		'			{{#if avatarEnabled}}' +
-		'			<div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
+		'	<li data-share-id="{{shareId}}" data-share-type="{{shareType}}" data-share-with="{{shareWith}}">' +
+		'		<a href="#" class="unshare"><span class="icon-loading-small hidden"></span><span class="icon icon-delete"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
+		'		<a href="#" class="toggleShareDetails"><span class="icon icon-settings-dark"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
+		'		{{#if expirationDate}}' +
+		'		<a class="time"><span class="icon icon-time"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
+		'		{{/if}}' +
+		'		{{#if avatarEnabled}}' +
+		'		<div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
+		'		{{/if}}' +
+		'		<span class="has-tooltip username" title="{{shareWith}}">{{shareWithDisplayName}}</span>' +
+		'		{{#if shareWithAdditionalInfo}}' +
+		'		<span class="has-tooltip user-additional-info">({{shareWithAdditionalInfo}})</span>' +
+		'		{{/if}}' +
+		'		{{#if mailNotificationEnabled}}  {{#unless isRemoteShare}}' +
+		'		<span class="shareOption">' +
+		'		{{#unless wasMailSent}}' +
+		'		<span class="mailNotificationSpinner icon-loading-small hidden"></span>' +
+		'		<input id="mail-{{cid}}-{{shareWith}}" type="button" name="mailNotification" value="{{notifyByMailLabel}}" class="mailNotification checkbox" />' +
+		'		{{/unless}}' +
+		'		</span>' +
+		'		{{/unless}} {{/if}}' +
+		'		<div class="expirationOption">' +
+		'			{{#if isUserShare}}' +
+		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">Expiration: ' +
+		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-user" placeholder="Choose an expiration date" />' +
+		'				<button class="removeExpiration">Remove</button>' +
+		'			</label>' +
 		'			{{/if}}' +
-		'			<span class="has-tooltip username" title="{{shareWith}}">{{shareWithDisplayName}}</span>' +
-		'		</div>' + 
-		'		<div class="shareWithList__container--right">'+
-		'			{{#if expirationDate}}' +
-		'			<div class="action-item"><span class="icon icon-time"></span><span class="hidden-visually">{{unshareLabel}}</span></div>' +
+		'			{{#if isGroupShare}}' +
+		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">Expire share on: ' +
+		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-group"/>' +
+		'				<button class="removeExpiration">Remove</button>' +
+		'			</label>' +
 		'			{{/if}}' +
-		'			<a href="#" class="action-item toggleShareDetails"><span class="icon icon-settings-dark"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
-		'			<a href="#" class="action-item unshare"><span class="icon-loading-small hidden"></span><span class="icon icon-delete"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
-		'			{{#if shareWithAdditionalInfo}}' +
-		'			<span class="has-tooltip user-additional-info">({{shareWithAdditionalInfo}})</span>' +
+		'		</div>' +
+		'		<div class="coreShareOptions">' +
+		'			{{#if isResharingAllowed}} {{#if sharePermissionPossible}}' +
+		'			<span class="shareOption">' +
+		'				<input id="canShare-{{cid}}-{{shareWith}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
+		'				<label for="canShare-{{cid}}-{{shareWith}}">{{canShareLabel}}</label>' +
+		'			</span>' +
+		'			{{/if}} {{/if}}' +
+		'			{{#if editPermissionPossible}}' +
+		'			<span class="shareOption">' +
+		'				<input id="canEdit-{{cid}}-{{shareWith}}" type="checkbox" name="edit" class="permissions checkbox" {{#if hasEditPermission}}checked="checked"{{/if}} />' +
+		'				<label for="canEdit-{{cid}}-{{shareWith}}">{{canEditLabel}}</label>' +
+		'			</span>' +
 		'			{{/if}}' +
-		'			{{#if mailNotificationEnabled}} {{#unless isRemoteShare}}' +
-		'			<div class="shareOption">' +
-		'				{{#unless wasMailSent}}' +
-		'				<span class="mailNotificationSpinner icon-loading-small hidden"></span>' +
-		'				<input id="mail-{{cid}}-{{shareWith}}" type="button" name="mailNotification" value="{{notifyByMailLabel}}" class="mailNotification checkbox" />' +
-		'				{{/unless}}' +
-		'			</div>' +
-		'			{{/unless}}' +
+		'			{{#if createPermissionPossible}}' +
+		'			<span class="shareOption">' +
+		'				<input id="canCreate-{{cid}}-{{shareWith}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
+		'				<label for="canCreate-{{cid}}-{{shareWith}}">{{createPermissionLabel}}</label>' +
+		'			</span>' +
 		'			{{/if}}' +
-		'		</div>' + 
-		'		<div class="shareWithList__details hidden">'+
-		'			<div class="shareWithList__details-group">' +
-		'				{{#if isResharingAllowed}} {{#if sharePermissionPossible}}' +
-		'				<div class="shareOption">' +
-		'					<input id="canShare-{{cid}}-{{shareWith}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
-		'					<label for="canShare-{{cid}}-{{shareWith}}">{{canShareLabel}}</label>' +
-		'				</div>' +
-		'				{{/if}} {{/if}}' +
-		'				{{#if editPermissionPossible}}' +
-		'				<div class="shareOption">' +
-		'					<input id="canEdit-{{cid}}-{{shareWith}}" type="checkbox" name="edit" class="permissions checkbox" {{#if hasEditPermission}}checked="checked"{{/if}} />' +
-		'					<label for="canEdit-{{cid}}-{{shareWith}}">{{canEditLabel}}</label>' +
-		'				</div>' +
-		'				{{/if}}' +
-		'				{{#if createPermissionPossible}}' +
-		'				<div class="shareOption">' +
-		'					<input id="canCreate-{{cid}}-{{shareWith}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
-		'					<label for="canCreate-{{cid}}-{{shareWith}}">{{createPermissionLabel}}</label>' +
-		'				</div>' +
-		'				{{/if}}' +
-		'				{{#if updatePermissionPossible}}' +
-		'				<div class="shareOption">' +
-		'					<input id="canUpdate-{{cid}}-{{shareWith}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
-		'					<label for="canUpdate-{{cid}}-{{shareWith}}">{{updatePermissionLabel}}</label>' +
-		'				</div>' +
-		'				{{/if}}' +
-		'				{{#if deletePermissionPossible}}' +
-		'				<div class="shareOption">' +
-		'					<input id="canDelete-{{cid}}-{{shareWith}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
-		'					<label for="canDelete-{{cid}}-{{shareWith}}">{{deletePermissionLabel}}</label>' +
-		'				</div>' +
-		'				{{/if}}' +
-		'				<div class="shareAttributes"">' +
-		'					{{#each shareAttributesV1}}' +
-		'					<div class="shareOption">' +
-		'						<input id="can-{{name}}-{{cid}}-{{shareWith}}" type="checkbox" name="{{name}}" class="attributes checkbox" {{#if isReshare}}disabled{{/if}} {{#if enabled}}checked="checked"{{/if}} data-scope="{{scope}}" data-enabled="{{enabled}}""/>' +
-		'						<label for="can-{{name}}-{{cid}}-{{shareWith}}">{{label}}</label>' +
-		'					</div>' +
-		'					{{/each}}' +
-		'				</div>' +
-		'			</div>' + // .shareWithList__details-group
-		'			<div class="shareWithList__details-group">' +
-		'				{{#if isUserShare}}' +
-		'				<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">Expiration: ' +
-		'				   <input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-user" placeholder="Choose an expiration date" />' +
-		'				   <button class="removeExpiration">Remove</button>' +
-		'				</label>' +
-		'				{{/if}}' +
-		'				{{#if isGroupShare}}' +
-		'				<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">Expire share on: ' +
-		'				   <input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-group"/>' +
-		'				   <button class="removeExpiration">Remove</button>' +
-		'				</label>' +
-		'				{{/if}}' +
-		'			</div>' + 
-		'		</div>' + // .shareWithList__details-group
+		'			{{#if updatePermissionPossible}}' +
+		'			<span class="shareOption">' +
+		'				<input id="canUpdate-{{cid}}-{{shareWith}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
+		'				<label for="canUpdate-{{cid}}-{{shareWith}}">{{updatePermissionLabel}}</label>' +
+		'			</span>' +
+		'			{{/if}}' +
+		'			{{#if deletePermissionPossible}}' +
+		'				<span class="shareOption">' +
+		'				<input id="canDelete-{{cid}}-{{shareWith}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
+		'				<label for="canDelete-{{cid}}-{{shareWith}}">{{deletePermissionLabel}}</label>' +
+		'			</span>' +
+		'			{{/if}}' +
+		'		</div>' +
+		'		<div class="shareAttributes"">' +
+		'			{{#each shareAttributesV1}}' +
+		'			<span class="shareOption">' +
+		'				<input id="can-{{name}}-{{cid}}-{{shareWith}}" type="checkbox" name="{{name}}" class="attributes checkbox" {{#if isReshare}}disabled{{/if}} {{#if enabled}}checked="checked"{{/if}} data-scope="{{scope}}" data-enabled="{{enabled}}""/>' +
+		'				<label for="can-{{name}}-{{cid}}-{{shareWith}}">{{label}}</label>' +
+		'			</span>' +
+		'			{{/each}}' +
+		'		</div>' +
+		'       <! –– shareAttributesV2 div would be appended to this li element ––>' +
 		'	</li>' +
-		'{{/each}}' +
+		'	{{/each}}' +
 		'</ul>';
 
 	/**
@@ -122,13 +116,15 @@
 		/** @type {Function} **/
 		_template: undefined,
 
+		_currentlyToggled: [],
+
 		events: {
 			'click .unshare': 'onUnshare',
 			'click .permissions': 'onPermissionChange',
 			'click .attributes': 'onPermissionChange',
-			'click .toggleShareDetails' : 'onToggleShareDetails',
 			'click .mailNotification': 'onSendMailNotification',
-			'click .removeExpiration' : 'onRemoveExpiration'
+			'click .removeExpiration' : 'onRemoveExpiration',
+			'click .toggleShareDetails' : 'onToggleShareDetails'
 		},
 
 		initialize: function(options) {
@@ -297,15 +293,32 @@
 				self._setDatepicker(this, {
 					maxDate  : self.configModel.getDefaultExpireDateUser(),
 					enforced : self.configModel.isDefaultExpireDateUserEnforced()
-				})
-			})
+				});
+			});
 
 			this.$el.find('.expiration-group:not(.hasDatepicker)').each(function(){
 				self._setDatepicker(this, {
 					maxDate  : self.configModel.getDefaultExpireDateGroup(),
 					enforced : self.configModel.isDefaultExpireDateGroupEnforced()
-				})
-			})
+				});
+			});
+
+			this.$el.bind("DOMNodeInserted", function(){
+				// make sure to always enable toggled divs
+				if (!_.isUndefined(self._currentlyToggled)) {
+
+					self.$el.find('li').each(function()
+					{
+						var $li = $(this);
+						var shareId = $li.data('share-id');
+						if (!_.isUndefined(self._currentlyToggled[shareId])) {
+							self._toggleShareDivs(shareId, true);
+						} else {
+							self._toggleShareDivs(shareId, false);
+						}
+					});
+				}
+			});
 
 			this.delegateEvents();
 
@@ -396,9 +409,7 @@
 			this.model.updateShare(shareId,	{
 					permissions: permissions,
 					attributes: attributes
-				}, {
-					silent: true
-				}
+				}, {}
 			);
 		},
 
@@ -431,25 +442,50 @@
 			var shareId = $(event.target).closest('li').data('share-id');
 
 			this.model.updateShare( shareId, {
-				expireDate: null
-			});
+				expireDate: ''
+			}, {});
 		},
 
 		onToggleShareDetails: function(event) {
-			var $target = $(event.target);
-			$target.closest('.shareWithList__item').toggleClass('shareWithList__item--detailed').find('.shareWithList__details').toggleClass('hidden');
+			this._toggleShareDetails(event);
+		},
+
+		_toggleShareDetails: function(event) {
+			var $li = $(event.target).closest('li');
+			var shareId = $li.data('share-id');
+
+			if (!_.isUndefined(this._currentlyToggled[shareId])) {
+				this._currentlyToggled.splice(shareId, 1);
+				this._toggleShareDivs(shareId, false);
+			} else {
+				this._currentlyToggled[shareId] = true;
+				this._toggleShareDivs(shareId, true);
+			}
+		},
+
+		_toggleShareDivs: function(shareId, enabled) {
+			var $li = this.$el.find('li[data-share-id=' + shareId + ']');
+			$li.children("div").each(function()
+			{
+				var $div = $(this);
+				if (!$div.hasClass( "avatar" )) {
+					if (enabled) {
+						$div.css('display', 'block');
+					} else {
+						$div.css('display', 'none');
+					}
+				}
+			});
 		},
 
 		_onExpirationChange: function(el) {
-			var $el        = $(el)
+			var $el        = $(el);
 			var shareId    = $el.closest('li').data('share-id');
-			var expiration = moment($el.val(), 'DD-MM-YYYY').format()
+			var expiration = moment($el.val(), 'DD-MM-YYYY').format();
 
 			this.model.updateShare( shareId, {
-				expireDate: expiration,
-			}, {
-				silent: true
-			});
+				expireDate: expiration
+			}, {});
 		},
 
 		_setDatepicker: function(el, params) {
@@ -460,7 +496,7 @@
 				minDate: "+1d",
 				dateFormat : 'dd-mm-yy',
 				onSelect : function() {
-					self._onExpirationChange(el)
+					self._onExpirationChange(el);
 				}
 			});
 

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -39,15 +39,19 @@
 		'		{{/unless}} {{/if}}' +
 		'		<div class="expirationOption">' +
 		'			{{#if isUserShare}}' +
-		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">Expiration: ' +
-		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-user" placeholder="Choose an expiration date" />' +
+		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">{{expirationLabel}}: ' +
+		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-user" placeholder="{{expirationDatePlaceholder}}" />' +
+		'				{{#unless isDefaultExpireDateUserEnforced}}' +
 		'				<button class="removeExpiration">Remove</button>' +
+		'				{{/unless}}' +
 		'			</label>' +
 		'			{{/if}}' +
 		'			{{#if isGroupShare}}' +
-		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">Expire share on: ' +
-		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-group"/>' +
+		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">{{expirationLabel}}: ' +
+		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-group" placeholder="{{expirationDatePlaceholder}}" />' +
+		'				{{#unless isDefaultExpireDateGroupEnforced}}' +
 		'				<button class="removeExpiration">Remove</button>' +
+		'				{{/unless}}' +
 		'			</label>' +
 		'			{{/if}}' +
 		'		</div>' +
@@ -116,7 +120,7 @@
 		/** @type {Function} **/
 		_template: undefined,
 
-		_currentlyToggled: [],
+		_currentlyToggled: {},
 
 		events: {
 			'click .unshare': 'onUnshare',
@@ -208,6 +212,10 @@
 				hasUpdatePermission: this.model.hasUpdatePermission(shareIndex),
 				hasDeletePermission: this.model.hasDeletePermission(shareIndex),
 				shareAttributesV1: this.getAttributesObject(shareIndex),
+				expirationLabel: t('core', 'Expiration'),
+				expirationDatePlaceholder: t('core', 'Choose an expiration date'),
+				isDefaultExpireDateUserEnforced: this.configModel.isDefaultExpireDateUserEnforced(),
+				isDefaultExpireDateGroupEnforced: this.configModel.isDefaultExpireDateGroupEnforced(),
 				expirationDate: this.model.getExpirationDate(shareIndex),
 				wasMailSent: this.model.notificationMailWasSent(shareIndex),
 				shareWith: shareWith,
@@ -289,14 +297,14 @@
 				placement: 'bottom'
 			});
 
-			this.$el.find('.expiration-user:not(.hasDatepicker)').each(function(){
+			this.$el.find('.expiration-user').each(function(){
 				self._setDatepicker(this, {
 					maxDate  : self.configModel.getDefaultExpireDateUser(),
 					enforced : self.configModel.isDefaultExpireDateUserEnforced()
 				});
 			});
 
-			this.$el.find('.expiration-group:not(.hasDatepicker)').each(function(){
+			this.$el.find('.expiration-group').each(function(){
 				self._setDatepicker(this, {
 					maxDate  : self.configModel.getDefaultExpireDateGroup(),
 					enforced : self.configModel.isDefaultExpireDateGroupEnforced()
@@ -455,7 +463,7 @@
 			var shareId = $li.data('share-id');
 
 			if (!_.isUndefined(this._currentlyToggled[shareId])) {
-				this._currentlyToggled.splice(shareId, 1);
+				delete(this._currentlyToggled[shareId]);
 				this._toggleShareDivs(shareId, false);
 			} else {
 				this._currentlyToggled[shareId] = true;
@@ -465,8 +473,7 @@
 
 		_toggleShareDivs: function(shareId, enabled) {
 			var $li = this.$el.find('li[data-share-id=' + shareId + ']');
-			$li.children("div").each(function()
-			{
+			$li.children("div").each(function() {
 				var $div = $(this);
 				if (!$div.hasClass( "avatar" )) {
 					if (enabled) {

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -33,22 +33,22 @@
 		'		<span class="shareOption">' +
 		'		{{#unless wasMailSent}}' +
 		'		<span class="mailNotificationSpinner icon-loading-small hidden"></span>' +
-		'		<input id="mail-{{cid}}-{{shareWith}}" type="button" name="mailNotification" value="{{notifyByMailLabel}}" class="mailNotification checkbox" />' +
+		'		<input id="mail-{{cid}}-{{shareWith}}-{{shareType}}" type="button" name="mailNotification" value="{{notifyByMailLabel}}" class="mailNotification checkbox" />' +
 		'		{{/unless}}' +
 		'		</span>' +
 		'		{{/unless}} {{/if}}' +
 		'		<div class="expirationOption">' +
 		'			{{#if isUserShare}}' +
-		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">{{expirationLabel}}: ' +
-		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-user" placeholder="{{expirationDatePlaceholder}}" />' +
+		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}">{{expirationLabel}}: ' +
+		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}" value="{{expirationDate}}" class="expiration expiration-user" placeholder="{{expirationDatePlaceholder}}" />' +
 		'				{{#unless isDefaultExpireDateUserEnforced}}' +
 		'				<button class="removeExpiration">Remove</button>' +
 		'				{{/unless}}' +
 		'			</label>' +
 		'			{{/if}}' +
 		'			{{#if isGroupShare}}' +
-		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}">{{expirationLabel}}: ' +
-		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}" value="{{expirationDate}}" class="expiration expiration-group" placeholder="{{expirationDatePlaceholder}}" />' +
+		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}">{{expirationLabel}}: ' +
+		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}" value="{{expirationDate}}" class="expiration expiration-group" placeholder="{{expirationDatePlaceholder}}" />' +
 		'				{{#unless isDefaultExpireDateGroupEnforced}}' +
 		'				<button class="removeExpiration">Remove</button>' +
 		'				{{/unless}}' +
@@ -58,40 +58,40 @@
 		'		<div class="coreShareOptions">' +
 		'			{{#if isResharingAllowed}} {{#if sharePermissionPossible}}' +
 		'			<span class="shareOption">' +
-		'				<input id="canShare-{{cid}}-{{shareWith}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
-		'				<label for="canShare-{{cid}}-{{shareWith}}">{{canShareLabel}}</label>' +
+		'				<input id="canShare-{{cid}}-{{shareWith}}-{{shareType}}-{{shareType}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
+		'				<label for="canShare-{{cid}}-{{shareWith}}-{{shareType}}-{{shareType}}">{{canShareLabel}}</label>' +
 		'			</span>' +
 		'			{{/if}} {{/if}}' +
 		'			{{#if editPermissionPossible}}' +
 		'			<span class="shareOption">' +
-		'				<input id="canEdit-{{cid}}-{{shareWith}}" type="checkbox" name="edit" class="permissions checkbox" {{#if hasEditPermission}}checked="checked"{{/if}} />' +
-		'				<label for="canEdit-{{cid}}-{{shareWith}}">{{canEditLabel}}</label>' +
+		'				<input id="canEdit-{{cid}}-{{shareWith}}-{{shareType}}" type="checkbox" name="edit" class="permissions checkbox" {{#if hasEditPermission}}checked="checked"{{/if}} />' +
+		'				<label for="canEdit-{{cid}}-{{shareWith}}-{{shareType}}">{{canEditLabel}}</label>' +
 		'			</span>' +
 		'			{{/if}}' +
 		'			{{#if createPermissionPossible}}' +
 		'			<span class="shareOption">' +
-		'				<input id="canCreate-{{cid}}-{{shareWith}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
-		'				<label for="canCreate-{{cid}}-{{shareWith}}">{{createPermissionLabel}}</label>' +
+		'				<input id="canCreate-{{cid}}-{{shareWith}}-{{shareType}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
+		'				<label for="canCreate-{{cid}}-{{shareWith}}-{{shareType}}">{{createPermissionLabel}}</label>' +
 		'			</span>' +
 		'			{{/if}}' +
 		'			{{#if updatePermissionPossible}}' +
 		'			<span class="shareOption">' +
-		'				<input id="canUpdate-{{cid}}-{{shareWith}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
-		'				<label for="canUpdate-{{cid}}-{{shareWith}}">{{updatePermissionLabel}}</label>' +
+		'				<input id="canUpdate-{{cid}}-{{shareWith}}-{{shareType}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
+		'				<label for="canUpdate-{{cid}}-{{shareWith}}-{{shareType}}">{{updatePermissionLabel}}</label>' +
 		'			</span>' +
 		'			{{/if}}' +
 		'			{{#if deletePermissionPossible}}' +
 		'				<span class="shareOption">' +
-		'				<input id="canDelete-{{cid}}-{{shareWith}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
-		'				<label for="canDelete-{{cid}}-{{shareWith}}">{{deletePermissionLabel}}</label>' +
+		'				<input id="canDelete-{{cid}}-{{shareWith}}-{{shareType}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
+		'				<label for="canDelete-{{cid}}-{{shareWith}}-{{shareType}}">{{deletePermissionLabel}}</label>' +
 		'			</span>' +
 		'			{{/if}}' +
 		'		</div>' +
 		'		<div class="shareAttributes"">' +
 		'			{{#each shareAttributesV1}}' +
 		'			<span class="shareOption">' +
-		'				<input id="can-{{name}}-{{cid}}-{{shareWith}}" type="checkbox" name="{{name}}" class="attributes checkbox" {{#if isReshare}}disabled{{/if}} {{#if enabled}}checked="checked"{{/if}} data-scope="{{scope}}" data-enabled="{{enabled}}""/>' +
-		'				<label for="can-{{name}}-{{cid}}-{{shareWith}}">{{label}}</label>' +
+		'				<input id="can-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}" type="checkbox" name="{{name}}" class="attributes checkbox" {{#if isReshare}}disabled{{/if}} {{#if enabled}}checked="checked"{{/if}} data-scope="{{scope}}" data-enabled="{{enabled}}""/>' +
+		'				<label for="can-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}">{{label}}</label>' +
 		'			</span>' +
 		'			{{/each}}' +
 		'		</div>' +

--- a/core/js/tests/specs/sharedialogexpirationviewSpec.js
+++ b/core/js/tests/specs/sharedialogexpirationviewSpec.js
@@ -19,7 +19,7 @@
 *
 */
 
-describe('OC.Share.ShareDialogExpirationView', function() {
+describe('OC.Share.ShareDialogLinkExpirationView', function() {
 	var itemModel;
 	var fileInfoModel;
 	var configModel;
@@ -61,7 +61,7 @@ describe('OC.Share.ShareDialogExpirationView', function() {
 			expireDate: null,
 		});
 
-		view = new OC.Share.ShareDialogExpirationView({
+		view = new OC.Share.ShareDialogLinkExpirationView({
 			model: model,
 			itemModel: itemModel
 		});

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -126,7 +126,31 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect($li.find('.user-additional-info').length).toEqual(0);
 		});
 
-		it('renders share attribute correctly', function () {
+		it('renders permission correctly', function () {
+			shareModel.set('shares', [
+				{
+					id: 100,
+					item_source: 123,
+					permissions: 31,
+					share_type: OC.Share.SHARE_TYPE_USER,
+					share_with: 'user1',
+					share_with_displayname: 'User One',
+					share_with_additional_info: 'user1@example.com'
+				}]
+			);
+
+			listView.render();
+
+			var $li = listView.$el.find('li[data-share-id=100]');
+
+			var $editCheckbox = $li.find("input[name='edit']");
+			expect($editCheckbox.is(':checked')).toEqual(true);
+			expect($editCheckbox.parent().attr('class')).toEqual('shareOption');
+			expect($editCheckbox.parent().parent().is('div')).toEqual(true);
+			expect($editCheckbox.parent().parent().parent().is('li')).toEqual(true);
+		});
+
+		it('renders share attribute v1 correctly', function () {
 			shareModel.registerShareAttribute({
 				scope: "test",
 				key: "test-attribute",
@@ -153,6 +177,62 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			var input = $li.find("input[name='test-attribute']");
 			expect(input.is(':checked')).toEqual(true);
 			expect($("label[for='" + input.attr('id') + "']").text()).toEqual('test attribute');
+		});
+
+		it('renders share attribute v2 correctly', function () {
+			var shareIdToAppend = 100;
+			shareModel.set('shares', [
+				{
+					id: shareIdToAppend,
+					item_source: 123,
+					permissions: 31,
+					attributes: [{ scope: 'test', key: 'test-attribute', enabled: true }],
+					share_type: OC.Share.SHARE_TYPE_USER,
+					share_with: 'user1',
+					share_with_displayname: 'User One',
+					share_with_additional_info: 'user1@example.com'
+				}]
+			);
+
+			function customAttributeRender(view) {
+				var $share = view.$el.find('li[data-share-id=' + shareIdToAppend + ']');
+				var template =
+					'<div class="testShareOptions">' +
+					'	<span class="shareOption">' +
+					'		<input id="attr-test-1" type="checkbox" name="test-attribute" class="testShareOption checkbox" checked="checked" data-share-id="' + shareIdToAppend + '" />' +
+					'		<label for="attr-test-1">test attribute</label>' +
+					'	</span' +
+					'</div>';
+
+				if ($share) {
+					var shares =shareModel.getSharesWithCurrentItem();
+					for(var shareIndex = 0; shareIndex < shares.length; shareIndex++) {
+						if (shares[shareIndex].id === shareIdToAppend) {
+							var share = shares[shareIndex];
+							if (share.attributes[0]['key'] === 'test-attribute') {
+								$share.append(Handlebars.compile(template));
+							}
+							break;
+						}
+					}
+				}
+			}
+
+			var baseRenderCall = listView.render;
+			listView.render = function() {
+				baseRenderCall.call(listView);
+				customAttributeRender(listView);
+			};
+
+			listView.render();
+
+			var $li = listView.$el.find('li[data-share-id=' + shareIdToAppend + ']');
+
+			var $attrCheckbox = $li.find("input[name='test-attribute']");
+			expect($attrCheckbox.is(':checked')).toEqual(true);
+			expect($attrCheckbox.parent().attr('class')).toEqual('shareOption');
+			expect($attrCheckbox.parent().parent().is('div')).toEqual(true);
+			expect($attrCheckbox.parent().parent().parent().is('li')).toEqual(true);
 		});
 	});
 
@@ -256,7 +336,7 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(listView.$el.find("input[name='mailNotification']").hasClass('hidden')).toEqual(false);
 		});
 
-		it('unchecks share attribute when clicked on checked', function () {
+		it('unchecks share attribute v1 when clicked on checked', function () {
 			shareModel.registerShareAttribute({
 				scope: "test",
 				key: "test-attribute",
@@ -284,7 +364,7 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(updateShareStub.calledOnce).toEqual(true);
 		});
 
-		it('shows share attribute checkbox when checking required permission', function () {
+		it('shows share attribute v1 checkbox when checking required permission', function () {
 			shareModel.registerShareAttribute({
 				scope: "test",
 				key: "test-attribute",
@@ -330,7 +410,7 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(updateShareStub.calledOnce).toEqual(true);
 		});
 
-		it('shows share attribute checkbox when unchecking incompatible attribute', function () {
+		it('shows share attribute v1 checkbox when unchecking incompatible attribute v1', function () {
 			shareModel.registerShareAttribute({
 				scope: "test",
 				key: "incompatible-attribute",
@@ -390,7 +470,7 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(updateShareStub.calledOnce).toEqual(true);
 		});
 		
-		it('prevents checking/unchecking attribute when reshared', function () {
+		it('prevents checking/unchecking attribute v1 when reshared', function () {
 			shareModel.registerShareAttribute({
 				scope: "test",
 				key: "test-attribute-checked",

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -545,7 +545,7 @@ describe('OC.Share.ShareItemModel', function() {
 				});
 			}
 
-			var requestBody = OC.parseQueryString(_.last(fakeServer.requests).requestBody);
+			var requestBody = JSON.parse(_.last(fakeServer.requests).requestBody);
 			return parseInt(requestBody.permissions, 10);
 		}
 
@@ -656,7 +656,7 @@ describe('OC.Share.ShareItemModel', function() {
 		 * @return {int}
 		 */
 		function parseLastRequestPermissions(){
-			var requestBody = OC.parseQueryString(_.last(fakeServer.requests).requestBody);
+			var requestBody = JSON.parse(_.last(fakeServer.requests).requestBody);
 			return parseInt(requestBody.permissions, 10);
 		}
 
@@ -667,27 +667,8 @@ describe('OC.Share.ShareItemModel', function() {
 		 * @return {OC.Share.Types.ShareAttribute[]}
 		 */
 		function parseLastRequestAttributes() {
-			var requestBody = OC.parseQueryString(fakeServer.requests[0].requestBody);
-
-			var i = -1;
-			var attributes = [];
-			_.map(Object.keys(requestBody), function(key) {
-				if (key.indexOf('attributes') !== -1) {
-					if (key.indexOf('scope') !== -1) {
-						i = i + 1;
-						attributes.push({});
-						attributes[i].scope = requestBody[key];
-					}
-					if (key.indexOf('key') !== -1) {
-						attributes[i].key = requestBody[key];
-					}
-					if (key.indexOf('enabled') !== -1) {
-						attributes[i].enabled = JSON.parse(requestBody[key]);
-					}
-				}
-			});
-
-			return attributes;
+			var requestBody = JSON.parse(fakeServer.requests[0].requestBody);
+			return requestBody.attributes;
 		}
 
 		/**
@@ -785,7 +766,7 @@ describe('OC.Share.ShareItemModel', function() {
 				// define expected result and test
 				expect(
 					testAddShareWithAttributes(permissionsToSet, attributesToRegister, sharePropertiesToAdd)
-				).toEqual([]);
+				).toEqual(undefined);
 			});
 
 			it('adds attributes if specified in shareAttributesApi v2', function () {
@@ -1134,10 +1115,10 @@ describe('OC.Share.ShareItemModel', function() {
 				OC.linkToOCS('apps/files_sharing/api/v1', 2) +
 				'shares?format=json'
 			);
-			expect(OC.parseQueryString(fakeServer.requests[0].requestBody)).toEqual({
+			expect(JSON.parse(fakeServer.requests[0].requestBody)).toEqual({
 				path: '/subdir/shared_file_name.txt',
-				permissions: '' + OC.PERMISSION_READ,
-				shareType: '' + OC.Share.SHARE_TYPE_GROUP,
+				permissions: OC.PERMISSION_READ,
+				shareType: OC.Share.SHARE_TYPE_GROUP,
 				shareWith: 'group1'
 			});
 		});
@@ -1161,7 +1142,7 @@ describe('OC.Share.ShareItemModel', function() {
 			});
 
 			expect(fakeServer.requests.length).toEqual(1);
-			expect(OC.parseQueryString(fakeServer.requests[0].requestBody)).toEqual( jasmine.objectContaining({expireDate: expireUserDate}) )
+			expect(JSON.parse(fakeServer.requests[0].requestBody)).toEqual( jasmine.objectContaining({expireDate: expireUserDate}) )
 		})
 		it('sends defaultExpireDateGroup if enabled', function() {
 			var expireUserDays  = 7;
@@ -1183,7 +1164,7 @@ describe('OC.Share.ShareItemModel', function() {
 			});
 
 			expect(fakeServer.requests.length).toEqual(1);
-			expect(OC.parseQueryString(fakeServer.requests[0].requestBody)).toEqual( jasmine.objectContaining({expireDate: expireGroupDate}) )
+			expect(JSON.parse(fakeServer.requests[0].requestBody)).toEqual( jasmine.objectContaining({expireDate: expireGroupDate}) )
 		})
 		it('calls error handler with error message', function() {
 			var errorStub = sinon.stub();
@@ -1212,7 +1193,7 @@ describe('OC.Share.ShareItemModel', function() {
 		});
 	});
 	describe('updating shares', function() {
-		it('sends PUT method to endpoint with passed values', function() {
+		it('sends PUT method to endpoint with passed permissions values', function() {
 			model.updateShare(123, {
 				permissions: OC.PERMISSION_READ | OC.PERMISSION_SHARE
 			});
@@ -1223,8 +1204,8 @@ describe('OC.Share.ShareItemModel', function() {
 				OC.linkToOCS('apps/files_sharing/api/v1', 2) +
 				'shares/123?format=json'
 			);
-			expect(OC.parseQueryString(fakeServer.requests[0].requestBody)).toEqual({
-				permissions: '' + (OC.PERMISSION_READ | OC.PERMISSION_SHARE)
+			expect(JSON.parse(fakeServer.requests[0].requestBody)).toEqual({
+				permissions: (OC.PERMISSION_READ | OC.PERMISSION_SHARE)
 			});
 		});
 		it('calls error handler with error message', function() {

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -101,7 +101,7 @@ class Share extends Constants {
 					\OC_Util::addScript('core', 'sharedialoglinkshareview');
 					\OC_Util::addScript('core', 'sharedialogmailview');
 					\OC_Util::addScript('core', 'sharedialoglinksocialview');
-					\OC_Util::addScript('core', 'sharedialogexpirationview');
+					\OC_Util::addScript('core', 'sharedialoglinkexpirationview');
 					\OC_Util::addScript('core', 'sharedialogshareelistview');
 					\OC_Util::addScript('core', 'sharedialogview');
 					\OC_Util::addScript('core', 'share');

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -62,7 +62,7 @@ class SharingDialog extends OwncloudPage {
 	private $publicLinkRemoveBtnXpath = "//div[contains(@class, 'removeLink')]";
 	private $publicLinkTitleXpath = "//span[@class='link-entry--title']";
 	private $notifyByEmailBtnXpath = "//input[@name='mailNotification']";
-	private $shareWithExpirationFieldXpath = "//*[@id='shareWithList']//span[@class='has-tooltip username' and .='%s']/../..//input[contains(@class, 'expiration')]";
+	private $shareWithExpirationFieldXpath = "//*[@id='shareWithList']//span[@class='has-tooltip username' and .='%s']/..//input[contains(@class, 'expiration')]";
 	private $shareWithClearExpirationFieldXpath = "/following-sibling::button[@class='removeExpiration']"; // in relation to $shareWithExpirationFieldXpath
 	private $shareWithListXpath = "//ul[@id='shareWithList']/li";
 	private $shareWithListDetailsXpath = "//div[@class='shareWithList__details']";

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -54,7 +54,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 		'upload' => ".//label[contains(@for, 'sharingDialogAllowPublicUpload')]"
 	];
 	private $popupCloseButton = "//a[@class='oc-dialog-close']";
-	private $expirationDateRequiredErrorMessageXpath = './/*[@id="shareDialogExpirationView"]//span[@class="error-message"]';
+	private $expirationDateRequiredErrorMessageXpath = './/*[@id="shareDialogLinkExpirationView"]//span[@class="error-message"]';
 
 	/**
 	 * sets the NodeElement for the current popup

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -921,10 +921,10 @@ class ManagerTest extends \Test\TestCase {
 		$data[] = [$share, $fileReshare, 'Cannot set the requested share permissions for sharedfile', true];
 
 		// Normal reshare should just use supershare node attributes
-		// exception when trying to share with more attributes than supershare has
+		// exception when trying to remove share attributes that supershare has
 		$superShareAttributes = new ShareAttributes();
+		$superShareAttributes->setAttribute('test', 'test', true);
 		$shareAttributes = new ShareAttributes();
-		$shareAttributes->setAttribute('test', 'test', true);
 		$superShare = $this->createMock(IShare::class);
 		$superShare->method('getPermissions')->willReturn(17);
 		$superShare->method('getAttributes')->willReturn($superShareAttributes);
@@ -3637,17 +3637,17 @@ class ManagerTest extends \Test\TestCase {
 	/**
 	 * @dataProvider strictSubsetOfAttributesDataProvider
 	 *
-	 * @param IAttributes $allowedAttributes
-	 * @param IAttributes $newAttributes
+	 * @param IAttributes $requiredAttributes
+	 * @param IAttributes $currentAttributes
 	 * @param boolean $expected
 	 */
-	public function testStrictSubsetOfAttributes($allowedAttributes, $newAttributes, $expected) {
+	public function testStrictSubsetOfAttributes($requiredAttributes, $currentAttributes, $expected) {
 		$this->assertEquals(
 			$expected,
 			$this->invokePrivate(
 				$this->manager,
 				'strictSubsetOfAttributes',
-				[$allowedAttributes, $newAttributes]
+				[$requiredAttributes, $currentAttributes]
 			)
 		);
 	}
@@ -3665,17 +3665,17 @@ class ManagerTest extends \Test\TestCase {
 		$shareAttributes->setAttribute('test', 'test', true);
 		$data[] = [$superShareAttributes,$shareAttributes, true];
 
-		// no exception - disabling attribute that supershare has enabled
+		// no exception - adding an attribute while supershare has none
+		$superShareAttributes = new ShareAttributes();
+		$shareAttributes = new ShareAttributes();
+		$shareAttributes->setAttribute('test', 'test', true);
+		$data[] = [$superShareAttributes,$shareAttributes, true];
+
+		// exception - disabling attribute that supershare has enabled
 		$superShareAttributes = new ShareAttributes();
 		$superShareAttributes->setAttribute('test', 'test', true);
 		$shareAttributes = new ShareAttributes();
 		$shareAttributes->setAttribute('test', 'test', false);
-		$data[] = [$superShareAttributes,$shareAttributes, true];
-
-		// exception - adding an attribute while supershare has none
-		$superShareAttributes = new ShareAttributes();
-		$shareAttributes = new ShareAttributes();
-		$shareAttributes->setAttribute('test', 'test', true);
 		$data[] = [$superShareAttributes,$shareAttributes, false];
 
 		// exception - enabling attribute that supershare has disabled


### PR DESCRIPTION
related issue: https://github.com/owncloud/core/issues/36751

also last commit fixes #36813 

- [x] rollback html and css structure changes from https://github.com/owncloud/core/pull/36573 that broke compatibility with advanced share attributes that get registered by apps (example: https://github.com/owncloud/richdocuments/blob/master/js/viewer/shareoptions.js#L222-L260 and https://github.com/ONLYOFFICE/onlyoffice-owncloud/blob/master/js/share.js#L322-L372)
- [x] make sure expiration code works as expected
- [x] adjust required unit and acceptance tests
- [x] add js test to share attributes v2 checking proper rendering

![ezgif com-video-to-gif-2](https://user-images.githubusercontent.com/13368647/72468787-42ba6280-37de-11ea-9ec6-d00193cabca7.gif)
