### PR TITLE
[Tests-only] use PROPFIND helper method to get file-size

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1113,11 +1113,10 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function userGetsSizeOfFileUsingTheWebdavApi($user, $resource) {
-		$headers = $this->guzzleClientHeaders;
+		$user = $this->getActualUsername($user);
 		$password = $this->getPasswordForUser($user);
-		$url = $this->getBaseUrl() . "/remote.php/dav/files/{$user}/{$resource}";
-		$this->response = HttpRequestHelper::sendRequest(
-			$url, "PROPFIND", $user, $password, $headers, null, null, null
+		$this->response = WebDavHelper::propfind(
+			$this->getBaseUrl(), $user, $password, $resource, []
 		);
 	}
 


### PR DESCRIPTION
## Description
use the proper helper method to make a PROPFIND requests

## Related Issue
helps with https://github.com/owncloud/ocis-reva/issues/23

## Motivation and Context
one less place where the DAV URL is defined

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
