### PR TITLE
[Tests-only] simplify trashbin tests by not using skeleton folder

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -6,12 +6,17 @@ Feature: files and folders can be deleted from the trashbin
 
   Background:
     Given the administrator has enabled DAV tech_preview
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "to delete" to "/textfile0.txt"
+    And user "user0" has uploaded file with content "to delete" to "/textfile1.txt"
+    And user "user0" has created folder "PARENT"
+    And user "user0" has created folder "PARENT/CHILD"
+    And user "user0" has uploaded file with content "to delete" to "/PARENT/parent.txt"
+    And user "user0" has uploaded file with content "to delete" to "/PARENT/CHILD/child.txt"
 
   @smokeTest
   Scenario Outline: Trashbin can be emptied
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And a new browser session for "user0" has been started
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
     And as "user0" file "/textfile0.txt" should exist in trash
@@ -25,8 +30,7 @@ Feature: files and folders can be deleted from the trashbin
       | new      |
 
   Scenario: delete a single file from the trashbin
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted file "/textfile0.txt"
+    Given user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
     And user "user0" has deleted file "/PARENT/parent.txt"
     And user "user0" has deleted file "/PARENT/CHILD/child.txt"
@@ -38,8 +42,7 @@ Feature: files and folders can be deleted from the trashbin
     And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
 
   Scenario: delete multiple files from the trashbin and make sure the correct ones are gone
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
+    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/child.txt"
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
@@ -56,8 +59,7 @@ Feature: files and folders can be deleted from the trashbin
 
   @skipOnOcV10.3
   Scenario: User tries to delete another user's trashbin
-    Given user "user0" has been created with default attributes and skeleton files
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
     And user "user0" has deleted file "/PARENT/parent.txt"
@@ -70,8 +72,7 @@ Feature: files and folders can be deleted from the trashbin
     And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
 
   Scenario: User tries to delete trashbin file using invalid password
-    Given user "user0" has been created with default attributes and skeleton files
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
     And user "user0" has deleted file "/PARENT/parent.txt"
@@ -84,8 +85,7 @@ Feature: files and folders can be deleted from the trashbin
     And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
 
   Scenario: User tries to delete trashbin file using no password
-    Given user "user0" has been created with default attributes and skeleton files
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
     And user "user0" has deleted file "/PARENT/parent.txt"

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -6,13 +6,12 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Background:
     Given the administrator has enabled DAV tech_preview
-    And using OCS API version "1"
-    And as the administrator
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "to delete" to "/textfile0.txt"
 
   @smokeTest
   Scenario Outline: deleting a file moves it to trashbin
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     When user "user0" deletes file "/textfile0.txt" using the WebDAV API
     Then as "user0" file "/textfile0.txt" should exist in trash
     But as "user0" file "/textfile0.txt" should not exist
@@ -23,7 +22,6 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a folder moves it to trashbin
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/tmp"
     When user "user0" deletes folder "/tmp" using the WebDAV API
     Then as "user0" folder "/tmp" should exist in trash
@@ -34,7 +32,6 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: deleting a file in a folder moves it to the trashbin root
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
@@ -49,10 +46,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @files_sharing-app-required
   Scenario Outline: deleting a file in a shared folder moves it to the trashbin root
     Given using <dav-path> DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -68,10 +62,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @files_sharing-app-required
   Scenario Outline: deleting a shared folder moves it to trashbin
     Given using <dav-path> DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -85,10 +76,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @files_sharing-app-required
   Scenario Outline: deleting a received folder doesn't move it to trashbin
     Given using <dav-path> DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -103,10 +91,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @files_sharing-app-required
   Scenario Outline: deleting a file in a received folder moves it to trashbin
     Given using <dav-path> DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -125,7 +110,6 @@ Feature: files and folders exist in the trashbin after being deleted
   # thus testing the required behavior.
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/folderA"
     And user "user0" has created folder "/folderB"
     And user "user0" has created folder "/folderC"
@@ -154,7 +138,6 @@ Feature: files and folders exist in the trashbin after being deleted
   # Note: the underlying acceptance test code ensures that each delete step is separated by a least 1 second
   Scenario Outline: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/folderA"
     And user "user0" has created folder "/folderB"
     And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
@@ -176,7 +159,6 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: Deleting a folder into external storage moves it to the trashbin
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
@@ -186,13 +168,11 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  # This issue makes this scenario behave differently based on previously created users.
-  # So we use user that has not been created in any other scenarios.
   @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user40" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user40" has deleted file "/textfile1.txt"
     When user "user1" tries to list the trashbin content for user "user40"
     Then the HTTP status code should be "401"
@@ -204,13 +184,11 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  # This issue makes this scenario behave differently based on previously created users.
-  # So we use user that has not been created in any other scenarios.
   @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user60" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user60" has deleted file "/textfile0.txt"
     And user "user60" has deleted file "/textfile2.txt"
     When user "user1" tries to list the trashbin content for user "user60"
@@ -224,13 +202,11 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  # This issue makes this scenario behave differently based on previously created users.
-  # So we use user that has not been created in any other scenarios.
   @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "user504" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user504" has deleted file "/textfile0.txt"
     And user "user504" has deleted file "/textfile2.txt"
     And the administrator deletes user "user504" using the provisioning API
@@ -252,7 +228,6 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: Get trashbin content with wrong password
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" tries to list the trashbin content for user "user0" using password "invalid"
     Then the HTTP status code should be "401"
