### PR TITLE
Fix the width of some confirmation buttons

### DIFF
--- a/changelog/unreleased/36807
+++ b/changelog/unreleased/36807
@@ -1,0 +1,5 @@
+Bugfix: Fix one-time password (OTP) verify button width
+
+The one-time password (OTP) verify button width has been extended.
+
+https://github.com/owncloud/core/pull/36807

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -607,6 +607,7 @@ label.infield {
 #body-login input[type="submit"] {
 	padding: 10px 0px; /* larger log in and installation buttons */
 	max-width: 269px;
+	width: 269px;
 }
 #remember_login {
 	margin: 18px 5px 0 16px !important;


### PR DESCRIPTION
### Description
Some buttons need the width property to react correctly. 

## Motivation and Context
I noticed that some input buttons are too short, actually as long as the text. This often looks unattractive. By setting the width this is fixed.

## How Has This Been Tested?
Manual tested

## Screenshots (if appropriate):
| Before  |  After |
|---|---|
|   <img width="359" alt="Screenshot 2020-01-22 at 13 40 25 1" src="https://user-images.githubusercontent.com/33026403/72896819-d630ed80-3d20-11ea-9a53-a81000b6435d.png"> |  <img width="383" alt="Screenshot 2020-01-22 at 13 50 36" src="https://user-images.githubusercontent.com/33026403/72896824-d9c47480-3d20-11ea-9fc3-42db42b3565d.png"> |

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
