### PR TITLE
[Tests-Only] Adjust CommentsContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -200,7 +200,10 @@ class CommentsContext implements Context {
 		);
 		$messages = $elementList->xpath("//d:prop/oc:message");
 		Assert::assertCount(
-			(int) $numberOfComments, $messages
+			(int) $numberOfComments,
+			$messages,
+			"Expected: {$user} should have {$numberOfComments} on {$path} but got "
+			. \count($messages)
 		);
 	}
 
@@ -288,9 +291,10 @@ class CommentsContext implements Context {
 				}
 			}
 		}
-		if ($found === false) {
-			throw new \Exception("Cannot find property $key with $value");
-		}
+		Assert::assertTrue(
+			$found,
+			"The response does not contain a property {$key} with value {$value}"
+		);
 	}
 
 	/**
@@ -303,11 +307,12 @@ class CommentsContext implements Context {
 	 */
 	public function theResponseShouldContainOnlyComments($number) {
 		$response = $this->featureContext->getResponse();
-		if (\count($response) !== (int) $number) {
-			throw new \Exception(
-				"Found more comments than $number (" . \count($response) . ")"
-			);
-		}
+		Assert::assertEquals(
+			(int) $number,
+			\count($response),
+			"Expected: the response should contain {$number} comments but got "
+			. \count($response)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the CommentsContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
