### PR TITLE
[Tests-Only] Change deprecated assertInternalType to assertIsInt

### DIFF
--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -200,6 +200,6 @@ class ConnectionTest extends \Test\TestCase {
 			'textfield' => 'foo'
 		]);
 
-		$this->assertInternalType(IsType::TYPE_INT, $numNewRows);
+		$this->assertIsInt($numNewRows);
 	}
 }


### PR DESCRIPTION
## Description
`assertInternalType` is deprecated, it will give warnings in phpunit 8 and errors in phpunit 9.

Most of them were replaced a while ago. This one got missed. Fix it now.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
