### PR TITLE
[Tests-Only] Fixup Symfony\Component\Console\Application constructors in tests

### DIFF
--- a/tests/Core/Command/Maintenance/RepairTest.php
+++ b/tests/Core/Command/Maintenance/RepairTest.php
@@ -39,18 +39,13 @@ class RepairTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$application = new Application(
-			\OC::$server->getConfig(),
-			\OC::$server->getEventDispatcher(),
-			\OC::$server->getRequest()
-		);
 		$command = new Repair(
 			new \OC\Repair(\OC\Repair::getRepairSteps(), \OC::$server->getEventDispatcher()),
 			\OC::$server->getConfig(),
 			\OC::$server->getEventDispatcher(),
 			\OC::$server->getAppManager()
 		);
-		$command->setApplication($application);
+		$command->setApplication(new Application());
 		$this->commandTester = new CommandTester($command);
 	}
 

--- a/tests/Core/Command/User/AddTest.php
+++ b/tests/Core/Command/User/AddTest.php
@@ -42,9 +42,8 @@ class AddTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$application = new Application(\OC::$server->getConfig(), \OC::$server->getEventDispatcher(), \OC::$server->getRequest());
 		$command = new Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager(), \OC::$server->getMailer());
-		$command->setApplication($application);
+		$command->setApplication(new Application());
 		$this->commandTester = new CommandTester($command);
 		$this->createUser('user1');
 	}

--- a/tests/Core/Command/User/DeleteTest.php
+++ b/tests/Core/Command/User/DeleteTest.php
@@ -42,14 +42,8 @@ class DeleteTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$application = new Application(
-			\OC::$server->getConfig(),
-			\OC::$server->getEventDispatcher(),
-			\OC::$server->getRequest()
-		);
-
 		$command = new Delete($this->userManager);
-		$command->setApplication($application);
+		$command->setApplication(new Application());
 		$this->commandTester = new CommandTester($command);
 	}
 


### PR DESCRIPTION
## Description
The constructor of `Symfony\Component\Console\Application` takes 2 string parameters - name and version. But in some unit tests it passes various objects. This was reported when I tried Symfony 4.4, but actually it is an existing "problem". I have no idea why the existing code is like it is.

Remove the excess parameters from `new Application()`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
