### PR TITLE
Change the wording in the additional tab to not confuse users

### DIFF
--- a/changelog/unreleased/36775
+++ b/changelog/unreleased/36775
@@ -1,0 +1,5 @@
+Change: Adjust wording displayed for empty additional settings panel
+
+The wording displayed when the admin personal settings panel is empty has been improved.
+
+https://github.com/owncloud/core/pull/36775

--- a/settings/templates/settingsPage.php
+++ b/settings/templates/settingsPage.php
@@ -60,8 +60,8 @@ style('settings', 'settings');
 	if ($numPanels === 0 || ($numPanels === 1 && $_['panels'][0]['id'] === $legacyClass && empty(\trim($_['panels'][0]['content'])))) {
 		?>
 		<div class="section">
-			<h2><?php p($l->t('Other')); ?></h2>
-			<p><?php p($l->t('No panels for this section.')); ?></p>
+			<h2><?php p($l->t('Currently no settings are available in this category')); ?></h2>
+			<p><?php p($l->t('The administrators can enable additional apps which add settings sections here.')); ?></p>
 		</div>
 	<?php
 	} ?>


### PR DESCRIPTION
## Description
This PR changes two strings that caused confusion in the additional tab.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/2500

## Motivation and Context
Confusion should be avoided.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
