### PR TITLE
Change Error to Other on settingsPage

### DIFF
--- a/changelog/unreleased/36776
+++ b/changelog/unreleased/36776
@@ -1,0 +1,6 @@
+Change: Adjust wording displayed for empty additional settings panel
+
+The wording displayed when the admin personal settings panel is empty has been
+adjusted so that it no longer looks like there is an error.
+
+https://github.com/owncloud/core/pull/36776

--- a/settings/templates/settingsPage.php
+++ b/settings/templates/settingsPage.php
@@ -60,7 +60,7 @@ style('settings', 'settings');
 	if ($numPanels === 0 || ($numPanels === 1 && $_['panels'][0]['id'] === $legacyClass && empty(\trim($_['panels'][0]['content'])))) {
 		?>
 		<div class="section">
-			<h2><?php p($l->t('Error')); ?></h2>
+			<h2><?php p($l->t('Other')); ?></h2>
 			<p><?php p($l->t('No panels for this section.')); ?></p>
 		</div>
 	<?php


### PR DESCRIPTION
## Description
If we change `Error` to `Other` (which is already a translated string) then we avoid the translation problem. IMO "Other" is an OK title for this "Additional" settings page when it is empty.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/2500

## Motivation and Context
Confusion should be avoided.

## How Has This Been Tested?
Manual

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
