### PR TITLE
Try CI with unknown acceptance test step

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -26,6 +26,7 @@ Feature: capabilities
 
   Scenario: Check that group sharing can be disabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "yes"
+    And some other thing has happened
     And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be "1"
     When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
     Then the capabilities setting of "files_sharing" path "group_sharing" should be ""

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -347,6 +347,7 @@ function run_behat_tests() {
 	${BEHAT} --colors --strict -c ${BEHAT_YML} -f junit -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${BEHAT_FEATURE} -v  2>&1 | tee -a ${TEST_LOG_FILE}
 
 	BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
+	echo "runsh: Exit code of this run: ${BEHAT_EXIT_STATUS}"
 
 	if [ ${BEHAT_EXIT_STATUS} -eq 0 ]
 	then


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/files_antivirus/1156/20/12
gave:
```
--- FeatureContext has missing steps. Define them with these snippets:

    /**
     * @Given parameter :arg1 of app :arg2 has been set to :arg3
     */
    public function parameterOfAppHasBeenSetTo($arg1, $arg2, $arg3)
    {
        throw new PendingException();
    }

runsh: Exit code of main run: 0
```
It exited "success" even though there was a missing step definition.

Let's see what happens when I purposely do this in core.