### PR TITLE
[Tests-Only] Adjust EmailContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -65,7 +65,7 @@ class EmailContext implements Context {
 		Assert::assertContains(
 			$expectedContent,
 			$emailBody,
-			"The email address {$address} should have received an email with the body containing {$content}
+			"The email address {$address} should have received an email with the body containing {$expectedContent}
 			but the received email is {$emailBody}"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -61,9 +61,12 @@ class EmailContext implements Context {
 		$expectedContent = $this->featureContext->substituteInLineCodes(
 			$expectedContent
 		);
+		$emailBody = EmailHelper::getBodyOfLastEmail($this->localMailhogUrl, $address);
 		Assert::assertContains(
 			$expectedContent,
-			EmailHelper::getBodyOfLastEmail($this->localMailhogUrl, $address)
+			$emailBody,
+			"The email address {$address} should have received an email with the body containing {$content}
+			but the received email is {$emailBody}"
 		);
 	}
 
@@ -76,9 +79,11 @@ class EmailContext implements Context {
 	 * @return void
 	 */
 	public function theResetEmailSenderEmailAddressShouldBe($receiverAddress, $senderAddress) {
+		$actualSenderAddress = EmailHelper::getSenderOfEmail($this->localMailhogUrl, $receiverAddress);
 		Assert::assertContains(
 			$senderAddress,
-			EmailHelper::getSenderOfEmail($this->localMailhogUrl, $receiverAddress)
+			$actualSenderAddress,
+			"The sender address is expected to be {$senderAddress} but the actual sender is {$actualSenderAddress}"
 		);
 	}
 
@@ -95,7 +100,7 @@ class EmailContext implements Context {
 			EmailHelper::emailReceived(
 				EmailHelper::getLocalMailhogUrl(), $address
 			),
-			"Email exists with email address: {$address}."
+			"Email exists with email address: {$address} but was not expected to be."
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the EmailContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
