### PR TITLE
Allow deletion of encrypted files when the Encryption module is missing

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -251,7 +251,11 @@ class Encryption extends Wrapper {
 			return $this->storage->unlink($path);
 		}
 
-		$encryptionModule = ($this->encryptionManager->isEnabled()) ? $this->getEncryptionModule($path) : "";
+		try {
+			$encryptionModule = ($this->encryptionManager->isEnabled()) ? $this->getEncryptionModule($path) : "";
+		} catch (ModuleDoesNotExistsException $e) {
+			$encryptionModule = null;
+		}
 		if ($encryptionModule) {
 			$this->keyStorage->deleteAllFileKeys($this->getFullPath($path));
 		}


### PR DESCRIPTION
## Description
Suppress the exception caused by the missing encryption module  when we want to delete the encrypted file

## Related Issue
- Fixes https://github.com/owncloud/core/issues/22805
- Fixes https://github.com/owncloud/enterprise/issues/1739


## Motivation and Context
It's not possible to delete externally encrypted file. 
The file starting with 
`HBEGIN:cipher:AnyMIssingModule:HEND`
e.g.
`HBEGIN:cipher:AES-256-CFB:HEND`

## How Has This Been Tested?
in progress

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
