### PR TITLE
[Tests-only] move and adjust code from webUI to API test contexts

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -40,6 +40,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 use TestHelpers\DeleteHelper;
 use TestHelpers\Asserts\WebDav as WebDavAssert;
 use TestHelpers\HttpRequestHelper;
+use TestHelpers\UploadHelper;
 
 require_once 'bootstrap.php';
 
@@ -1851,7 +1852,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
 		$remoteFile = $this->currentFolder . "/" . \trim($remoteFile, $remoteFile[0]);
-		$localFile = \getenv("FILES_FOR_UPLOAD") . "/" . \trim($localFile, $localFile[0]);
+		$localFile = UploadHelper::getUploadFilesDir(\trim($localFile, $localFile[0]));
 		$shouldBeSame = ($shouldOrNot !== "not");
 		$this->assertContentOfRemoteAndLocalFileIsSame(
 			$remoteFile, $localFile, $shouldBeSame, $checkOnRemoteServer
@@ -1876,7 +1877,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$checkOnRemoteServer = ($remoteServer === 'on the remote server');
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
-		$localFile = \getenv("FILES_FOR_UPLOAD") . "/" . \trim($localFile);
+		$localFile = UploadHelper::getUploadFilesDir(\trim($localFile));
 		$shouldBeSame = ($shouldOrNot !== "not");
 		$this->assertContentOfRemoteAndLocalFileIsSameForUser(
 			$remoteFile, $localFile, $user, $shouldBeSame, $checkOnRemoteServer

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -581,7 +581,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @throws InvalidArgumentException
 	 */
 	public function aFileWithSizeAndNameHasBeenCreatedLocally($size, $name) {
-		$fullPath = \getenv("FILES_FOR_UPLOAD") . $name;
+		$fullPath = UploadHelper::getUploadFilesDir($name);
 		if (\file_exists($fullPath)) {
 			throw new InvalidArgumentException(
 				__METHOD__ . " could not create '$fullPath' file exists"

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -64,7 +64,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 
 	private $oldCSRFSetting = null;
 	private $oldPreviewSetting = [];
-	private $createdFiles = [];
 
 	/**
 	 *
@@ -572,26 +571,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given a file with the size of :size bytes and the name :name has been created locally
-	 *
-	 * @param int $size if not int given it will be cast to int
-	 * @param string $name
-	 *
-	 * @return void
-	 * @throws InvalidArgumentException
-	 */
-	public function aFileWithSizeAndNameHasBeenCreatedLocally($size, $name) {
-		$fullPath = UploadHelper::getUploadFilesDir($name);
-		if (\file_exists($fullPath)) {
-			throw new InvalidArgumentException(
-				__METHOD__ . " could not create '$fullPath' file exists"
-			);
-		}
-		UploadHelper::createFileSpecificSize($fullPath, (int) $size);
-		$this->createdFiles[] = $fullPath;
-	}
-
-	/**
 	 *
 	 * @When the user/administrator reloads the current page of the webUI
 	 * @Given the user/administrator has reloaded the current page of the webUI
@@ -806,10 +785,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$this->featureContext->setSystemConfig(
 				'csrf.disabled', $this->oldCSRFSetting, 'boolean'
 			);
-		}
-
-		foreach ($this->createdFiles as $file) {
-			\unlink($file);
 		}
 	}
 

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -25,6 +25,7 @@ namespace Page;
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use TestHelpers\UploadHelper;
 use WebDriver\Key;
 use WebDriver\Exception\NoSuchElement;
 use WebDriver\Exception\StaleElementReference;
@@ -467,7 +468,7 @@ class FilesPageCRUD extends FilesPageBasic {
 			" id $this->fileUploadInputId " .
 			"could not find file upload input field"
 		);
-		$uploadField->attachFile(\getenv("FILES_FOR_UPLOAD") . $name);
+		$uploadField->attachFile(UploadHelper::getUploadFilesDir($name));
 		$this->waitForAjaxCallsToStartAndFinish($session, 20000);
 		$this->waitForUploadProgressbarToFinish();
 	}


### PR DESCRIPTION
## Description
1) Make use of `UploadHelper::getUploadFilesDir` rather than mentioning `FILES_FOR_UPLOAD` env var in multiple places.

2) Move `aFileWithSizeAndNameHasBeenCreatedLocally` from webUI context to `BasicStructure` - that step is a local thing that should be available to any acceptance test feature file.

## Related Issue
- https://github.com/owncloud/QA/issues/637

(this is a last little bit of refactoring that I noticed related to the issue)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
