### PR TITLE
[Tests-only] simplify delete folder tests by not using the skeleton folder

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -5,8 +5,8 @@ Feature: delete folder
   So that I can quickly remove unwanted data
 
   Background:
-    Given using OCS API version "1"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" creates folder "/PARENT" using the WebDAV API
 
   Scenario Outline: delete a folder
     Given using <dav_version> DAV path
@@ -20,7 +20,6 @@ Feature: delete folder
 
   Scenario Outline: delete a folder when 2 folder exist with different case
     Given using <dav_version> DAV path
-    And user "user0" creates folder "/PARENT" using the WebDAV API
     And user "user0" creates folder "/parent" using the WebDAV API
     When user "user0" deletes folder "/PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -33,6 +32,8 @@ Feature: delete folder
 
   Scenario Outline: delete a sub-folder
     Given using <dav_version> DAV path
+    And user "user0" creates folder "/PARENT/CHILD" using the WebDAV API
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/PARENT/parent.txt"
     When user "user0" deletes folder "/PARENT/CHILD" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "user0" folder "/PARENT/CHILD" should not exist

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
@@ -5,24 +5,23 @@ Feature: delete folder contents
   So that I can quickly remove unwanted data
 
   Background:
-    Given using OCS API version "1"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   Scenario Outline: Removing everything of a folder
     Given using <dav_version> DAV path
-    And user "user0" has moved file "/welcome.txt" to "/FOLDER/welcome.txt"
+    And user "user0" has created folder "/PARENT/"
+    And user "user0" has created folder "/FOLDER/"
     And user "user0" has created folder "/FOLDER/SUBFOLDER"
-    And user "user0" has copied file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/textfile0.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/textfile1.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/FOLDER/welcome.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/FOLDER/SUBFOLDER/textfile0.txt"
     When user "user0" deletes everything from folder "/FOLDER/" using the WebDAV API
     Then user "user0" should see the following elements
       | /FOLDER/           |
       | /PARENT/           |
-      | /PARENT/parent.txt |
       | /textfile0.txt     |
       | /textfile1.txt     |
-      | /textfile2.txt     |
-      | /textfile3.txt     |
-      | /textfile4.txt     |
     And user "user0" should not see the following elements
       | /FOLDER/SUBFOLDER/              |
       | /FOLDER/welcome.txt             |


### PR DESCRIPTION
## Description
make tests easier to understand by not using the skeleton folder

## Motivation and Context
that will make it easier to run OCIS tests, because there we cannot use the skeleton folder yet
part of https://github.com/owncloud/ocis-reva/issues/23

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
