### PR TITLE
[Tests-Only] Adjust appManagementContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -25,9 +25,7 @@
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;
 use TestHelpers\AppConfigHelper;
-use TestHelpers\HttpRequestHelper;
 use TestHelpers\OcsApiHelper;
-use TestHelpers\SetupHelper;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
 
@@ -186,6 +184,7 @@ class AppConfigurationContext implements Context {
 	 * @Given the administrator has retrieved the capabilities
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theAdministratorGetsCapabilitiesCheckResponse() {
 		$this->userGetsCapabilitiesCheckResponse($this->featureContext->getAdminUsername());

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -167,6 +167,7 @@ class AppConfigurationContext implements Context {
 	 * @Given the user has retrieved the capabilities
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theUserGetsCapabilitiesCheckResponse() {
 		$this->userGetsCapabilitiesCheckResponse($this->featureContext->getCurrentUser());
@@ -480,8 +481,8 @@ class AppConfigurationContext implements Context {
 	public function theTrustedServerListIsCleared() {
 		$this->theAdministratorDeletesAllTrustedServersUsingTheTestingApi();
 		$statusCode = $this->featureContext->getResponse()->getStatusCode();
-		$contents = $this->featureContext->getResponse()->getBody()->getContents();
 		if ($statusCode !== 204) {
+			$contents = $this->featureContext->getResponse()->getBody()->getContents();
 			throw new \Exception(
 				__METHOD__
 				. "Failed to clear all trusted servers" . $contents

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -220,7 +220,7 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminListsTheDisabledApps() {
-		$occStatus = $this->featureContext->runOcc(
+		$this->featureContext->runOcc(
 			['app:list', '--disabled', '--no-ansi']
 		);
 	}
@@ -232,7 +232,7 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminListsTheEnabledAndDisabledApps() {
-		$occStatus = $this->featureContext->runOcc(
+		$this->featureContext->runOcc(
 			['app:list', '--enabled', '--disabled', '--no-ansi']
 		);
 	}


### PR DESCRIPTION

## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the AppManagementContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
