### PR TITLE
[Tests-only] skipOnOcV10.3 'notify by email' tests that will not work on 10.3

### DIFF
--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -131,7 +131,7 @@ Feature: Sharing files and folders with internal groups
     Then a tooltip with the text "No users or groups found for system-group" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
 
-  @skipOnEncryptionType:user-keys @issue-encryption-126
+  @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126
   @mailhog
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
@@ -149,7 +149,7 @@ Feature: Sharing files and folders with internal groups
       just letting you know that User Three shared lorem.txt with you.
       """
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "user3" has logged in using the webUI
@@ -161,6 +161,7 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email using the webUI
 
+  @skipOnOcV10.3
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
     And user "user3" has logged in using the webUI
@@ -168,7 +169,7 @@ Feature: Sharing files and folders with internal groups
     When the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email using the webUI
 
-  @mailhog @skipOnLDAP
+  @mailhog @skipOnLDAP @skipOnOcV10.3
   Scenario: user should not get an email notification if the user is added to the group after the mail notification was sent
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "user0" has been created with default attributes and skeleton files
@@ -180,7 +181,7 @@ Feature: Sharing files and folders with internal groups
     When the administrator adds user "user0" to group "grp1" using the provisioning API
     Then the email address "user0@example.org" should not have received an email
 
-  @skipOnEncryptionType:user-keys @issue-encryption-126
+  @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126
   @mailhog
   Scenario: user should get an error message when trying to send notification by email to the group where some user have set up their email and others haven't
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -273,7 +273,7 @@ Feature: Sharing files and folders with internal users
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
     And as "user2" file "lorem (2).txt" should not exist
 
-  @skipOnEncryptionType:user-keys @issue-encryption-126
+  @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126
   @mailhog
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
@@ -289,7 +289,7 @@ Feature: Sharing files and folders with internal users
       just letting you know that User One shared lorem.txt with you.
       """
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
   Scenario: user should get and error message when trying to send notification by email to a user who has not setup their email
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files
@@ -304,7 +304,7 @@ Feature: Sharing files and folders with internal users
       | title                       | content                                             |
       | Email notification not sent | Couldn't send mail to following recipient(s): user0 |
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "user1" has been created with default attributes and skeleton files
@@ -318,6 +318,7 @@ Feature: Sharing files and folders with internal users
     And the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email using the webUI
 
+  @skipOnOcV10.3
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
     And user "user1" has been created with default attributes and skeleton files


### PR DESCRIPTION
## Description
The exact UI workflow for opening the sharing details panel in order to click the "notify by email" button has changed for 10.4 (current core master). So the UI test code from current core master that clicks the "notify by email" button will not work against a 10.3 system.

Skip those tests on oC V10.3

https://drone.owncloud.com/owncloud/files_primary_s3/1463/61/19
```
--- Failed scenarios:

    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature:278
    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature:293
    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature:308
    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature:321

29 scenarios (25 passed, 4 failed)
292 steps (281 passed, 4 failed, 7 skipped)
```

https://drone.owncloud.com/owncloud/files_primary_s3/1463/60/19
```
--- Failed scenarios:

    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature:136
    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature:153
    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature:164
    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature:172
    /var/www/owncloud/testrunner/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature:185

31 scenarios (26 passed, 5 failed)
469 steps (451 passed, 5 failed, 13 skipped)
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
