### PR TITLE
[Tests-Only] Skip mixed-case username tests on oCV10.3

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -108,6 +108,7 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
+  @skipOnOcV10.3
   Scenario: a normal user gets their own information, providing uppercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |
@@ -118,6 +119,7 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
+  @skipOnOcV10.3
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -110,6 +110,7 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
+  @skipOnOcV10.3
   Scenario: a normal user gets their own information, providing uppercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |
@@ -120,6 +121,7 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
+  @skipOnOcV10.3
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
     Given these users have been created with default attributes and skeleton files:
       | username | displayname |


### PR DESCRIPTION
## Description
Issue #36822 was fixed yesterday in core for 10.4
The related tests will not pass against a 10.3 system, so skip them.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
