### PR TITLE
clear memory usages of the processed files in occ files:checksums:verify

### DIFF
--- a/changelog/unreleased/36787
+++ b/changelog/unreleased/36787
@@ -1,0 +1,7 @@
+Bugfix: Optimize memory consumption of occ files:checksums:verify command
+
+Memory consumption reduced by clearing memory usages of processed files and folders.
+Also, information messages of the command improved by showing the current processed user and the command run result.
+
+https://github.com/owncloud/core/issues/31133
+https://github.com/owncloud/core/pull/36787


### PR DESCRIPTION
## Description
We are calling the recursive `walkNodes` function for each user when calculating file checksums. 
https://github.com/owncloud/core/blob/c0da7c638999eced48b95a8132c1886699e16dc5/apps/files/lib/Command/VerifyChecksums.php#L174

In recursive calls, memory does not free until the root call finished. Because of that, the worst-case memory complexity of the current approach is the size of all node objects of a user. Let's say the average node object size is 1 KB, a user with 1 million files exceeds 1 GB PHP memory limit in the current approach.

As an easy optimization of the current case, This pr first calculates checksums of the files in a directory and then unsets memories of the processed files and folders. In this case, the limitation will be `getDirectoryListing()` method which returns the node object list of a given directory. This means if a user has 1 million files in a folder (without nested files),  again it exceeds 1 GB PHP memory limit. 

However, since there are already other usages of `getDirectoryListing` method, I guess, we do not need to think about optimization of this method. Reducing worst-case memory complexity to the size of `getDirectoryListing` method should be sufficient.

Also, the pr improves information messages of the command by showing the current processed user and the command run result.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3624
- Fixes https://github.com/owncloud/core/issues/31133

## Motivation and Context

## How Has This Been Tested?
- Create `10000` random files in the root of a user's home directory 
- Create a folder and another `10000` random files inside of the new folder
- Create `30000` randomly located folder in user's home directory 
- Run `occ files:checksums:verify` and measure peak memory usage with PHP `memory_get_peak_usage()` method.

I applied the above scenario in the current master and the PR's branch. The result is proving improvement. Memory usage is much less in PR's branch.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
