### PR TITLE
[Tests-only] Added getter function for ldap configs

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -345,6 +345,27 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getLdapHost() {
+		return $this->ldapHost;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLdapHostWithoutScheme() {
+		return $this->removeSchemeFromUrl($this->ldapHost);
+	}
+
+	/**
+	 * @return integer
+	 */
+	public function getLdapPort() {
+		return $this->ldapPort;
+	}
+
+	/**
 	 * @return bool
 	 */
 	public function isTestingWithLdap() {

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -390,6 +390,15 @@ trait Provisioning {
 			$this->ldap->add($items['dn'], $items);
 		} else {
 			foreach ($items as $item) {
+				if (isset($item["objectclass"])) {
+					if (\in_array("posixGroup", $item["objectclass"])) {
+						\array_push($this->ldapCreatedGroups, $item["cn"][0]);
+						\array_push($this->createdGroups, $item["cn"][0]);
+					} elseif (\in_array("inetOrgPerson", $item["objectclass"])) {
+						\array_push($this->ldapCreatedUsers, $item["uid"][0]);
+						\array_push($this->createdUsers, $item["uid"][0]);
+					}
+				}
 				$this->ldap->add($item['dn'], $item);
 			}
 		}


### PR DESCRIPTION
## Description
When migrating zend_ldap connections settings from user_ldap to core, some of the getter function were left. Those remaining function are added!

## How Has This Been Tested?
- :robot: 

## Related Issue
- https://github.com/owncloud/user_ldap/pull/495

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