@@ -266,7 +241,6 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Scenario Outline: Get trashbin content without password
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" tries to list the trashbin content for user "user0" using password ""
     Then the HTTP status code should be "401"

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -6,16 +6,13 @@ Feature: Restore deleted files/folders
 
   Background:
     Given the administrator has enabled DAV tech_preview
-    And using OCS API version "1"
-    And as the administrator
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "file to delete" to "/textfile0.txt"
 
   @files_sharing-app-required
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
     Given using <dav-path> DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user1" has been created with default attributes and skeleton files
     And user "user0" has created folder "/shared"
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
@@ -37,7 +34,13 @@ Feature: Restore deleted files/folders
   @smokeTest
   Scenario Outline: A deleted file can be restored
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has created folder "/FOLDER"
+    And user "user0" has created folder "/PARENT"
+    And user "user0" has uploaded file with content "to delete" to "/PARENT/parent.txt"
+    And user "user0" has uploaded file with content "to delete" to "/textfile1.txt"
+    And user "user0" has uploaded file with content "to delete" to "/textfile2.txt"
+    And user "user0" has uploaded file with content "to delete" to "/textfile3.txt"
+    And user "user0" has uploaded file with content "to delete" to "/textfile4.txt"
     And user "user0" has deleted file "/textfile0.txt"
     And as "user0" file "/textfile0.txt" should exist in trash
     When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
@@ -61,7 +64,6 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: A file deleted from a folder can be restored to the original folder
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
@@ -76,7 +78,6 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and restored
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
@@ -93,7 +94,9 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: a file is deleted and restored to a new destination
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has created folder "/PARENT"
+    And user "user0" has created folder "/PARENT/CHILD"
+    And user "user0" has uploaded file with content "to delete" to "<delete-path>"
     And user "user0" has deleted file "<delete-path>"
     When user "user0" restores the file with original path "<delete-path>" to "<restore-path>" using the trashbin API
     Then the HTTP status code should be "201"
@@ -108,14 +111,13 @@ Feature: Restore deleted files/folders
       | new      | /PARENT/parent.txt      | parent.txt           |
       | old      | /PARENT/CHILD/child.txt | child.txt            |
       | new      | /PARENT/CHILD/child.txt | child.txt            |
-      | old      | /textfile0.txt          | FOLDER/textfile0.txt |
-      | new      | /textfile0.txt          | FOLDER/textfile0.txt |
+      | old      | /textfile0.txt          | PARENT/textfile0.txt |
+      | new      | /textfile0.txt          | PARENT/textfile0.txt |
 
   @issue-35974
   Scenario Outline: restoring a file to an already existing path overrides the file
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has uploaded file with content "file to delete" to "/textfile0.txt"
+    And user "user0" has created folder "/PARENT"
     And user "user0" has uploaded file with content "PARENT textfile0 content" to "/PARENT/textfile0.txt"
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" restores the file with original path "/textfile0.txt" to "/PARENT/textfile0.txt" using the trashbin API
@@ -139,10 +141,7 @@ Feature: Restore deleted files/folders
   @issue-35900 @files_sharing-app-required
   Scenario Outline: restoring a file to a read-only folder
     Given using <dav-path> DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has created folder "shareFolderParent"
     And user "user1" has shared folder "shareFolderParent" with user "user0" with permissions "read"
     And as "user0" folder "/shareFolderParent" should exist
@@ -164,10 +163,7 @@ Feature: Restore deleted files/folders
   @issue-35900 @files_sharing-app-required
   Scenario Outline: restoring a file to a read-only sub-folder
     Given using <dav-path> DAV path
-    And these users have been created with default attributes and skeleton files:
-      | username |
-      | user0    |
-      | user1    |
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has created folder "shareFolderParent"
     And user "user1" has created folder "shareFolderParent/shareFolderChild"
     And user "user1" has shared folder "shareFolderParent" with user "user0" with permissions "read"
@@ -189,7 +185,6 @@ Feature: Restore deleted files/folders
 
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "user0" has deleted file "/new-folder/new-file.txt"
@@ -212,7 +207,6 @@ Feature: Restore deleted files/folders
   Scenario Outline: Deleting a file into external storage moves it to the trashbin and can be restored
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
@@ -237,7 +231,6 @@ Feature: Restore deleted files/folders
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
     Given using old DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
@@ -254,7 +247,6 @@ Feature: Restore deleted files/folders
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
     Given using new DAV path
     And the administrator has invoked occ command "files:scan --all"
-    And user "user0" has been created with default attributes and skeleton files
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has uploaded the following chunks to "/local_storage/tmp/textfile0.txt" with new chunking
@@ -270,8 +262,7 @@ Feature: Restore deleted files/folders
   @smokeTest @skipOnOcV10.3
   Scenario Outline: A deleted file cannot be restored by a different user
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     When user "user1" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the trashbin API
     Then the HTTP status code should be "401"
@@ -286,8 +277,7 @@ Feature: Restore deleted files/folders
   @smokeTest
   Scenario Outline: A deleted file cannot be restored with invalid password
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the password "invalid" and the trashbin API
     Then the HTTP status code should be "401"
@@ -302,8 +292,7 @@ Feature: Restore deleted files/folders
   @smokeTest
   Scenario Outline: A deleted file cannot be restored without using a password
     Given using <dav-path> DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the password "" and the trashbin API
     Then the HTTP status code should be "401"


### PR DESCRIPTION
## Description
make the trasbin tests more readable but reducing the use of the skeleton folder
also makes it easier to implement the ocis tests

## Related Issue
helps with https://github.com/owncloud/ocis-reva/issues/23
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
