### PR TITLE
[Tests-only] Remove unneeded 'given using old/new dav path'

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecial/createShareDefaultExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareDefaultExpirationDate.feature
@@ -2,8 +2,7 @@
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares without specifying expireDate

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareDefaultFolderForReceivedShares.feature
@@ -2,8 +2,7 @@
 Feature: shares are received in the default folder for received shares
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario Outline: Do not allow sharing of the entire share_folder

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareGroupAndUserWithSameName.feature
@@ -2,8 +2,7 @@
 Feature: sharing works when a username and group name are the same
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: creating a new share with user and a group having same name

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareGroupCaseSensitive.feature
@@ -2,8 +2,7 @@
 Feature: share with groups, group names are case-sensitive
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareReceivedInMultipleWays.feature
@@ -2,8 +2,7 @@
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Creating a new share with user who already received a share through their group
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareUniqueReceivedNames.feature
@@ -2,8 +2,7 @@
 Feature: resources shared with the same name are received with unique names
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario: unique target names for incoming shares

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareWhenExcludedFromSharing.feature
@@ -2,8 +2,7 @@
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -2,8 +2,7 @@
 Feature: cannot share resources outside the group when share with membership groups is enabled
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareWithDisabledUser.feature
@@ -2,8 +2,7 @@
 Feature: share resources with a disabled user
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Creating a new share with a disabled user
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareWithInvalidPermissions.feature
@@ -2,8 +2,7 @@
 Feature: cannot share resources with invalid permissions
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Cannot create a share of a file or folder with invalid permissions
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -5,8 +5,7 @@ Feature: sharing
   So that ownCloud users cannot share file or folder
 
   Background:
-    Given using old DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -3,7 +3,6 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And using old DAV path
     And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -3,7 +3,6 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And using old DAV path
     And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -2,8 +2,7 @@
 Feature: sharing
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
     @skipOnEncryptionType:user-keys @issue-32322

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -1,9 +1,6 @@
 @api @TestAlsoOnExternalUserBackend @files_sharing-app-required
 Feature: sharing
 
-  Background:
-    Given using old DAV path
-
   Scenario Outline: Delete all group shares
     Given these users have been created with default attributes and skeleton files:
       | username |

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -2,8 +2,7 @@
 Feature: sharing
 
   Background:
-    Given using old DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -2,8 +2,7 @@
 Feature: sharing
 
   Background:
-    Given using old DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -2,8 +2,7 @@
 Feature: accessing a public link share
 
   Background:
-    Given using old DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -2,8 +2,7 @@
 Feature: create a public link share
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
 
   @smokeTest
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1)

--- a/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
@@ -2,8 +2,7 @@
 Feature: multilinksharing
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And as user "user0"
 
   @smokeTest

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
@@ -5,8 +5,7 @@ Feature: reshare as public link
   So that I can give controlled access to others
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
   Scenario Outline: creating a public link from a share with read permission only is not allowed

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -3,7 +3,6 @@ Feature: update a public link share
 
   Background:
     Given using OCS API version "1"
-    And using old DAV path
     And user "user0" has been created with default attributes and skeleton files
 
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info

--- a/tests/acceptance/features/apiShareReshare1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare1/reShare.feature
@@ -2,8 +2,7 @@
 Feature: sharing
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
   Scenario Outline: User is not allowed to reshare file when reshare permission is not given

--- a/tests/acceptance/features/apiShareReshare2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareChain.feature
@@ -2,8 +2,7 @@
 Feature: resharing can be done on a reshared resource
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
   Scenario: Reshared files can be still accessed if a user in the middle removes it.

--- a/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
@@ -2,8 +2,7 @@
 Feature: resharing can be disabled
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled

--- a/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
@@ -2,8 +2,7 @@
 Feature: a subfolder of a received share can be reshared
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
   Scenario Outline: User is allowed to reshare a sub-folder with the same permissions

--- a/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -2,8 +2,7 @@
 Feature: resharing a resource with an expiration date
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
   Scenario Outline: User should not be able to re-share a folder to a group which he/she is not member of when share with only member group is enabled

--- a/tests/acceptance/features/apiShareReshare2/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareWithExpiryDate.feature
@@ -2,8 +2,7 @@
 Feature: resharing a resource with an expiration date
 
   Background:
-    Given using old DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -3,7 +3,6 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And using old DAV path
     And user "user0" has been created with default attributes and skeleton files
 
   @smokeTest

--- a/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
@@ -2,8 +2,7 @@
 Feature: updating shares to users and groups that have the same name
 
   Background:
-    Given using old DAV path
-    And these users have been created with default attributes and without skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | user1    |

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -5,8 +5,7 @@ Feature: Scanning files on local storage
   So that I can manage the balance between performance and "up-to-date-ness" of local storage
 
   Scenario: Adding a file to local storage and running scan should add files.
-    Given using new DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
     And the administrator has scanned the filesystem for all users
@@ -23,8 +22,7 @@ Feature: Scanning files on local storage
       | /hello2.txt |
 
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
-    Given using new DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     And user "user0" has created folder "/local_storage/folder1"
     And user "user0" has created folder "/local_storage/folder2"
@@ -49,8 +47,7 @@ Feature: Scanning files on local storage
 
   @files_sharing-app-required
   Scenario Outline: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
-    Given using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -82,8 +79,7 @@ Feature: Scanning files on local storage
       | commas,in,group,name |
 
   Scenario: Adding a folder to local storage, sharing with groups and running scan for a list of groups should add files for users in the groups
-    Given using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |
@@ -140,8 +136,7 @@ Feature: Scanning files on local storage
       | /hello3.txt |
 
   Scenario: Deleting a file from local storage and running scan for a specific path should remove the file.
-    Given using new DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/hello1.txt"
     When user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
     Then the propfind result should contain these entries:
@@ -156,8 +151,7 @@ Feature: Scanning files on local storage
       | /hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific user should add file for only that user
-    Given using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
@@ -185,8 +179,7 @@ Feature: Scanning files on local storage
       | /hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific group should add file for only the users of that group
-    Given using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and skeleton files:
       | username |
       | user1    |
       | user2    |


### PR DESCRIPTION
## Description
A lot of (mainly sharing) feature files have `Given using old DAV path` in the background section. That is the default anyway, and actually these scenarios are not specially testing a particular DAV path. They are testing sharing API calls. So remove this unneeded line.

In the 2nd commit, remove some `Given using new DAV path` that are not needed.

## Motivation and Context
https://github.com/owncloud/core/pull/36793#discussion_r368930236

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
