### PR TITLE
Fixes to share list view panel after expiration refactor

### DIFF
--- a/changelog/unreleased/36573
+++ b/changelog/unreleased/36573
@@ -12,3 +12,4 @@ user and group shares.
 
 https://github.com/owncloud/core/pull/36573
 https://github.com/owncloud/core/pull/36766
+https://github.com/owncloud/core/pull/36847

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -103,7 +103,7 @@
 }
 #shareWithList .shareOption {
 	white-space: nowrap;
-	display: inline-block;
+	display: none;
 }
 
 #shareWithList .showCruds img,

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -301,14 +301,14 @@
 				placement: 'bottom'
 			});
 
-			this.$el.find('.expiration-user').each(function(){
+			this.$el.find('.expiration-user:not(.hasDatepicker)').each(function(){
 				self._setDatepicker(this, {
 					maxDate  : self.configModel.getDefaultExpireDateUser(),
 					enforced : self.configModel.isDefaultExpireDateUserEnforced()
 				});
 			});
 
-			this.$el.find('.expiration-group').each(function(){
+			this.$el.find('.expiration-group:not(.hasDatepicker)').each(function(){
 				self._setDatepicker(this, {
 					maxDate  : self.configModel.getDefaultExpireDateGroup(),
 					enforced : self.configModel.isDefaultExpireDateGroupEnforced()
@@ -452,10 +452,23 @@
 		},
 
 		onRemoveExpiration: function(event) {
-			var shareId = $(event.target).closest('li').data('share-id');
+			// make sure that click event is not propagated further
+			event.preventDefault();
 
+			// update share unsetting expiry date
+			var shareId = $(event.target).closest('li').data('share-id');
 			this.model.updateShare( shareId, {
 				expireDate: ''
+			}, {});
+		},
+
+		onExpirationChange: function(el) {
+			var $el        = $(el);
+			var shareId    = $el.closest('li').data('share-id');
+			var expiration = moment($el.val(), 'DD-MM-YYYY').format();
+
+			this.model.updateShare( shareId, {
+				expireDate: expiration
 			}, {});
 		},
 
@@ -497,16 +510,6 @@
 			});
 		},
 
-		_onExpirationChange: function(el) {
-			var $el        = $(el);
-			var shareId    = $el.closest('li').data('share-id');
-			var expiration = moment($el.val(), 'DD-MM-YYYY').format();
-
-			this.model.updateShare( shareId, {
-				expireDate: expiration
-			}, {});
-		},
-
 		_setDatepicker: function(el, params) {
 			var self = this;
 			var $el = $(el);
@@ -515,7 +518,7 @@
 				minDate: "+0d",
 				dateFormat : 'dd-mm-yy',
 				onSelect : function() {
-					self._onExpirationChange(el);
+					self.onExpirationChange(el);
 				}
 			});
 

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -417,6 +417,24 @@
 		},
 
 		/**
+		 * Returns share entry by share id. Share will only be returned that only apply to the current item
+		 * (file/folder)
+		 *
+		 * @param shareId
+		 * @return {OC.Share.Types.ShareInfo}
+		 */
+		getShareById: function(shareId) {
+			var shares = this.get('shares') || [];
+			for(var shareIndex = 0; shareIndex < shares.length; shareIndex++) {
+				if (shares[shareIndex].id === shareId) {
+					return shares[shareIndex];
+				}
+			}
+
+			throw t('core', 'Unknown Share');
+		},
+
+		/**
 		 * @param shareIndex
 		 * @returns {string}
 		 */

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -497,6 +497,40 @@ describe('OC.Share.ShareItemModel', function() {
 		});
 	});
 
+	describe('getShareById', function() {
+		it('exception when user share does not exist', function() {
+			/* jshint camelcase: false */
+			fetchReshareDeferred.resolve(makeOcsResponse([]));
+			fetchSharesDeferred.resolve(makeOcsResponse([]));
+
+			model.fetch();
+
+			var thrown = false;
+			try {
+				model.getShareById(1);
+			} catch(e) {
+				thrown = true;
+			}
+			expect(thrown).toEqual(true);
+		});
+		it('returns share when user share exist', function() {
+			/* jshint camelcase: false */
+			fetchReshareDeferred.resolve(makeOcsResponse([]));
+			fetchSharesDeferred.resolve(makeOcsResponse([{
+				id: 1,
+				share_type: OC.Share.SHARE_TYPE_USER,
+				share_with: 'user1',
+				item_source: '123'
+			}]));
+
+			model.fetch();
+
+			var share = model.getShareById(1);
+			expect(share.id).toEqual(1);
+			expect(share.share_with).toEqual('user1');
+		});
+	});
+
 	describe('Util', function() {
 		it('parseTime should properly parse strings', function() {
 

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1020,15 +1020,24 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function sendShareNotificationByEmailUsingTheWebui() {
+		Assert::assertNotNull(
+			$this->sharingDialog, "Sharing Dialog is not open"
+		);
+		$this->sharingDialog->openShareActionsDropDown();
+		$this->sharingDialog->sendShareNotificationByEmail($this->getSession());
+		$this->sharingDialog->closeShareActionsDropDown();
+	}
+
+	/**
 	 * @When the user sends the share notification by email using the webUI
 	 *
 	 * @return void
 	 */
 	public function theUserSendsTheShareNotificationByEmailUsingTheWebui() {
-		Assert::assertNotNull(
-			$this->sharingDialog, "Sharing Dialog is not open"
-		);
-		$this->sharingDialog->sendShareNotificationByEmail($this->getSession());
+		$this->sendShareNotificationByEmailUsingTheWebui();
 	}
 
 	/**
@@ -1038,11 +1047,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theUserShouldNotBeAbleToSendTheShareNotificationByEmailUsingTheWebui() {
 		$errorMessage = "";
-		Assert::assertNotNull(
-			$this->sharingDialog, "Sharing Dialog is not open"
-		);
 		try {
-			$this->sharingDialog->sendShareNotificationByEmail($this->getSession());
+			$this->sendShareNotificationByEmailUsingTheWebui();
 		} catch (Exception $e) {
 			$errorMessage = $e->getMessage();
 		}


### PR DESCRIPTION
This PR targets two problems listed in https://github.com/owncloud/core/issues/36735:
- [x] make sure that share options are displayed when toggled (previously logic was enabled->disabled->enabled or enabled->disabled, now disabled->disabled or disabled->enabled)
- [x] when unsetting expiry do not show datepicker
