### PR TITLE
[Tests-only] Add test scenarios for updating a share when a user and group have the same name

### DIFF
--- a/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
@@ -1,0 +1,50 @@
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+Feature: updating shares to users and groups that have the same name
+
+  Background:
+    Given using old DAV path
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "user1" has been created
+    And user "user2" has been added to group "user1"
+    And user "user0" has created folder "/TMP"
+    And user "user0" has uploaded file with content "user0 file" to "/TMP/randomfile.txt"
+
+  @skipOnLDAP
+  Scenario Outline: update permissions of a user share with a user and a group having the same name
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared folder "/TMP" with group "user1"
+    And user "user0" has shared folder "/TMP" with user "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | read |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And the content of file "/TMP/randomfile.txt" for user "user1" should be "user0 file"
+    And the content of file "/TMP/randomfile.txt" for user "user2" should be "user0 file"
+    And user "user2" should be able to upload file "filesForUpload/textfile.txt" to "TMP/textfile-by-user2.txt"
+    But user "user1" should not be able to upload file "filesForUpload/textfile.txt" to "TMP/textfile-by-user1.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnLDAP
+  Scenario Outline: update permissions of a group share with a user and a group having the same name
+    Given using OCS API version "<ocs_api_version>"
+    And user "user0" has shared folder "/TMP" with user "user1"
+    And user "user0" has shared folder "/TMP" with group "user1"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | read |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And the content of file "/TMP/randomfile.txt" for user "user1" should be "user0 file"
+    And the content of file "/TMP/randomfile.txt" for user "user2" should be "user0 file"
+    And user "user1" should be able to upload file "filesForUpload/textfile.txt" to "TMP/textfile-by-user2.txt"
+    But user "user2" should not be able to upload file "filesForUpload/textfile.txt" to "TMP/textfile-by-user1.txt"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1074,12 +1074,15 @@ trait Sharing {
 	}
 
 	/**
-	 * @param string $userOrGroup
+	 * @param string $userOrGroupId
+	 * @param string|int $shareType 0 or "user" for user, 1 or "group" for group
 	 * @param int|int[]|string|string[] $permissions
 	 *
 	 * @return bool
 	 */
-	public function isUserOrGroupInSharedData($userOrGroup, $permissions = null) {
+	public function isUserOrGroupInSharedData($userOrGroupId, $shareType, $permissions = null) {
+		$shareType = SharingHelper::getShareType($shareType);
+
 		if ($permissions !== null) {
 			if (\is_string($permissions) && !\is_numeric($permissions)) {
 				$permissions = $this->splitPermissionsString($permissions);
@@ -1090,7 +1093,8 @@ trait Sharing {
 		$data = $this->getResponseXml()->data[0];
 		if (\is_iterable($data)) {
 			foreach ($data as $element) {
-				if ($element->share_with->__toString() === $userOrGroup
+				if (($element->share_type->__toString() === (string) $shareType)
+					&& ($element->share_with->__toString() === $userOrGroupId)
 					&& ($permissions === null
 					|| $permissionSum === (int) $element->permissions->__toString())
 				) {
@@ -1137,7 +1141,7 @@ trait Sharing {
 			[],
 			$this->ocsApiVersion
 		);
-		if ($getShareData && $this->isUserOrGroupInSharedData($user2, $permissions)) {
+		if ($getShareData && $this->isUserOrGroupInSharedData($user2, "user", $permissions)) {
 			return;
 		} else {
 			$this->createShare(
@@ -1195,7 +1199,7 @@ trait Sharing {
 		);
 		// this is expected to fail if a file is shared with create and delete permissions, which is not possible
 		Assert::assertTrue(
-			$this->isUserOrGroupInSharedData($user2, $permissions),
+			$this->isUserOrGroupInSharedData($user2, "user", $permissions),
 			"User $user1 failed to share $filepath with user $user2"
 		);
 	}
@@ -1318,7 +1322,7 @@ trait Sharing {
 			[],
 			$this->ocsApiVersion
 		);
-		if ($getShareData && $this->isUserOrGroupInSharedData($group, $permissions)) {
+		if ($getShareData && $this->isUserOrGroupInSharedData($group, "group", $permissions)) {
 			return;
 		} else {
 			$this->createShare(
@@ -1377,7 +1381,7 @@ trait Sharing {
 
 		Assert::assertEquals(
 			true,
-			$this->isUserOrGroupInSharedData($group, $permissions)
+			$this->isUserOrGroupInSharedData($group, "group", $permissions)
 		);
 	}
 


### PR DESCRIPTION
## Description
Add acceptance test scenarios that share with a user and group that have the same name, and then update sharing permissions of one of the shares.

I had to fix `isUserOrGroupInSharedData()` - it needs to know if it is supposed to be matching a user or group share.

Note: we already have test scenarios that create shares with a user and group having the same name. https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecial/createShareGroupAndUserWithSameName.feature

## Issue
#36813 

## Motivation and Context
There is an issue on the webUI with changing sharing permissions when a user and group have the same name. First demonstrate that the API is OK.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
