### PR TITLE
[Tests-only] expose getSourceIpAddress so we can read it from other acceptance test code

### DIFF
--- a/tests/acceptance/features/bootstrap/IpContext.php
+++ b/tests/acceptance/features/bootstrap/IpContext.php
@@ -57,6 +57,13 @@ class IpContext implements Context {
 	private $guzzleClientHeaders = [];
 
 	/**
+	 * @return string|null
+	 */
+	public function getSourceIpAddress() {
+		return $this->sourceIpAddress;
+	}
+
+	/**
 	 * returns the base URL that matches the currently selected source IP
 	 * address (which might be an IPv4 or IPv6 address)
 	 *


### PR DESCRIPTION
## Description
Now that we have `IpContext` rather than `Ip` trait in the acceptance tests, we cannot just get the setting of `sourceIpAddress`. But we need it in some app acceptance test logic.

Provide a getter.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
