### PR TITLE
[Tests-only] simplify feature files

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -5,8 +5,7 @@ Feature: dav-versions
   Background:
     Given using OCS API version "2"
     And using new DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And file "/davtest.txt" has been deleted for user "user0"
+    And user "user0" has been created with default attributes and without skeleton files
 
   Scenario: Upload file and no version is available
     When user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" using the WebDAV API
@@ -73,6 +72,7 @@ Feature: dav-versions
   @smokeTest @skipOnStorage:ceph @files_primary_s3-issue-161
   Scenario Outline: Uploading a chunked file does create the correct version that can be restored
     Given using <dav-path> DAV path
+    And user "user0" has uploaded file with content "textfile0" to "textfile0.txt"
     When user "user0" uploads file "filesForUpload/davtest.txt" to "/textfile0.txt" in 2 chunks using the WebDAV API
     And user "user0" uploads file "filesForUpload/lorem.txt" to "/textfile0.txt" in 3 chunks using the WebDAV API
     Then the version folder of file "/textfile0.txt" for user "user0" should contain "2" elements
@@ -86,6 +86,7 @@ Feature: dav-versions
   @skipOnStorage:ceph @files_primary_s3-issue-161
   Scenario: Uploading a file asynchronously does create the correct version that can be restored
     Given the administrator has enabled async operations
+    And user "user0" has uploaded file with content "textfile0" to "textfile0.txt"
     When user "user0" uploads file "filesForUpload/davtest.txt" asynchronously to "textfile0.txt" in 2 chunks using the WebDAV API
     And user "user0" uploads file "filesForUpload/lorem.txt" asynchronously to "textfile0.txt" in 2 chunks using the WebDAV API
     Then the version folder of file "/textfile0.txt" for user "user0" should contain "2" elements
@@ -102,7 +103,7 @@ Feature: dav-versions
     And as user "user0" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
 
   Scenario: User cannot access meta folder of a file which is owned by somebody else
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "123" to "/davtest.txt"
     And we save it into "FILEID"
     When user "user1" sends HTTP method "PROPFIND" to URL "/remote.php/dav/meta/<<FILEID>>"
@@ -110,7 +111,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: User can access meta folder of a file which is owned by somebody else but shared with that user
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "123" to "/davtest.txt"
     And user "user0" has uploaded file with content "456789" to "/davtest.txt"
     And we save it into "FILEID"
@@ -123,7 +124,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
     And user "user0" has shared file "sharefile.txt" with user "user1"
     When user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
@@ -132,7 +133,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
     And user "user0" has shared file "sharefile.txt" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
@@ -143,7 +144,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharer can restore a file inside a shared folder modified by sharee
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -155,7 +156,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder modified by sharee
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -167,7 +168,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -179,7 +180,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -191,7 +192,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user1" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -203,7 +204,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -215,7 +216,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has shared folder "/sharingfolder" with user "user1"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -229,7 +230,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "old content" to "/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharefile.txt"
     And user "user0" has shared file "/sharefile.txt" with user "user1"
@@ -242,7 +243,7 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/sharingfolder"
     And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
     And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
@@ -256,8 +257,8 @@ Feature: dav-versions
 
   @files_sharing-app-required
   Scenario: sharer can restore a file inside a group shared folder modified by sharee
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
@@ -328,6 +329,8 @@ Feature: dav-versions
   @skipOnOcV10.3.0 @files_sharing-app-required
   Scenario: Receiver tries to get file versions of unshared file from the sharer
     Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "textfile0" to "textfile0.txt"
+    And user "user0" has uploaded file with content "textfile1" to "textfile1.txt"
     And user "user0" has shared file "textfile0.txt" with user "user1"
     When user "user1" tries to get versions of file "textfile1.txt" from "user0"
     Then the HTTP status code should be "404"
@@ -336,6 +339,7 @@ Feature: dav-versions
   @skipOnStorage:ceph @files_primary_s3-issue-161 @files_sharing-app-required
   Scenario: Receiver tries get file versions of shared file from the sharer
     Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "textfile0" to "textfile0.txt"
     And user "user0" has uploaded file with content "version 1" to "textfile0.txt"
     And user "user0" has uploaded file with content "version 2" to "textfile0.txt"
     And user "user0" has uploaded file with content "version 3" to "textfile0.txt"

--- a/tests/acceptance/features/apiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties/copyFile.feature
@@ -6,14 +6,17 @@ Feature: copy file
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "user0" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
+    And user "user0" has created folder "/FOLDER"
 
   @smokeTest
   Scenario Outline: Copying a file
     Given using <dav_version> DAV path
-    When user "user0" copies file "/welcome.txt" to "/FOLDER/welcome.txt" using the WebDAV API
+    When user "user0" copies file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
+    And the content of file "/FOLDER/textfile0.txt" for user "user0" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |
@@ -22,9 +25,9 @@ Feature: copy file
   @smokeTest
   Scenario Outline: Copying and overwriting a file
     Given using <dav_version> DAV path
-    When user "user0" copies file "/welcome.txt" to "/textfile1.txt" using the WebDAV API
+    When user "user0" copies file "/textfile0.txt" to "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And the downloaded content when downloading file "/textfile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
+    And the content of file "/textfile1.txt" for user "user0" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |
@@ -35,8 +38,8 @@ Feature: copy file
     # "/textfile1.txt" already exists in the skeleton, make another with only case differences in the file name
     When user "user0" copies file "/textfile0.txt" to "/TextFile1.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the content of file "/textfile1.txt" for user "user0" should be "ownCloud test text file 1" plus end-of-line
-    And the content of file "/TextFile1.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/textfile1.txt" for user "user0" should be "ownCloud test text file 1"
+    And the content of file "/TextFile1.txt" for user "user0" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |


### PR DESCRIPTION
## Description
make tests easier to understand by not using the skeleton folder

## Motivation and Context
that will make it easier to run OCIS tests, because there we cannot use the skeleton folder yet

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
