### PR TITLE
[Tests-only] only generate token for tests where its needed

### DIFF
--- a/tests/acceptance/features/apiAuth/filesAppAuth.feature
+++ b/tests/acceptance/features/apiAuth/filesAppAuth.feature
@@ -3,7 +3,6 @@ Feature: auth
 
   Background:
     Given user "user0" has been created with default attributes and skeleton files
-    And a new client token for "user0" has been generated
 
   @smokeTest
   Scenario: access files app anonymously
@@ -17,11 +16,13 @@ Feature: auth
 
   @smokeTest
   Scenario: access files app with basic token auth
+    Given a new client token for "user0" has been generated
     When user "user0" requests "/index.php/apps/files" with "GET" using basic token auth
     Then the HTTP status code should be "200"
 
   @smokeTest
   Scenario: access files app with a client token
+    Given a new client token for "user0" has been generated
     When the user requests "/index.php/apps/files" with "GET" using the generated client token
     Then the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -3,7 +3,6 @@ Feature: auth
 
   Background:
     Given user "user0" has been created with default attributes and skeleton files
-    And a new client token for "user0" has been generated
 
   Scenario: using WebDAV anonymously
     When a user requests "/remote.php/webdav" with "PROPFIND" and no authentication
@@ -14,6 +13,7 @@ Feature: auth
     Then the HTTP status code should be "207"
 
   Scenario: using WebDAV with token auth
+    Given a new client token for "user0" has been generated
     When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
     Then the HTTP status code should be "207"
 


### PR DESCRIPTION
## Description
not all of the scenarios need a token, so only create it when its needed

## Related Issue
part of https://github.com/owncloud/ocis-reva/issues/23

## Motivation and Context
1. don't do useless work, don't waste resources, save the :earth_asia: 
2. the token endpoint does not exists in OCIS, so this will make it easier to run more tests that should work and only skip those that do not work because of the missing endpoint

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
