### PR TITLE
fix: implement missing getSize method in SharedFile.php

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/SharedFile.php
+++ b/apps/dav/lib/Files/PublicFiles/SharedFile.php
@@ -71,4 +71,8 @@ class SharedFile extends File implements IACL, IFileNode, IPublicSharedNode {
 			throw new Forbidden('Permission denied to change data');
 		}
 	}
+
+	public function getSize() {
+		return $this->file->getSize();
+	}
 }

--- a/apps/dav/tests/unit/Files/PublicFiles/PublicFileTest.php
+++ b/apps/dav/tests/unit/Files/PublicFiles/PublicFileTest.php
@@ -34,4 +34,12 @@ class PublicFileTest extends TestCase {
 		$metaFile = new SharedFile($file, $share);
 		$this->assertEquals('"123456"', $metaFile->getETag());
 	}
+
+	public function testSize() {
+		$file = $this->createMock(File::class);
+		$file->method('getSize')->willReturn(42);
+		$share = $this->createMock(IShare::class);
+		$metaFile = new SharedFile($file, $share);
+		$this->assertEquals(42, $metaFile->getSize());
+	}
 }

--- a/changelog/unreleased/36778
+++ b/changelog/unreleased/36778
@@ -1,0 +1,4 @@
+Bugfix: Return correct file size in the public files webdav API
+
+https://github.com/owncloud/core/issues/36741
+https://github.com/owncloud/core/pull/36778

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -505,3 +505,13 @@ Feature: create a public link share
     When the public downloads file "parent.txt" from inside the last public shared folder using the old public WebDAV API
     Then the value of the item "//s:message" in the response should be ""
     And the HTTP status code should be "404"
+
+  Scenario: Get the size of a file shared by public link
+    Given the administrator has enabled DAV tech_preview
+    And user "user0" has uploaded file with content "This is a test file" to "test-file.txt"
+    And user "user0" has created a public link share with settings
+      | path        | test-file.txt |
+      | permissions | read          |
+    When the public gets the size of the last shared public link using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the size of the file should be "19"

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -80,3 +80,9 @@ Feature: download file
       | dav_version |
       | old         |
       | new         |
+
+  Scenario: Get the size of a file
+    Given user "user0" has uploaded file with content "This is a test file" to "test-file.txt"
+    When user "user0" gets the size of file "test-file.txt" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the size of the file should be "19"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1089,6 +1089,53 @@ trait WebDav {
 	}
 
 	/**
+	 * @When the public gets the size of the last shared public link using the WebDAV API
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function publicGetsSizeOfLastSharedPublicLinkUsingTheWebdavApi() {
+		$tokenArray = $this->getLastShareData()->data->token;
+		$token = (string)$tokenArray[0];
+		$url = $this->getBaseUrl() . "/remote.php/dav/public-files/{$token}";
+		$this->response = HttpRequestHelper::sendRequest(
+			$url, "PROPFIND", null, null, null
+		);
+	}
+
+	/**
+	 * @When user :user gets the size of file :resource using the WebDAV API
+	 *
+	 * @param $user
+	 * @param $resource
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsSizeOfFileUsingTheWebdavApi($user, $resource) {
+		$headers = $this->guzzleClientHeaders;
+		$password = $this->getPasswordForUser($user);
+		$url = $this->getBaseUrl() . "/remote.php/dav/files/{$user}/{$resource}";
+		$this->response = HttpRequestHelper::sendRequest(
+			$url, "PROPFIND", $user, $password, $headers, null, null, null
+		);
+	}
+
+	/**
+	 * @Then the size of the file should be :size
+	 *
+	 * @param $size
+	 *
+	 * @return void
+	 */
+	public function theSizeOfTheFileShouldBe($size) {
+		$responseXml = HttpRequestHelper::getResponseXml($this->response);
+		$responseXml->registerXPathNamespace('d', 'DAV:');
+		$xmlPart = $responseXml->xpath("//d:prop/d:getcontentlength");
+		Assert::assertEquals($size, (string) $xmlPart[0]);
+	}
+
+	/**
 	 * @Then the following headers should be set
 	 *
 	 * @param TableNode $table


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Implement the method `getSize` in `SharedFile.php`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #36741

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The webdav-api for public files couldn't get the correct file size
since `SharedFile.php` did not implement the `getSize` method.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test execute a PROPFIND request for a shared file via the webdav public-files API
`curl -s --user user:password --basic http://localhost:8080/remote.php/dav/public-files/HXEGrChNif8AWBq -X PROPFIND`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
