### PR TITLE
[Tests-only] Adjust IpContext to know about FeatureContext

### DIFF
--- a/tests/acceptance/features/bootstrap/IpContext.php
+++ b/tests/acceptance/features/bootstrap/IpContext.php
@@ -21,12 +21,19 @@
  */
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\IpHelper;
 
 /**
  * Ip trait
  */
 class IpContext implements Context {
+
+	/**
+	 *
+	 * @var FeatureContext
+	 */
+	private $featureContext;
 
 	/**
 	 * The local source IP address from which to initiate API actions.
@@ -143,11 +150,21 @@ class IpContext implements Context {
 	}
 
 	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
 	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
 	 *
 	 * @return void
 	 */
-	public function setUpScenarioGetIpUrls() {
+	public function setUpScenarioGetIpUrls(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+
 		$this->ipv4Url = \getenv('IPV4_URL');
 		$this->ipv6Url = \getenv('IPV6_URL');
 	}


### PR DESCRIPTION
## Description
Enhance acceptance test `IpContext` so it knows how to get access to `FeatureContext`

## Related Issue
Some changes were missed in PR #36771 
`IpContext` is only used by apps, so this is not noticed in core CI.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
