### PR TITLE
Run tests to support MariaDB:10.4

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1123,7 +1123,7 @@ def phptests(testType):
 	default = {
 		'phpVersions': ['7.1', '7.2', '7.3'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
+			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,

--- a/.drone.yml
+++ b/.drone.yml
@@ -1808,6 +1808,140 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: phpunit-php7.1-mariadb10.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /drone
+  path: src
+
+steps:
+- name: cache-restore
+  pull: always
+  image: plugins/s3-cache:1
+  settings:
+    access_key:
+      from_secret: cache_s3_access_key
+    endpoint:
+      from_secret: cache_s3_endpoint
+    restore: true
+    secret_key:
+      from_secret: cache_s3_secret_key
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+- name: composer-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-composer-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: vendorbin-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make vendor-bin-deps
+  environment:
+    COMPOSER_HOME: /drone/src/.cache/composer
+
+- name: yarn-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make install-nodejs-deps
+  environment:
+    NPM_CONFIG_CACHE: /drone/src/.cache/npm
+    YARN_CACHE_FOLDER: /drone/src/.cache/yarn
+    bower_storage__packages: /drone/src/.cache/bower
+
+- name: install-server
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - bash tests/drone/install-server.sh
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ security:certificates:import /drone/server.crt
+  - php occ security:certificates
+  environment:
+    DB_TYPE: mariadb
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /drone/src
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /drone/src/data/owncloud.log
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - su-exec www-data bash tests/drone/test-phpunit.sh
+  environment:
+    COVERAGE: true
+    DB_TYPE: mariadb
+
+- name: coverage-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    files:
+    - "*.xml"
+    flags:
+    - phpunit
+    paths:
+    - tests/output/coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov_token
+  when:
+    instance:
+    - drone.owncloud.services
+    - drone.owncloud.com
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.4
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.3
+- changelog
+- phpstan-php7.1
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: phpunit-php7.1-mysql5.5
 
 platform:
@@ -16131,6 +16265,7 @@ depends_on:
 - phpunit-php7.1-sqlite
 - phpunit-php7.1-mariadb10.2
 - phpunit-php7.1-mariadb10.3
+- phpunit-php7.1-mariadb10.4
 - phpunit-php7.1-mysql5.5
 - phpunit-php7.1-mysql5.7
 - phpunit-php7.1-mysql8.0

--- a/changelog/unreleased/36800
+++ b/changelog/unreleased/36800
@@ -1,0 +1,6 @@
+Enhancement: MariaDb 10.4 support
+
+MariaDb 10.4 is now supported
+
+https://github.com/owncloud/core/issues/36799
+https://github.com/owncloud/core/pull/36800


### PR DESCRIPTION
## Description
Run a pipeline of unit tests on MariaDB:10.4

Note: #36798 demonstrates running a full set of acceptance tests on MariaDB:10.4

## Related Issue
- #36799 

## Motivation and Context
Support the current stable release of MariaDB

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
