### PR TITLE
Add additional info for share owner and initiator

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -144,7 +144,7 @@ class Share20OcsController extends OCSController {
 	 */
 	protected function formatShare(IShare $share, $received = false) {
 		$sharedBy = $this->userManager->get($share->getSharedBy());
-		$shareOwner = $this->userManager->get($share->getShareOwner());
+		$shareFileOwner = $this->userManager->get($share->getShareOwner());
 
 		$result = [
 			'id' => $share->getId(),
@@ -157,8 +157,14 @@ class Share20OcsController extends OCSController {
 			'expiration' => null,
 			'token' => null,
 			'uid_file_owner' => $share->getShareOwner(),
-			'displayname_file_owner' => $shareOwner !== null ? $shareOwner->getDisplayName() : $share->getShareOwner()
+			'displayname_file_owner' => $shareFileOwner !== null ? $shareFileOwner->getDisplayName() : $share->getShareOwner()
 		];
+		if ($sharedBy !== null) {
+			$result['additional_info_owner'] = $this->getAdditionalUserInfo($sharedBy);
+		}
+		if ($shareFileOwner !== null) {
+			$result['additional_info_file_owner'] = $this->getAdditionalUserInfo($shareFileOwner);
+		}
 
 		if ($received) {
 			// also add state

--- a/changelog/unreleased/36823
+++ b/changelog/unreleased/36823
@@ -1,0 +1,8 @@
+Enhancement: Additional share owner and initiator info in shares API response
+
+We've extended the OCS Share API response for share recipients to also include
+additional fields for the share owner and initiator.
+Additional fields are configured in the admin settings and can be set to email or user id
+and are useful to distinguish users who have the same display name.
+
+https://github.com/owncloud/core/issues/36823


### PR DESCRIPTION
## Description
Extend the OCS share response to also include additional information
(email or id) for the share owner and initiator.

Developed together with @kulmann 

## Related Issue
Fixes https://github.com/owncloud/core/issues/36823

## Motivation and Context
For https://github.com/owncloud/phoenix/issues/2898

## How Has This Been Tested?
- Tested with https://github.com/owncloud/phoenix/pull/2915 which uses the values
- Unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
