### PR TITLE
Fix files_external:list --mount-options output

### DIFF
--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -215,7 +215,7 @@ class ListCommand extends Base {
 			$configString = \implode(', ', $configStrings);
 
 			$mountOptions = $config->getMountOptions();
-			$mountOptions = \array_intersect($defaultMountOptions, $mountOptions);
+			$mountOptions = \array_merge($defaultMountOptions, $mountOptions);
 			// hide defaults
 			if (!$showMountOptions) {
 				foreach ($mountOptions as $key => $value) {

--- a/changelog/unreleased/36839
+++ b/changelog/unreleased/36839
@@ -1,0 +1,7 @@
+Bugfix: Fix output of files_external:list command
+
+The files_external:list command was not displaying the correct information in
+the Options column. The Options column output has been corrected.
+
+https://github.com/owncloud/core/issues/36839
+https://github.com/owncloud/core/pull/36841

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -421,6 +421,16 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * List created local storage mount with --mount-options
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function listLocalStorageMountOptions() {
+		$this->invokingTheCommand('files_external:list --mount-options --output=json');
+	}
+
+	/**
 	 * @When the administrator enables DAV tech_preview
 	 *
 	 * @return void
@@ -1216,6 +1226,16 @@ class OccContext implements Context {
 	 */
 	public function adminListsLocalStorageMountShortUsingTheOccCommand() {
 		$this->listLocalStorageMountShort();
+	}
+
+	/**
+	 * @When the administrator lists the local storage with --mount-options using the occ command
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminListsLocalStorageMountOptionsUsingTheOccCommand() {
+		$this->listLocalStorageMountOptions();
 	}
 
 	/**

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -11,7 +11,7 @@ Feature: export created local storage mounts from the command line
     And the administrator has uploaded file with content "new file" to "/new_local_storage/new-file"
     When the administrator exports the local storage mounts using the occ command
     Then the following local storage should be listed:
-      | MountPoint         | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
-      | /local_storage2    | Local   | None               | datadir:      |         | All             |                  |
-      | /new_local_storage | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage     | Local   | None               | datadir:      |         | All             |                  |
+      | MountPoint         | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage2    | Local   | None               | datadir:      |                      | All             |                  |
+      | /new_local_storage | Local   | None               | datadir:      |                      | All             |                  |
+      | /local_storage     | Local   | None               | datadir:      | enable_sharing: true | All             |                  |

--- a/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
@@ -13,10 +13,10 @@ Feature: list created local storage from the command line
   Scenario: List the created local storage
     When the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
-      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
-      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage2 | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage3 | Local   | None               | datadir:      |         | All             |                  |
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |                      | All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      |                      | All             |                  |
 
   Scenario: List local storage with applicable users
     Given these users have been created with default attributes and without skeleton files:
@@ -29,10 +29,10 @@ Feature: list created local storage from the command line
     And the administrator has added user "user2" as the applicable user for local storage mount "local_storage3"
     When the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
-      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
-      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage2 | Local   | None               | datadir:      |         | user0           |                  |
-      | /local_storage3 | Local   | None               | datadir:      |         | user1, user2    |                  |
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |                      | user0           |                  |
+      | /local_storage3 | Local   | None               | datadir:      |                      | user1, user2    |                  |
 
   Scenario: List local storage with applicable groups
     Given group "grp1" has been created
@@ -43,10 +43,10 @@ Feature: list created local storage from the command line
     And the administrator has added group "grp3" as the applicable group for local storage mount "local_storage3"
     When the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
-      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
-      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage2 | Local   | None               | datadir:      |         |                 | grp1             |
-      | /local_storage3 | Local   | None               | datadir:      |         |                 | grp2, grp3       |
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |                      |                 | grp1             |
+      | /local_storage3 | Local   | None               | datadir:      |                      |                 | grp2, grp3       |
 
   Scenario: List local storage with applicable users and groups
     Given these users have been created with default attributes and without skeleton files:
@@ -65,10 +65,10 @@ Feature: list created local storage from the command line
     And the administrator has added group "grp3" as the applicable group for local storage mount "local_storage3"
     When the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
-      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
-      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage2 | Local   | None               | datadir:      |         | user0           | grp1             |
-      | /local_storage3 | Local   | None               | datadir:      |         | user1, user2    | grp2, grp3       |
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |                      | user0           | grp1             |
+      | /local_storage3 | Local   | None               | datadir:      |                      | user1, user2    | grp2, grp3       |
 
   Scenario: Short list of local storage with applicable users and groups
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
@@ -92,34 +92,28 @@ Feature: list created local storage from the command line
       | /local_storage2 | User | user0           | grp1             | Admin |
       | /local_storage3 | User | user1, user2    | grp2, grp3       | Admin |
 
-  @issue-36839
   Scenario: List local storage with non-default options (one storage set to read-only)
     Given the administrator has set the external storage "local_storage2" to read-only
     When the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
-      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
-      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
-      | /local_storage2 | Local   | None               | datadir:      |         | All             |                  |
-      #| /local_storage2 | Local   | None               | datadir:      | read_only: true | All             |                  |
-      | /local_storage3 | Local   | None               | datadir:      |         | All             |                  |
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      | read_only: 1         | All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      |                      | All             |                  |
 
-  @issue-36839
   Scenario: List local storage with --mount-options
     When the administrator lists the local storage with --mount-options using the occ command
     Then the following local storage should be listed:
-      | MountPoint      | Storage | AuthenticationType | Configuration | Options                                                                | ApplicableUsers | ApplicableGroups |
-      | /local_storage  | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1             | All             |                  |
-      | /local_storage2 | Local   | None               | datadir:      | read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
-      #| /local_storage2 | Local   | None               | datadir:      | read_only: true, enable_sharing: false, encoding_compatibility: false and other stuff...| All             |                  |
-      | /local_storage3 | Local   | None               | datadir:      | read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options                                                                                                                            | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: false, enable_sharing: true, encoding_compatibility: false  | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
 
-  @issue-36839
   Scenario: List local storage with --mount-options and non-default options (one storage set to read-only)
     Given the administrator has set the external storage "local_storage2" to read-only
     When the administrator lists the local storage with --mount-options using the occ command
     Then the following local storage should be listed:
       | MountPoint      | Storage | AuthenticationType | Configuration | Options                                                                                                                            | ApplicableUsers | ApplicableGroups |
-      | /local_storage  | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1                                                                         | All             |                  |
-      | /local_storage2 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
-      #| /local_storage2 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: true, enable_sharing: false, encoding_compatibility: false | All             |                  |
-      | /local_storage3 | Local   | None               | datadir:      | read_only: false, enable_sharing: false, encoding_compatibility: false                                                             | All             |                  |
+      | /local_storage  | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: false, enable_sharing: true, encoding_compatibility: false  | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: 1, enable_sharing: false, encoding_compatibility: false     | All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |

--- a/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
@@ -91,3 +91,35 @@ Feature: list created local storage from the command line
       | /local_storage  | User | All             |                  | Admin |
       | /local_storage2 | User | user0           | grp1             | Admin |
       | /local_storage3 | User | user1, user2    | grp2, grp3       | Admin |
+
+  @issue-36839
+  Scenario: List local storage with non-default options (one storage set to read-only)
+    Given the administrator has set the external storage "local_storage2" to read-only
+    When the administrator lists the local storage using the occ command
+    Then the following local storage should be listed:
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      |         | All             |                  |
+      #| /local_storage2 | Local   | None               | datadir:      | read_only: true | All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      |         | All             |                  |
+
+  @issue-36839
+  Scenario: List local storage with --mount-options
+    When the administrator lists the local storage with --mount-options using the occ command
+    Then the following local storage should be listed:
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options                                                                | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1             | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      | read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
+      #| /local_storage2 | Local   | None               | datadir:      | read_only: true, enable_sharing: false, encoding_compatibility: false and other stuff...| All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      | read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
+
+  @issue-36839
+  Scenario: List local storage with --mount-options and non-default options (one storage set to read-only)
+    Given the administrator has set the external storage "local_storage2" to read-only
+    When the administrator lists the local storage with --mount-options using the occ command
+    Then the following local storage should be listed:
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options                                                                                                                            | ApplicableUsers | ApplicableGroups |
+      | /local_storage  | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1                                                                         | All             |                  |
+      | /local_storage2 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: false, enable_sharing: false, encoding_compatibility: false | All             |                  |
+      #| /local_storage2 | Local   | None               | datadir:      | encrypt: true, previews: true, filesystem_check_changes: 1, read_only: true, enable_sharing: false, encoding_compatibility: false | All             |                  |
+      | /local_storage3 | Local   | None               | datadir:      | read_only: false, enable_sharing: false, encoding_compatibility: false                                                             | All             |                  |


### PR DESCRIPTION
## Description
Display the correct output in the Options column of `files_external:list` (with and without `--mount-options` )

The 1st commit adds acceptance tests that demonstrate the old (bad) behaviour.

The 2nd commit fixes the code, adds some unit tests (for more general unit test coverage of this code), adjusts the acceptance tests to demonstrate the new (correct) behaviour and adds a changelog entry.

## Related Issue
- Fixes #36839 

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
