### PR TITLE
[Tests-only] simplify deleteFile and downloadFile feature descriptions

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
@@ -5,12 +5,12 @@ Feature: delete file
   So that I can remove unwanted data
 
   Background:
-    Given using OCS API version "1"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: delete a file
     Given using <dav_version> DAV path
+    And user "user0" has uploaded file with content "to delete" to "/textfile0.txt"
     When user "user0" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "user0" file "/textfile0.txt" should not exist

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -5,14 +5,15 @@ Feature: download file
   So that I can work wih local copies of files on my client system
 
   Background:
-    Given using OCS API version "1"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "user0" has uploaded file with content "Welcome this is just an example file for developers." to "/welcome.txt"
 
   @smokeTest
   Scenario Outline: download a file
     Given using <dav_version> DAV path
     When user "user0" downloads file "/textfile0.txt" using the WebDAV API
-    Then the downloaded content should be "ownCloud test text file 0" plus end-of-line
+    Then the downloaded content should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |
@@ -20,7 +21,7 @@ Feature: download file
 
   Scenario Outline: download a file with range
     Given using <dav_version> DAV path
-    When user "user0" downloads file "/welcome.txt" with range "bytes=51-77" using the WebDAV API
+    When user "user0" downloads file "/welcome.txt" with range "bytes=24-50" using the WebDAV API
     Then the downloaded content should be "example file for developers"
     Examples:
       | dav_version |
@@ -52,7 +53,7 @@ Feature: download file
       | X-Permitted-Cross-Domain-Policies | none                                                             |
       | X-Robots-Tag                      | none                                                             |
       | X-XSS-Protection                  | 1; mode=block                                                    |
-    And the downloaded content should start with "Welcome to your ownCloud account!"
+    And the downloaded content should start with "Welcome"
     Examples:
       | dav_version |
       | old         |
@@ -62,7 +63,7 @@ Feature: download file
     Given using <dav_version> DAV path
     And user "user0" has logged in to a web-style session
     When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" without requesttoken
-    Then the downloaded content should start with "Welcome to your ownCloud account!"
+    Then the downloaded content should start with "Welcome"
     And the HTTP status code should be "200"
     Examples:
       | dav_version |
@@ -73,7 +74,7 @@ Feature: download file
     Given using <dav_version> DAV path
     And user "user0" has logged in to a web-style session
     When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken
-    Then the downloaded content should start with "Welcome to your ownCloud account!"
+    Then the downloaded content should start with "Welcome"
     And the HTTP status code should be "200"
     Examples:
       | dav_version |


### PR DESCRIPTION
## Description
make tests easier to understand by not using the skeleton folder

## Related Issue
part of owncloud/ocis-reva#23

## Motivation and Context
that will make it easier to run OCIS tests, because there we cannot use the skeleton folder yet

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
