### PR TITLE
[Tests-only] delete second function to calc dav-path

### DIFF
--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -22,6 +22,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\HttpRequestHelper;
+use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';
 
@@ -149,7 +150,11 @@ class ChecksumContext implements Context {
     <oc:checksums />
   </d:prop>
 </d:propfind>';
-		$url = $this->featureContext->getBaseUrl() . '/' . $this->featureContext->getDavFilesPath($user) . $path;
+		$url = $this->featureContext->getBaseUrl() . '/' .
+			WebDavHelper::getDavPath(
+				$user, $this->featureContext->getDavPathVersion()
+			) . $path;
+		$url = WebDavHelper::sanitizeUrl($url);
 		$response = HttpRequestHelper::sendRequest(
 			$url,
 			'PROPFIND',

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -233,19 +233,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @param string $user
-	 *
-	 * @return string
-	 */
-	public function getDavFilesPath($user) {
-		if ($this->usingOldDavPath === true) {
-			return $this->davPath;
-		} else {
-			return "$this->davPath/files/$user";
-		}
-	}
-
-	/**
 	 * gives the dav path of a file including the subfolder of the webserver
 	 * e.g. when the server runs in `http://localhost/owncloud/`
 	 * this function will return `owncloud/remote.php/webdav/prueba.txt`
@@ -255,9 +242,10 @@ trait WebDav {
 	 * @return string
 	 */
 	public function getFullDavFilesPath($user) {
-		return \ltrim(
-			$this->getBasePath() . "/" . $this->getDavFilesPath($user), "/"
-		);
+		$path = $this->getBasePath() . "/" .
+			WebDavHelper::getDavPath($user, $this->getDavPathVersion());
+		$path = WebDavHelper::sanitizeUrl($path);
+		return \ltrim($path, "/");
 	}
 
 	/**
@@ -466,7 +454,8 @@ trait WebDav {
 	 * @return string
 	 */
 	public function destinationHeaderValue($user, $fileDestination) {
-		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
+		$fullUrl = $this->getBaseUrl() . '/' .
+			WebDavHelper::getDavPath($user, $this->getDavPathVersion());
 		return $fullUrl . '/' . \ltrim($fileDestination, '/');
 	}
 


### PR DESCRIPTION
## Description
reduce complexity by removing one of two functions that calculates the dav-path

## Motivation and Context
we have two places where the dav-path is constructed, WebDavHelper https://github.com/owncloud/core/blob/56b692799d5255c14899427488b999935c7d8303/tests/TestHelpers/WebDavHelper.php#L324 and `getDavFilesPath` in WebDav Trait.
To make the code easier to maintain delete one of them

## How Has This Been Tested?
- ran some tests that uses the changed functions locally in a setup where oC is executed in a sub-folder `http://localhost/owncloud-core`
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
