### PR TITLE
Change Bugfix by Enhancement Changelog. Spelling MariaDB fix.

### DIFF
--- a/changelog/10.4.0_2020-01-31/36290-2
+++ b/changelog/10.4.0_2020-01-31/36290-2
@@ -1,6 +1,6 @@
-Enhancement: MariaDb 10.3 support
+Enhancement: MariaDB 10.3 support
 
-MariaDb 10.3 is now supported
+MariaDB 10.3 is now supported
 
 https://github.com/owncloud/core/issues/29483
 https://github.com/owncloud/core/pull/36290

--- a/changelog/10.4.0_2020-01-31/36787
+++ b/changelog/10.4.0_2020-01-31/36787
@@ -1,4 +1,4 @@
-Bugfix: Optimize memory consumption of occ files:checksums:verify command
+Enhancement: Optimize memory consumption of occ files:checksums:verify command
 
 Memory consumption reduced by clearing memory usages of processed files and folders.
 Also, information messages of the command improved by showing the current processed user and the command run result.

--- a/changelog/10.4.0_2020-01-31/36800
+++ b/changelog/10.4.0_2020-01-31/36800
@@ -1,6 +1,6 @@
-Enhancement: MariaDb 10.4 support
+Enhancement: MariaDB 10.4 support
 
-MariaDb 10.4 is now supported
+MariaDB 10.4 is now supported
 
 https://github.com/owncloud/core/issues/36799
 https://github.com/owncloud/core/pull/36800


### PR DESCRIPTION
Memory consumption optimization not Bugfix but Enhancement.

MariaDb spelling MariaDB correctly: https://mariadb.org/ ->  New to MariaDB Server?