### PR TITLE
[Tests-Only] Adjust NotificationsCoreContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -96,7 +96,13 @@ class NotificationsCoreContext implements Context {
 			$this->featureContext->getResponse()
 		);
 		Assert::assertCount(
-			(int) $numNotifications, $notifications
+			(int) $numNotifications,
+			$notifications,
+			"Expected notifications count to have '"
+			. (int) $numNotifications
+			. "' entries but got '"
+			. \count($notifications)
+			. "' entries"
 		);
 
 		$notificationIds = [];
@@ -121,12 +127,19 @@ class NotificationsCoreContext implements Context {
 			$user, 'GET', '/apps/notifications/api/v1/notifications?format=json'
 		);
 		Assert::assertEquals(
-			200, $this->featureContext->getResponse()->getStatusCode()
+			200,
+			$this->featureContext->getResponse()->getStatusCode(),
+			"Expected status code to be '200' but got '"
+			. $this->featureContext->getResponse()->getStatusCode()
+			. "'"
 		);
 
 		$previousNotificationIds = [];
 		if ($missingLast) {
-			Assert::assertNotEmpty($this->getNotificationIds());
+			Assert::assertNotEmpty(
+				$this->getNotificationIds(),
+				"The notifications is empty, but was not expected to be empty when step is used '{$missingLast}'"
+			);
 			$previousNotificationIds = $this->getLastNotificationIds();
 		}
 
@@ -140,7 +153,11 @@ class NotificationsCoreContext implements Context {
 				$now[] = $this->getDeletedNotification();
 			}
 
-			Assert::assertEquals($previousNotificationIds, $now);
+			Assert::assertEquals(
+				$previousNotificationIds,
+				$now,
+				"The actual notifications, {$missingLast}, are not what was expected. {$numNotifications} were expected.See the differences below."
+			);
 		}
 	}
 
@@ -202,7 +219,11 @@ class NotificationsCoreContext implements Context {
 			"/apps/notifications/api/v1/notifications/$notificationId?format=json"
 		);
 		Assert::assertEquals(
-			200, $this->featureContext->getResponse()->getStatusCode()
+			200,
+			$this->featureContext->getResponse()->getStatusCode(),
+			"Expected status code to be '200', but got '"
+			. $this->featureContext->getResponse()->getStatusCode()
+			. "'"
 		);
 		$response = \json_decode(
 			$this->featureContext->getResponse()->getBody()->getContents(), true
@@ -211,7 +232,9 @@ class NotificationsCoreContext implements Context {
 		$this->featureContext->verifyTableNodeColumns($formData, ['key', 'regex']);
 		foreach ($formData->getHash() as $notification) {
 			Assert::assertArrayHasKey(
-				$notification['key'], $response['ocs']['data']
+				$notification['key'],
+				$response['ocs']['data'],
+				"Could not find notification with key '${notification['key']}' matching '${notification['regex']}', in " . __METHOD__
 			);
 			if ($regex) {
 				$value = $this->featureContext->substituteInLineCodes(
@@ -224,7 +247,9 @@ class NotificationsCoreContext implements Context {
 			} else {
 				$value = $this->featureContext->substituteInLineCodes($notification['regex']);
 				Assert::assertEquals(
-					$value, $response['ocs']['data'][$notification['key']]
+					$value,
+					$response['ocs']['data'][$notification['key']],
+					"Expected {$value} but got {$response['ocs']['data'][$notification['key']]}"
 				);
 			}
 		}
@@ -256,9 +281,17 @@ class NotificationsCoreContext implements Context {
 			"DELETE",
 			'/apps/testing/api/v1/notifications'
 		);
-		Assert::assertEquals(200, $response->getStatusCode());
 		Assert::assertEquals(
-			200, (int) $this->ocsContext->getOCSResponseStatusCode($response)
+			200,
+			$response->getStatusCode(),
+			"Expected status code to be '200' but got {$response->getStatusCode()}"
+		);
+		Assert::assertEquals(
+			200,
+			(int) $this->ocsContext->getOCSResponseStatusCode($response),
+			"Expected status code to be '200' but got '"
+			. (int) $this->ocsContext->getOCSResponseStatusCode($response)
+			. "'"
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the NotificationsCoreContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
