### PR TITLE
[Tests-Only] Add verifyTableNodeColumns check to acceptance test step checkingAttributesInLastShareResponse

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -26,7 +26,6 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
-use TestHelpers\SetupHelper;
 use TestHelpers\SharingHelper;
 use TestHelpers\HttpRequestHelper;
 
@@ -1933,6 +1932,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function checkingAttributesInLastShareResponse(TableNode $attributes) {
+		$this->verifyTableNodeColumns($attributes, ['scope', 'key', 'enabled']);
 		$attributes = $attributes->getHash();
 
 		// change string "true"/"false" to boolean inside array


### PR DESCRIPTION
## Description
This acceptance test step was added to core recently. The step expects a table with headings 'scope', 'key', 'enabled'. Nowadays we should check that the table does have the required headings, and fail early.

And remove an unused `use` statement while I am here.

## Motivation and Context
I had a test scenario in an app. That scenario used this step, but forgot to provide the expected headings. I  wasted some time before I realised that the column headings were missing.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
