### PR TITLE
Fix issue 36925

### DIFF
--- a/changelog/unreleased/36925
+++ b/changelog/unreleased/36925
@@ -1,0 +1,13 @@
+Bugfix: user:resetpassword with --send-email --password-from-env
+
+When trying to do command:
+occ user:resetpassword Anne --send-email --password-from-env
+
+If Anne does not have an email address setup then an error was logged in the
+ownCloud log.
+
+This has been corrected. Now the administrator is shown the correct error
+"Email address is not set for the user Anne"
+
+https://github.com/owncloud/core/issues/36925
+https://github.com/owncloud/core/pull/36926

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -179,6 +179,10 @@ class ResetPassword extends Command {
 		if ($emailLink) {
 			$userId = $user->getUID();
 			list(, $token) = $this->lostController->generateTokenAndLink($userId);
+			if (!$this->hasValidEmailAddress($user->getEMailAddress())) {
+				$output->writeln('<error>Email address is not set for the user ' . $user->getUID() . '</error>');
+				return 1;
+			}
 			$this->config->setUserValue($userId, 'owncloud', 'lostpassword', $this->timeFactory->getTime() . ':' . $token);
 			$success = $this->lostController->setPassword($token, $userId, $password, false);
 			if (\is_array($success) && isset($success['status']) && $success['status'] === 'success') {

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -286,17 +286,22 @@ class ResetPasswordTest extends TestCase {
 				->method('setPassword')
 				->willReturn(['status' => 'success']);
 
+			$user->method('getEMailAddress')
+				->willReturn('foo@example.com');
+
 			$output->expects($this->once())
 				->method('writeln')
 				->with("<info>Successfully reset password for foo.</info>");
 		} else {
-			$this->lostController->expects($this->once())
-				->method('setPassword')
-				->willReturn("failed");
+			$this->lostController->expects($this->never())
+				->method('setPassword');
+
+			$user->method('getEMailAddress')
+				->willReturn('');
 
 			$output->expects($this->once())
 				->method('writeln')
-				->with("<error>Error while resetting password!</error>");
+				->with("<error>Email address is not set for the user foo</error>");
 		}
 
 		$result = $this->invokePrivate($this->resetPassword, 'execute', [$input, $output]);

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -48,15 +48,14 @@ Feature: reset user password
     Then the command should have failed with exit code 1
     And the command output should contain the text "Email address is not set for the user brand-new-user"
 
-  @issue-36925
+  @skipOnOcV10.3
   Scenario: administrator gets error message while trying to reset specifying user password with send email when the email address of the user is not setup
     Given these users have been created with skeleton files:
       | username       | password  | displayname |
       | brand-new-user | %regular% | New user    |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
     Then the command should have failed with exit code 1
-    And the command output should contain the text "Error while resetting password!"
-    #And the command output should contain the text "Email address is not set for the user brand-new-user"
+    And the command output should contain the text "Email address is not set for the user brand-new-user"
 
   Scenario: user should not get an email when the smtpmode value points to an invalid or missing mail program
     Given these users have been created with skeleton files:

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -48,6 +48,16 @@ Feature: reset user password
     Then the command should have failed with exit code 1
     And the command output should contain the text "Email address is not set for the user brand-new-user"
 
+  @issue-36925
+  Scenario: administrator gets error message while trying to reset specifying user password with send email when the email address of the user is not setup
+    Given these users have been created with skeleton files:
+      | username       | password  | displayname |
+      | brand-new-user | %regular% | New user    |
+    When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "Error while resetting password!"
+    #And the command output should contain the text "Email address is not set for the user brand-new-user"
+
   Scenario: user should not get an email when the smtpmode value points to an invalid or missing mail program
     Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |


### PR DESCRIPTION
## Description
1st commit: Add test scenario to demonstrate the problem with:
```
php occ user:resetpassword phil --send-email --password-from-env
```
(using both these command options together)

2nd commit: fix the problem. Add code to check that the user does have an email address (similar to the checks done higher up in the case when generating/sending a password-reset link)

## Related Issue
- fixes #36925 

## How Has This Been Tested?
Local run of test scenario

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
