### PR TITLE
Adjust Symfony eventDispatcher->dispatch calls

### DIFF
--- a/changelog/unreleased/36881
+++ b/changelog/unreleased/36881
@@ -8,4 +8,8 @@ symfony/process
 symfony/routing
 symfony/translation
 
+Symfony EventDispatcher->dispatch() events have been adjusted to conform to the
+Symfony4 standard.
+
 https://github.com/owncloud/core/pull/36881
+https://github.com/owncloud/core/pull/36897

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -235,8 +235,10 @@ class AllConfig implements IConfig {
 			'uid' => $userId, 'key' => $key, 'value' => $value,
 			'app' => $appName, 'precondition' => $preCondition
 		];
-		$this->eventDispatcher->dispatch('userpreferences.beforeSetValue',
-			new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.beforeSetValue'
+		);
 		$this->connection->setValues('preferences', [
 			'userid' => $userId,
 			'appid' => $appName,
@@ -253,7 +255,10 @@ class AllConfig implements IConfig {
 			$this->userCache[$userId][$appName][$key] = $value;
 		}
 
-		$this->eventDispatcher->dispatch('userpreferences.afterSetValue', new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.afterSetValue'
+		);
 
 		return true;
 	}
@@ -303,8 +308,10 @@ class AllConfig implements IConfig {
 		$this->fixDIInit();
 
 		$arguments = ['uid' => $userId, 'key' => $key, 'app' => $appName];
-		$this->eventDispatcher->dispatch('userpreferences.beforeDeleteValue',
-			new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.beforeDeleteValue'
+		);
 
 		$sql = 'DELETE FROM `*PREFIX*preferences` '.
 			'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?';
@@ -314,8 +321,10 @@ class AllConfig implements IConfig {
 			unset($this->userCache[$userId][$appName][$key]);
 		}
 
-		$this->eventDispatcher->dispatch('userpreferences.afterDeleteValue',
-			new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.afterDeleteValue'
+		);
 		return true;
 	}
 
@@ -330,7 +339,10 @@ class AllConfig implements IConfig {
 		$this->fixDIInit();
 
 		$arguments = ['uid' => $userId];
-		$this->eventDispatcher->dispatch('userpreferences.beforeDeleteUser', new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.beforeDeleteUser'
+		);
 
 		$sql = 'DELETE FROM `*PREFIX*preferences` '.
 			'WHERE `userid` = ?';
@@ -338,7 +350,10 @@ class AllConfig implements IConfig {
 
 		unset($this->userCache[$userId]);
 
-		$this->eventDispatcher->dispatch('userpreferences.afterDeleteUser', new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.afterDeleteUser'
+		);
 
 		return true;
 	}
@@ -354,7 +369,10 @@ class AllConfig implements IConfig {
 		$this->fixDIInit();
 
 		$arguments = ['app' => $appName];
-		$this->eventDispatcher->dispatch('userpreferences.beforeDeleteApp', new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.beforeDeleteApp'
+		);
 
 		$sql = 'DELETE FROM `*PREFIX*preferences` '.
 			'WHERE `appid` = ?';
@@ -364,7 +382,10 @@ class AllConfig implements IConfig {
 			unset($userCache[$appName]);
 		}
 
-		$this->eventDispatcher->dispatch('userpreferences.afterDeleteApp', new GenericEvent(null, $arguments));
+		$this->eventDispatcher->dispatch(
+			new GenericEvent(null, $arguments),
+			'userpreferences.afterDeleteApp'
+		);
 		return true;
 	}
 

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -251,9 +251,10 @@ class AppManager implements IAppManager {
 
 		$this->installedAppsCache[$appId] = 'yes';
 		$this->appConfig->setValue($appId, 'enabled', 'yes');
-		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE, new ManagerEvent(
-			ManagerEvent::EVENT_APP_ENABLE, $appId
-		));
+		$this->dispatcher->dispatch(
+			new ManagerEvent(ManagerEvent::EVENT_APP_ENABLE, $appId),
+			ManagerEvent::EVENT_APP_ENABLE
+		);
 		$this->clearAppsCache();
 	}
 
@@ -318,9 +319,10 @@ class AppManager implements IAppManager {
 		}, $groups);
 		$this->installedAppsCache[$appId] = \json_encode($groupIds);
 		$this->appConfig->setValue($appId, 'enabled', \json_encode($groupIds));
-		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, new ManagerEvent(
-			ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, $appId, $groups
-		));
+		$this->dispatcher->dispatch(
+			new ManagerEvent(ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, $appId, $groups),
+			ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS
+		);
 		$this->clearAppsCache();
 	}
 
@@ -336,9 +338,10 @@ class AppManager implements IAppManager {
 		}
 		unset($this->installedAppsCache[$appId]);
 		$this->appConfig->setValue($appId, 'enabled', 'no');
-		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_DISABLE, new ManagerEvent(
-			ManagerEvent::EVENT_APP_DISABLE, $appId
-		));
+		$this->dispatcher->dispatch(
+			new ManagerEvent(ManagerEvent::EVENT_APP_DISABLE, $appId),
+			ManagerEvent::EVENT_APP_DISABLE
+		);
 		$this->clearAppsCache();
 	}
 

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -506,10 +506,10 @@ class Manager implements ICommentsManager {
 			}
 
 			if ($affectedRows > 0 && $comment instanceof IComment) {
-				$this->dispatcher->dispatch(CommentsEvent::EVENT_DELETE, new CommentsEvent(
-					CommentsEvent::EVENT_DELETE,
-					$comment
-				));
+				$this->dispatcher->dispatch(
+					new CommentsEvent(CommentsEvent::EVENT_DELETE, $comment),
+					CommentsEvent::EVENT_DELETE
+				);
 			}
 
 			return ($affectedRows > 0);
@@ -589,10 +589,10 @@ class Manager implements ICommentsManager {
 			$comment->setId(\strval($qb->getLastInsertId()));
 		}
 
