### PR TITLE
[Tests-only] Move function "set last login date" from "testingAppContext" to "FeatureContext"

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -22,6 +22,7 @@
  */
 
 use rdx\behatvars\BehatVariablesContext;
+use TestHelpers\OcsApiHelper;
 
 require_once 'bootstrap.php';
 
@@ -40,5 +41,29 @@ class FeatureContext extends BehatVariablesContext {
 		$this->savedCapabilitiesXml[$this->getBaseUrl()] = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
 		$this->setCapabilities($this->getCommonSharingConfigs());
+	}
+
+	/**
+	 * @Given the administrator has set the last login date for user :user to :days days ago
+	 * @When the administrator sets the last login date for user :user to :days days ago using the testing API
+	 *
+	 * @param string $user
+	 * @param string $days
+	 *
+	 * @return void
+	 */
+	public function theAdministratorSetsTheLastLoginDateForUserToDaysAgoUsingTheTestingApi($user, $days) {
+		$adminUser = $this->getAdminUsername();
+		$baseUrl = "/apps/testing/api/v1/lastlogindate/{$user}";
+		$response = OcsApiHelper::sendRequest(
+			$this->getBaseUrl(),
+			$adminUser,
+			$this->getAdminPassword(),
+			'POST',
+			$baseUrl,
+			['days' => $days],
+			$this->getOcsApiVersion()
+		);
+		$this->setResponse($response);
 	}
 }


### PR DESCRIPTION

## Description
This PR moves function `theAdministratorSetsTheLastLoginDateForUserToDaysAgoUsingTheTestingApi()` from `TextingAppContext.php` to `FeatureContext.Php` as the function is required in `core`'s test.
## Related Issue
From https://github.com/owncloud/testing/pull/132

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
