### PR TITLE
[Tests-only] have a single after scenario to clean users and groups

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3174,7 +3174,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @AfterScenario
 	 *
 	 * @return void
 	 */
@@ -3285,7 +3284,6 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	private function restoreParameters($server) {
 		if ($this->isTestingWithLdap()) {
-			$this->deleteLdapUsersAndGroups();
 			$this->resetOldLdapConfig();
 		}
 		if (\key_exists($this->getBaseUrl(), $this->savedCapabilitiesChanges)) {

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3572,7 +3572,22 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function cleanupUsers() {
+	public function afterScenario() {
+		$this->restoreParametersAfterScenario();
+		if ($this->isTestingWithLdap()) {
+			$this->deleteLdapUsersAndGroups();
+		} else {
+			$this->cleanupDatabaseUsers();
+			$this->cleanupDatabaseGroups();
+		}
+	}
+
+	/**
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function cleanupDatabaseUsers() {
 		$this->authContext->deleteTokenAuthEnforcedAfterScenario();
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
@@ -3587,12 +3602,11 @@ trait Provisioning {
 	}
 
 	/**
-	 * @AfterScenario
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function cleanupGroups() {
+	public function cleanupDatabaseGroups() {
 		$this->authContext->deleteTokenAuthEnforcedAfterScenario();
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');


### PR DESCRIPTION
## Description
use a single after scenario to do the cleanup of users and groups

restore parameters need to happen before user/group deletion
deleting users in the DB does not need to happen when running on LDAP

follow up for #36750

## Motivation and Context
make sure actions are done in the correct order and in the correct cases

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
