### PR TITLE
[Tests-only] added getter/setter for user_ldap old config

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -327,6 +327,24 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * @return array
+	 */
+	public function getOldLdapConfig() {
+		return $this->oldLdapConfig;
+	}
+
+	/**
+	 * @param $configId
+	 * @param $configKey
+	 * @param $value
+	 *
+	 * @return void
+	 */
+	public function setOldLdapConfig($configId, $configKey, $value) {
+		$this->oldLdapConfig[$configId][$configKey] = $value;
+	}
+
+	/**
 	 * @return bool
 	 */
 	public function isTestingWithLdap() {

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -448,6 +448,9 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When the LDAP users are resynced
+	 * @Given the LDAP users have been resynced
+	 *
 	 * @return void
 	 * @throws Exception
 	 */


### PR DESCRIPTION
## Description
Added function for setting ldap config to oldLdapConfig and getting oldLdapConfig

## How Has This Been Tested?
- :robot: 

## Related Issue
- https://github.com/owncloud/user_ldap/pull/495

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
