### PR TITLE
[Tests-only] for files_external:list with applicable users and groups and --short

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -411,6 +411,16 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * List created local storage mount with --short
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function listLocalStorageMountShort() {
+		$this->invokingTheCommand('files_external:list --short --output=json');
+	}
+
+	/**
 	 * @When the administrator enables DAV tech_preview
 	 *
 	 * @return void
@@ -1194,8 +1204,18 @@ class OccContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userListsLocalStorageMountUsingTheOccCommand() {
+	public function adminListsLocalStorageMountUsingTheOccCommand() {
 		$this->listLocalStorageMount();
+	}
+
+	/**
+	 * @When the administrator lists the local storage with --short using the occ command
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminListsLocalStorageMountShortUsingTheOccCommand() {
+		$this->listLocalStorageMountShort();
 	}
 
 	/**
@@ -1247,18 +1267,81 @@ class OccContext implements Context {
 	 * @throws Exception
 	 */
 	public function theFollowingLocalStorageShouldBeListed(TableNode $table) {
+		$this->featureContext->verifyTableNodeColumns(
+			$table,
+			['MountPoint', 'ApplicableUsers', 'ApplicableGroups'],
+			['Storage', 'AuthenticationType', 'Configuration', 'Options', 'Auth', 'Type']
+		);
 		$expectedLocalStorages = $table->getColumnsHash();
 		$commandOutput = \json_decode($this->featureContext->getStdOutOfOccCommand());
 		foreach ($expectedLocalStorages as $expectedStorageEntry) {
 			$isStorageEntryListed = false;
 			foreach ($commandOutput as $listedStorageEntry) {
 				if ($expectedStorageEntry["MountPoint"] === $listedStorageEntry->mount_point) {
-					Assert::assertEquals($expectedStorageEntry['Storage'], $listedStorageEntry->storage, "Storage column does not have the expected value");
-					Assert::assertEquals($expectedStorageEntry['AuthenticationType'], $listedStorageEntry->authentication_type, "AuthenticationType column does not have the expected value");
-					Assert::assertStringStartsWith($expectedStorageEntry['Configuration'], $listedStorageEntry->configuration, "Configuration column does not have the expected value");
-					Assert::assertEquals($expectedStorageEntry['Options'], $listedStorageEntry->options, "Options column does not have the expected value");
-					Assert::assertEquals($expectedStorageEntry['ApplicableUsers'], $listedStorageEntry->applicable_users, "ApplicableUsers column does not have the expected value");
-					Assert::assertEquals($expectedStorageEntry['ApplicableGroups'], $listedStorageEntry->applicable_groups, "ApplicableGroups column does not have the expected value");
+					if (isset($expectedStorageEntry['Storage'])) {
+						Assert::assertEquals(
+							$expectedStorageEntry['Storage'],
+							$listedStorageEntry->storage,
+							"Storage column does not have the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
+					if (isset($expectedStorageEntry['AuthenticationType'])) {
+						Assert::assertEquals(
+							$expectedStorageEntry['AuthenticationType'],
+							$listedStorageEntry->authentication_type,
+							"AuthenticationType column does not have the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
+					if (isset($expectedStorageEntry['Auth'])) {
+						Assert::assertEquals(
+							$expectedStorageEntry['Auth'],
+							$listedStorageEntry->auth,
+							"Auth column does not have the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
+					if (isset($expectedStorageEntry['Configuration'])) {
+						Assert::assertStringStartsWith(
+							$expectedStorageEntry['Configuration'],
+							$listedStorageEntry->configuration,
+							"Configuration column does not start with the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
+					if (isset($expectedStorageEntry['Options'])) {
+						Assert::assertEquals(
+							$expectedStorageEntry['Options'],
+							$listedStorageEntry->options,
+							"Options column does not have the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
+					if (isset($expectedStorageEntry['ApplicableUsers'])) {
+						Assert::assertEquals(
+							$expectedStorageEntry['ApplicableUsers'],
+							$listedStorageEntry->applicable_users,
+							"ApplicableUsers column does not have the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
+					if (isset($expectedStorageEntry['ApplicableGroups'])) {
+						Assert::assertEquals(
+							$expectedStorageEntry['ApplicableGroups'],
+							$listedStorageEntry->applicable_groups,
+							"ApplicableGroups column does not have the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
+					if (isset($expectedStorageEntry['Type'])) {
+						Assert::assertEquals(
+							$expectedStorageEntry['Type'],
+							$listedStorageEntry->type,
+							"Type column does not have the expected value for storage "
+							. $expectedStorageEntry['MountPoint']
+						);
+					}
 					$isStorageEntryListed = true;
 				}
 			}

--- a/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
@@ -6,21 +6,88 @@ Feature: list created local storage from the command line
 
   Background:
     Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has created the local storage mount "new_local_storage"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
-    And the administrator has uploaded file with content "new file" to "/new_local_storage/new-file"
+    And the administrator has created the local storage mount "local_storage3"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage.txt"
+    And the administrator has uploaded file with content "this is a file in local storage3" to "/local_storage3/new-file"
 
   Scenario: List the created local storage
     When the administrator lists the local storage using the occ command
-    Then the following local storage should exist
-      | localStorage      |
-      | local_storage2    |
-      | new_local_storage |
+    Then the following local storage should be listed:
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |         | All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      |         | All             |                  |
 
-  Scenario: Test the other columns of listed local storage
+  Scenario: List local storage with applicable users
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And the administrator has added user "user0" as the applicable user for local storage mount "local_storage2"
+    And the administrator has added user "user1" as the applicable user for local storage mount "local_storage3"
+    And the administrator has added user "user2" as the applicable user for local storage mount "local_storage3"
     When the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
-      | MountPoint         | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
-      | /local_storage2    | Local   | None               | datadir:      |         | All             |                  |
-      | /new_local_storage | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage     | Local   | None               | datadir:      |         | All             |                  |
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |         | user0           |                  |
+      | /local_storage3 | Local   | None               | datadir:      |         | user1, user2    |                  |
+
+  Scenario: List local storage with applicable groups
+    Given group "grp1" has been created
+    And group "grp2" has been created
+    And group "grp3" has been created
+    And the administrator has added group "grp1" as the applicable group for local storage mount "local_storage2"
+    And the administrator has added group "grp2" as the applicable group for local storage mount "local_storage3"
+    And the administrator has added group "grp3" as the applicable group for local storage mount "local_storage3"
+    When the administrator lists the local storage using the occ command
+    Then the following local storage should be listed:
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |         |                 | grp1             |
+      | /local_storage3 | Local   | None               | datadir:      |         |                 | grp2, grp3       |
+
+  Scenario: List local storage with applicable users and groups
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And group "grp3" has been created
+    And the administrator has added user "user0" as the applicable user for local storage mount "local_storage2"
+    And the administrator has added user "user1" as the applicable user for local storage mount "local_storage3"
+    And the administrator has added user "user2" as the applicable user for local storage mount "local_storage3"
+    And the administrator has added group "grp1" as the applicable group for local storage mount "local_storage2"
+    And the administrator has added group "grp2" as the applicable group for local storage mount "local_storage3"
+    And the administrator has added group "grp3" as the applicable group for local storage mount "local_storage3"
+    When the administrator lists the local storage using the occ command
+    Then the following local storage should be listed:
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |         | user0           | grp1             |
+      | /local_storage3 | Local   | None               | datadir:      |         | user1, user2    | grp2, grp3       |
+
+  Scenario: Short list of local storage with applicable users and groups
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And group "grp3" has been created
+    And the administrator has added user "user0" as the applicable user for local storage mount "local_storage2"
+    And the administrator has added user "user1" as the applicable user for local storage mount "local_storage3"
+    And the administrator has added user "user2" as the applicable user for local storage mount "local_storage3"
+    And the administrator has added group "grp1" as the applicable group for local storage mount "local_storage2"
+    And the administrator has added group "grp2" as the applicable group for local storage mount "local_storage3"
+    And the administrator has added group "grp3" as the applicable group for local storage mount "local_storage3"
+    When the administrator lists the local storage with --short using the occ command
+    Then the following local storage should be listed:
+      | MountPoint      | Auth | ApplicableUsers | ApplicableGroups | Type  |
+      | /local_storage  | User | All             |                  | Admin |
+      | /local_storage2 | User | user0           | grp1             | Admin |
+      | /local_storage3 | User | user1, user2    | grp2, grp3       | Admin |


### PR DESCRIPTION
## Description
Add scenarios to test:
- `files_external:list` with local storage having "applicable users" and "applicable groups"
- `files_external:list --short`

## Related Issue
Part of #36704 

## How Has This Been Tested?
Local run of new test scenarios + CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
