### PR TITLE
[Tests-only] don't force to check the ocs-status

### DIFF
--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -230,11 +230,12 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function userRequestsEndpointsWithPassword($user, $method, $password, TableNode $table) {
-		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code', 'ocs-code'], ['body']);
+		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code'], ['ocs-code', 'body']);
 		foreach ($table->getHash() as $row) {
 			$body = $row['body'] ?? null;
+			$ocsCode = $row['ocs-code'] ?? null;
 			$this->userRequestsURLWithUsingBasicAuth($user, $row['endpoint'], $method, $password, $body);
-			$this->verifyStatusCode($row['ocs-code'], $row['http-code'], $row['endpoint']);
+			$this->verifyStatusCode($ocsCode, $row['http-code'], $row['endpoint']);
 		}
 	}
 
@@ -264,14 +265,15 @@ class AuthContext implements Context {
 		$password,
 		TableNode $table
 	) {
-		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code', 'ocs-code']);
+		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code'], ['ocs-code']);
 		foreach ($table->getHash() as $row) {
 			$this->administratorRequestsURLWithUsingBasicAuth(
 				$row['endpoint'],
 				$method,
 				$password
 			);
-			$this->verifyStatusCode($row['ocs-code'], $row['http-code'], $row['endpoint']);
+			$ocsCode = $row['ocs-code'] ?? null;
+			$this->verifyStatusCode($ocsCode, $row['http-code'], $row['endpoint']);
 		}
 	}
 
@@ -285,10 +287,11 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function whenUserWithNewClientTokenRequestsForEndpointUsingBasicTokenAuth($user, $method, TableNode $table) {
-		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code', 'ocs-code']);
+		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code'], ['ocs-code']);
 		foreach ($table->getHash() as $row) {
+			$ocsCode = $row['ocs-code'] ?? null;
 			$this->userRequestsURLWithUsingBasicTokenAuth($user, $row['endpoint'], $method);
-			$this->verifyStatusCode($row['ocs-code'], $row['http-code'], $row['endpoint']);
+			$this->verifyStatusCode($ocsCode, $row['http-code'], $row['endpoint']);
 		}
 	}
 
@@ -301,10 +304,11 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function userRequestsTheseEndpointsUsingNewBrowserSession($method, TableNode $table) {
-		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code', 'ocs-code']);
+		$this->featureContext->verifyTableNodeColumns($table, ['endpoint', 'http-code'], ['ocs-code']);
 		foreach ($table->getHash() as $row) {
+			$ocsCode = $row['ocs-code'] ?? null;
 			$this->userRequestsURLWithBrowserSession($row['endpoint'], $method);
-			$this->verifyStatusCode($row['ocs-code'], $row['http-code'], $row['endpoint']);
+			$this->verifyStatusCode($ocsCode, $row['http-code'], $row['endpoint']);
 		}
 	}
 


### PR DESCRIPTION
## Description
allow these steps to check only the HTTP status code

## Related Issue
part of owncloud/ocis-reva#23

## Motivation and Context
OCIS replies with an empty result in case of HTTP `401`. This change will allow us to do meaningful OCIS tests, in case of HTTP `401` by not checking the ocs status code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
