### PR TITLE
Add debug output in very verbose mode for polling

### DIFF
--- a/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
+++ b/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
@@ -102,11 +102,18 @@ class PollIncomingShares extends Command {
 			/** @var \OCA\Files_Sharing\External\Mount $mount */
 			foreach ($userMounts as $mount) {
 				try {
+					$shareData = $this->getExternalShareData($data['user'], $mount->getMountPoint());
+					if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
+						$encodedData = \json_encode($shareData);
+						$output->writeln(
+							"User: \"{$data['user']}\", Share data: $encodedData"
+						);
+					}
+
 					/** @var Storage $storage */
 					$storage = $mount->getStorage();
 					$this->refreshStorageRoot($storage);
 				} catch (NoUserException $e) {
-					$shareData = $this->getExternalShareData($data['user'], $mount->getMountPoint());
 					$entryId = $shareData['id'];
 					$remote = $shareData['remote'];
 					// uid was null so we need to set it
@@ -118,7 +125,6 @@ class PollIncomingShares extends Command {
 						"Remote \"$remote\" reports that external share with id \"$entryId\" no longer exists. Removing it.."
 					);
 				} catch (\Exception $e) {
-					$shareData = $this->getExternalShareData($data['user'], $mount->getMountPoint());
 					$entryId = $shareData['id'];
 					$remote = $shareData['remote'];
 					$reason = $e->getMessage();

--- a/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
+++ b/apps/federatedfilesharing/tests/Command/PollIncomingSharesTest.php
@@ -36,6 +36,7 @@ use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -193,7 +194,7 @@ class PollIncomingSharesTest extends TestCase {
 		$qbMock->method('execute')->willReturn($statementMock);
 
 		$userMock = $this->createMock(IUser::class);
-		$this->userManager->expects($this->once())->method('get')
+		$this->userManager->method('get')
 			->with($uid)->willReturn($userMock);
 
 		$this->externalManager->expects($this->once())->method('removeShare');
@@ -208,8 +209,12 @@ class PollIncomingSharesTest extends TestCase {
 			->willReturn([$mount]);
 
 		$this->dbConnection->method('getQueryBuilder')->willReturn($qbMock);
-		$this->commandTester->execute([]);
+		$this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE]);
 		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString(
+			'User: "foo", Share data: ',
+			$output
+		);
 		$this->assertStringContainsString(
 			'Remote "example.org" reports that external share with id "50" no longer exists. Removing it..',
 			$output

--- a/changelog/unreleased/36832
+++ b/changelog/unreleased/36832
@@ -1,0 +1,6 @@
+Enhancement: Add very verbose mode to remote shares polling
+
+Adds an additional output to the incoming-shares:poll command when it is run
+with -vv key
+
+https://github.com/owncloud/core/pull/36832


### PR DESCRIPTION
## Description
additional debug output when it is called with `occ incoming-shares:poll -vv`

## Motivation and Context
Possibility of tracking the current share the polling

## How Has This Been Tested?
`occ incoming-shares:poll -vv`


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