-		$this->dispatcher->dispatch(CommentsEvent::EVENT_ADD, new CommentsEvent(
-			CommentsEvent::EVENT_ADD,
-			$comment
-		));
+		$this->dispatcher->dispatch(
+			new CommentsEvent(CommentsEvent::EVENT_ADD, $comment),
+			CommentsEvent::EVENT_ADD
+		);
 		return $this->emittingCall(function () use ($affectedRows) {
 			return $affectedRows > 0;
 		}, [
@@ -632,10 +632,10 @@ class Manager implements ICommentsManager {
 				throw new NotFoundException('Comment to update does ceased to exist');
 			}
 
-			$this->dispatcher->dispatch(CommentsEvent::EVENT_UPDATE, new CommentsEvent(
-				CommentsEvent::EVENT_UPDATE,
-				$comment
-			));
+			$this->dispatcher->dispatch(
+				new CommentsEvent(CommentsEvent::EVENT_UPDATE, $comment),
+				CommentsEvent::EVENT_UPDATE
+			);
 
 			return $affectedRows > 0;
 		}, [

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -158,10 +158,10 @@ class Application {
 	 */
 	public function run(InputInterface $input = null, OutputInterface $output = null) {
 		$args = isset($this->request->server['argv']) ? $this->request->server['argv'] : [];
-		$this->dispatcher->dispatch(ConsoleEvent::EVENT_RUN, new ConsoleEvent(
-			ConsoleEvent::EVENT_RUN,
-			$args
-		));
+		$this->dispatcher->dispatch(
+			new ConsoleEvent(ConsoleEvent::EVENT_RUN, $args),
+			ConsoleEvent::EVENT_RUN
+		);
 		return $this->application->run($input, $output);
 	}
 

--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -241,13 +241,13 @@ class Migrator {
 		if ($this->dispatcher === null) {
 			return;
 		}
-		$this->dispatcher->dispatch('\OC\DB\Migrator::executeSql', new GenericEvent($sql, [$step+1, $max]));
+		$this->dispatcher->dispatch(new GenericEvent($sql, [$step+1, $max]), '\OC\DB\Migrator::executeSql');
 	}
 
 	private function emitCheckStep($tableName, $step, $max) {
 		if ($this->dispatcher === null) {
 			return;
 		}
-		$this->dispatcher->dispatch('\OC\DB\Migrator::checkTable', new GenericEvent($tableName, [$step+1, $max]));
+		$this->dispatcher->dispatch(new GenericEvent($tableName, [$step+1, $max]), '\OC\DB\Migrator::checkTable');
 	}
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -635,7 +635,7 @@ class View {
 			]);
 			if ($run) {
 				$event->setArgument('run', $run);
-				$this->eventDispatcher->dispatch('file.beforeCreate', $event);
+				$this->eventDispatcher->dispatch($event, 'file.beforeCreate');
 				if ($event->getArgument('run') === false) {
 					$run = $event->getArgument('run');
 				}
@@ -647,7 +647,7 @@ class View {
 			]);
 			if ($run) {
 				$event->setArgument('run', $run);
-				$this->eventDispatcher->dispatch('file.beforeUpdate', $event);
+				$this->eventDispatcher->dispatch($event, 'file.beforeUpdate');
 				if ($event->getArgument('run') === false) {
 					$run = $event->getArgument('run');
 				}
@@ -659,7 +659,7 @@ class View {
 		]);
 		if ($run) {
 			$event->setArgument('run', $run);
-			$this->eventDispatcher->dispatch('file.beforeWrite', $event);
+			$this->eventDispatcher->dispatch($event, 'file.beforeWrite');
 			if ($event->getArgument('run') === false) {
 				$run = $event->getArgument('run');
 			}

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -156,7 +156,7 @@ class Group implements IGroup {
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\Group', 'preAddUser', [$this, $user]);
 		}
-		$this->eventDispatcher->dispatch('group.preAddUser', new GenericEvent($this, ['user' => $user]));
+		$this->eventDispatcher->dispatch(new GenericEvent($this, ['user' => $user]), 'group.preAddUser');
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::ADD_TO_GROUP)) {
 				$backend->addToGroup($user->getUID(), $this->gid);
@@ -166,7 +166,7 @@ class Group implements IGroup {
 				if ($this->emitter) {
 					$this->emitter->emit('\OC\Group', 'postAddUser', [$this, $user]);
 				}
-				$this->eventDispatcher->dispatch('group.postAddUser', new GenericEvent($this, ['user' => $user]));
+				$this->eventDispatcher->dispatch(new GenericEvent($this, ['user' => $user]), 'group.postAddUser');
 				return;
 			}
 		}
@@ -182,7 +182,7 @@ class Group implements IGroup {
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\Group', 'preRemoveUser', [$this, $user]);
 		}
-		$this->eventDispatcher->dispatch('group.preRemoveUser', new GenericEvent($this, ['user' => $user]));
+		$this->eventDispatcher->dispatch(new GenericEvent($this, ['user' => $user]), 'group.preRemoveUser');
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::REMOVE_FROM_GOUP) and $backend->inGroup($user->getUID(), $this->gid)) {
 				$backend->removeFromGroup($user->getUID(), $this->gid);
@@ -193,7 +193,7 @@ class Group implements IGroup {
 			if ($this->emitter) {
 				$this->emitter->emit('\OC\Group', 'postRemoveUser', [$this, $user]);
 			}
-			$this->eventDispatcher->dispatch('group.postRemoveUser', new GenericEvent($this, ['user' => $user]));
+			$this->eventDispatcher->dispatch(new GenericEvent($this, ['user' => $user]), 'group.postRemoveUser');
 			if ($this->users) {
 				foreach ($this->users as $index => $groupUser) {
 					if ($groupUser->getUID() === $user->getUID()) {
@@ -281,7 +281,7 @@ class Group implements IGroup {
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\Group', 'preDelete', [$this]);
 		}
-		$this->eventDispatcher->dispatch('group.preDelete', new GenericEvent($this));
+		$this->eventDispatcher->dispatch(new GenericEvent($this), 'group.preDelete');
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::DELETE_GROUP)) {
 				$result = true;
@@ -291,7 +291,7 @@ class Group implements IGroup {
 		if ($result and $this->emitter) {
 			$this->emitter->emit('\OC\Group', 'postDelete', [$this]);
 		}
-		$this->eventDispatcher->dispatch('group.postDelete', new GenericEvent($this));
+		$this->eventDispatcher->dispatch(new GenericEvent($this), 'group.postDelete');
 		return $result;
 	}
 

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -216,14 +216,14 @@ class Manager extends PublicEmitter implements IGroupManager {
 			return $group;
 		} else {
 			$this->emit('\OC\Group', 'preCreate', [$gid]);
-			$this->eventDispatcher->dispatch('group.preCreate', new GenericEvent(null, ['gid' => $gid]));
+			$this->eventDispatcher->dispatch(new GenericEvent(null, ['gid' => $gid]), 'group.preCreate');
 			foreach ($this->backends as $backend) {
 				if ($backend->implementsActions(\OC\Group\Backend::CREATE_GROUP)) {
 					/* @phan-suppress-next-line PhanUndeclaredMethod */
 					$backend->createGroup($gid);
 					$group = $this->getGroupObject($gid);
 					$this->emit('\OC\Group', 'postCreate', [$group]);
-					$this->eventDispatcher->dispatch('group.postCreate', new GenericEvent($group, ['gid' => $gid]));
+					$this->eventDispatcher->dispatch(new GenericEvent($group, ['gid' => $gid]), 'group.postCreate');
 					return $group;
 				}
 			}

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -385,7 +385,7 @@ class Log implements ILogger {
 			$this->inEvent = true;
 			$event = new GenericEvent(null);
 			$event->setArguments($eventArgs);
-			$this->eventDispatcher->dispatch('log.beforewrite', $event);
+			$this->eventDispatcher->dispatch($event, 'log.beforewrite');
 		}
 
 		if ($level >= $minLevel) {
@@ -402,7 +402,7 @@ class Log implements ILogger {
 			$event = new GenericEvent(null);
 			$event->setArguments($eventArgs);
 			try {
-				$this->eventDispatcher->dispatch('log.afterwrite', $event);
+				$this->eventDispatcher->dispatch($event, 'log.afterwrite');
 			} finally {
 				$this->inEvent = false;
 			}

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -144,7 +144,7 @@ class Manager implements IManager {
 
 		$this->builtAppsHolder = [];
 		$registerAppEvent = new RegisterConsumerEventImpl($this);
-		$this->dispatcher->dispatch(RegisterConsumerEvent::NAME, $registerAppEvent);
+		$this->dispatcher->dispatch($registerAppEvent, RegisterConsumerEvent::NAME);
 		$this->apps = \array_merge($this->apps, $this->builtAppsHolder);
 
 		return $this->apps;
@@ -169,7 +169,7 @@ class Manager implements IManager {
 
 		$this->builtNotifiersHolder = [];
 		$registerNotifierEvent = new RegisterNotifierEventImpl($this);
-		$this->dispatcher->dispatch(RegisterNotifierEvent::NAME, $registerNotifierEvent);
+		$this->dispatcher->dispatch($registerNotifierEvent, RegisterNotifierEvent::NAME);
 		foreach ($this->builtNotifiersHolder as $notifierData) {
 			$this->notifiers[] = $notifierData['notifier'];
 		}
@@ -199,7 +199,7 @@ class Manager implements IManager {
 
 		$this->builtNotifiersHolder = [];
 		$registerNotifierEvent = new RegisterNotifierEventImpl($this);
-		$this->dispatcher->dispatch(RegisterNotifierEvent::NAME, $registerNotifierEvent);
+		$this->dispatcher->dispatch($registerNotifierEvent, RegisterNotifierEvent::NAME);
 		foreach ($this->builtNotifiersHolder as $id => $notifierData) {
 			$this->notifiersInfo[$id] = $notifierData['name'];
 		}

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -222,8 +222,10 @@ class Repair implements IOutput {
 	 */
 	public function emit($scope, $method, array $arguments = []) {
 		if ($this->dispatcher !== null) {
-			$this->dispatcher->dispatch("$scope::$method",
-				new GenericEvent("$scope::$method", $arguments));
+			$this->dispatcher->dispatch(
+				new GenericEvent("$scope::$method", $arguments),
+				"$scope::$method"
+			);
 		}
 	}
 

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -241,11 +241,11 @@ class Apps implements IRepairStep {
 			$output->info("Fetching app from market: $app");
 			try {
 				$this->eventDispatcher->dispatch(
-					\sprintf('%s::%s', IRepairStep::class, $event),
 					new GenericEvent(
 						$app,
 						['isMajorUpdate' => $this->isMajorCoreUpdate()]
-					)
+					),
+					\sprintf('%s::%s', IRepairStep::class, $event)
 				);
 			} catch (AppAlreadyInstalledException $e) {
 				$output->info($e->getMessage());

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -363,7 +363,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			});
 			$userSession->listen('\OC\User', 'preLogout', function () {
 				$event = new GenericEvent(null, []);
-				\OC::$server->getEventDispatcher()->dispatch('\OC\User\Session::pre_logout', $event);
+				\OC::$server->getEventDispatcher()->dispatch($event, '\OC\User\Session::pre_logout');
 			});
 			$userSession->listen('\OC\User', 'logout', function () {
 				\OC_Hook::emit('OC_User', 'logout', []);

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -267,7 +267,7 @@ class MailNotifications {
 		$replyTo = $this->getReplyTo($sender->getEMailAddress());
 
 		$event = new GenericEvent(null, ['link' => $link, 'to' => $recipientsAsString]);
-		$this->eventDispatcher->dispatch('share.sendmail', $event);
+		$this->eventDispatcher->dispatch($event, 'share.sendmail');
 		$failedRecipients =  $this->sendLinkShareMailFromBody($recipients, $subject, $htmlBody, $textBody, $from, $replyTo);
 		if (empty($failedRecipients)) {
 			$event = $this->activityManager->generateEvent();

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -2849,8 +2849,8 @@ class Share extends Constants {
 		}
 
 		\OC::$server->getEventDispatcher()->dispatch(
-			'OCP\Share::validatePassword',
-			new GenericEvent(null, ['password' => $password])
+			new GenericEvent(null, ['password' => $password]),
+			'OCP\Share::validatePassword'
 		);
 	}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -201,8 +201,8 @@ class Manager implements IManager {
 		}
 
 		$this->eventDispatcher->dispatch(
-			'OCP\Share::validatePassword',
-			new GenericEvent(null, ['password' => $password])
+			new GenericEvent(null, ['password' => $password]),
+			'OCP\Share::validatePassword'
 		);
 	}
 
@@ -767,7 +767,7 @@ class Manager implements IManager {
 		\OC_Hook::emit('OCP\Share', 'pre_shared', $preHookData);
 
 		$beforeEvent = new GenericEvent(null, ['shareData' => $preHookData, 'shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.beforeCreate', $beforeEvent);
+		$this->eventDispatcher->dispatch($beforeEvent, 'share.beforeCreate');
 
 		if ($run === false) {
 			throw new \Exception($error);
@@ -797,7 +797,7 @@ class Manager implements IManager {
 		\OC_Hook::emit('OCP\Share', 'post_shared', $postHookData);
 
 		$afterEvent = new GenericEvent(null, ['shareData' => $postHookData, 'shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.afterCreate', $afterEvent);
+		$this->eventDispatcher->dispatch($afterEvent, 'share.afterCreate');
 
 		return $share;
 	}
@@ -1044,7 +1044,7 @@ class Manager implements IManager {
 		}
 
 		if ($update === true) {
-			$this->eventDispatcher->dispatch('share.afterupdate', $shareAfterUpdateEvent);
+			$this->eventDispatcher->dispatch($shareAfterUpdateEvent, 'share.afterupdate');
 		}
 		return $share;
 	}
@@ -1123,7 +1123,7 @@ class Manager implements IManager {
 		\OC_Hook::emit('OCP\Share', 'pre_unshare', $hookParams);
 
 		$beforeEvent = new GenericEvent(null, ['shareData' => $hookParams, 'shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.beforeDelete', $beforeEvent);
+		$this->eventDispatcher->dispatch($beforeEvent, 'share.beforeDelete');
 		// Get all children and delete them as well
 		$deletedShares = $this->deleteChildren($share);
 
@@ -1142,7 +1142,7 @@ class Manager implements IManager {
 		// Emit post hook
 		\OC_Hook::emit('OCP\Share', 'post_unshare', $hookParams);
 		$afterEvent = new GenericEvent(null, ['shareData' => $hookParams['deletedShares'], 'shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.afterDelete', $afterEvent);
+		$this->eventDispatcher->dispatch($afterEvent, 'share.afterDelete');
 	}
 
 	/**
@@ -1174,7 +1174,7 @@ class Manager implements IManager {
 			'recipientPath' => $share->getTarget(),
 			'ownerPath' => $share->getNode()->getPath(),
 			'nodeType' => $share->getNodeType()]);
-		$this->eventDispatcher->dispatch('fromself.unshare', $event);
+		$this->eventDispatcher->dispatch($event, 'fromself.unshare');
 	}
 
 	/**

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -251,9 +251,10 @@ class SystemTagManager implements ISystemTagManager {
 			(bool)$editable
 		);
 
-		$this->dispatcher->dispatch(ManagerEvent::EVENT_CREATE, new ManagerEvent(
-			ManagerEvent::EVENT_CREATE, $tag
-		));
+		$this->dispatcher->dispatch(
+			new ManagerEvent(ManagerEvent::EVENT_CREATE, $tag),
+			ManagerEvent::EVENT_CREATE
+		);
 
 		return $tag;
 	}
@@ -319,9 +320,10 @@ class SystemTagManager implements ISystemTagManager {
 			);
 		}
 
-		$this->dispatcher->dispatch(ManagerEvent::EVENT_UPDATE, new ManagerEvent(
-			ManagerEvent::EVENT_UPDATE, $afterUpdate, $beforeUpdate
-		));
+		$this->dispatcher->dispatch(
+			new ManagerEvent(ManagerEvent::EVENT_UPDATE, $afterUpdate, $beforeUpdate),
+			ManagerEvent::EVENT_UPDATE
+		);
 	}
 
 	/**
@@ -364,9 +366,10 @@ class SystemTagManager implements ISystemTagManager {
 			->execute();
 
 		foreach ($tags as $tag) {
-			$this->dispatcher->dispatch(ManagerEvent::EVENT_DELETE, new ManagerEvent(
-				ManagerEvent::EVENT_DELETE, $tag
-			));
+			$this->dispatcher->dispatch(
+				new ManagerEvent(ManagerEvent::EVENT_DELETE, $tag),
+				ManagerEvent::EVENT_DELETE
+			);
 		}
 
 		if ($tagNotFoundException !== null) {

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -165,12 +165,15 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			}
 		}
 
-		$this->dispatcher->dispatch(MapperEvent::EVENT_ASSIGN, new MapperEvent(
-			MapperEvent::EVENT_ASSIGN,
-			$objectType,
-			$objId,
-			$tagIds
-		));
+		$this->dispatcher->dispatch(
+			new MapperEvent(
+				MapperEvent::EVENT_ASSIGN,
+				$objectType,
+				$objId,
+				$tagIds
+			),
+			MapperEvent::EVENT_ASSIGN
+		);
 	}
 
 	/**
@@ -193,12 +196,15 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
 			->execute();
 
-		$this->dispatcher->dispatch(MapperEvent::EVENT_UNASSIGN, new MapperEvent(
-			MapperEvent::EVENT_UNASSIGN,
-			$objectType,
-			$objId,
-			$tagIds
-		));
+		$this->dispatcher->dispatch(
+			new MapperEvent(
+				MapperEvent::EVENT_UNASSIGN,
+				$objectType,
+				$objId,
+				$tagIds
+			),
+			MapperEvent::EVENT_UNASSIGN
+		);
 	}
 
 	/**

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -368,8 +368,8 @@ class Manager extends PublicEmitter implements IUserManager {
 
 			$this->emit('\OC\User', 'preCreateUser', [$uid, $password]);
 			\OC::$server->getEventDispatcher()->dispatch(
-				'OCP\User::validatePassword',
-				new GenericEvent(null, ['uid' => $uid, 'password' => $password])
+				new GenericEvent(null, ['uid' => $uid, 'password' => $password]),
+				'OCP\User::validatePassword'
 			);
 
 			if (empty($this->backends)) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -462,8 +462,8 @@ class Session implements IUserSession, Emitter {
 			}
 
 			// trigger any other initialization
-			$this->eventDispatcher->dispatch(IUser::class . '::firstLogin', new GenericEvent($this->getUser()));
-			$this->eventDispatcher->dispatch('user.firstlogin', new GenericEvent($this->getUser()));
+			$this->eventDispatcher->dispatch(new GenericEvent($this->getUser()), IUser::class . '::firstLogin');
+			$this->eventDispatcher->dispatch(new GenericEvent($this->getUser()), 'user.firstlogin');
 		}
 	}
 
@@ -514,7 +514,7 @@ class Session implements IUserSession, Emitter {
 	 */
 	private function loginWithPassword($login, $password) {
 		$beforeEvent = new GenericEvent(null, ['loginType' => 'password', 'login' => $login, 'uid' => $login, '_uid' => 'deprecated: please use \'login\', the real uid is not yet known', 'password' => $password]);
-		$this->eventDispatcher->dispatch('user.beforelogin', $beforeEvent);
+		$this->eventDispatcher->dispatch($beforeEvent, 'user.beforelogin');
 		$this->manager->emit('\OC\User', 'preLogin', [$login, $password]);
 
 		$user = $this->manager->checkPassword($login, $password);
@@ -532,7 +532,7 @@ class Session implements IUserSession, Emitter {
 				$this->prepareUserLogin($firstTimeLogin);
 
 				$afterEvent = new GenericEvent(null, ['loginType' => 'password', 'user' => $user, 'uid' => $user->getUID(), 'password' => $password]);
-				$this->eventDispatcher->dispatch('user.afterlogin', $afterEvent);
+				$this->eventDispatcher->dispatch($afterEvent, 'user.afterlogin');
 
 				return true;
 			}
@@ -573,7 +573,7 @@ class Session implements IUserSession, Emitter {
 
 		$this->manager->emit('\OC\User', 'preLogin', [$uid, $password]);
 		$beforeEvent = new GenericEvent(null, ['loginType' => 'token', 'login' => $uid, 'uid' => $uid, 'password' => $password]);
-		$this->eventDispatcher->dispatch('user.beforelogin', $beforeEvent);
+		$this->eventDispatcher->dispatch($beforeEvent, 'user.beforelogin');
 
 		$user = $this->manager->get($uid);
 		if ($user === null) {
@@ -593,7 +593,7 @@ class Session implements IUserSession, Emitter {
 		$this->setLoginName($dbToken->getLoginName());
 		$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
 		$afterEvent = new GenericEvent(null, ['loginType' => 'token', 'user' => $user, 'login' => $user->getUID(), 'uid' => $user->getUID(), 'password' => $password]);
-		$this->eventDispatcher->dispatch('user.afterlogin', $afterEvent);
+		$this->eventDispatcher->dispatch($afterEvent, 'user.afterlogin');
 
 		if ($this->isLoggedIn()) {
 			$this->prepareUserLogin();
@@ -655,7 +655,7 @@ class Session implements IUserSession, Emitter {
 
 		$this->manager->emit('\OC\User', 'preLogin', [$uid, '']);
 		$beforeEvent = new GenericEvent(null, ['loginType' => 'apache', 'login' => $uid, 'uid' => $uid, 'password' => '']);
-		$this->eventDispatcher->dispatch('user.beforelogin', $beforeEvent);
+		$this->eventDispatcher->dispatch($beforeEvent, 'user.beforelogin');
 
 		// Die here if not valid
 		if (!$apacheBackend->isSessionActive()) {
@@ -688,7 +688,7 @@ class Session implements IUserSession, Emitter {
 			$firstTimeLogin = $user->updateLastLoginTimestamp();
 			$this->manager->emit('\OC\User', 'postLogin', [$user, '']);
 			$afterEvent = new GenericEvent(null, ['loginType' => 'apache', 'user' => $user, 'login' => $user->getUID(), 'uid' => $user->getUID(), 'password' => '']);
-			$this->eventDispatcher->dispatch('user.afterlogin', $afterEvent);
+			$this->eventDispatcher->dispatch($afterEvent, 'user.afterlogin');
 			if ($this->isLoggedIn()) {
 				$this->prepareUserLogin($firstTimeLogin);
 				return true;
@@ -1076,7 +1076,7 @@ class Session implements IUserSession, Emitter {
 	public function logout() {
 		return $this->emittingCall(function () {
 			$event = new GenericEvent(null, ['cancel' => false]);
-			$this->eventDispatcher->dispatch('\OC\User\Session::pre_logout', $event);
+			$this->eventDispatcher->dispatch($event, '\OC\User\Session::pre_logout');
 
 			$this->manager->emit('\OC\User', 'preLogout');
 
@@ -1211,7 +1211,7 @@ class Session implements IUserSession, Emitter {
 		$this->manager->emit('\OC\User', 'failedLogin', [$user]);
 
 		$loginFailedEvent = new GenericEvent(null, ['user' => $user]);
-		$this->eventDispatcher->dispatch('user.loginfailed', $loginFailedEvent);
+		$this->eventDispatcher->dispatch($loginFailedEvent, 'user.loginfailed');
 	}
 
 	/**

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -299,8 +299,8 @@ class User implements IUser {
 			if ($this->emitter) {
 				$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);
 				\OC::$server->getEventDispatcher()->dispatch(
-					'OCP\User::validatePassword',
-					new GenericEvent(null, ['uid'=> $this->getUID(), 'password' => $password])
+					new GenericEvent(null, ['uid'=> $this->getUID(), 'password' => $password]),
+					'OCP\User::validatePassword'
 				);
 			}
 			if ($this->canChangePassword()) {
@@ -423,7 +423,7 @@ class User implements IUser {
 		$this->mapper->update($this->account);
 
 		if ($this->eventDispatcher) {
-			$this->eventDispatcher->dispatch(self::class . '::postSetEnabled', new GenericEvent($this));
+			$this->eventDispatcher->dispatch(new GenericEvent($this), self::class . '::postSetEnabled');
 		}
 	}
 

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -136,7 +136,7 @@ class OC_Files {
 
 			//Dispatch an event to see if any apps have problem with download
 			$event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['dir' => $dir, 'files' => $files, 'run' => true]);
-			OC::$server->getEventDispatcher()->dispatch('file.beforeCreateZip', $event);
+			OC::$server->getEventDispatcher()->dispatch($event, 'file.beforeCreateZip');
 			if (($event->getArgument('run') === false) or ($event->hasArgument('errorMessage'))) {
 				throw new \OC\ForbiddenException($event->getArgument('errorMessage'));
 			}
@@ -170,7 +170,7 @@ class OC_Files {
 			\set_time_limit($executionTime);
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			$event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['result' => 'success', 'dir' => $dir, 'files' => $files]);
-			OC::$server->getEventDispatcher()->dispatch('file.afterCreateZip', $event);
+			OC::$server->getEventDispatcher()->dispatch($event, 'file.afterCreateZip');
 		} catch (\OCP\Lock\LockedException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
@@ -269,7 +269,7 @@ class OC_Files {
 		}
 
 		$event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['path' => $filename]);
-		OC::$server->getEventDispatcher()->dispatch('file.beforeGetDirect', $event);
+		OC::$server->getEventDispatcher()->dispatch($event, 'file.beforeGetDirect');
 
 		if (\OC\Files\Filesystem::isReadable($filename) && !$event->hasArgument('errorMessage')) {
 			self::sendHeaders($filename, $name, $rangeArray);

--- a/lib/public/Events/EventEmitterTrait.php
+++ b/lib/public/Events/EventEmitterTrait.php
@@ -45,12 +45,12 @@ trait EventEmitterTrait {
 	 */
 	public function emittingCall(\Closure $fn, $arguments, $class, $eventName) {
 		if (isset($arguments['before']) && \count($arguments['before']) > 0) {
-			\OC::$server->getEventDispatcher()->dispatch("$class.before$eventName", new GenericEvent(null, $arguments['before']));
+			\OC::$server->getEventDispatcher()->dispatch(new GenericEvent(null, $arguments['before']), "$class.before$eventName");
 		}
 		$result = isset($arguments['after']) ? $fn($arguments['after']) : $fn([]);
 		if (($result !== false) && ($result !== null) &&
 			(isset($arguments['after']) && \count($arguments['after']) > 0)) {
-			\OC::$server->getEventDispatcher()->dispatch("$class.after$eventName", new GenericEvent(null, $arguments['after']));
+			\OC::$server->getEventDispatcher()->dispatch(new GenericEvent(null, $arguments['after']), "$class.after$eventName");
 		}
 		return $result;
 	}

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -444,7 +444,7 @@ class UsersController extends Controller {
 		try {
 			if (($password === '') && ($email !== '')) {
 				$event = new GenericEvent();
-				$this->eventDispatcher->dispatch('OCP\User::createPassword', $event);
+				$this->eventDispatcher->dispatch($event, 'OCP\User::createPassword');
 				if ($event->hasArgument('password')) {
 					$password = $event->getArgument('password');
 				} else {

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -84,12 +84,12 @@ class AllConfigTest extends \Test\TestCase {
 		$this->eventDispatcher->expects($this->exactly(6))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('userpreferences.beforeSetValue'), $this->equalTo($event)],
-				[$this->equalTo('userpreferences.afterSetValue'), $this->equalTo($event)],
-				[$this->equalTo('userpreferences.beforeSetValue'), $this->equalTo($event2)],
-				[$this->equalTo('userpreferences.afterSetValue'), $this->equalTo($event2)],
-				[$this->equalTo('userpreferences.beforeDeleteValue'), $this->equalTo($event3)],
-				[$this->equalTo('userpreferences.afterDeleteValue'), $this->equalTo($event3)]
+				[$this->equalTo($event), $this->equalTo('userpreferences.beforeSetValue')],
+				[$this->equalTo($event), $this->equalTo('userpreferences.afterSetValue')],
+				[$this->equalTo($event2), $this->equalTo('userpreferences.beforeSetValue')],
+				[$this->equalTo($event2), $this->equalTo('userpreferences.afterSetValue')],
+				[$this->equalTo($event3), $this->equalTo('userpreferences.beforeDeleteValue')],
+				[$this->equalTo($event3), $this->equalTo('userpreferences.afterDeleteValue')]
 			);
 
 		$config->setUserValue('userSet', 'appSet', 'keySet', 'valueSet');
@@ -381,8 +381,8 @@ class AllConfigTest extends \Test\TestCase {
 		$this->eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('userpreferences.beforeDeleteUser'), $this->equalTo($event)],
-				[$this->equalTo('userpreferences.afterDeleteUser'), $this->equalTo($event)]
+				[$this->equalTo($event), $this->equalTo('userpreferences.beforeDeleteUser')],
+				[$this->equalTo($event), $this->equalTo('userpreferences.afterDeleteUser')]
 			);
 
 		$config->deleteAllUserValues('userFetch3');
@@ -422,10 +422,10 @@ class AllConfigTest extends \Test\TestCase {
 		$this->eventDispatcher->expects($this->exactly(4))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('userpreferences.beforeDeleteApp'), $this->equalTo(new GenericEvent(null, ['app' => 'appFetch1']))],
-				[$this->equalTo('userpreferences.afterDeleteApp'), $this->equalTo(new GenericEvent(null, ['app' => 'appFetch1']))],
-				[$this->equalTo('userpreferences.beforeDeleteApp'), $this->equalTo(new GenericEvent(null, ['app' => 'appFetch2']))],
-				[$this->equalTo('userpreferences.afterDeleteApp'), $this->equalTo(new GenericEvent(null, ['app' => 'appFetch2']))]
+				[$this->equalTo(new GenericEvent(null, ['app' => 'appFetch1'])), $this->equalTo('userpreferences.beforeDeleteApp')],
+				[$this->equalTo(new GenericEvent(null, ['app' => 'appFetch1'])), $this->equalTo('userpreferences.afterDeleteApp')],
+				[$this->equalTo(new GenericEvent(null, ['app' => 'appFetch2'])), $this->equalTo('userpreferences.beforeDeleteApp')],
+				[$this->equalTo(new GenericEvent(null, ['app' => 'appFetch2'])), $this->equalTo('userpreferences.afterDeleteApp')]
 			);
 
 		$config->deleteAppFromAllUsers('appFetch1');

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -50,7 +50,7 @@ class GroupTest extends \Test\TestCase {
 				$eventMap[$eventName][] = $callable;
 			}));
 		$eventDispatcher->method('dispatch')
-			->will($this->returnCallback(function ($eventName, $event) use (&$eventMap) {
+			->will($this->returnCallback(function ($event, $eventName) use (&$eventMap) {
 				if (isset($eventMap[$eventName])) {
 					foreach ($eventMap[$eventName] as $callable) {
 						$callable($event);

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -133,7 +133,7 @@ class ManagerTest extends \Test\TestCase {
 				$eventMap[$eventName][] = $callable;
 			}));
 		$eventDispatcher->method('dispatch')
-			->will($this->returnCallback(function ($eventName, $event) use (&$eventMap) {
+			->will($this->returnCallback(function ($event, $eventName) use (&$eventMap) {
 				if (isset($eventMap[$eventName])) {
 					foreach ($eventMap[$eventName] as $callable) {
 						$callable($event);

--- a/tests/lib/Migration/BackgroundRepairTest.php
+++ b/tests/lib/Migration/BackgroundRepairTest.php
@@ -108,7 +108,7 @@ class BackgroundRepairTest extends TestCase {
 		/** @var EventDispatcher | \PHPUnit\Framework\MockObject\MockObject $dispatcher */
 		$dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcher');
 		$dispatcher->expects($this->once())->method('dispatch')
-			->with('\OC\Repair::step', new GenericEvent('\OC\Repair::step', ['A test repair step']));
+			->with(new GenericEvent('\OC\Repair::step', ['A test repair step']), '\OC\Repair::step');
 
 		$this->jobList->expects($this->once())->method('remove');
 		$this->job->setDispatcher($dispatcher);

--- a/tests/lib/Notification/ManagerTest.php
+++ b/tests/lib/Notification/ManagerTest.php
@@ -54,7 +54,7 @@ class ManagerTest extends TestCase {
 				$eventMap[$eventName][] = $callable;
 			}));
 		$this->eventDispatcher->method('dispatch')
-			->will($this->returnCallback(function ($eventName, $event) use (&$eventMap) {
+			->will($this->returnCallback(function ($event, $eventName) use (&$eventMap) {
 				if (isset($eventMap[$eventName])) {
 					foreach ($eventMap[$eventName] as $callable) {
 						$callable($event);

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -135,7 +135,7 @@ class AppsTest extends TestCase {
 
 		$this->eventDispatcher->expects($this->once())->method('dispatch')
 			->willReturnCallback(
-				function ($eventName, $event) use ($appName) {
+				function ($event, $eventName) use ($appName) {
 					$this->assertEquals($appName, $event->getSubject());
 					$this->assertEquals(true, $event->getArgument('isMajorUpdate'));
 				}

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -268,8 +268,8 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.beforelogin'), $this->equalTo($beforeEvent)],
-				[$this->equalTo('user.afterlogin'), $this->equalTo($afterEvent)]
+				[$this->equalTo($beforeEvent), $this->equalTo('user.beforelogin')],
+				[$this->equalTo($afterEvent), $this->equalTo('user.afterlogin')]
 			);
 		$userSession->login('foo', 'bar');
 	}
@@ -434,7 +434,7 @@ class SessionTest extends TestCase {
 			->with('token_auth_enforced', false)
 			->will($this->returnValue(true));
 		$this->logger->expects($this->once())->method('warning')->with("Login failed: 'john' (Remote IP: '12.34.56.78')");
-		$eventDispatcher->expects($this->once())->method('dispatch')->with('user.loginfailed', new GenericEvent(null, ['user' => 'john']));
+		$eventDispatcher->expects($this->once())->method('dispatch')->with(new GenericEvent(null, ['user' => 'john']), 'user.loginfailed');
 
 		$userSession->logClientIn('john', 'doe', $request);
 	}
@@ -533,7 +533,7 @@ class SessionTest extends TestCase {
 			->with('john')
 			->will($this->returnValue(true));
 		$this->logger->expects($this->once())->method('warning')->with("Login failed: 'john' (Remote IP: '12.34.56.78')");
-		$eventDispatcher->expects($this->once())->method('dispatch')->with('user.loginfailed', new GenericEvent(null, ['user' => 'john']));
+		$eventDispatcher->expects($this->once())->method('dispatch')->with(new GenericEvent(null, ['user' => 'john']), 'user.loginfailed');
 
 		$userSession->logClientIn('john', 'doe', $request);
 	}
@@ -1199,8 +1199,8 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.beforelogin'), $this->equalTo($beforeLoginEvent)],
-				[$this->equalTo('user.loginfailed'), $this->equalTo($failedEvent)]
+				[$this->equalTo($beforeLoginEvent), $this->equalTo('user.beforelogin')],
+				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
 			);
 
 		$userSession->loginWithApache($apacheBackend);
@@ -1243,8 +1243,8 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.beforelogin'), $this->equalTo($beforeLoginEvent)],
-				[$this->equalTo('user.afterlogin'), $this->equalTo($afterLoginEvent)]
+				[$this->equalTo($beforeLoginEvent), $this->equalTo('user.beforelogin')],
+				[$this->equalTo($afterLoginEvent), $this->equalTo('user.afterlogin')]
 			);
 
 		$this->assertTrue($userSession->loginWithApache($apacheBackend));
@@ -1274,8 +1274,8 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.beforelogin'), $this->equalTo($beforeEvent)],
-				[$this->equalTo('user.loginfailed'), $this->equalTo($failedLogin)]
+				[$this->equalTo($beforeEvent), $this->equalTo('user.beforelogin')],
+				[$this->equalTo($failedLogin), $this->equalTo('user.loginfailed')]
 			);
 
 		$this->invokePrivate($userSession, 'loginWithPassword', ['foo', 'foo']);
@@ -1315,8 +1315,8 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.beforelogin'), $this->equalTo($beforeEvent)],
-				[$this->equalTo('user.afterlogin'), $this->equalTo($afterEvent)]
+				[$this->equalTo($beforeEvent), $this->equalTo('user.beforelogin')],
+				[$this->equalTo($afterEvent), $this->equalTo('user.afterlogin')]
 			);
 
 		$result = $this->invokePrivate($userSession, 'loginWithPassword', ['foo', 'foopass']);
@@ -1358,8 +1358,8 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.beforelogin'), $this->equalTo($event)],
-				[$this->equalTo('user.loginfailed'), $this->equalTo($failedEvent)]
+				[$this->equalTo($event), $this->equalTo('user.beforelogin')],
+				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
 			);
 
 		$this->invokePrivate($userSession, 'loginWithToken', ['token']);
@@ -1414,8 +1414,8 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.beforelogin'), $this->equalTo($beforeEvent)],
-				[$this->equalTo('user.afterlogin'), $this->equalTo($afterEvent)]
+				[$this->equalTo($beforeEvent), $this->equalTo('user.beforelogin')],
+				[$this->equalTo($afterEvent), $this->equalTo('user.afterlogin')]
 			);
 
 		$result = $this->invokePrivate($userSession, 'loginWithToken', ['token']);
@@ -1549,7 +1549,7 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->once())
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.loginfailed'), $this->equalTo($failedEvent)]
+				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
 			);
 
 		$this->invokePrivate($userSession, 'loginUser', [null, 'foo']);
@@ -1604,7 +1604,7 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->once())
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.loginfailed'), $this->equalTo($failedEvent)]
+				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
 			);
 
 		$iUser = $this->createMock(IUser::class);
@@ -1620,7 +1620,7 @@ class SessionTest extends TestCase {
 		$eventDispatcher->expects($this->once())
 			->method('dispatch')
 			->withConsecutive(
-				[$this->equalTo('user.loginfailed'), $this->equalTo($failedEvent)]
+				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
 			);
 
 		$this->invokePrivate($userSession, 'loginUser', [$iUser, 'foo']);

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -496,6 +496,7 @@ class UserTest extends TestCase {
 		$this->eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->with(
+				$this->anything(),
 				$this->callback(
 					function ($eventName) {
 						if ($eventName === User::class . '::postSetEnabled') {
@@ -503,8 +504,7 @@ class UserTest extends TestCase {
 						}
 						return false;
 					}
-				),
-				$this->anything()
+				)
 			)
 		;
 


### PR DESCRIPTION
## Description
We updated from Symfony 3.4 to 4.4 in PR #36881 
Symfony 4.3 (and thus 4.4) adjusted the `EventDispatcher` `dispatch` method to take parameters in the opposite order.
https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching
https://github.com/symfony/symfony/pull/28920
https://github.com/symfony/symfony/pull/33115

The change was made in a BC way - if the parameters are provided the old way around, then the `dispatch` method flips them. So existing code is OK. But in Symfony5 the "old way" is likely to have been removed.

I noticed this because some apps have `phan` code analysis that reports that the parameters are around the "wrong way" (the old way). e.g.
```
lib/Jobs/PasswordExpirationNotifierJob.php:170 PhanTypeMismatchArgument Argument 1 (event) is 'user.passwordAboutToExpire' but \Symfony\Component\EventDispatcher\EventDispatcher::dispatch() takes object defined at ../../lib/composer/symfony/event-dispatcher/EventDispatcher.php:51
lib/Jobs/PasswordExpirationNotifierJob.php:215 PhanTypeMismatchArgument Argument 1 (event) is 'user.passwordExpired' but \Symfony\Component\EventDispatcher\EventDispatcher::dispatch() takes object defined at ../../lib/composer/symfony/event-dispatcher/EventDispatcher.php:51
```

IMO it is good to refactor this in core now, rather than leave it waiting to break things when we go to Symfony5 some day.

I adjusted the existing Symfony4 update changelog to include this PR.

## How Has This Been Tested?
Local unit test runs and CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
