### PR TITLE
Allow expiration date to be today

### DIFF
--- a/core/js/sharedialoglinkexpirationview.js
+++ b/core/js/sharedialoglinkexpirationview.js
@@ -115,8 +115,6 @@
 			// what if there is another date picker on that page?
 			var minDate = new Date();
 			var maxDate = null;
-			// min date should always be the next day
-			minDate.setDate(minDate.getDate()+1);
 
 			if(isExpirationSet) {
 				if(isExpirationEnforced) {

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -500,7 +500,7 @@
 			var $el = $(el);
 
 			$el.datepicker({
-				minDate: "+1d",
+				minDate: "+0d",
 				dateFormat : 'dd-mm-yy',
 				onSelect : function() {
 					self._onExpirationChange(el);

--- a/core/js/tests/specs/sharedialogexpirationviewSpec.js
+++ b/core/js/tests/specs/sharedialogexpirationviewSpec.js
@@ -122,7 +122,7 @@ describe('OC.Share.ShareDialogLinkExpirationView', function() {
 			beforeEach(function() {
 				// pick a fake date
 				clock = sinon.useFakeTimers(new Date(2014, 0, 20, 14, 0, 0).getTime());
-				expectedMinDate = new Date(2014, 0, 21, 14, 0, 0);
+				expectedMinDate = new Date(2014, 0, 20, 14, 0, 0);
 
 				datepickerStub = sinon.stub($.fn, 'datepicker');
 				setDefaultsStub = sinon.stub($.datepicker, 'setDefaults');

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -26,6 +26,7 @@
 
 namespace OC\Share20;
 
+use DateTimeZone;
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\View;
@@ -405,12 +406,14 @@ class Manager implements IManager {
 		$expirationDate = $share->getExpirationDate();
 
 		if ($expirationDate !== null) {
-			//Make sure the expiration date is a date
-			$expirationDate->setTime(0, 0, 0);
+			// Set the expiration date to just the date at "zero" time in the day
+			$expirationDate->setTime(0, 0, 0, 0);
 
-			$date = new \DateTime();
-			$date->setTime(0, 0, 0);
-			if ($date >= $expirationDate) {
+			// Get the current date in the same timezone, and at "zero" time in the day
+			$date = new \DateTime('now', new DateTimeZone($expirationDate->getTimezone()->getName()));
+			$date->setTime(0, 0, 0, 0);
+
+			if ($date > $expirationDate) {
 				$message = $this->l->t('Expiration date is in the past');
 				throw new GenericShareException($message, $message, 404);
 			}

--- a/tests/acceptance/features/apiShareCreateSpecial/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial/createShareExpirationDate.feature
@@ -590,31 +590,41 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 11.12.2050 12:30:40 |
 
   @skipOnOcV10.3
-  Scenario Outline: sharing with default expiration date enforced for users, user shares with humanized expiration date format
+  Scenario Outline: user shares with humanized expiration date format
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
     And user "user1" has been created with default attributes and without skeleton files
     When user "user0" creates a share using the sharing API with settings
-      | path               | textfile0.txt |
-      | shareType          | user          |
-      | shareWith          | user1         |
-      | permissions        | read,share    |
-      | expireDateAsString | tomorrow      |
+      | path               | textfile0.txt     |
+      | shareType          | user              |
+      | shareWith          | user1             |
+      | permissions        | read,share        |
+      | expireDateAsString | <expiration_date> |
     Then the fields of the last response should include
-      | expiration | tomorrow |
+      | expiration | <expiration_date> |
     And the response when user "user1" gets the info of the last share should include
-      | expiration | tomorrow |
+      | expiration | <expiration_date> |
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | expiration_date | default | enforce |
+      | 1               | today           | yes     | yes     |
+      | 2               | today           | yes     | yes     |
+      | 1               | tomorrow        | yes     | yes     |
+      | 2               | tomorrow        | yes     | yes     |
+      | 1               | today           | yes     | no      |
+      | 2               | today           | yes     | no      |
+      | 1               | tomorrow        | yes     | no      |
+      | 2               | tomorrow        | yes     | no      |
+      | 1               | today           | no      | no      |
+      | 2               | today           | no      | no      |
+      | 1               | tomorrow        | no      | no      |
+      | 2               | tomorrow        | no      | no      |
 
   @skipOnOcV10.3
-  Scenario Outline: sharing with default expiration date enforced for users, user shares with humanized expiration date format in past
+  Scenario Outline: user shares with humanized expiration date format in past
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
     And user "user1" has been created with default attributes and without skeleton files
     When user "user0" creates a share using the sharing API with settings
       | path               | textfile0.txt |
@@ -627,15 +637,19 @@ Feature: a default expiration date can be specified for shares with users or gro
     And the OCS status message should be "Expiration date is in the past"
     And user "user1" should not have any received shares
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 404             | 200              |
-      | 2               | 404             | 404              |
+      | ocs_api_version | ocs_status_code | http_status_code | default | enforce |
+      | 1               | 404             | 200              | yes     | yes     |
+      | 2               | 404             | 404              | yes     | yes     |
+      | 1               | 404             | 200              | yes     | no      |
+      | 2               | 404             | 404              | yes     | no      |
+      | 1               | 404             | 200              | no      | no      |
+      | 2               | 404             | 404              | no      | no      |
 
   @skipOnOcV10.3
-  Scenario Outline: sharing with default expiration date enforced for users, user shares with invalid humanized expiration date
+  Scenario Outline: user shares with invalid humanized expiration date
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
     And user "user1" has been created with default attributes and without skeleton files
     When user "user0" creates a share using the sharing API with settings
       | path               | textfile0.txt |
@@ -648,9 +662,13 @@ Feature: a default expiration date can be specified for shares with users or gro
     And the OCS status message should be "Invalid date, date format must be YYYY-MM-DD"
     And user "user1" should not have any received shares
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 404             | 200              |
-      | 2               | 404             | 404              |
+      | ocs_api_version | ocs_status_code | http_status_code | default | enforce |
+      | 1               | 404             | 200              | yes     | yes     |
+      | 2               | 404             | 404              | yes     | yes     |
+      | 1               | 404             | 200              | yes     | no      |
+      | 2               | 404             | 404              | yes     | no      |
+      | 1               | 404             | 200              | no      | no      |
+      | 2               | 404             | 404              | no      | no      |
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enforced for users, user shares with past expiration date set

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupUsingExpirationDate.feature
@@ -62,20 +62,24 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | expiration  | +3 days    |
       | uid_owner   | user1      |
 
-  Scenario: expiration date is enforced for group, user shares a file
+  Scenario Outline: expiration date is enforced for group, user shares a file
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
-    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "3"
+    And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "<num_days>"
     And user "user1" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
-    And the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
+    And the expiration date input field should be "<days>" for the group "grp1" in the share dialog
     And the information of the last share of user "user1" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | expiration  | +3 days    |
+      | expiration  | <days>     |
       | uid_owner   | user1      |
+    Examples:
+      | num_days | days     |
+      | 3        | +3 days  |
+      | 0        | today    |
 
   Scenario: expiration date is enforced for group, user shares and tries to change expiration date more than allowed
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -268,18 +272,23 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | expiration  | +20 days             |
       | share_with  | grp1                 |
 
-  Scenario: expiration date is disabled for sharing with group, user shares file with group and sets expiration date
+  Scenario Outline: expiration date is disabled for sharing with group, user shares file with group and sets expiration date
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "no"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
     And user "user1" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
-    And the user changes expiration date for share of group "grp1" to "+15 days" in the share dialog
+    And the user changes expiration date for share of group "grp1" to "<days>" in the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
-    And the expiration date input field should be "+15 days" for the group "grp1" in the share dialog
+    And the expiration date input field should be "<days>" for the group "grp1" in the share dialog
     And the information of the last share of user "user1" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | expiration  | +15 days   |
+      | expiration  | <days>     |
       | uid_owner   | user1      |
       | share_with  | grp1       |
+    Examples:
+      | days     |
+      | +15 days |
+      | +1 days  |
+      | today    |

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUserUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUserUsingExpirationDate.feature
@@ -45,20 +45,24 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | expiration  | +7 days    |
       | uid_owner   | user1      |
 
-  Scenario: expiration date is enforced for user, user shares file
+  Scenario Outline: expiration date is enforced for user, user shares file
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
-    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "3"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "<num_days>"
     And user "user1" has logged in using the webUI
     When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be "+3 days" for the user "User Two" in the share dialog
+    And the expiration date input field should be "<days>" for the user "User Two" in the share dialog
     And the information of the last share of user "user1" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | expiration  | +3 days    |
+      | expiration  | <days>     |
       | uid_owner   | user1      |
+    Examples:
+      | num_days | days     |
+      | 3        | +3 days  |
+      | 0        | today    |
 
   Scenario: expiration date is enforced for user, user shares and tries to change expiration date more than allowed
     Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -249,17 +253,22 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | expiration  | +20 days             |
       | share_with  | user2                |
 
-  Scenario: expiration date is disabled for sharing with users, user shares file with another user and sets expiration date
+  Scenario Outline: expiration date is disabled for sharing with users, user shares file with another user and sets expiration date
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "no"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
     And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "user1" has logged in using the webUI
     When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    And the user changes expiration date for share of user "User Two" to "+15 days" in the share dialog
+    And the user changes expiration date for share of user "User Two" to "<days>" in the share dialog
     Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be "+15 days" for the user "User Two" in the share dialog
+    And the expiration date input field should be "<days>" for the user "User Two" in the share dialog
     And the information of the last share of user "user1" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | expiration  | +15 days   |
+      | expiration  | <days>     |
       | uid_owner   | user1      |
+    Examples:
+      | days     |
+      | +15 days |
+      | +1 days  |
+      | today    |

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1009,6 +1009,18 @@ class ManagerTest extends \Test\TestCase {
 
 	/**
 	 */
+	public function testValidateExpirationDateToday() {
+		$today = new \DateTime();
+		$today->setTime(0, 0, 0);
+		$share = $this->manager->newShare();
+		$share->setExpirationDate($today);
+
+		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+		$this->assertEquals($today, $share->getExpirationDate());
+	}
+
+	/**
+	 */
 	public function testvalidateExpirationDateEnforceButNotSet() {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Expiration date is enforced');


### PR DESCRIPTION
## Description
The expiration date validation code had some issues when the server was not in UTC. 

The proposed expiration date was in a `DateTime` object that had the time-zone of the server - e.g. it represented `2020-01-27:00:00:00+01:00`. 

The date-time was being compared with "current day" - a new default `DateTime` object that had the time zeroed, but that object was in UTC time - e.g. `2020-01-27:00:00:00+00:00` - but in the local timezone that is actually `2020-01-27:01:00+01:00`

And so the proposed expiration date was 1 hour before the "current day" and the request would return "Expiration date is in the past".

- adjust the webUI JS date-picker so it allows "today"  to be selected
- add API acceptance tests that set share expiration to "today" for various combinations of default/enforced expiration

## Related Issue
- Fixes #36569 

## How Has This Been Tested?
CI an locally using the date-picker in webUI to choose "today"

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
