### PR TITLE
Allow users to lookup themselves with mixed-case in the Provisioning API

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -205,7 +205,7 @@ class Users {
 			$data['enabled'] = $targetUserObject->isEnabled() ? 'true' : 'false';
 		} else {
 			// Check they are looking up themselves
-			if ($currentLoggedInUser->getUID() !== $userId) {
+			if (\strcasecmp($currentLoggedInUser->getUID(), $userId) !== 0) {
 				return new Result(null, API::RESPOND_UNAUTHORISED);
 			}
 		}

--- a/changelog/unreleased/36822
+++ b/changelog/unreleased/36822
@@ -1,0 +1,11 @@
+Bugfix: Fix provisioning API request for user information in mixed case
+
+When a user requested their own user information using the provisioning API,
+the request URL had to contain the UID in exactly the same case as was used
+when the user was created.
+
+The issue has been fixed so that the UID in the request URL is no longer
+case-sensitive.
+
+https://github.com/owncloud/core/issues/36822
+https://github.com/owncloud/core/pull/36878

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -108,31 +108,25 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
-  @issue-36822
   Scenario: a normal user gets their own information, providing uppercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | newuser  | New User    |
     When user "newuser" retrieves the information of user "NEWUSER" using the provisioning API
-    Then the OCS status code should be "997"
-    #Then the OCS status code should be "100"
-    And the HTTP status code should be "401"
-    #And the HTTP status code should be "200"
-    #And the display name returned by the API should be "New User"
-    #And the quota definition returned by the API should be "default"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "New User"
+    And the quota definition returned by the API should be "default"
 
-  @issue-36822
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | NewUser  | New User    |
     When user "NewUser" retrieves the information of user "newuser" using the provisioning API
-    Then the OCS status code should be "997"
-    #Then the OCS status code should be "100"
-    And the HTTP status code should be "401"
-    #And the HTTP status code should be "200"
-    #And the display name returned by the API should be "New User"
-    #And the quota definition returned by the API should be "default"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "New User"
+    And the quota definition returned by the API should be "default"
 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and skeleton files:

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -110,31 +110,25 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
-  @issue-36822
   Scenario: a normal user gets their own information, providing uppercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | newuser  | New User    |
     When user "newuser" retrieves the information of user "NEWUSER" using the provisioning API
-    Then the OCS status code should be "997"
-    #Then the OCS status code should be "200"
-    And the HTTP status code should be "401"
-    #And the HTTP status code should be "200"
-    #And the display name returned by the API should be "New User"
-    #And the quota definition returned by the API should be "default"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "New User"
+    And the quota definition returned by the API should be "default"
 
-  @issue-36822
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |
       | NewUser  | New User    |
     When user "NewUser" retrieves the information of user "newuser" using the provisioning API
-    Then the OCS status code should be "997"
-    #Then the OCS status code should be "200"
-    And the HTTP status code should be "401"
-    #And the HTTP status code should be "200"
-    #And the display name returned by the API should be "New User"
-    #And the quota definition returned by the API should be "default"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "New User"
+    And the quota definition returned by the API should be "default"
 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and skeleton files:


### PR DESCRIPTION
## Description
If a user had a UID like `NewUser` then to get their own user information using the provisioning API, they had to specify exactly `NewUser` in the URL of the request. That is a bit tricky for any client that tries to use this provisioning API endpoint - they have to know exact the case of the UID.

The admin can do the same request and it is not case sensitive.

See the issue for more detail.

Compare the request UID with the actual internal UID in a case-insensitive manner when checking if the request is for the currently-authenticated user.

## Related Issue
- Fixes #36822 

## How Has This Been Tested?
Local runs of the adjusted acceptance tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
