### PR TITLE
[Tests-only] SkipOnOcV10.3 20200125

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -506,6 +506,7 @@ Feature: create a public link share
     Then the value of the item "//s:message" in the response should be ""
     And the HTTP status code should be "404"
 
+  @skipOnOcV10.3
   Scenario: Get the size of a file shared by public link
     Given the administrator has enabled DAV tech_preview
     And user "user0" has uploaded file with content "This is a test file" to "test-file.txt"

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -598,6 +598,7 @@ Feature: Share by public link
     And the public accesses the last created public link using the webUI
     Then it should be possible to delete file "lorem-big.txt" using the webUI
 
+  @skipOnOcV10.3
   Scenario: user tries to deletes the expiration date of already existing public link using webUI when expiration date is enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
@@ -639,6 +640,7 @@ Feature: Share by public link
     Then the fields of the last response should include
       | expiration |  |
 
+  @skipOnOcV10.3
   Scenario: user creates a new public link using webUI removing expiration date when default expire date is set and enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"


### PR DESCRIPTION
## Description
1) new test added for bugfix in PR #36778 will not pass on old oC10.3, skip it there.
2) In PR #36766 https://github.com/owncloud/core/commit/1e58d1555a12704edaaa709e700780a513048901#diff-73ed261bd73f14fbf179a07b475b90dbR57 the Id of the public link expiration element was refactored (among other things). Some tests use this, so the new test code works against the new 10.4 code, but not against a 10.3 system - skip those tests on 10.3

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
