### PR TITLE
show reshare public links to the original share owner

### DIFF
--- a/changelog/unreleased/36865
+++ b/changelog/unreleased/36865
@@ -1,0 +1,6 @@
+Bugfix: show re-share public links to share-owner
+
+Public links created by share-recipient were not visible to share-owner.
+This problem has been resolved.
+
+https://github.com/owncloud/core/pull/36865

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -803,14 +803,6 @@
 						|| share.item_source === this.get('itemSource'));
 
 					if (isShareLink) {
-						/*
-						 * Ignore reshared link shares for now
-						 * FIXME: Find a way to display properly
-						 */
-						if (share.uid_owner !== OC.currentUser) {
-							return share;
-						}
-
 						linkShares.push(share);
 						return share;
 					}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -38,7 +38,6 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 use TestHelpers\EmailHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\SetupHelper;
-use PHPUnit\Framework\Exception;
 
 require_once 'bootstrap.php';
 
@@ -1637,11 +1636,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function createPublicShareLink($name, $settings = null) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		//close any open sharing dialog
-		//if there is no dialog open and we try to close it
-		//an exception will be thrown, but we do not care
 		try {
 			$this->filesPage->closeDetailsDialog();
-		} catch (Exception $e) {
+		} catch (ElementNotFoundException $e) {
+			//if there is no dialog open and we try to close it
+			//an exception will be thrown, but we do not care
 		}
 		$session = $this->getSession();
 		$this->sharingDialog = $this->filesPage->openSharingDialog(

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -38,6 +38,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 use TestHelpers\EmailHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\SetupHelper;
+use PHPUnit\Framework\Exception;
 
 require_once 'bootstrap.php';
 
@@ -1914,5 +1915,17 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				"Expected: " . $filename . " not to be marked as shared but it is"
 			);
 		}
+	}
+
+	/**
+	 * @Then public link share with name :arg1 should be visible
+	 *
+	 * @param string $expectedLinkEntryName
+	 *
+	 * @return void
+	 */
+	public function publicLinkShareWithNameShouldBeVisible($expectedLinkEntryName) {
+		$actualNamesArrayOfPublicLinks = $this->publicShareTab->getListedPublicLinksNames();
+		Assert::assertTrue(\in_array($expectedLinkEntryName, $actualNamesArrayOfPublicLinks));
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1918,14 +1918,31 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then public link share with name :arg1 should be visible
+	 * @Then a public link share with name :arg1 should be visible on the webUI
 	 *
 	 * @param string $expectedLinkEntryName
 	 *
 	 * @return void
 	 */
-	public function publicLinkShareWithNameShouldBeVisible($expectedLinkEntryName) {
+	public function publicLinkShareWithNameShouldBeVisibleOnTheWebUI($expectedLinkEntryName) {
 		$actualNamesArrayOfPublicLinks = $this->publicShareTab->getListedPublicLinksNames();
 		Assert::assertTrue(\in_array($expectedLinkEntryName, $actualNamesArrayOfPublicLinks));
+	}
+
+	/**
+	 * @Then :arg1 public link shares with name :arg2 should be visible on the webUI
+	 *
+	 * @param string $expectedCount
+	 * @param string $expectedLinkEntryName
+	 *
+	 * @return void
+	 */
+	public function publicLinkSharesWithNameShouldBeVisibleOnTheWebUI($expectedCount, $expectedLinkEntryName) {
+		$actualNamesArrayOfPublicLinks = $this->publicShareTab->getListedPublicLinksNames();
+		Assert::assertTrue(\in_array($expectedLinkEntryName, $actualNamesArrayOfPublicLinks));
+		Assert::assertEquals(
+			\array_count_values($actualNamesArrayOfPublicLinks)[$expectedLinkEntryName],
+			$expectedCount
+		);
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -41,6 +41,7 @@ class PublicLinkTab extends OwncloudPage {
 	private $createLinkBtnXpath = ".//button[@class='addLink']";
 	private $popupXpath = ".//div[@class='oc-dialog' and not(contains(@style,'display: none'))]";
 	private $linkEntryByNameXpath = ".//*[@class='link-entry--title' and .=%s]/..";
+	private $linkEntriesNamesXpath = "//div[@id='shareDialogLinkList']//span[@class='link-entry--title']";
 	private $linkUrlInputXpath = ".//input";
 	private $publicLinkWarningMessageXpath = ".//*[@class='error-message-global'][last()]";
 	private $linkEditBtnXpath = "//div[@class='link-entry--icon-button editLink']";
@@ -344,5 +345,19 @@ class PublicLinkTab extends OwncloudPage {
 			" could not find link entry with the given name"
 		);
 		return $linkEntry;
+	}
+
+	/**
+	 * gets listed public links names created/re-shares
+	 *
+	 * @return array
+	 */
+	public function getListedPublicLinksNames() {
+		$namesArray = [];
+		$visibleNamesArray = $this->findAll("xpath", $this->linkEntriesNamesXpath);
+		foreach ($visibleNamesArray as $entry) {
+			\array_push($namesArray, $entry->getText());
+		}
+		return $namesArray;
 	}
 }

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -260,3 +260,18 @@ Feature: Sharing files and folders with internal users
     And file "textfile.txt" should be listed on the webUI
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
     And it should not be possible to share file "textfile.txt" using the webUI
+
+  Scenario: reshare indicators of public links to the original share owner
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And user "user0" has uploaded file with content "uploaded content" to "lorem.txt"
+    And user "user0" has shared file "lorem.txt" with user "user1"
+    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user1" has created a public link share of file "lorem.txt"
+    And user "user0" has logged in using the webUI
+    When the user opens the share dialog for file "lorem.txt"
+    And the user opens the public link share tab
+    Then public link share with name "Public link" should be visible

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -266,12 +266,30 @@ Feature: Sharing files and folders with internal users
       | username |
       | user0    |
       | user1    |
-      | user2    |
     And user "user0" has uploaded file with content "uploaded content" to "lorem.txt"
     And user "user0" has shared file "lorem.txt" with user "user1"
-    And user "user1" has shared file "lorem.txt" with user "user2"
-    And user "user1" has created a public link share of file "lorem.txt"
+    And user "user1" has created a public link share with settings
+      | path | /lorem.txt  |
+      | name | Public link |
     And user "user0" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt"
     And the user opens the public link share tab
-    Then public link share with name "Public link" should be visible
+    Then a public link share with name "Public link" should be visible on the webUI
+
+  Scenario: reshare indicators of multiple public links with same name to the original share owner
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And user "user0" has uploaded file with content "uploaded content" to "lorem.txt"
+    And user "user0" has shared file "lorem.txt" with user "user1"
+    And user "user0" has created a public link share with settings
+      | path | /lorem.txt  |
+      | name | Public link |
+    And user "user1" has created a public link share with settings
+      | path | lorem.txt  |
+      | name | Public link |
+    And user "user0" has logged in using the webUI
+    When the user opens the share dialog for file "lorem.txt"
+    And the user opens the public link share tab
+    Then 2 public link shares with name "Public link" should be visible on the webUI


### PR DESCRIPTION
## Description
With this PR, reshare public links will be visible for the original share-owner. 
There will be no difference in the UI between owner-created public links and reshare public links. However, if we want to show reshares to the owner properly, we need a solution for all clients (desktop, mobile, web). The desktop client already shows this information, no need to hide them in here.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3757

## Motivation and Context


## How Has This Been Tested?
- create a reshare public link
- it should be visible for original share owner

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
