### PR TITLE
[Tests-Only] Adjust appConfigurationContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -141,17 +141,17 @@ class AppConfigurationContext implements Context {
 	 * @param string $username
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function userGetsCapabilitiesCheckResponse($username) {
 		$this->userGetsCapabilities($username);
 		$statusCode = $this->featureContext->getResponse()->getStatusCode();
-
-		Assert::assertEquals(
-			200,
-			$statusCode,
-			__METHOD__
-			. "'user $username returned unexpected status $statusCode"
-		);
+		if ($statusCode !== 200) {
+			throw new \Exception(
+				__METHOD__
+				. "user $username returned unexpected status $statusCode"
+			);
+		}
 	}
 
 	/**
@@ -475,16 +475,18 @@ class AppConfigurationContext implements Context {
 	 * @Given the trusted server list is cleared
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theTrustedServerListIsCleared() {
 		$this->theAdministratorDeletesAllTrustedServersUsingTheTestingApi();
-		Assert::assertEquals(
-			204,
-			$this->featureContext->getResponse()->getStatusCode(),
-			__METHOD__
-			. "Failed to clear all trusted servers"
-			. $this->featureContext->getResponse()->getBody()->getContents()
-		);
+		$statusCode = $this->featureContext->getResponse()->getStatusCode();
+		$contents = $this->featureContext->getResponse()->getBody()->getContents();
+		if ($statusCode !== 204) {
+			throw new \Exception(
+				__METHOD__
+				. "Failed to clear all trusted servers" . $contents
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps  respectively in the AppConfigurationContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
