### PR TITLE
Fix the padding of some confirmation buttons

### DIFF
--- a/changelog/unreleased/36807
+++ b/changelog/unreleased/36807
@@ -3,3 +3,4 @@ Bugfix: Fix one-time password (OTP) verify button width
 The one-time password (OTP) verify button width has been extended.
 
 https://github.com/owncloud/core/pull/36807
+https://github.com/owncloud/core/pull/36892

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -605,9 +605,8 @@ label.infield {
 	float: right;
 }
 #body-login input[type="submit"] {
-	padding: 10px 0px; /* larger log in and installation buttons */
+	padding: 11px 10px 9px; /* larger log in and installation buttons */
 	max-width: 269px;
-	width: 269px;
 }
 #remember_login {
 	margin: 18px 5px 0 16px !important;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Some buttons need more padding to look better.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/36845


## Motivation and Context
Unfortunately I marched in the wrong direction with the last PR https://github.com/owncloud/core/pull/36807. By setting more padding the buttons look nicer and the input field is not affected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested

## Screenshots (if appropriate):
| Before  | After  |
|---|---|
|  ![image](https://user-images.githubusercontent.com/33026403/73826512-2cf8f580-47fe-11ea-957e-1ee0b2e22e08.png) |  ![image](https://user-images.githubusercontent.com/33026403/73826542-397d4e00-47fe-11ea-9d75-27cc201424c3.png) |

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
