### PR TITLE
Fix federated addressbooks sync after OCS improvement

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -149,6 +149,9 @@ class GetSharedSecret extends Job {
 							'url' => $source,
 							'token' => $token
 						],
+					'headers' => [
+						'OCS-APIREQUEST' => 'true'
+					],
 					'timeout' => 3,
 					'connect_timeout' => 3,
 				]

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -145,6 +145,9 @@ class RequestSharedSecret extends Job {
 						'url' => $source,
 						'token' => $token,
 					],
+					'headers' => [
+						'OCS-APIREQUEST' => 'true'
+					],
 					'timeout' => 3,
 					'connect_timeout' => 3,
 				]

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -159,6 +159,9 @@ class GetSharedSecretTest extends TestCase {
 							'url' => $source,
 							'token' => $token
 						],
+					'headers' => [
+						'OCS-APIREQUEST' => 'true'
+					],
 					'timeout' => 3,
 					'connect_timeout' => 3,
 				]

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -145,6 +145,9 @@ class RequestSharedSecretTest extends TestCase {
 							'url' => $source,
 							'token' => $token
 						],
+					'headers' => [
+						'OCS-APIREQUEST' => 'true'
+					],
 					'timeout' => 3,
 					'connect_timeout' => 3,
 				]

--- a/changelog/unreleased/36856
+++ b/changelog/unreleased/36856
@@ -1,0 +1,7 @@
+Bugfix: Pass OCS-APIREQUEST header on getting shared secret for federation
+
+OCS-APIREQUEST header added to the federation app cronjobs responsible for
+the shared secret exchange.
+
+https://github.com/owncloud/core/pull/36856
+https://github.com/owncloud/core/pull/36762


### PR DESCRIPTION
## Description
It's not possible sync federated address books for newly added servers after https://github.com/owncloud/core/pull/36762

## Motivation and Context
Not possible for OC instances to exchange with secrets any more

## How Has This Been Tested?
1. Setup 2 OC instances to trust each other
2. run `occ system:cron` to initiate a exchange with secrets

# Expected 
The `shared_secret` is populated in `oc_trusted_servers` DB table

# Actual
The `shared_secret` is NOT populated in `oc_trusted_servers` DB table due to 
HTTP status `401 not authorised` while requesting `/ocs/v2.php/apps/federation/api/v1/request-shared-secret?format=json`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
